### PR TITLE
Add CORS support to the gateway

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 )
 
 require (
+	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/go-logr/logr v1.4.2 // indirect
 	github.com/go-task/slim-sprig/v3 v3.0.0 // indirect
 	github.com/google/go-cmp v0.7.0 // indirect
@@ -35,6 +36,7 @@ require (
 require (
 	github.com/golang-jwt/jwt/v4 v4.5.1
 	github.com/golang-migrate/migrate/v4 v4.18.2
+	github.com/gorilla/handlers v1.5.2
 	github.com/jackc/pgx/v5 v5.7.2
 	github.com/onsi/ginkgo/v2 v2.22.2
 	github.com/onsi/gomega v1.36.2

--- a/go.sum
+++ b/go.sum
@@ -38,6 +38,8 @@ github.com/google/pprof v0.0.0-20241210010833-40e02aabc2ad h1:a6HEuzUHeKH6hwfN/Z
 github.com/google/pprof v0.0.0-20241210010833-40e02aabc2ad/go.mod h1:vavhavw2zAxS5dIdcRluK6cSGGPlZynqzFM8NdvU144=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/gorilla/handlers v1.5.2 h1:cLTUSsNkgcwhgRqvCNmdbRWG0A3N4F+M2nWKdScwyEE=
+github.com/gorilla/handlers v1.5.2/go.mod h1:dX+xVpaxdSw+q0Qek8SSsl3dfMk3jNddUkMzo0GtH0w=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.26.1 h1:e9Rjr40Z98/clHv5Yg79Is0NtosR5LXRvdr7o/6NwbA=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.26.1/go.mod h1:tIxuGz/9mpox++sgp9fJjHO0+q1X9/UOWd798aAm22M=
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=

--- a/internal/network/cors.go
+++ b/internal/network/cors.go
@@ -1,0 +1,129 @@
+/*
+Copyright (c) 2025 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package network
+
+import (
+	"errors"
+	"log/slog"
+	"net/http"
+	"slices"
+
+	"github.com/gorilla/handlers"
+	"github.com/spf13/pflag"
+)
+
+// CorsMiddlewareBuilder contains the data and logic needed to create A CORS middleware. Don't create instances of this
+// object directly, use the NewCorsMiddleware function instead.
+type CorsMiddlewareBuilder struct {
+	logger         *slog.Logger
+	name           string
+	allowedOrigins []string
+}
+
+// NewCorsMiddleware creates a builder that can then be used to configure and create a CORS middleware.
+func NewCorsMiddleware() *CorsMiddlewareBuilder {
+	return &CorsMiddlewareBuilder{}
+}
+
+// SetLogger sets the logger that the middleware will use to send messages to the log. This is mandatory.
+func (b *CorsMiddlewareBuilder) SetLogger(value *slog.Logger) *CorsMiddlewareBuilder {
+	b.logger = value
+	return b
+}
+
+// SetFlags sets the command line flags that should be used to configure the middleware.
+//
+// The name is used to select the options when there are multiple instances. For example, if it is 'API' then it will
+// only take into accounts the flags starting with '--api'.
+//
+// This is optional.
+func (b *CorsMiddlewareBuilder) SetFlags(flags *pflag.FlagSet, name string) *CorsMiddlewareBuilder {
+	// Save the name of the listener:
+	b.name = name
+
+	// Prepare some variables and helper functions to avoid repeating code:
+	if flags == nil {
+		return b
+	}
+	var (
+		flag string
+		err  error
+	)
+	failure := func() {
+		b.logger.Error(
+			"Failed to get flag value",
+			slog.String("flag", flag),
+			slog.String("error", err.Error()),
+		)
+	}
+
+	// Address:
+	flag = corsFlagName(name, corsAllowedOriginsFlagSuffix)
+	if flags.Changed(flag) {
+		values, err := flags.GetStringSlice(flag)
+		if err != nil {
+			failure()
+		} else {
+			b.AddAllowedOrigins(values...)
+		}
+	}
+
+	return b
+}
+
+// AddAllowedOrigins adds a list of allowed origins to the CORS middleware. This is optional, and the default value is
+// '*'.
+func (b *CorsMiddlewareBuilder) AddAllowedOrigins(values ...string) *CorsMiddlewareBuilder {
+	b.allowedOrigins = append(b.allowedOrigins, values...)
+	return b
+}
+
+// Build uses the data stored in the builder to create a new CORS middleware.
+func (b *CorsMiddlewareBuilder) Build() (result func(http.Handler) http.Handler, err error) {
+	// Check parameters:
+	if b.logger == nil {
+		err = errors.New("logger is mandatory")
+		return
+	}
+
+	// If no allowed origins are set, use the default value:
+	allowedOrigins := slices.Clone(b.allowedOrigins)
+	if len(b.allowedOrigins) == 0 {
+		allowedOrigins = []string{"*"}
+	}
+	b.logger.Info(
+		"CORS configuration",
+		slog.String("listener", b.name),
+		slog.Any("allowed_origins", allowedOrigins),
+	)
+
+	// Create the middleware:
+	result = handlers.CORS(
+		handlers.AllowedOrigins(allowedOrigins),
+		handlers.AllowedMethods([]string{
+			http.MethodDelete,
+			http.MethodGet,
+			http.MethodHead,
+			http.MethodPatch,
+			http.MethodPost,
+			http.MethodPut,
+		}),
+		handlers.AllowCredentials(),
+		handlers.AllowedHeaders([]string{
+			"Authorization",
+			"Content-Type",
+		}),
+	)
+	return
+}

--- a/internal/network/cors_flags.go
+++ b/internal/network/cors_flags.go
@@ -1,0 +1,51 @@
+/*
+Copyright (c) 2025 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package network
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/spf13/pflag"
+)
+
+// AddCorsFlags adds to the given flag set the flags needed to configure the CORS middleware. It receives the name of
+// the listerner where the CORS support will be enabled. For example, to configure an API listener:
+//
+//	network.AddCorsFlags(flags, "API")
+//
+// The name will be converted to lower case to generate a prefix for the flags, and will be used unchanged as a prefix
+// for the help text. The above example will result in the following flags:
+//
+//	--api-cors-allowed-origins strings API CORS allowed origins. (default "*")
+func AddCorsFlags(flags *pflag.FlagSet, name string) {
+	_ = flags.StringSlice(
+		corsFlagName(name, corsAllowedOriginsFlagSuffix),
+		[]string{
+			"*",
+		},
+		fmt.Sprintf("%s CORS allowed origins.", name),
+	)
+}
+
+// Names of the flags:
+const (
+	corsAllowedOriginsFlagSuffix = "cors-allowed-origins"
+)
+
+// corsFlagName calculates a complete flag name from a listener name and a flag name suffix. For example, if the
+// listener name is 'API' and the flag name suffix is 'allowed-origins' it returns 'api-cors-allowed-origins'.
+func corsFlagName(name, suffix string) string {
+	return fmt.Sprintf("%s-%s", strings.ToLower(name), suffix)
+}

--- a/internal/network/cors_test.go
+++ b/internal/network/cors_test.go
@@ -1,0 +1,173 @@
+package network
+
+import (
+	"net/http"
+	"net/http/httptest"
+
+	"github.com/spf13/pflag"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("CORS middleware", func() {
+	// verifyAllowedOrigin verifies that the given middleware allows the given origin.
+	verifyAllowedOrigin := func(middleware func(http.Handler) http.Handler, origin, expected string) {
+		handler := middleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		}))
+		request := httptest.NewRequest(http.MethodGet, "/", nil)
+		request.Header.Set("Origin", origin)
+		recorder := httptest.NewRecorder()
+		handler.ServeHTTP(recorder, request)
+		Expect(recorder.Code).To(Equal(http.StatusOK))
+		origins := recorder.Header().Get("Access-Control-Allow-Origin")
+		ExpectWithOffset(1, origins).To(Equal(expected))
+	}
+
+	Context("Using the builder", func() {
+		It("Fails if the logger is not set", func() {
+			// Create the middleware without setting the logger:
+			_, err := NewCorsMiddleware().
+				Build()
+			Expect(err).To(HaveOccurred())
+
+			// Verify the result:
+			Expect(err.Error()).To(ContainSubstring("logger"))
+			Expect(err.Error()).To(ContainSubstring("mandatory"))
+		})
+
+		It("Uses default allowed origins", func() {
+			// Create the middleware with the default allowed origins:
+			middleware, err := NewCorsMiddleware().
+				SetLogger(logger).
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+
+			// Verify the result:
+			verifyAllowedOrigin(middleware, "http://my.com", "*")
+		})
+
+		It("Uses custom allowed origin", func() {
+			// Create the middleware with the default allowed origins:
+			middleware, err := NewCorsMiddleware().
+				SetLogger(logger).
+				AddAllowedOrigins("http://my.com").
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+
+			// Verify the result:
+			verifyAllowedOrigin(middleware, "http://my.com", "http://my.com")
+		})
+
+		It("Uses multiple custom allowed origins from one call", func() {
+			// Create the middleware with the default allowed origins:
+			middleware, err := NewCorsMiddleware().
+				SetLogger(logger).
+				AddAllowedOrigins("http://my.com", "http://your.com").
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+
+			// Verify the result:
+			verifyAllowedOrigin(middleware, "http://my.com", "http://my.com")
+			verifyAllowedOrigin(middleware, "http://your.com", "http://your.com")
+		})
+
+		It("Uses multiple custom allowed origins from multiple calls", func() {
+			// Create the middleware with the default allowed origins:
+			middleware, err := NewCorsMiddleware().
+				SetLogger(logger).
+				AddAllowedOrigins("http://my.com").
+				AddAllowedOrigins("http://your.com").
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+
+			// Verify the result:
+			verifyAllowedOrigin(middleware, "http://my.com", "http://my.com")
+			verifyAllowedOrigin(middleware, "http://your.com", "http://your.com")
+		})
+	})
+
+	Context("Using flags", func() {
+		var flags *pflag.FlagSet
+
+		BeforeEach(func() {
+			// Prepare the flag set:
+			flags = pflag.NewFlagSet("", pflag.ContinueOnError)
+			AddCorsFlags(flags, "my")
+		})
+
+		It("Uses default allowed origins", func() {
+			// Prepare the flags:
+			err := flags.Parse([]string{})
+			Expect(err).ToNot(HaveOccurred())
+
+			// Create the middleware with the default allowed origins:
+			middleware, err := NewCorsMiddleware().
+				SetLogger(logger).
+				SetFlags(flags, "my").
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+
+			// Verify the result:
+			verifyAllowedOrigin(middleware, "http://my.com", "*")
+		})
+
+		It("Uses custom allowed origins", func() {
+			// Prepare the flags:
+			err := flags.Parse([]string{
+				"--my-cors-allowed-origins=http://my.com",
+			})
+			Expect(err).ToNot(HaveOccurred())
+
+			// Create the middleware with the default allowed origins:
+			middleware, err := NewCorsMiddleware().
+				SetLogger(logger).
+				SetFlags(flags, "my").
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+
+			// Verify the result:
+			verifyAllowedOrigin(middleware, "http://my.com", "http://my.com")
+		})
+
+		It("Uses multiple custom allowed origins in one flag", func() {
+			// Prepare the flags:
+			err := flags.Parse([]string{
+				"--my-cors-allowed-origins=http://my.com,http://your.com",
+			})
+			Expect(err).ToNot(HaveOccurred())
+
+			// Create the middleware with the default allowed origins:
+			middleware, err := NewCorsMiddleware().
+				SetLogger(logger).
+				SetFlags(flags, "my").
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+
+			// Verify the result:
+			verifyAllowedOrigin(middleware, "http://my.com", "http://my.com")
+			verifyAllowedOrigin(middleware, "http://your.com", "http://your.com")
+		})
+
+		It("Uses multiple custom allowed origins in multiple flags", func() {
+			// Prepare the flags:
+			err := flags.Parse([]string{
+				"--my-cors-allowed-origins=http://my.com",
+				"--my-cors-allowed-origins=http://your.com",
+			})
+			Expect(err).ToNot(HaveOccurred())
+
+			// Create the middleware with the default allowed origins:
+			middleware, err := NewCorsMiddleware().
+				SetLogger(logger).
+				SetFlags(flags, "my").
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+
+			// Verify the result:
+			verifyAllowedOrigin(middleware, "http://my.com", "http://my.com")
+			verifyAllowedOrigin(middleware, "http://your.com", "http://your.com")
+		})
+	})
+})


### PR DESCRIPTION
The support is enabled by default for all domains, and can be configured using the `--http-cors-allowed-origins` flag.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Integrated robust CORS support to enhance secure handling of cross-origin requests.
  - Introduced new command-line options allowing users to customize allowed origins for improved flexibility and security.
  - Added indirect dependencies to support new functionalities. 

- **Tests**
  - Introduced a new test suite for validating CORS middleware behavior, ensuring correct handling of allowed origins.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->