### PR TITLE
Add gRPC ACL authorization interceptor

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	google.golang.org/genproto/googleapis/api v0.0.0-20250204164813-702378808489
 	google.golang.org/grpc v1.70.0
 	google.golang.org/protobuf v1.36.5
+	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (
@@ -30,7 +31,6 @@ require (
 	golang.org/x/sync v0.11.0 // indirect
 	golang.org/x/tools v0.28.0 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20250204164813-702378808489 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
 require (

--- a/internal/auth/grpc_acl_authz_flags.go
+++ b/internal/auth/grpc_acl_authz_flags.go
@@ -1,0 +1,30 @@
+/*
+Copyright (c) 2025 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package auth
+
+import "github.com/spf13/pflag"
+
+// AddGrpcAclAuthzFlags adds the flags related to authorization with ACL files to the given flag set.
+func AddGrpcAclAuthzFlags(set *pflag.FlagSet) {
+	_ = set.StringArray(
+		grpcAclAuthzFileFlagName,
+		[]string{},
+		"File containing the ACL.",
+	)
+}
+
+// Names of the flags:
+const (
+	grpcAclAuthzFileFlagName = "grpc-authz-acl-file"
+)

--- a/internal/auth/grpc_acl_authz_func.go
+++ b/internal/auth/grpc_acl_authz_func.go
@@ -1,0 +1,230 @@
+/*
+Copyright (c) 2025 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package auth
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+	"regexp"
+
+	"github.com/spf13/pflag"
+	grpccodes "google.golang.org/grpc/codes"
+	grpcstatus "google.golang.org/grpc/status"
+	"gopkg.in/yaml.v3"
+)
+
+// GrpcAclAuthzType is the name of the guest authentication function.
+const GrpcAclAuthzType = "acl"
+
+// GrpcAclAuthzFuncBuilder contains the data and logic needed to create an authorization function that checks if the
+// subject from the context matches a set of rules in a simple access control list.
+type GrpcAclAuthzFuncBuilder struct {
+	logger        *slog.Logger
+	publicMethods []string
+	aclFiles      []string
+}
+
+type grpcAclAuthzFunc struct {
+	logger        *slog.Logger
+	publicMethods []*regexp.Regexp
+	aclItems      []grpcAclAuthzItem
+}
+
+type grpcAclAuthzItem struct {
+	Claim   string
+	Pattern *regexp.Regexp
+}
+
+// NewGrpcAclAuthzFunc creates a builder that can then be configured and used to create a new authorization function.
+func NewGrpcAclAuthzFunc() *GrpcAclAuthzFuncBuilder {
+	return &GrpcAclAuthzFuncBuilder{}
+}
+
+// SetLogger sets the logger that the function will use to write messages to the log. This is mandatory.
+func (b *GrpcAclAuthzFuncBuilder) SetLogger(value *slog.Logger) *GrpcAclAuthzFuncBuilder {
+	b.logger = value
+	return b
+}
+
+// AddPublicMethodRegex adds a regular expression that describes a sets of methods that are considered public, and
+// therefore require no authorization. The regular expression will be matched against to the full gRPC method name,
+// including the leading slash. For example, to consider public all the methods of the `example.v1.Products` service
+// the regular expression could be `^/example\.v1\.Products/.*$`.
+//
+// This method may be called multiple times to add multiple regular expressions. A method will be considered public if
+// it matches at least one of them.
+func (b *GrpcAclAuthzFuncBuilder) AddPublicMethodRegex(value string) *GrpcAclAuthzFuncBuilder {
+	b.publicMethods = append(b.publicMethods, value)
+	return b
+}
+
+// SetFlags sets the command line flags that should be used to configure the function. This is optional.
+func (b *GrpcAclAuthzFuncBuilder) SetFlags(flags *pflag.FlagSet) *GrpcAclAuthzFuncBuilder {
+	if flags == nil {
+		return b
+	}
+
+	if flags.Changed(grpcAclAuthzFileFlagName) {
+		values, err := flags.GetStringArray(grpcAclAuthzFileFlagName)
+		if err == nil {
+			for _, value := range values {
+				b.AddAclFile(value)
+			}
+		}
+	}
+
+	return b
+}
+
+// AddAclFile adds a file that contains items of the access control list. This should be a YAML file with the following
+// format:
+//
+//   - claim: email
+//     pattern: ^.*@redhat\.com$
+//
+//   - claim: sub
+//     pattern: ^f:b3f7b485-7184-43c8-8169-37bd6d1fe4aa:myuser$
+//
+// The claim field is the name of the claim of the subject that will be checked. The pattern field is a regular
+// expression. If the claim matches at least one of the regular expression then access will be allowed, otherwise it
+// will be denied.
+func (b *GrpcAclAuthzFuncBuilder) AddAclFile(value string) *GrpcAclAuthzFuncBuilder {
+	if value != "" {
+		b.aclFiles = append(b.aclFiles, value)
+	}
+	return b
+}
+
+// Build uses the data stored in the builder to create a new authorization function.
+func (b *GrpcAclAuthzFuncBuilder) Build() (result GrpcAuthzFunc, err error) {
+	// Check parameters:
+	if b.logger == nil {
+		err = fmt.Errorf("logger is mandatory")
+		return
+	}
+
+	// Load the ACL files:
+	var aclItems []grpcAclAuthzItem
+	for _, file := range b.aclFiles {
+		var fileItems []grpcAclAuthzItem
+		fileItems, err = b.loadAclFile(file)
+		if err != nil {
+			return
+		}
+		aclItems = append(aclItems, fileItems...)
+	}
+
+	// Try to compile the regular expressions that define the set of public methods:
+	publicMethods := make([]*regexp.Regexp, len(b.publicMethods))
+	for i, expr := range b.publicMethods {
+		publicMethods[i], err = regexp.Compile(expr)
+		if err != nil {
+			return
+		}
+	}
+
+	// Create and populate the object:
+	object := &grpcAclAuthzFunc{
+		logger:        b.logger,
+		publicMethods: publicMethods,
+		aclItems:      aclItems,
+	}
+	result = object.call
+
+	return
+}
+
+// grpcAclAuthzItemYaml is the type used to read a single ACL item from a YAML document.
+type grpcAclAuthzItemYaml struct {
+	Claim   string `yaml:"claim"`
+	Pattern string `yaml:"pattern"`
+}
+
+// loadAclFile loads the given ACL file into the given map of ACL items.
+func (b *GrpcAclAuthzFuncBuilder) loadAclFile(file string) (items []grpcAclAuthzItem, err error) {
+	// Load the YAML data:
+	yamlData, err := os.ReadFile(file)
+	if err != nil {
+		return
+	}
+
+	// Parse the YAML data:
+	var listData []grpcAclAuthzItemYaml
+	err = yaml.Unmarshal(yamlData, &listData)
+	if err != nil {
+		return
+	}
+
+	// Process the items:
+	for _, itemData := range listData {
+		var itemRe *regexp.Regexp
+		itemRe, err = regexp.Compile(itemData.Pattern)
+		if err != nil {
+			return
+		}
+		items = append(items, grpcAclAuthzItem{
+			Claim:   itemData.Claim,
+			Pattern: itemRe,
+		})
+	}
+
+	return
+}
+
+func (f *grpcAclAuthzFunc) call(ctx context.Context, method string) error {
+	if f.isPublicMethod(method) {
+		return nil
+	}
+	subject := SubjectFromContext(ctx)
+	if !f.checkAcl(subject.Claims) {
+		f.logger.InfoContext(
+			ctx,
+			"Access denied",
+			slog.String("subject", subject.Name),
+			slog.Any("claims", subject.Claims),
+			slog.String("method", method),
+		)
+		return grpcstatus.Errorf(grpccodes.PermissionDenied, "Access denied")
+	}
+	return nil
+}
+
+// checkAcl checks if the given set of claims match at least one of the items of the access control list.
+func (f *grpcAclAuthzFunc) checkAcl(claims map[string]any) bool {
+	for _, aclItem := range f.aclItems {
+		value, ok := claims[aclItem.Claim]
+		if !ok {
+			continue
+		}
+		text, ok := value.(string)
+		if !ok {
+			continue
+		}
+		if aclItem.Pattern.MatchString(text) {
+			return true
+		}
+	}
+	return false
+}
+
+func (f *grpcAclAuthzFunc) isPublicMethod(method string) bool {
+	for _, publicMethod := range f.publicMethods {
+		if publicMethod.MatchString(method) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/auth/grpc_acl_authz_func_test.go
+++ b/internal/auth/grpc_acl_authz_func_test.go
@@ -1,0 +1,247 @@
+/*
+Copyright (c) 2025 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package auth
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+
+	. "github.com/onsi/ginkgo/v2/dsl/core"
+	. "github.com/onsi/gomega"
+	grpccodes "google.golang.org/grpc/codes"
+	grpcstatus "google.golang.org/grpc/status"
+)
+
+var _ = Describe("gRPC ACL authorization", func() {
+	var ctx context.Context
+
+	BeforeEach(func() {
+		ctx = context.Background()
+	})
+
+	It("Can't be built without a logger", func() {
+		_, err := NewGrpcAclAuthzFunc().
+			Build()
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("logger"))
+		Expect(err.Error()).To(ContainSubstring("mandatory"))
+	})
+
+	It("Can't be built with an ACL file that doesn't exist", func() {
+		// Create a file name that doesn't exist:
+		dir, err := os.MkdirTemp("", "*.acls")
+		Expect(err).ToNot(HaveOccurred())
+		defer func() {
+			err := os.RemoveAll(dir)
+			Expect(err).ToNot(HaveOccurred())
+		}()
+		file := filepath.Join(dir, "bad.yaml")
+
+		// Try to create the wrapper:
+		_, err = NewGrpcAclAuthzFunc().
+			SetLogger(logger).
+			AddAclFile(file).
+			Build()
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("no such file"))
+	})
+
+	It("Accepts request that matches ACL", func() {
+		// Prepare the ACL:
+		acl, err := os.CreateTemp("", "acl-*.yaml")
+		Expect(err).ToNot(HaveOccurred())
+		_, err = acl.WriteString(`[{
+			"claim": "sub",
+			"pattern: ^mysubject$"
+		}]`)
+		Expect(err).ToNot(HaveOccurred())
+		defer func() {
+			err := os.Remove(acl.Name())
+			Expect(err).ToNot(HaveOccurred())
+		}()
+		err = acl.Close()
+		Expect(err).ToNot(HaveOccurred())
+
+		// Create the function:
+		function, err := NewGrpcAclAuthzFunc().
+			SetLogger(logger).
+			AddAclFile(acl.Name()).
+			Build()
+		Expect(err).ToNot(HaveOccurred())
+
+		// Verify the result:
+		subject := &Subject{
+			Name: "mysubject",
+			Claims: map[string]any{
+				"sub": "mysubject",
+			},
+		}
+		ctx = ContextWithSubject(ctx, subject)
+		err = function(ctx, "/my_package/MyMethod")
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	It("Accepts request that matches second of two ACL items", func() {
+		// Prepare the ACL:
+		acl, err := os.CreateTemp("", "acl-*.yaml")
+		Expect(err).ToNot(HaveOccurred())
+		_, err = acl.WriteString((`[
+			{
+				"claim": "sub",
+				"pattern": "^mysubject$"
+			},
+			{
+				"claim": "sub",
+				"pattern": "^yoursubject$"
+			}
+		]`))
+		Expect(err).ToNot(HaveOccurred())
+		defer func() {
+			err := os.Remove(acl.Name())
+			Expect(err).ToNot(HaveOccurred())
+		}()
+		err = acl.Close()
+		Expect(err).ToNot(HaveOccurred())
+
+		// Create the function:
+		function, err := NewGrpcAclAuthzFunc().
+			SetLogger(logger).
+			AddAclFile(acl.Name()).
+			Build()
+		Expect(err).ToNot(HaveOccurred())
+
+		// Verify the result:
+		subject := &Subject{
+			Name: "yoursubject",
+			Claims: map[string]any{
+				"sub": "yoursubject",
+			},
+		}
+		ctx = ContextWithSubject(ctx, subject)
+		err = function(ctx, "/my_package/MyMethod")
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	It("Accepts request that matches second of two ACL files", func() {
+		// Prepare the ACL files:
+		dir, err := os.MkdirTemp("", "acls.*")
+		Expect(err).ToNot(HaveOccurred())
+		defer func() {
+			err := os.RemoveAll(dir)
+			Expect(err).ToNot(HaveOccurred())
+		}()
+		file1 := filepath.Join(dir, "acl1.yaml")
+		err = os.WriteFile(
+			file1,
+			[]byte(`[{
+				"claim": "sub",
+				"pattern": "^mysubject$"
+			}]`),
+			0600,
+		)
+		Expect(err).ToNot(HaveOccurred())
+		file2 := filepath.Join(dir, "acl2.yaml")
+		err = os.WriteFile(
+			file2,
+			[]byte(`[{
+				"claim": "sub",
+				"pattern": "^yoursubject$"
+			}]`),
+			0600,
+		)
+		Expect(err).ToNot(HaveOccurred())
+
+		// Create the function:
+		function, err := NewGrpcAclAuthzFunc().
+			SetLogger(logger).
+			AddAclFile(file1).
+			AddAclFile(file2).
+			Build()
+		Expect(err).ToNot(HaveOccurred())
+
+		// Verify the result:
+		subject := &Subject{
+			Name: "yoursubject",
+			Claims: map[string]any{
+				"sub": "yoursubject",
+			},
+		}
+		ctx = ContextWithSubject(ctx, subject)
+		err = function(ctx, "/my_package/MyMethod")
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	It("Rejects request if there is no ACL", func() {
+		// Create the function:
+		function, err := NewGrpcAclAuthzFunc().
+			SetLogger(logger).
+			Build()
+		Expect(err).ToNot(HaveOccurred())
+
+		// Verify the result:
+		subject := &Subject{
+			Name: "mysubject",
+			Claims: map[string]any{
+				"sub": "mysubject",
+			},
+		}
+		ctx = ContextWithSubject(ctx, subject)
+		err = function(ctx, "/my_request/MyMethod")
+		Expect(err).To(HaveOccurred())
+		status, ok := grpcstatus.FromError(err)
+		Expect(ok).To(BeTrue())
+		Expect(status.Code()).To(Equal(grpccodes.PermissionDenied))
+		Expect(status.Message()).To(Equal("Access denied"))
+	})
+
+	It("Rejects request if there are ACL items but none matches", func() {
+		// Prepare the ACL:
+		acl, err := os.CreateTemp("", "acl-*.yaml")
+		Expect(err).ToNot(HaveOccurred())
+		_, err = acl.WriteString(`[{
+			"claim": "sub",
+			"pattern": "^mysubject$"
+		}]`)
+		Expect(err).ToNot(HaveOccurred())
+		defer func() {
+			err := os.Remove(acl.Name())
+			Expect(err).ToNot(HaveOccurred())
+		}()
+		err = acl.Close()
+		Expect(err).ToNot(HaveOccurred())
+
+		// Create the function:
+		function, err := NewGrpcAclAuthzFunc().
+			SetLogger(logger).
+			AddAclFile(acl.Name()).
+			Build()
+		Expect(err).ToNot(HaveOccurred())
+
+		// Verify the result:
+		subject := &Subject{
+			Name: "yoursubject",
+			Claims: map[string]any{
+				"sub": "yoursubject",
+			},
+		}
+		ctx = ContextWithSubject(ctx, subject)
+		err = function(ctx, "/my_package/MyMethod")
+		Expect(err).To(HaveOccurred())
+		status, ok := grpcstatus.FromError(err)
+		Expect(ok).To(BeTrue())
+		Expect(status.Code()).To(Equal(grpccodes.PermissionDenied))
+		Expect(status.Message()).To(Equal("Access denied"))
+	})
+})

--- a/internal/auth/grpc_all_authz_func.go
+++ b/internal/auth/grpc_all_authz_func.go
@@ -1,0 +1,72 @@
+/*
+Copyright (c) 2025 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package auth
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	"github.com/spf13/pflag"
+)
+
+// GrpcAllAuthzType is the name of the authentication function that authorizes everything unconditionally.
+const GrpcAllAuthzType = "all"
+
+// GrpcAllAuthzFuncBuilder contains the data and logic needed to create an authorization function.
+type GrpcAllAuthzFuncBuilder struct {
+	logger *slog.Logger
+}
+
+type grpcAllAuthzFunc struct {
+	logger *slog.Logger
+}
+
+// NewGrpcAllAuthzFunc creates a builder that can then be configured and used to create a new authorization function.
+func NewGrpcAllAuthzFunc() *GrpcAllAuthzFuncBuilder {
+	return &GrpcAllAuthzFuncBuilder{}
+}
+
+// SetLogger sets the logger that the function will use to write messages to the log. This is mandatory.
+func (b *GrpcAllAuthzFuncBuilder) SetLogger(value *slog.Logger) *GrpcAllAuthzFuncBuilder {
+	b.logger = value
+	return b
+}
+
+// SetFlags sets the command line flags that should be used to configure the function. This is optional.
+func (b *GrpcAllAuthzFuncBuilder) SetFlags(flags *pflag.FlagSet) *GrpcAllAuthzFuncBuilder {
+	// No flags defined yet.
+	return b
+}
+
+// Build uses the data stored in the builder to create a new authorization function.
+func (b *GrpcAllAuthzFuncBuilder) Build() (result GrpcAuthzFunc, err error) {
+	// Check parameters:
+	if b.logger == nil {
+		err = fmt.Errorf("logger is mandatory")
+		return
+	}
+
+	// Create and populate the object:
+	object := &grpcAllAuthzFunc{
+		logger: b.logger,
+	}
+	result = object.call
+
+	return
+}
+
+func (f *grpcAllAuthzFunc) call(ctx context.Context, method string) error {
+	return nil
+}

--- a/internal/auth/grpc_all_authz_func_test.go
+++ b/internal/auth/grpc_all_authz_func_test.go
@@ -1,0 +1,61 @@
+/*
+Copyright (c) 2025 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package auth
+
+import (
+	"context"
+
+	"github.com/google/uuid"
+	. "github.com/onsi/ginkgo/v2/dsl/core"
+	. "github.com/onsi/ginkgo/v2/dsl/decorators"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("gRPC all authorization function", func() {
+	var (
+		ctx      context.Context
+		function GrpcAuthzFunc
+	)
+
+	BeforeEach(func() {
+		var err error
+
+		ctx = context.Background()
+
+		function, err = NewGrpcAllAuthzFunc().
+			SetLogger(logger).
+			Build()
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	It("Can't be built without a logger", func() {
+		_, err := NewGrpcAllAuthzFunc().
+			Build()
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("logger"))
+		Expect(err.Error()).To(ContainSubstring("mandatory"))
+	})
+
+	It("Accepts any subject", MustPassRepeatedly(10), func() {
+		subject := &Subject{
+			Name: uuid.NewString(),
+			Claims: map[string]any{
+				"sub": uuid.NewString(),
+			},
+		}
+		ctx = ContextWithSubject(ctx, subject)
+		err := function(ctx, "/my_package/MyMethod")
+		Expect(err).ToNot(HaveOccurred())
+	})
+})

--- a/internal/auth/grpc_authz_func.go
+++ b/internal/auth/grpc_authz_func.go
@@ -1,0 +1,23 @@
+/*
+Copyright (c) 2025 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package auth
+
+import (
+	"context"
+)
+
+// GrpcAuthzFunc is a function that checks authorization for gRPC calls using the subject from the context and the
+// method name. Returns nil if authorization succeeds, or an error suitable for sending directly to the caller if
+// authorization fails.
+type GrpcAuthzFunc func(ctx context.Context, method string) error

--- a/internal/auth/grpc_authz_interceptor.go
+++ b/internal/auth/grpc_authz_interceptor.go
@@ -1,0 +1,93 @@
+/*
+Copyright (c) 2025 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package auth
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+
+	"google.golang.org/grpc"
+)
+
+// GrpcAuthzInterceptorBuilder contains the data and logic needed to build an interceptor that checks authorization.
+// Don't create instances of this type directly, use the NewGrpcAuthzInterceptor function instead.
+type GrpcAuthzInterceptorBuilder struct {
+	logger   *slog.Logger
+	function GrpcAuthzFunc
+}
+
+// GrpcAuthzInterceptor contains the data needed by the interceptor.
+type GrpcAuthzInterceptor struct {
+	logger   *slog.Logger
+	function GrpcAuthzFunc
+}
+
+// NewGrpcAuthzInterceptor creates a builder that can then be used to configure and create an authorization interceptor.
+func NewGrpcAuthzInterceptor() *GrpcAuthzInterceptorBuilder {
+	return &GrpcAuthzInterceptorBuilder{}
+}
+
+// SetLogger sets the logger that will be used to write to the log. This is mandatory.
+func (b *GrpcAuthzInterceptorBuilder) SetLogger(value *slog.Logger) *GrpcAuthzInterceptorBuilder {
+	b.logger = value
+	return b
+}
+
+// SetFunction sets the authorization function. This is mandatory.
+func (b *GrpcAuthzInterceptorBuilder) SetFunction(value GrpcAuthzFunc) *GrpcAuthzInterceptorBuilder {
+	b.function = value
+	return b
+}
+
+// Build uses the data stored in the builder to create and configure a new interceptor.
+func (b *GrpcAuthzInterceptorBuilder) Build() (result *GrpcAuthzInterceptor, err error) {
+	// Check parameters:
+	if b.logger == nil {
+		err = errors.New("logger is mandatory")
+		return
+	}
+	if b.function == nil {
+		err = errors.New("authorization function is mandatory")
+		return
+	}
+
+	// Create and populate the object:
+	result = &GrpcAuthzInterceptor{
+		logger:   b.logger,
+		function: b.function,
+	}
+	return
+}
+
+// UnaryServer is the unary server interceptor function.
+func (i *GrpcAuthzInterceptor) UnaryServer(ctx context.Context, request any, info *grpc.UnaryServerInfo,
+	handler grpc.UnaryHandler) (response any, err error) {
+	err = i.function(ctx, info.FullMethod)
+	if err != nil {
+		return
+	}
+	response, err = handler(ctx, request)
+	return
+}
+
+// StreamServer is the stream server interceptor function.
+func (i *GrpcAuthzInterceptor) StreamServer(server any, stream grpc.ServerStream, info *grpc.StreamServerInfo,
+	handler grpc.StreamHandler) error {
+	err := i.function(stream.Context(), info.FullMethod)
+	if err != nil {
+		return err
+	}
+	return handler(server, stream)
+}

--- a/manifests/service/deployment.yaml
+++ b/manifests/service/deployment.yaml
@@ -29,6 +29,9 @@ spec:
       - name: sockets
         emptyDir:
           medium: Memory
+      - name: config
+        configMap:
+          name: fulfillment-service-config
       - name: envoy
         configMap:
           name: fulfillment-service-envoy
@@ -43,6 +46,8 @@ spec:
         volumeMounts:
         - name: sockets
           mountPath: /run/sockets
+        - name: config
+          mountPath: /etc/fulfillment-service
         command:
         - /usr/local/bin/fulfillment-service
         - start
@@ -57,6 +62,8 @@ spec:
         - --grpc-authn-jwks-url=https://kubernetes.default.svc/openid/v1/jwks
         - --grpc-authn-jwks-ca-file=/run/secrets/kubernetes.io/serviceaccount/ca.crt
         - --grpc-authn-jwks-token-file=/run/secrets/kubernetes.io/serviceaccount/token
+        - --grpc-authz-type=acl
+        - --grpc-authz-acl-file=/etc/fulfillment-service/acl.yaml
 
       - name: gateway
         image: fulfillment-service

--- a/manifests/service/files/acl.yaml
+++ b/manifests/service/files/acl.yaml
@@ -1,0 +1,16 @@
+#
+# Copyright (c) 2025 Red Hat Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+# the License. You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+# Grant access to the 'client' service account.
+- claim: sub
+  pattern: ^system:serviceaccount:innabox:client$

--- a/manifests/service/kustomization.yaml
+++ b/manifests/service/kustomization.yaml
@@ -12,5 +12,8 @@ resources:
 
 configMapGenerator:
 - files:
+  - files/acl.yaml
+  name: fulfillment-service-config
+- files:
   - files/envoy.yaml
   name: fulfillment-service-envoy


### PR DESCRIPTION
This patch introduces an authorization interceptor that expects to receive a set of claims associated to the authenticated subject (typically from a JSON web token) and checks them against a simple ACL file. The format of the file is a set of rules containing claim names and claim value patterns. If the subject matches at least one of those rules then it is authorized, otherwise it is reject. For example, if the server is configured to authorize Kubernetes service account then the following ACL will allow access only to the `client` service account of the `innabox` namespace:

    - claim: sub
      pattern: ^system:serviceaccount:innabox:client$

The patch also changes the Kubernetes deployment to use the example ACL above.

Note that this pull request includes the changes in #8, it will need to be rebased once that is merged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced configurable gRPC authorization modes, allowing users to choose between an ACL-based approach and an allow-all mode via a new command-line flag.
  - Enabled custom access control through a dedicated configuration file, integrated into the service deployment.
  - Enhanced JWT authentication with improved key refresh handling for robust security.

- **Tests**
  - Added comprehensive tests to validate the new authorization and authentication workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->