### PR TITLE
Log stack trace for errors

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -34,6 +34,7 @@ require (
 )
 
 require (
+	github.com/DataDog/gostackparse v0.7.0
 	github.com/golang-jwt/jwt/v5 v5.2.1
 	github.com/golang-migrate/migrate/v4 v4.18.2
 	github.com/gorilla/handlers v1.5.2

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/Azure/go-ansiterm v0.0.0-20230124172434-306776ec8161 h1:L/gRVlceqvL25UVaW/CKtUDjefjrs0SPonmDGUVOYP0=
 github.com/Azure/go-ansiterm v0.0.0-20230124172434-306776ec8161/go.mod h1:xomTg63KZ2rFqZQzSB4Vz2SUXa1BpHTVz9L5PTmPC4E=
+github.com/DataDog/gostackparse v0.7.0 h1:i7dLkXHvYzHV308hnkvVGDL3BR4FWl7IsXNPz/IGQh4=
+github.com/DataDog/gostackparse v0.7.0/go.mod h1:lTfqcJKqS9KnXQGnyQMCugq3u1FP6UZMfWR0aitKFMM=
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
 github.com/cpuguy83/go-md2man/v2 v2.0.4/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=

--- a/internal/auth/grpc_jwks_authn_func.go
+++ b/internal/auth/grpc_jwks_authn_func.go
@@ -388,7 +388,7 @@ func (f *grpcJwksAuthnFunc) callWithAuth(ctx context.Context, method string, aut
 				ctx,
 				"Authentication failed for public method",
 				slog.String("method", method),
-				slog.String("error", err.Error()),
+				slog.Any("error", err),
 			)
 			result = ContextWithSubject(ctx, Guest)
 			err = nil
@@ -539,7 +539,7 @@ func (f *grpcJwksAuthnFunc) loadKeys(ctx context.Context) error {
 				ctx,
 				"Failed load keys from file",
 				slog.String("file", keysFile),
-				slog.String("error", err.Error()),
+				slog.Any("error", err),
 			)
 		}
 	}
@@ -557,7 +557,7 @@ func (f *grpcJwksAuthnFunc) loadKeys(ctx context.Context) error {
 				ctx,
 				"Failed to load keys from URL",
 				slog.String("url", keysURL),
-				slog.String("error", err.Error()),
+				slog.Any("error", err),
 			)
 		}
 	}
@@ -578,7 +578,7 @@ func (f *grpcJwksAuthnFunc) loadKeysFile(ctx context.Context, file string) error
 				ctx,
 				"Failed to close keys file",
 				slog.String("file", file),
-				slog.String("error", err.Error()),
+				slog.Any("error", err),
 			)
 		}
 	}()
@@ -607,7 +607,7 @@ func (f *grpcJwksAuthnFunc) loadKeysURL(ctx context.Context, addr string) error 
 				ctx,
 				"Failed to close response body",
 				slog.String("url", addr),
-				slog.String("error", err.Error()),
+				slog.Any("error", err),
 			)
 		}
 	}()
@@ -632,7 +632,7 @@ func (f *grpcJwksAuthnFunc) selectKeysToken(ctx context.Context) string {
 				ctx,
 				"Failed to read keys token from file",
 				slog.String("file", f.keysTokenFile),
-				slog.String("error", err.Error()),
+				slog.Any("error", err),
 			)
 		} else {
 			return string(data)
@@ -713,7 +713,7 @@ func (f *grpcJwksAuthnFunc) readKeys(ctx context.Context, reader io.Reader) erro
 				ctx,
 				"Key will be ignored because it can't be parsed",
 				slog.String("kid", keyData.Kid),
-				slog.String("error", err.Error()),
+				slog.Any("error", err),
 			)
 			continue
 		}
@@ -769,7 +769,7 @@ func (f *grpcJwksAuthnFunc) checkToken(ctx context.Context, bearer string) (toke
 			ctx,
 			"Failed to parse token",
 			slog.String("!token", bearer),
-			slog.String("error", err.Error()),
+			slog.Any("error", err),
 		)
 		switch {
 		case errors.Is(err, jwt.ErrTokenMalformed):

--- a/internal/database/dao/cluster_orders_dao.go
+++ b/internal/database/dao/cluster_orders_dao.go
@@ -94,7 +94,7 @@ func (d *clusterOrdersDAO) List(ctx context.Context) (items []*models.ClusterOrd
 			d.logger.ErrorContext(
 				ctx,
 				"Failed to rollback transaction",
-				slog.String("error", err.Error()),
+				slog.Any("error", err),
 			)
 		}
 	}()
@@ -152,7 +152,7 @@ func (d *clusterOrdersDAO) Exists(ctx context.Context, id string) (ok bool, err 
 			d.logger.ErrorContext(
 				ctx,
 				"Failed to rollback transaction",
-				slog.String("error", err.Error()),
+				slog.Any("error", err),
 			)
 		}
 	}()
@@ -186,7 +186,7 @@ func (d *clusterOrdersDAO) Get(ctx context.Context, id string) (item *models.Clu
 			d.logger.ErrorContext(
 				ctx,
 				"Failed to rollback transaction",
-				slog.String("error", err.Error()),
+				slog.Any("error", err),
 			)
 		}
 	}()
@@ -237,7 +237,7 @@ func (d *clusterOrdersDAO) Insert(ctx context.Context, order *models.ClusterOrde
 			d.logger.ErrorContext(
 				ctx,
 				"Failed to commit transaction",
-				slog.String("error", err.Error()),
+				slog.Any("error", err),
 			)
 		}
 	}()
@@ -273,7 +273,7 @@ func (d *clusterOrdersDAO) Delete(ctx context.Context, id string) error {
 			d.logger.ErrorContext(
 				ctx,
 				"Failed to commit transaction",
-				slog.String("error", err.Error()),
+				slog.Any("error", err),
 			)
 		}
 	}()
@@ -299,7 +299,7 @@ func (d *clusterOrdersDAO) UpdateState(ctx context.Context, id string, state mod
 			d.logger.ErrorContext(
 				ctx,
 				"Failed to commit transaction",
-				slog.String("error", err.Error()),
+				slog.Any("error", err),
 			)
 		}
 	}()

--- a/internal/database/dao/cluster_templates_dao.go
+++ b/internal/database/dao/cluster_templates_dao.go
@@ -88,7 +88,7 @@ func (d *clusterTemplatesDAO) List(ctx context.Context) (items []*models.Cluster
 			d.logger.ErrorContext(
 				ctx,
 				"Failed to rollback transaction",
-				slog.String("error", err.Error()),
+				slog.Any("error", err),
 			)
 		}
 	}()
@@ -136,7 +136,7 @@ func (d *clusterTemplatesDAO) Get(ctx context.Context, id string) (item *models.
 			d.logger.ErrorContext(
 				ctx,
 				"Failed to rollback transaction",
-				slog.String("error", err.Error()),
+				slog.Any("error", err),
 			)
 		}
 	}()

--- a/internal/database/dao/clusters_dao.go
+++ b/internal/database/dao/clusters_dao.go
@@ -92,7 +92,7 @@ func (d *clustersDAO) List(ctx context.Context) (items []*models.Cluster, err er
 			d.logger.ErrorContext(
 				ctx,
 				"Failed to rollback transaction",
-				slog.String("error", err.Error()),
+				slog.Any("error", err),
 			)
 		}
 	}()
@@ -147,7 +147,7 @@ func (d *clustersDAO) Exists(ctx context.Context, id string) (ok bool, err error
 			d.logger.ErrorContext(
 				ctx,
 				"Failed to rollback transaction",
-				slog.String("error", err.Error()),
+				slog.Any("error", err),
 			)
 		}
 	}()
@@ -181,7 +181,7 @@ func (d *clustersDAO) Get(ctx context.Context, id string) (item *models.Cluster,
 			d.logger.ErrorContext(
 				ctx,
 				"Failed to rollback transaction",
-				slog.String("error", err.Error()),
+				slog.Any("error", err),
 			)
 		}
 	}()
@@ -229,7 +229,7 @@ func (d *clustersDAO) Insert(ctx context.Context, cluster *models.Cluster) (id s
 			d.logger.ErrorContext(
 				ctx,
 				"Failed to commit transaction",
-				slog.String("error", err.Error()),
+				slog.Any("error", err),
 			)
 		}
 	}()
@@ -268,7 +268,7 @@ func (d *clustersDAO) Delete(ctx context.Context, id string) error {
 			d.logger.ErrorContext(
 				ctx,
 				"Failed to commit transaction",
-				slog.String("error", err.Error()),
+				slog.Any("error", err),
 			)
 		}
 	}()

--- a/internal/database/database_tool.go
+++ b/internal/database/database_tool.go
@@ -90,7 +90,7 @@ func (b *ToolBuilder) SetFlags(flags *pflag.FlagSet) *ToolBuilder {
 		b.logger.Error(
 			"Failed to get flag value",
 			slog.String("flag", flag),
-			slog.String("error", err.Error()),
+			slog.Any("error", err),
 		)
 	}
 
@@ -145,7 +145,7 @@ func (t *tool) Wait(ctx context.Context) error {
 			t.logger.InfoContext(
 				ctx,
 				"Database isn't responding yet",
-				slog.String("error", err.Error()),
+				slog.Any("error", err),
 			)
 			time.Sleep(1 * time.Second)
 			continue
@@ -155,7 +155,7 @@ func (t *tool) Wait(ctx context.Context) error {
 			t.logger.ErrorContext(
 				ctx,
 				"Failed to close database connection",
-				slog.String("error", err.Error()),
+				slog.Any("error", err),
 			)
 		}
 		return nil
@@ -192,8 +192,8 @@ func (t *tool) Migrate(ctx context.Context) error {
 			t.logger.ErrorContext(
 				ctx,
 				"Failed to close migrations",
-				slog.String("source", sourceErr.Error()),
-				slog.String("database", databaseErr.Error()),
+				slog.Any("source", sourceErr),
+				slog.Any("database", databaseErr),
 			)
 		}
 	}()

--- a/internal/logging/logging_interceptor.go
+++ b/internal/logging/logging_interceptor.go
@@ -189,7 +189,7 @@ func (i *Interceptor) UnaryServer(ctx context.Context, request any, info *grpc.U
 		}
 	}
 	if err != nil {
-		errField := slog.String("error", err.Error())
+		errField := slog.Any("error", err)
 		responseFields = append(responseFields, errField)
 	}
 	i.logger.DebugContext(ctx, "Sent unary response", responseFields...)
@@ -256,7 +256,7 @@ func (i *Interceptor) StreamServer(server any, stream grpc.ServerStream, info *g
 		timeField,
 	}
 	if err != nil {
-		errField := slog.String("error", err.Error())
+		errField := slog.Any("error", err)
 		responseFields = append(responseFields, errField)
 	}
 	i.logger.DebugContext(ctx, "Sent stream stop response", responseFields...)
@@ -310,7 +310,7 @@ func (i *Interceptor) dumpMessage(ctx context.Context, key string, value any) (f
 			i.logger.ErrorContext(
 				ctx,
 				"Failed to marshal protocol buffers message",
-				slog.String("error", err.Error()),
+				slog.Any("error", err),
 			)
 			return
 		}
@@ -320,7 +320,7 @@ func (i *Interceptor) dumpMessage(ctx context.Context, key string, value any) (f
 			i.logger.ErrorContext(
 				ctx,
 				"Failed to unmarshal protocol buffers message",
-				slog.String("error", err.Error()),
+				slog.Any("error", err),
 			)
 			return
 		}
@@ -363,7 +363,7 @@ func (s *interceptorStream) RecvMsg(message any) error {
 		}
 	}
 	if err != nil {
-		errField := slog.String("error", err.Error())
+		errField := slog.Any("error", err)
 		messageFields = append(messageFields, errField)
 	}
 	s.logger.DebugContext(ctx, "Received stream message", messageFields...)
@@ -386,7 +386,7 @@ func (s *interceptorStream) SendHeader(md metadata.MD) error {
 		metadataFields = append(metadataFields, mdField)
 	}
 	if err != nil {
-		errField := slog.String("error", err.Error())
+		errField := slog.Any("error", err)
 		metadataFields = append(metadataFields, errField)
 	}
 	s.logger.DebugContext(ctx, "Sent stream metadata", metadataFields...)
@@ -408,7 +408,7 @@ func (s *interceptorStream) SendMsg(message any) error {
 		}
 	}
 	if err != nil {
-		errField := slog.String("error", err.Error())
+		errField := slog.Any("error", err)
 		messageFields = append(messageFields, errField)
 	}
 	s.logger.DebugContext(ctx, "Sent stream message", messageFields...)
@@ -431,7 +431,7 @@ func (s *interceptorStream) SetHeader(md metadata.MD) error {
 		metadataFields = append(metadataFields, mdField)
 	}
 	if err != nil {
-		errField := slog.String("error", err.Error())
+		errField := slog.Any("error", err)
 		metadataFields = append(metadataFields, errField)
 	}
 	s.logger.DebugContext(ctx, "Set stream metadata", metadataFields...)

--- a/internal/network/cors.go
+++ b/internal/network/cors.go
@@ -64,7 +64,7 @@ func (b *CorsMiddlewareBuilder) SetFlags(flags *pflag.FlagSet, name string) *Cor
 		b.logger.Error(
 			"Failed to get flag value",
 			slog.String("flag", flag),
-			slog.String("error", err.Error()),
+			slog.Any("error", err),
 		)
 	}
 

--- a/internal/network/grpc_client.go
+++ b/internal/network/grpc_client.go
@@ -66,7 +66,7 @@ func (b *GrpcClientBuilder) SetFlags(flags *pflag.FlagSet, name string) *GrpcCli
 		b.logger.Error(
 			"Failed to get flag value",
 			slog.String("flag", flag),
-			slog.String("error", err.Error()),
+			slog.Any("error", err),
 		)
 	}
 

--- a/internal/network/listener.go
+++ b/internal/network/listener.go
@@ -67,7 +67,7 @@ func (b *ListenerBuilder) SetFlags(flags *pflag.FlagSet, name string) *ListenerB
 		b.logger.Error(
 			"Failed to get flag value",
 			slog.String("flag", "flag"),
-			slog.String("error", err.Error()),
+			slog.Any("error", err),
 		)
 	}
 

--- a/internal/servers/cluster_orders_server.go
+++ b/internal/servers/cluster_orders_server.go
@@ -89,7 +89,7 @@ func (s *ClusterOrdersServer) List(ctx context.Context,
 		s.logger.ErrorContext(
 			ctx,
 			"Failed to list cluster orders",
-			slog.String("error", err.Error()),
+			slog.Any("error", err),
 		)
 		err = grpcstatus.Errorf(grpccodes.Internal, "failed to list cluster orders")
 		return
@@ -102,7 +102,7 @@ func (s *ClusterOrdersServer) List(ctx context.Context,
 			s.logger.ErrorContext(
 				ctx,
 				"Failed to map outbound cluster order",
-				slog.String("error", err.Error()),
+				slog.Any("error", err),
 			)
 			err = grpcstatus.Errorf(grpccodes.Internal, "failed to map outbound cluster order")
 			return
@@ -209,7 +209,7 @@ func (s *ClusterOrdersServer) Place(ctx context.Context,
 		s.logger.ErrorContext(
 			ctx,
 			"Failed to insert cluster order",
-			slog.String("error", err.Error()),
+			slog.Any("error", err),
 		)
 		err = grpcstatus.Errorf(grpccodes.Internal, "failed to create order")
 		return
@@ -221,7 +221,7 @@ func (s *ClusterOrdersServer) Place(ctx context.Context,
 		s.logger.ErrorContext(
 			ctx,
 			"Failed to get cluster order",
-			slog.String("error", err.Error()),
+			slog.Any("error", err),
 		)
 		err = grpcstatus.Errorf(grpccodes.Internal, "failed to get cluster order with identifier '%s'", id)
 		return
@@ -232,7 +232,7 @@ func (s *ClusterOrdersServer) Place(ctx context.Context,
 		s.logger.ErrorContext(
 			ctx,
 			"Failed to map outbound cluster order",
-			slog.String("error", err.Error()),
+			slog.Any("error", err),
 		)
 		err = grpcstatus.Errorf(grpccodes.Internal, "failed to map outbound cluster")
 		return
@@ -252,7 +252,7 @@ func (s *ClusterOrdersServer) Cancel(ctx context.Context,
 			ctx,
 			"Failed to check if cluster order exists",
 			slog.String("order_id", request.OrderId),
-			slog.String("error", err.Error()),
+			slog.Any("error", err),
 		)
 		err = grpcstatus.Errorf(grpccodes.Internal,
 			"failed to check if cluster order '%s' exists",
@@ -276,7 +276,7 @@ func (s *ClusterOrdersServer) Cancel(ctx context.Context,
 			ctx,
 			"Failed to update cluster order state",
 			slog.String("order_id", request.OrderId),
-			slog.String("error", err.Error()),
+			slog.Any("error", err),
 		)
 		err = grpcstatus.Errorf(
 			grpccodes.Internal,

--- a/internal/servers/cluster_templates_server.go
+++ b/internal/servers/cluster_templates_server.go
@@ -88,7 +88,7 @@ func (s *ClusterTemplatesServer) List(ctx context.Context,
 		s.logger.ErrorContext(
 			ctx,
 			"Failed to list cluster templates",
-			slog.String("error", err.Error()),
+			slog.Any("error", err),
 		)
 		err = grpcstatus.Errorf(grpccodes.Internal, "failed to list cluster templates")
 		return
@@ -101,7 +101,7 @@ func (s *ClusterTemplatesServer) List(ctx context.Context,
 			s.logger.ErrorContext(
 				ctx,
 				"Failed to map outbound cluster template",
-				slog.String("error", err.Error()),
+				slog.Any("error", err),
 			)
 			return
 		}
@@ -122,7 +122,7 @@ func (s *ClusterTemplatesServer) Get(ctx context.Context,
 			ctx,
 			"Failed to get cluster template",
 			slog.String("template_id", request.TemplateId),
-			slog.String("error", err.Error()),
+			slog.Any("error", err),
 		)
 		err = grpcstatus.Errorf(
 			grpccodes.Internal,
@@ -145,7 +145,7 @@ func (s *ClusterTemplatesServer) Get(ctx context.Context,
 		s.logger.ErrorContext(
 			ctx,
 			"Failed to map outbound cluster template",
-			slog.String("error", err.Error()),
+			slog.Any("error", err),
 		)
 		err = grpcstatus.Errorf(grpccodes.Internal, "failed to map outbound template")
 		return

--- a/internal/servers/clusters_server.go
+++ b/internal/servers/clusters_server.go
@@ -88,7 +88,7 @@ func (s *ClustersServer) List(ctx context.Context,
 		s.logger.ErrorContext(
 			ctx,
 			"Failed to list clusters",
-			slog.String("error", err.Error()),
+			slog.Any("error", err),
 		)
 		err = grpcstatus.Errorf(grpccodes.Internal, "failed to list clusters")
 		return
@@ -101,7 +101,7 @@ func (s *ClustersServer) List(ctx context.Context,
 			s.logger.ErrorContext(
 				ctx,
 				"Failed to map outbound cluster",
-				slog.String("error", err.Error()),
+				slog.Any("error", err),
 			)
 			err = grpcstatus.Errorf(grpccodes.Internal, "failed to map outbound cluster")
 			return
@@ -137,7 +137,7 @@ func (s *ClustersServer) Get(ctx context.Context,
 		s.logger.ErrorContext(
 			ctx,
 			"Failed to map outbound cluster",
-			slog.String("error", err.Error()),
+			slog.Any("error", err),
 		)
 		err = grpcstatus.Errorf(grpccodes.Internal, "failed to map outbound cluster")
 		return
@@ -187,7 +187,7 @@ func (s *ClustersServer) getKubeconfig(ctx context.Context, clusterId string) (k
 			ctx,
 			"Failed to get cluster",
 			slog.String("cluster_id", clusterId),
-			slog.String("error", err.Error()),
+			slog.Any("error", err),
 		)
 		err = grpcstatus.Errorf(grpccodes.Internal, "failed to get cluster with id '%s'", clusterId)
 		return


### PR DESCRIPTION
This patch changes the logging configuration so that it will add to messages that contain an error the stack trace of the point where that error was logged:

```json
{
  "time": "2025-03-20T18:25:49Z",
  "level": "ERROR",
  "msg": "Failed to run command",
  "args": [
    "./fulfillment-service",
    "start",
    "server"
  ],
  "error": {
    "message": "connection URL is mandatory",
    "goroutine": 1,
    "stack": [
      {
        "function": "github.com/innabox/fulfillment-service/internal.(*Tool).Run",
        "source": "/files/projects/innabox/fulfillment-service/repository/internal/tool.go:175"
      },
      {
        "function": "main.main",
        "source": "/files/projects/innabox/fulfillment-service/repository/main.go:46"
      }
    ]
  }
}
```

Let me stress that it is the location where the error was logged, not where it was generated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced error logging now provides more detailed diagnostic data, including stack traces and runtime identifiers.
- **Refactor**
	- Overhauled the logging mechanism across multiple components to uniformly capture complete error objects.
- **Tests**
	- Added test cases to verify complete error details are logged correctly.
- **Chores**
	- Integrated an external dependency for advanced stack trace parsing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->