### PR TITLE
Implement pagination

### DIFF
--- a/internal/database/dao/dao_suite_test.go
+++ b/internal/database/dao/dao_suite_test.go
@@ -1,0 +1,47 @@
+/*
+Copyright (c) 2025 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package dao
+
+import (
+	"log/slog"
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2/dsl/core"
+	. "github.com/onsi/gomega"
+
+	"github.com/innabox/fulfillment-service/internal/logging"
+	. "github.com/innabox/fulfillment-service/internal/testing"
+)
+
+func TestDAO(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "DAO")
+}
+
+var (
+	logger *slog.Logger
+	server *DatabaseServer
+)
+
+var _ = BeforeSuite(func() {
+	var err error
+
+	logger, err = logging.NewLogger().
+		SetOut(GinkgoWriter).
+		Build()
+	Expect(err).ToNot(HaveOccurred())
+
+	server = MakeDatabaseServer()
+	DeferCleanup(server.Close)
+})

--- a/internal/database/dao/generic_dao.go
+++ b/internal/database/dao/generic_dao.go
@@ -20,8 +20,8 @@ import (
 	"log/slog"
 
 	"github.com/google/uuid"
+	"github.com/innabox/fulfillment-service/internal/database"
 	"github.com/jackc/pgx/v5"
-	"github.com/jackc/pgx/v5/pgxpool"
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/reflect/protoreflect"
@@ -29,9 +29,11 @@ import (
 
 // GenericDAOBuilder is a builder for creating generic data access objects.
 type GenericDAOBuilder[M proto.Message] struct {
-	logger *slog.Logger
-	table  string
-	pool   *pgxpool.Pool
+	logger       *slog.Logger
+	table        string
+	defaultOrder string
+	defaultLimit int32
+	maxLimit     int32
 }
 
 // GenericDAO provides generic data access operations for protocol buffers messages. It assumes that objects will be
@@ -42,16 +44,21 @@ type GenericDAOBuilder[M proto.Message] struct {
 //
 // Objects must have field named `id` of string type.
 type GenericDAO[M proto.Message] struct {
-	logger     *slog.Logger
-	table      string
-	pool       *pgxpool.Pool
-	reflectMsg protoreflect.Message
-	reflectId  protoreflect.FieldDescriptor
+	logger       *slog.Logger
+	table        string
+	defaultOrder string
+	defaultLimit int32
+	maxLimit     int32
+	reflectMsg   protoreflect.Message
+	reflectId    protoreflect.FieldDescriptor
 }
 
 // NewGenericDAO creates a builder that can then be used to configure and create a generic DAO.
 func NewGenericDAO[M proto.Message]() *GenericDAOBuilder[M] {
-	return &GenericDAOBuilder[M]{}
+	return &GenericDAOBuilder[M]{
+		defaultLimit: 100,
+		maxLimit:     1000,
+	}
 }
 
 // SetLogger sets the logger. This is mandatory.
@@ -60,15 +67,30 @@ func (b *GenericDAOBuilder[M]) SetLogger(value *slog.Logger) *GenericDAOBuilder[
 	return b
 }
 
-// SetPool sets the database connection pool. This is mandatory.
-func (b *GenericDAOBuilder[M]) SetPool(value *pgxpool.Pool) *GenericDAOBuilder[M] {
-	b.pool = value
-	return b
-}
-
 // SetTable sets the table name. This is mandatory.
 func (b *GenericDAOBuilder[M]) SetTable(value string) *GenericDAOBuilder[M] {
 	b.table = value
+	return b
+}
+
+// SetDefaultOrder sets the default order criteria to use when nothing has been requested by the user. This is optional
+// and the default is no order. This is intended only for use in unit tests, where it is convenient to have some
+// predictable ordering.
+func (b *GenericDAOBuilder[M]) SetDefaultOrder(value string) *GenericDAOBuilder[M] {
+	b.defaultOrder = value
+	return b
+}
+
+// SetDefaultLimit sets the default number of items returned. It will be used when the value of the limit parameter
+// of the list request is zero. This is optional, and the default is 100.
+func (b *GenericDAOBuilder[M]) SetDefaultLimit(value int) *GenericDAOBuilder[M] {
+	b.defaultLimit = int32(value)
+	return b
+}
+
+// SetMaxLimit sets the maximum number of items returned. This is optional and the default value is 1000.
+func (b *GenericDAOBuilder[M]) SetMaxLimit(value int) *GenericDAOBuilder[M] {
+	b.maxLimit = int32(value)
 	return b
 }
 
@@ -79,12 +101,24 @@ func (b *GenericDAOBuilder[M]) Build() (result *GenericDAO[M], err error) {
 		err = errors.New("logger is mandatory")
 		return
 	}
-	if b.pool == nil {
-		err = errors.New("database connection pool is mandatory")
-		return
-	}
 	if b.table == "" {
 		err = errors.New("table is mandatory")
+		return
+	}
+	if b.defaultLimit <= 0 {
+		err = fmt.Errorf("default limit must be a possitive integer, but it is %d", b.defaultLimit)
+		return
+	}
+	if b.maxLimit <= 0 {
+		err = fmt.Errorf("max limit must be a possitive integer, but it is %d", b.maxLimit)
+		return
+	}
+	if b.maxLimit < b.defaultLimit {
+		err = fmt.Errorf(
+			"max limit must be greater or equal to default limit, but max limit is %d and default limit "+
+				"is %d",
+			b.maxLimit, b.defaultLimit,
+		)
 		return
 	}
 
@@ -93,7 +127,7 @@ func (b *GenericDAOBuilder[M]) Build() (result *GenericDAO[M], err error) {
 	reflectMsg := object.ProtoReflect()
 
 	// Check that the object has an `id` field, and save it for future use:
-	reflectId := object.ProtoReflect().Type().Descriptor().Fields().ByName("id")
+	reflectId := reflectMsg.Type().Descriptor().Fields().ByName("id")
 	if reflectId == nil {
 		err = fmt.Errorf("object of type '%T' doesn't have an identifier field", object)
 		return
@@ -101,60 +135,105 @@ func (b *GenericDAOBuilder[M]) Build() (result *GenericDAO[M], err error) {
 
 	// Create and populate the object:
 	result = &GenericDAO[M]{
-		logger:     b.logger,
-		table:      b.table,
-		pool:       b.pool,
-		reflectMsg: reflectMsg,
-		reflectId:  reflectId,
+		logger:       b.logger,
+		table:        b.table,
+		defaultOrder: b.defaultOrder,
+		defaultLimit: b.defaultLimit,
+		maxLimit:     b.maxLimit,
+		reflectMsg:   reflectMsg,
+		reflectId:    reflectId,
 	}
 	return
 }
 
+// ListRequest represents the parameters for paginated queries.
+type ListRequest struct {
+	// Offset specifies the starting point.
+	Offset int32
+
+	// Limit specifies the maximum number of items.
+	Limit int32
+}
+
+// ListResponse represents the result of a paginated query.
+type ListResponse[I any] struct {
+	// Size is the actual number of items returned.
+	Size int32
+
+	// Total is the total number of items available.
+	Total int32
+
+	// Items is the list of items.
+	Items []I
+}
+
 // List retrieves all rows from the table and deserializes them into a slice of messages.
-func (d *GenericDAO[M]) List(ctx context.Context) (results []M, err error) {
+func (d *GenericDAO[M]) List(ctx context.Context, request ListRequest) (response ListResponse[M], err error) {
 	// Start a transaction:
-	tx, err := d.pool.BeginTx(ctx, pgx.TxOptions{
-		AccessMode: pgx.ReadOnly,
-	})
+	tx, err := database.TxFromContext(ctx)
 	if err != nil {
 		return
 	}
-	defer func() {
-		err := tx.Rollback(ctx)
-		if err != nil {
-			d.logger.ErrorContext(
-				ctx,
-				"Failed to rollback transaction",
-				slog.String("error", err.Error()),
-			)
-		}
-	}()
+	defer tx.ReportError(&err)
+
+	// Calculate the order cluase:
+	var order string
+	if d.defaultOrder != "" {
+		order = fmt.Sprintf("order by %s", d.defaultOrder)
+	}
+
+	// Calculate the offset:
+	offset := request.Offset
+	if offset < 0 {
+		offset = 0
+	}
+
+	// Calculate the limit:
+	limit := request.Limit
+	if limit < 0 {
+		limit = 0
+	} else if limit == 0 {
+		limit = d.defaultLimit
+	} else if limit > d.maxLimit {
+		limit = d.maxLimit
+	}
+
+	// Count the total number of results, disregarding the offset and the limit:
+	totalQuery := fmt.Sprintf("select count(*) from %s", d.table)
+	row := tx.QueryRow(ctx, totalQuery)
+	var total int
+	err = row.Scan(&total)
+	if err != nil {
+		return
+	}
 
 	// Fetch the results:
-	query := fmt.Sprintf("select data from %s", d.table)
-	rows, err := tx.Query(ctx, query)
+	itemsQuery := fmt.Sprintf("select data from %s %s offset $1 limit $2", d.table, order)
+	rows, err := tx.Query(ctx, itemsQuery, offset, limit)
 	if err != nil {
 		return
 	}
-	var tmp []M
+	var items []M
 	for rows.Next() {
 		var data []byte
 		err = rows.Scan(&data)
 		if err != nil {
 			return
 		}
-		result := d.reflectMsg.New().Interface().(M)
-		err = protojson.Unmarshal(data, result)
+		item := d.reflectMsg.New().Interface().(M)
+		err = protojson.Unmarshal(data, item)
 		if err != nil {
 			return
 		}
-		tmp = append(tmp, result)
+		items = append(items, item)
 	}
 	err = rows.Err()
 	if err != nil {
 		return
 	}
-	results = tmp
+	response.Size = int32(len(items))
+	response.Total = int32(total)
+	response.Items = items
 	return
 }
 
@@ -162,22 +241,11 @@ func (d *GenericDAO[M]) List(ctx context.Context) (results []M, err error) {
 // is no row with the given identifier.
 func (d *GenericDAO[M]) Get(ctx context.Context, id string) (result M, err error) {
 	// Start a transaction:
-	tx, err := d.pool.BeginTx(ctx, pgx.TxOptions{
-		AccessMode: pgx.ReadOnly,
-	})
+	tx, err := database.TxFromContext(ctx)
 	if err != nil {
 		return
 	}
-	defer func() {
-		err := tx.Rollback(ctx)
-		if err != nil {
-			d.logger.ErrorContext(
-				ctx,
-				"Failed to rollback transaction",
-				slog.String("error", err.Error()),
-			)
-		}
-	}()
+	defer tx.ReportError(&err)
 
 	// Fetch the results:
 	query := fmt.Sprintf("select data from %s where id = $1", d.table)
@@ -201,22 +269,11 @@ func (d *GenericDAO[M]) Get(ctx context.Context, id string) (result M, err error
 // given identifier.
 func (d *GenericDAO[M]) Exists(ctx context.Context, id string) (ok bool, err error) {
 	// Start a transaction:
-	tx, err := d.pool.BeginTx(ctx, pgx.TxOptions{
-		AccessMode: pgx.ReadOnly,
-	})
+	tx, err := database.TxFromContext(ctx)
 	if err != nil {
 		return
 	}
-	defer func() {
-		err := tx.Rollback(ctx)
-		if err != nil {
-			d.logger.ErrorContext(
-				ctx,
-				"Failed to rollback transaction",
-				slog.String("error", err.Error()),
-			)
-		}
-	}()
+	defer tx.ReportError(&err)
 
 	// Check if the row exists:
 	query := fmt.Sprintf("select count(*) from %s where id = $1", d.table)
@@ -233,20 +290,11 @@ func (d *GenericDAO[M]) Exists(ctx context.Context, id string) (ok bool, err err
 // Insert adds a new row to the table with a generated identifier and serialized data.
 func (d *GenericDAO[M]) Insert(ctx context.Context, object M) (id string, err error) {
 	// Start a transaction:
-	tx, err := d.pool.Begin(ctx)
+	tx, err := database.TxFromContext(ctx)
 	if err != nil {
 		return
 	}
-	defer func() {
-		err := tx.Commit(ctx)
-		if err != nil {
-			d.logger.ErrorContext(
-				ctx,
-				"Failed to commit transaction",
-				slog.String("error", err.Error()),
-			)
-		}
-	}()
+	defer tx.ReportError(&err)
 
 	// Generate a new identifier:
 	tmp := uuid.NewString()
@@ -267,53 +315,35 @@ func (d *GenericDAO[M]) Insert(ctx context.Context, object M) (id string, err er
 }
 
 // Update modifies an existing row in the table by its identifier with the result of serializing the provided object.
-func (d *GenericDAO[M]) Update(ctx context.Context, id string, object M) error {
+func (d *GenericDAO[M]) Update(ctx context.Context, id string, object M) (err error) {
 	// Start a transaction:
-	tx, err := d.pool.Begin(ctx)
+	tx, err := database.TxFromContext(ctx)
 	if err != nil {
-		return err
+		return
 	}
-	defer func() {
-		err := tx.Commit(ctx)
-		if err != nil {
-			d.logger.ErrorContext(
-				ctx,
-				"Failed to commit transaction",
-				slog.String("error", err.Error()),
-			)
-		}
-	}()
+	defer tx.ReportError(&err)
 
 	// Update the row:
 	data, err := protojson.Marshal(object)
 	if err != nil {
-		return err
+		return
 	}
 	query := fmt.Sprintf("update %s set data = $1 where id = $2", d.table)
 	_, err = tx.Exec(ctx, query, data, id)
-	return err
+	return
 }
 
 // Delete removes a row from the table by its identifier.
-func (d *GenericDAO[M]) Delete(ctx context.Context, id string) error {
+func (d *GenericDAO[M]) Delete(ctx context.Context, id string) (err error) {
 	// Start a transaction:
-	tx, err := d.pool.Begin(ctx)
+	tx, err := database.TxFromContext(ctx)
 	if err != nil {
-		return err
+		return
 	}
-	defer func() {
-		err := tx.Commit(ctx)
-		if err != nil {
-			d.logger.ErrorContext(
-				ctx,
-				"Failed to commit transaction",
-				slog.String("error", err.Error()),
-			)
-		}
-	}()
+	defer tx.ReportError(&err)
 
 	// Delete the row:
 	query := fmt.Sprintf("delete from %s where id = $1", d.table)
 	_, err = tx.Exec(ctx, query)
-	return err
+	return
 }

--- a/internal/database/dao/generic_dao_test.go
+++ b/internal/database/dao/generic_dao_test.go
@@ -1,0 +1,388 @@
+/*
+Copyright (c) 2025 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package dao
+
+import (
+	"context"
+	"sort"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"google.golang.org/protobuf/types/known/wrapperspb"
+
+	api "github.com/innabox/fulfillment-service/internal/api/fulfillment/v1"
+	"github.com/innabox/fulfillment-service/internal/database"
+)
+
+var _ = Describe("Generic DAO", func() {
+	const (
+		defaultLimit = 5
+		maxLimit     = 10
+		objectCount  = maxLimit + 1
+	)
+
+	var (
+		ctx context.Context
+		tx  database.Tx
+	)
+
+	BeforeEach(func() {
+		var err error
+
+		// Create a context:
+		ctx = context.Background()
+
+		// Prepare the database pool:
+		db := server.MakeDatabase()
+		DeferCleanup(db.Close)
+		pool, err := pgxpool.New(ctx, db.MakeURL())
+		Expect(err).ToNot(HaveOccurred())
+		DeferCleanup(pool.Close)
+
+		// Create the transaction manager:
+		tm, err := database.NewTxManager().
+			SetLogger(logger).
+			SetPool(pool).
+			Build()
+		Expect(err).ToNot(HaveOccurred())
+
+		// Start a transaction and add it to the context:
+		tx, err = tm.Begin(ctx)
+		Expect(err).ToNot(HaveOccurred())
+		DeferCleanup(func() {
+			err := tm.End(ctx, tx)
+			Expect(err).ToNot(HaveOccurred())
+		})
+		ctx = database.TxIntoContext(ctx, tx)
+	})
+
+	Describe("Creation", func() {
+		It("Can be built if all the required parameters are set", func() {
+			generic, err := NewGenericDAO[*api.Cluster]().
+				SetLogger(logger).
+				SetTable("clusters").
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(generic).ToNot(BeNil())
+		})
+
+		It("Fails if logger is not set", func() {
+			generic, err := NewGenericDAO[*api.Cluster]().
+				SetTable("clusters").
+				Build()
+			Expect(err).To(MatchError("logger is mandatory"))
+			Expect(generic).To(BeNil())
+		})
+
+		It("Fails if table is not set", func() {
+			generic, err := NewGenericDAO[*api.Cluster]().
+				SetLogger(logger).
+				Build()
+			Expect(err).To(MatchError("table is mandatory"))
+			Expect(generic).To(BeNil())
+		})
+
+		It("Fails if object doesn't have identifier", func() {
+			generic, err := NewGenericDAO[*wrapperspb.Int32Value]().
+				SetLogger(logger).
+				SetTable("integers").
+				Build()
+			Expect(err).To(MatchError(
+				"object of type '*wrapperspb.Int32Value' doesn't have an identifier field",
+			))
+			Expect(generic).To(BeNil())
+		})
+
+		It("Fails if default limit is zero", func() {
+			generic, err := NewGenericDAO[*api.Cluster]().
+				SetLogger(logger).
+				SetTable("clusters").
+				SetDefaultLimit(0).
+				Build()
+			Expect(err).To(MatchError("default limit must be a possitive integer, but it is 0"))
+			Expect(generic).To(BeNil())
+		})
+
+		It("Fails if default limit is negative", func() {
+			generic, err := NewGenericDAO[*api.Cluster]().
+				SetLogger(logger).
+				SetTable("clusters").
+				SetDefaultLimit(-1).
+				Build()
+			Expect(err).To(MatchError("default limit must be a possitive integer, but it is -1"))
+			Expect(generic).To(BeNil())
+		})
+
+		It("Fails if max limit is zero", func() {
+			generic, err := NewGenericDAO[*api.Cluster]().
+				SetLogger(logger).
+				SetTable("clusters").
+				SetMaxLimit(0).
+				Build()
+			Expect(err).To(MatchError("max limit must be a possitive integer, but it is 0"))
+			Expect(generic).To(BeNil())
+		})
+
+		It("Fails if max limit is negative", func() {
+			generic, err := NewGenericDAO[*api.Cluster]().
+				SetLogger(logger).
+				SetTable("clusters").
+				SetMaxLimit(-1).
+				Build()
+			Expect(err).To(MatchError("max limit must be a possitive integer, but it is -1"))
+			Expect(generic).To(BeNil())
+		})
+
+		It("Fails if max limit is less than default limit", func() {
+			generic, err := NewGenericDAO[*api.Cluster]().
+				SetLogger(logger).
+				SetTable("clusters").
+				SetMaxLimit(100).
+				SetDefaultLimit(1000).
+				Build()
+			Expect(err).To(MatchError(
+				"max limit must be greater or equal to default limit, but max limit is 100 and " +
+					"default limit is 1000",
+			))
+			Expect(generic).To(BeNil())
+		})
+	})
+
+	Describe("Behaviour", func() {
+		var generic *GenericDAO[*api.Cluster]
+
+		BeforeEach(func() {
+			// Create the table:
+			_, err := tx.Exec(
+				ctx,
+				`
+				create table clusters (
+					id uuid not null primary key,
+					data jsonb not null
+				)
+				`,
+			)
+			Expect(err).ToNot(HaveOccurred())
+
+			// Create the DAO:
+			generic, err = NewGenericDAO[*api.Cluster]().
+				SetLogger(logger).
+				SetTable("clusters").
+				SetDefaultOrder("id").
+				SetDefaultLimit(defaultLimit).
+				SetMaxLimit(maxLimit).
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("Inserts object", func() {
+			// Insert the object:
+			object := &api.Cluster{}
+			id, err := generic.Insert(ctx, object)
+			Expect(err).ToNot(HaveOccurred())
+
+			// Check the database:
+			row := tx.QueryRow(ctx, `select data from clusters where id = $1`, id)
+			var data []byte
+			err = row.Scan(&data)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(data).ToNot(BeNil())
+		})
+
+		It("Gets object", func() {
+			// Insert the row:
+			id, err := generic.Insert(ctx, &api.Cluster{})
+			Expect(err).ToNot(HaveOccurred())
+
+			// Try to get it:
+			object, err := generic.Get(ctx, id)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(object).ToNot(BeNil())
+		})
+
+		It("Lists objects", func() {
+			// Insert a couple of rows:
+			const count = 2
+			for range count {
+				_, err := generic.Insert(ctx, &api.Cluster{})
+				Expect(err).ToNot(HaveOccurred())
+			}
+
+			// Try to list:
+			request, err := generic.List(ctx, ListRequest{})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(request.Items).To(HaveLen(count))
+			for _, item := range request.Items {
+				Expect(item).ToNot(BeNil())
+			}
+		})
+
+		Describe("Paging", func() {
+			var objects []*api.Cluster
+
+			BeforeEach(func() {
+				// Create a list of objects and sort it like they will be sorted by the DAO. Not that
+				// this works correctly because the DAO is configured with a default sorting. That is
+				// intended for use only in these unit tests.
+				objects = make([]*api.Cluster, objectCount)
+				for i := range len(objects) {
+					objects[i] = &api.Cluster{}
+					_, err := generic.Insert(ctx, objects[i])
+					Expect(err).ToNot(HaveOccurred())
+				}
+				sort.Slice(objects, func(i, j int) bool {
+					return strings.Compare(objects[i].Id, objects[j].Id) < 0
+				})
+			})
+
+			It("Uses zero as default offset", func() {
+				response, err := generic.List(ctx, ListRequest{
+					Limit: 1,
+				})
+				Expect(err).ToNot(HaveOccurred())
+				Expect(response.Items[0].Id).To(Equal(objects[0].Id))
+			})
+
+			It("Honours valid offset", func() {
+				for i := range len(objects) {
+					response, err := generic.List(ctx, ListRequest{
+						Offset: int32(i),
+						Limit:  1,
+					})
+					Expect(err).ToNot(HaveOccurred())
+					Expect(response.Items[0].Id).To(Equal(objects[i].Id))
+				}
+			})
+
+			It("Returns empty list if offset is greater or equal than available items", func() {
+				response, err := generic.List(ctx, ListRequest{
+					Offset: objectCount,
+					Limit:  1,
+				})
+				Expect(err).ToNot(HaveOccurred())
+				Expect(response.Items).To(BeEmpty())
+			})
+
+			It("Ignores negative offset", func() {
+				response, err := generic.List(ctx, ListRequest{
+					Offset: -123,
+					Limit:  1,
+				})
+				Expect(err).ToNot(HaveOccurred())
+				Expect(response.Items[0].Id).To(Equal(objects[0].Id))
+			})
+
+			It("Interprets negative limit as requesting zero items", func() {
+				response, err := generic.List(ctx, ListRequest{
+					Limit: -123,
+				})
+				Expect(err).ToNot(HaveOccurred())
+				Expect(response.Size).To(BeZero())
+				Expect(response.Items).To(BeEmpty())
+			})
+
+			It("Interprets zero limit as requesting the default number of items", func() {
+				response, err := generic.List(ctx, ListRequest{
+					Limit: 0,
+				})
+				Expect(err).ToNot(HaveOccurred())
+				Expect(response.Size).To(BeNumerically("==", defaultLimit))
+				Expect(response.Items).To(HaveLen(defaultLimit))
+			})
+
+			It("Truncates limit to the maximum", func() {
+				response, err := generic.List(ctx, ListRequest{
+					Limit: maxLimit + 1,
+				})
+				Expect(err).ToNot(HaveOccurred())
+				Expect(response.Size).To(BeNumerically("==", maxLimit))
+				Expect(response.Items).To(HaveLen(maxLimit))
+			})
+
+			It("Honours valid limit", func() {
+				for i := 1; i < maxLimit; i++ {
+					response, err := generic.List(ctx, ListRequest{
+						Limit: int32(i),
+					})
+					Expect(err).ToNot(HaveOccurred())
+					Expect(response.Size).To(BeNumerically("==", i))
+					Expect(response.Items).To(HaveLen(i))
+				}
+			})
+
+			It("Returns less items than requested if there are not enough", func() {
+				response, err := generic.List(ctx, ListRequest{
+					Offset: objectCount - 2,
+					Limit:  10,
+				})
+				Expect(err).ToNot(HaveOccurred())
+				Expect(response.Size).To(BeNumerically("==", 2))
+				Expect(response.Items).To(HaveLen(2))
+			})
+
+			It("Returns the total number of items", func() {
+				response, err := generic.List(ctx, ListRequest{
+					Limit: 1,
+				})
+				Expect(err).ToNot(HaveOccurred())
+				Expect(response.Total).To(BeNumerically("==", objectCount))
+			})
+		})
+
+		Describe("Check if object exists", func() {
+			It("Returns true if the object exists", func() {
+				// Insert the object:
+				object := &api.Cluster{}
+				id, err := generic.Insert(ctx, object)
+				Expect(err).ToNot(HaveOccurred())
+
+				// Check if it exists:
+				exists, err := generic.Exists(ctx, id)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(exists).To(BeTrue())
+			})
+
+			It("Returns false if the object doesn't exist", func() {
+				// The database is empty, check the result:
+				exists, err := generic.Exists(ctx, uuid.NewString())
+				Expect(err).ToNot(HaveOccurred())
+				Expect(exists).To(BeFalse())
+			})
+		})
+
+		It("Updates object", func() {
+			// Create the object:
+			object := &api.Cluster{
+				Status: &api.ClusterStatus{
+					ApiUrl: "my_url",
+				},
+			}
+			id, err := generic.Insert(ctx, object)
+			Expect(err).ToNot(HaveOccurred())
+
+			// Try to update:
+			object.Status.ApiUrl = "your_url"
+			err = generic.Update(ctx, id, object)
+			Expect(err).ToNot(HaveOccurred())
+
+			// Get it and verify that the changes have been applied:
+			object, err = generic.Get(ctx, id)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(object.Status.ApiUrl).To(Equal("your_url"))
+		})
+	})
+})

--- a/internal/servers/cluster_orders_server.go
+++ b/internal/servers/cluster_orders_server.go
@@ -82,7 +82,10 @@ func (b *ClusterOrdersServerBuilder) Build() (result *ClusterOrdersServer, err e
 
 func (s *ClusterOrdersServer) List(ctx context.Context,
 	request *api.ClusterOrdersListRequest) (response *api.ClusterOrdersListResponse, err error) {
-	orders, err := s.daos.ClusterOrders().List(ctx)
+	orders, err := s.daos.ClusterOrders().List(ctx, dao.ListRequest{
+		Offset: request.GetOffset(),
+		Limit:  request.GetLimit(),
+	})
 	if err != nil {
 		s.logger.ErrorContext(
 			ctx,
@@ -93,9 +96,9 @@ func (s *ClusterOrdersServer) List(ctx context.Context,
 		return
 	}
 	response = &api.ClusterOrdersListResponse{
-		Size:  proto.Int32(int32(len(orders))),
-		Total: proto.Int32(int32(len(orders))),
-		Items: orders,
+		Size:  proto.Int32(orders.Size),
+		Total: proto.Int32(orders.Total),
+		Items: orders.Items,
 	}
 	return
 }
@@ -183,6 +186,9 @@ func (s *ClusterOrdersServer) Place(ctx context.Context,
 	order := &api.ClusterOrder{
 		Spec: &api.ClusterOrderSpec{
 			TemplateId: templateId,
+		},
+		Status: &api.ClusterOrderStatus{
+			State: api.ClusterOrderState_CLUSTER_ORDER_STATE_ACCEPTED,
 		},
 	}
 	_, err = s.daos.ClusterOrders().Insert(ctx, order)

--- a/internal/servers/cluster_templates_server.go
+++ b/internal/servers/cluster_templates_server.go
@@ -82,7 +82,10 @@ func (b *ClusterTemplatesServerBuilder) Build() (result *ClusterTemplatesServer,
 
 func (s *ClusterTemplatesServer) List(ctx context.Context,
 	request *api.ClusterTemplatesListRequest) (response *api.ClusterTemplatesListResponse, err error) {
-	templates, err := s.daos.ClusterTemplates().List(ctx)
+	templates, err := s.daos.ClusterTemplates().List(ctx, dao.ListRequest{
+		Offset: request.GetOffset(),
+		Limit:  request.GetLimit(),
+	})
 	if err != nil {
 		s.logger.ErrorContext(
 			ctx,
@@ -93,9 +96,9 @@ func (s *ClusterTemplatesServer) List(ctx context.Context,
 		return
 	}
 	response = &api.ClusterTemplatesListResponse{
-		Size:  proto.Int32(int32(len(templates))),
-		Total: proto.Int32(int32(len(templates))),
-		Items: templates,
+		Size:  proto.Int32(templates.Size),
+		Total: proto.Int32(templates.Total),
+		Items: templates.Items,
 	}
 	return
 }

--- a/internal/servers/clusters_server.go
+++ b/internal/servers/clusters_server.go
@@ -82,7 +82,10 @@ func (b *ClustersServerBuilder) Build() (result *ClustersServer, err error) {
 
 func (s *ClustersServer) List(ctx context.Context,
 	request *api.ClustersListRequest) (response *api.ClustersListResponse, err error) {
-	clusters, err := s.daos.Clusters().List(ctx)
+	clusters, err := s.daos.Clusters().List(ctx, dao.ListRequest{
+		Offset: request.GetOffset(),
+		Limit:  request.GetLimit(),
+	})
 	if err != nil {
 		s.logger.ErrorContext(
 			ctx,
@@ -93,9 +96,9 @@ func (s *ClustersServer) List(ctx context.Context,
 		return
 	}
 	response = &api.ClustersListResponse{
-		Size:  proto.Int32(int32(len(clusters))),
-		Total: proto.Int32(int32(len(clusters))),
-		Items: clusters,
+		Size:  proto.Int32(clusters.Size),
+		Total: proto.Int32(clusters.Total),
+		Items: clusters.Items,
 	}
 	return
 }


### PR DESCRIPTION
This patch implements the `limit` and `offset` paginagion parameters as defined in the API specification.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced pagination controls across data retrieval operations for orders, templates, and clusters.
  - Added configurable defaults for ordering and limits to enhance data access flexibility.
  - Established an initial status for new orders during placement.

- **Tests**
  - Implemented new comprehensive test suites to validate DAO functionality, covering creation, behavior, and pagination.
  - Added a testing suite for the Generic DAO to ensure robust functionality validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->