### PR TITLE
Add database listener and notifier

### DIFF
--- a/internal/database/database_listener.go
+++ b/internal/database/database_listener.go
@@ -1,0 +1,406 @@
+/*
+Copyright (c) 2025 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package database
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"slices"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/anypb"
+)
+
+// ListenerPayloadCallback is a function that will be called by the listener when a notification arrives.
+type ListenerPayloadCallback func(ctx context.Context, payload proto.Message) error
+
+// ListenerReadyCallback is a function that will be called by the listener when it is actually listening for
+// notifications.
+type ListenerReadyCallback func(ctx context.Context) error
+
+// ListenerBuilder contains the data and logic needed to build a listener.
+type ListenerBuilder struct {
+	logger           *slog.Logger
+	url              string
+	channel          string
+	readyCallbacks   []ListenerReadyCallback
+	payloadCallbacks []ListenerPayloadCallback
+	waitTimeout      time.Duration
+	retryInterval    time.Duration
+}
+
+// Listener knows how to liste for notifications using PostgreSQL's `listen` mechanism.
+type Listener struct {
+	logger           *slog.Logger
+	url              string
+	channel          string
+	readyCallbacks   []ListenerReadyCallback
+	payloadCallbacks []ListenerPayloadCallback
+	waitTimeout      time.Duration
+	retryInterval    time.Duration
+	conn             *pgx.Conn
+}
+
+// NewListener uses the information stored in the builder to create a new listener.
+func NewListener() *ListenerBuilder {
+	return &ListenerBuilder{
+		waitTimeout:   5 * time.Minute,
+		retryInterval: 5 * time.Second,
+	}
+}
+
+// SetLogger sets the logger for the listener. This is mandatory.
+func (b *ListenerBuilder) SetLogger(logger *slog.Logger) *ListenerBuilder {
+	b.logger = logger
+	return b
+}
+
+// SetChannel sets the channel name for the listener. This is mandatory.
+func (b *ListenerBuilder) SetChannel(value string) *ListenerBuilder {
+	b.channel = value
+	return b
+}
+
+// SetUrl sets the database connection URL. This is mandatory.
+func (b *ListenerBuilder) SetUrl(value string) *ListenerBuilder {
+	b.url = value
+	return b
+}
+
+// AddReadyCallback adds a function that will be called by the listener when it is actually listening for notifications.
+// Errors returned by these functions will be logged, but the listener will continue working. This is optional.
+func (b *ListenerBuilder) AddReadyCallback(value ListenerReadyCallback) *ListenerBuilder {
+	b.readyCallbacks = append(b.readyCallbacks, value)
+	return b
+}
+
+// AddPayloadCallback adds a function that will be called by the listener when a notification arrives. Errors returned
+// by these functions will be logged, but the listener will continue working. At least one of these functions is
+// mandatory.
+func (b *ListenerBuilder) AddPayloadCallback(value ListenerPayloadCallback) *ListenerBuilder {
+	b.payloadCallbacks = append(b.payloadCallbacks, value)
+	return b
+}
+
+// SetWaitTimeout sets the maximum time that the listener will wait for a notification. After that it will close the
+// connection and open it again. This is intended to automatically recover from situations where the server or the
+// connection malfunction and stop sending the notifications. This is optional and the default is five minutes.
+func (b *ListenerBuilder) SetWaitTimeout(value time.Duration) *ListenerBuilder {
+	b.waitTimeout = value
+	return b
+}
+
+// SetRetryInterval sets the time that the listener will wait before trying to open a new connectio and start listening
+// after a failure. This is optional and the default is five seconds.
+func (b *ListenerBuilder) SetRetryInterval(value time.Duration) *ListenerBuilder {
+	b.retryInterval = value
+	return b
+}
+
+// Build constructs a listener instance using the configured parameters.
+func (b *ListenerBuilder) Build() (result *Listener, err error) {
+	// Check parameters:
+	if b.logger == nil {
+		err = errors.New("logger is mandatory")
+		return
+	}
+	if b.url == "" {
+		err = errors.New("database connection URL is mandatory")
+		return
+	}
+	if b.channel == "" {
+		err = errors.New("channel is mandatory")
+		return
+	}
+	if len(b.payloadCallbacks) == 0 {
+		err = errors.New("at least one payload callback is mandatory")
+		return
+	}
+	if b.waitTimeout <= 0 {
+		err = fmt.Errorf("wait timeout should be positive, but it is %s", b.waitTimeout)
+		return
+	}
+	if b.retryInterval <= 0 {
+		err = fmt.Errorf("retry interval should be positive, but it is %s", b.retryInterval)
+		return
+	}
+
+	// Create and populate the object:
+	logger := b.logger.With(
+		slog.String("channel", b.channel),
+	)
+	result = &Listener{
+		logger:           logger,
+		url:              b.url,
+		channel:          b.channel,
+		readyCallbacks:   slices.Clone(b.readyCallbacks),
+		payloadCallbacks: slices.Clone(b.payloadCallbacks),
+		waitTimeout:      b.waitTimeout,
+		retryInterval:    b.retryInterval,
+	}
+	return
+}
+
+// Listen waits for notifications in the configured channel, decodes the payload and runs the callbacks to process it.
+func (l *Listener) Listen(ctx context.Context) error {
+	// Always remember to close the database connection:
+	defer func() {
+		if l.conn != nil {
+			err := l.conn.Close(ctx)
+			if err != nil {
+				l.logger.ErrorContext(
+					ctx,
+					"Failed to close connection",
+					slog.Any("error", err),
+				)
+			}
+		}
+	}()
+
+	// Start listening, and call the ready callbacks when we succeed, but only the first time:
+	err := l.listenLoop(ctx)
+	if err != nil {
+		return err
+	}
+	l.runReadyCallbacks(ctx)
+
+	// Run the loop that waits for notifications and creates new connections in case of failure or timeout:
+	for {
+		err := l.waitLoop(ctx)
+		if err == nil {
+			l.logger.DebugContext(ctx, "Wait finishied")
+			continue
+		}
+		if errors.Is(err, context.DeadlineExceeded) {
+			l.logger.InfoContext(
+				ctx,
+				"Wait timeout exceeded",
+				slog.Duration("timeout", l.waitTimeout),
+			)
+			continue
+		}
+		if errors.Is(err, context.Canceled) {
+			l.logger.DebugContext(ctx, "Wait canceled")
+			return err
+		}
+		l.logger.ErrorContext(
+			ctx,
+			"Wait failed",
+			slog.Any("error", err),
+		)
+		err = l.sleepBeforeRetry(ctx)
+		if err != nil {
+			return err
+		}
+		err = l.listenLoop(ctx)
+		if err != nil {
+			return err
+		}
+	}
+}
+
+// listenLopp runs the `listen ...` SQL statement till it succeeds, dropping and creating the connection again when it
+// fails.
+func (l *Listener) listenLoop(ctx context.Context) error {
+	for {
+		err := l.listen(ctx)
+		if err == nil {
+			l.logger.DebugContext(ctx, "Listen succeeded")
+			return nil
+		}
+		l.logger.ErrorContext(
+			ctx,
+			"Failed to listen",
+			slog.Any("error", err),
+		)
+		err = l.sleepBeforeRetry(ctx)
+		if err != nil {
+			return err
+		}
+	}
+}
+
+// listen runs the `listen ...` SQL statement always with a freshly created connection, and closing the old one if it
+// is still open.
+func (l *Listener) listen(ctx context.Context) error {
+	if l.conn != nil {
+		err := l.conn.Close(ctx)
+		if err != nil {
+			l.logger.InfoContext(
+				ctx,
+				"Failed to close connection",
+				slog.Any("error", err),
+			)
+		}
+		l.conn = nil
+	}
+	conn, err := pgx.Connect(ctx, l.url)
+	if err != nil {
+		return err
+	}
+	l.conn = conn
+	_, err = l.conn.Exec(ctx, fmt.Sprintf("listen %s", l.channel))
+	return err
+}
+
+// waitLoop waits for notifications in a loop, while the connection is healthy. It returns when the connection fails or
+// the context is canceled.
+func (l *Listener) waitLoop(ctx context.Context) error {
+	for {
+		err := l.wait(ctx)
+		if err != nil {
+			return err
+		}
+	}
+}
+
+// wait waits for one notification and processes it.
+func (l *Listener) wait(ctx context.Context) error {
+	ctx, cancel := context.WithTimeout(ctx, l.waitTimeout)
+	defer cancel()
+	notification, err := l.conn.WaitForNotification(ctx)
+	if err != nil {
+		return err
+	}
+	l.processNotification(ctx, notification)
+	return nil
+}
+
+func (l *Listener) processNotification(ctx context.Context, notification *pgconn.Notification) {
+	l.logger.DebugContext(
+		ctx,
+		"Received notification",
+		slog.Uint64("pid", uint64(notification.PID)),
+		slog.Any("payload", notification.Payload),
+	)
+	data, err := base64.StdEncoding.DecodeString(notification.Payload)
+	if err != nil {
+		l.logger.ErrorContext(
+			ctx,
+			"Failed to decode payload",
+			slog.String("payload", notification.Payload),
+			slog.Any("error", err),
+		)
+		return
+	}
+	wrapper := &anypb.Any{}
+	err = proto.Unmarshal(data, wrapper)
+	if err != nil {
+		l.logger.ErrorContext(
+			ctx,
+			"Failed to unmarshal payload",
+			slog.String("payload", notification.Payload),
+			slog.Any("error", err),
+		)
+		return
+	}
+	payload, err := wrapper.UnmarshalNew()
+	if err != nil {
+		l.logger.ErrorContext(
+			ctx,
+			"Failed to unwrap payload",
+			slog.String("payload", notification.Payload),
+			slog.Any("error", err),
+		)
+		return
+	}
+	if l.logger.Enabled(ctx, slog.LevelDebug) {
+		data, err := protojson.Marshal(wrapper)
+		if err != nil {
+			l.logger.ErrorContext(
+				ctx,
+				"Failed to marshal payload",
+				slog.Any("error", err),
+			)
+		}
+		var object any
+		json.Unmarshal(data, &object)
+
+	}
+	if l.logger.Enabled(ctx, slog.LevelDebug) {
+		l.logger.DebugContext(
+			ctx,
+			"Decoded payload",
+			slog.Any("payload", payload),
+		)
+	}
+	l.runPayloadCallbacks(ctx, payload)
+}
+
+func (l *Listener) runReadyCallbacks(ctx context.Context) {
+	errors := 0
+	for i, readyCallback := range l.readyCallbacks {
+		err := readyCallback(ctx)
+		if err != nil {
+			l.logger.InfoContext(
+				ctx,
+				"Ready callback failed",
+				slog.Int("index", i),
+				slog.Any("error", err),
+			)
+			errors++
+		}
+	}
+	l.logger.DebugContext(
+		ctx,
+		"Ready callbacks completed",
+		slog.Int("total", len(l.readyCallbacks)),
+		slog.Int("errors", errors),
+	)
+}
+
+func (l *Listener) runPayloadCallbacks(ctx context.Context, payload proto.Message) {
+	errors := 0
+	for i, payloadCallback := range l.payloadCallbacks {
+		err := payloadCallback(ctx, payload)
+		if err != nil {
+			l.logger.ErrorContext(
+				ctx,
+				"Payload callback failed",
+				slog.Any("index", i),
+				slog.Any("error", err),
+			)
+			errors++
+		}
+	}
+	l.logger.DebugContext(
+		ctx,
+		"Payload callbacks completed",
+		slog.Int("total", len(l.payloadCallbacks)),
+		slog.Int("errors", errors),
+	)
+}
+
+// sleepBeforeRetry waits till the retry interval passes, or till the context is cancelled.
+func (l *Listener) sleepBeforeRetry(ctx context.Context) error {
+	l.logger.DebugContext(
+		ctx,
+		"Sleeping before retry",
+		slog.Duration("interval", l.retryInterval),
+	)
+	select {
+	case <-ctx.Done():
+		return context.Canceled
+	case <-time.After(l.retryInterval):
+		return nil
+	}
+}

--- a/internal/database/database_listener_test.go
+++ b/internal/database/database_listener_test.go
@@ -1,0 +1,244 @@
+/*
+Copyright (c) 2025 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package database
+
+import (
+	"context"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/wrapperspb"
+)
+
+var _ = Describe("Listener", func() {
+	const channel = "my_channel"
+
+	Describe("Creation", func() {
+		// This doesn't need to be a working URL, just enough to be able to create the object.
+		const url = "postgresql://myserver/mydb"
+
+		// A payload callback that does nothing.
+		nothing := func(ctx context.Context, payload proto.Message) error {
+			return nil
+		}
+
+		It("Can be created when all the required parameters are set", func() {
+			listener, err := NewListener().
+				SetLogger(logger).
+				SetUrl(url).
+				SetChannel(channel).
+				AddPayloadCallback(nothing).
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(listener).ToNot(BeNil())
+		})
+
+		It("Can't be created without a logger", func() {
+			listener, err := NewListener().
+				SetChannel(channel).
+				SetUrl(url).
+				AddPayloadCallback(nothing).
+				Build()
+			Expect(err).To(MatchError("logger is mandatory"))
+			Expect(listener).To(BeNil())
+		})
+
+		It("Can't be created without a channel", func() {
+			listener, err := NewListener().
+				SetLogger(logger).
+				SetUrl(url).
+				AddPayloadCallback(nothing).
+				Build()
+			Expect(err).To(MatchError("channel is mandatory"))
+			Expect(listener).To(BeNil())
+		})
+
+		It("Can't be created without database connection URL", func() {
+			listener, err := NewListener().
+				SetLogger(logger).
+				SetChannel(channel).
+				AddPayloadCallback(nothing).
+				Build()
+			Expect(err).To(MatchError("database connection URL is mandatory"))
+			Expect(listener).To(BeNil())
+		})
+
+		It("Can't be created without at least one payload callback", func() {
+			listener, err := NewListener().
+				SetLogger(logger).
+				SetChannel(channel).
+				SetUrl(url).
+				Build()
+			Expect(err).To(MatchError("at least one payload callback is mandatory"))
+			Expect(listener).To(BeNil())
+		})
+
+		It("Checks that wait timeout is positive", func() {
+			listener, err := NewListener().
+				SetLogger(logger).
+				SetChannel(channel).
+				SetUrl(url).
+				AddPayloadCallback(nothing).
+				SetWaitTimeout(-1 * time.Second).
+				Build()
+			Expect(err).To(MatchError("wait timeout should be positive, but it is -1s"))
+			Expect(listener).To(BeNil())
+		})
+
+		It("Checks that retry interval is positive", func() {
+			listener, err := NewListener().
+				SetLogger(logger).
+				SetChannel(channel).
+				SetUrl(url).
+				AddPayloadCallback(nothing).
+				SetRetryInterval(-1 * time.Second).
+				Build()
+			Expect(err).To(MatchError("retry interval should be positive, but it is -1s"))
+			Expect(listener).To(BeNil())
+		})
+	})
+
+	Describe("Behaviour", func() {
+		var (
+			ctx      context.Context
+			tm       TxManager
+			payloads chan proto.Message
+			listener *Listener
+			notifier *Notifier
+		)
+
+		BeforeEach(func() {
+			var err error
+
+			// Create a cancelable context that will be used to stop the listener:
+			var cancel context.CancelFunc
+			ctx, cancel = context.WithCancel(context.Background())
+			DeferCleanup(cancel)
+
+			// Prepare the database pool:
+			db := dbServer.MakeDatabase()
+			DeferCleanup(db.Close)
+			pool, err := pgxpool.New(ctx, db.MakeURL())
+			Expect(err).ToNot(HaveOccurred())
+			DeferCleanup(pool.Close)
+
+			// Create the payloads channel:
+			payloads = make(chan proto.Message)
+
+			// Create the listener and wait till it is ready:
+			ready := make(chan struct{})
+			listener, err = NewListener().
+				SetLogger(logger).
+				SetUrl(db.MakeURL()).
+				SetChannel(channel).
+				SetWaitTimeout(100 * time.Millisecond).
+				SetRetryInterval(10 * time.Millisecond).
+				AddReadyCallback(func(ctx context.Context) error {
+					close(ready)
+					return nil
+				}).
+				AddPayloadCallback(func(ctx context.Context, payload proto.Message) error {
+					payloads <- payload
+					return nil
+				}).
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+			go func() {
+				defer GinkgoRecover()
+				err := listener.Listen(ctx)
+				Expect(err).To(MatchError(context.Canceled))
+			}()
+			Eventually(ready).Should(BeClosed())
+
+			// Create the notifier:
+			notifier, err = NewNotifier().
+				SetLogger(logger).
+				SetChannel(channel).
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+
+			// Prepare the transaction manager:
+			tm, err = NewTxManager().
+				SetLogger(logger).
+				SetPool(pool).
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		// runWithTx starts a transaction, runs the given function using it, and ends the transaction when it
+		// finishes.
+		runWithTx := func(task func(ctx context.Context)) {
+			tx, err := tm.Begin(ctx)
+			Expect(err).ToNot(HaveOccurred())
+			taskCtx := TxIntoContext(ctx, tx)
+			task(taskCtx)
+			err = tm.End(ctx, tx)
+			Expect(err).ToNot(HaveOccurred())
+		}
+
+		It("Receives one notification", func() {
+			var err error
+			sent := wrapperspb.String("my payload")
+			runWithTx(func(ctx context.Context) {
+				err = notifier.Notify(ctx, sent)
+			})
+			Expect(err).ToNot(HaveOccurred())
+			var received *wrapperspb.StringValue
+			Eventually(payloads).Should(Receive(&received))
+			Expect(proto.Equal(received, sent)).To(BeTrue())
+		})
+
+		It("Receives multiple notifications", func() {
+			var err error
+			sent := []string{
+				"cero",
+				"uno",
+				"dos",
+				"tres",
+				"cuatro",
+				"cinco",
+				"seis",
+				"siete",
+				"ocho",
+				"nueve",
+			}
+			for _, value := range sent {
+				payload := wrapperspb.String(value)
+				runWithTx(func(ctx context.Context) {
+					err = notifier.Notify(ctx, payload)
+				})
+				Expect(err).ToNot(HaveOccurred())
+			}
+			var received []string
+			ctx, cancel := context.WithTimeout(ctx, 1*time.Second)
+			defer cancel()
+		loop:
+			for {
+				select {
+				case <-ctx.Done():
+				case payload := <-payloads:
+					wrapper := payload.(*wrapperspb.StringValue)
+					received = append(received, wrapper.Value)
+					if len(received) == len(sent) {
+						break loop
+					}
+				}
+			}
+			Expect(received).To(Equal(sent))
+		})
+	})
+})

--- a/internal/database/database_notifier.go
+++ b/internal/database/database_notifier.go
@@ -1,0 +1,122 @@
+/*
+Copyright (c) 2025 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package database
+
+import (
+	"context"
+	"encoding/base64"
+	"errors"
+	"log/slog"
+
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/anypb"
+)
+
+// NotifierBuilder contains the data and logic needed to build a notifier.
+type NotifierBuilder struct {
+	logger  *slog.Logger
+	channel string
+}
+
+// Notifier knows how to send notifications using PostgreSQL's NOTIFY command, using protocol buffers messages as
+// payload.
+type Notifier struct {
+	logger  *slog.Logger
+	channel string
+}
+
+// NewNotifier uses the information stored in the builder to create a new notifier.
+func NewNotifier() *NotifierBuilder {
+	return &NotifierBuilder{}
+}
+
+// SetLogger sets the logger for the notifier. This is mandatory.
+func (b *NotifierBuilder) SetLogger(logger *slog.Logger) *NotifierBuilder {
+	b.logger = logger
+	return b
+}
+
+// SetLogger sets the channel name. This is mandatory.
+func (b *NotifierBuilder) SetChannel(value string) *NotifierBuilder {
+	b.channel = value
+	return b
+}
+
+// Build constructs a notifier instance using the configured parameters.
+func (b *NotifierBuilder) Build() (result *Notifier, err error) {
+	// Check parameters:
+	if b.logger == nil {
+		err = errors.New("logger is mandatory")
+		return
+	}
+	if b.channel == "" {
+		err = errors.New("channel is mandatory")
+		return
+	}
+
+	// Create and populate the object:
+	logger := b.logger.With(
+		slog.String("channel", b.channel),
+	)
+	result = &Notifier{
+		logger:  logger,
+		channel: b.channel,
+	}
+	return
+}
+
+// Notify sends a notification with the given payload using the configured channel. The payload is placed into an
+// Any object, then marshalled using protocol buffers and encoded with Base64.
+//
+// Note that this method expects to find a transaction in the context.
+func (n *Notifier) Notify(ctx context.Context, payload proto.Message) (err error) {
+	// Get the transaction fron the context:
+	tx, err := TxFromContext(ctx)
+	if err != nil {
+		return
+	}
+	defer tx.ReportError(&err)
+
+	// Encode the payload:
+	wrapper, err := anypb.New(payload)
+	if err != nil {
+		return err
+	}
+	data, err := proto.Marshal(wrapper)
+	if err != nil {
+		n.logger.ErrorContext(
+			ctx,
+			"Failed to serialize payload",
+			slog.Any("payload", payload),
+			slog.Any("error", err),
+		)
+		return err
+	}
+	encoded := base64.StdEncoding.EncodeToString(data)
+
+	// Send the notification:
+	_, err = tx.Exec(ctx, "select pg_notify($1, $2)", n.channel, encoded)
+	if err != nil {
+		return err
+	}
+	if n.logger.Enabled(ctx, slog.LevelDebug) {
+		n.logger.DebugContext(
+			ctx,
+			"Sent notification",
+			slog.Any("payload", payload),
+		)
+	}
+
+	return nil
+}

--- a/internal/database/database_notifier_test.go
+++ b/internal/database/database_notifier_test.go
@@ -1,0 +1,108 @@
+/*
+Copyright (c) 2025 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package database
+
+import (
+	"context"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"google.golang.org/protobuf/types/known/wrapperspb"
+)
+
+var _ = Describe("Notifier", func() {
+	const channel = "my_channel"
+
+	var (
+		ctx context.Context
+		tm  TxManager
+	)
+
+	BeforeEach(func() {
+		var err error
+
+		// Create a context:
+		ctx = context.Background()
+
+		// Prepare the database pool:
+		db := dbServer.MakeDatabase()
+		DeferCleanup(db.Close)
+		pool, err := pgxpool.New(ctx, db.MakeURL())
+		Expect(err).ToNot(HaveOccurred())
+		DeferCleanup(pool.Close)
+
+		// Prepare the transaction manager:
+		tm, err = NewTxManager().
+			SetLogger(logger).
+			SetPool(pool).
+			Build()
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	// runWithTx starts a transaction, runs the given function using it, and ends the transaction when it finishes.
+	runWithTx := func(task func(ctx context.Context)) {
+		tx, err := tm.Begin(ctx)
+		Expect(err).ToNot(HaveOccurred())
+		taskCtx := TxIntoContext(ctx, tx)
+		task(taskCtx)
+		err = tm.End(ctx, tx)
+		Expect(err).ToNot(HaveOccurred())
+	}
+
+	Describe("Creation", func() {
+		It("Can be created when all the required parameters are set", func() {
+			notifier, err := NewNotifier().
+				SetLogger(logger).
+				SetChannel(channel).
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(notifier).ToNot(BeNil())
+		})
+
+		It("Can't be created without a logger", func() {
+			notifier, err := NewNotifier().
+				SetChannel(channel).
+				Build()
+			Expect(err).To(MatchError("logger is mandatory"))
+			Expect(notifier).To(BeNil())
+		})
+
+		It("Can't be created without a channel", func() {
+			notifier, err := NewNotifier().
+				SetLogger(logger).
+				Build()
+			Expect(err).To(MatchError("channel is mandatory"))
+			Expect(notifier).To(BeNil())
+		})
+	})
+
+	Describe("Behaviour", func() {
+		It("Sends notification", func() {
+			// Create the notifier:
+			notifier, err := NewNotifier().
+				SetLogger(logger).
+				SetChannel(channel).
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+
+			// Send the notification:
+			payload := wrapperspb.Int32(42)
+			runWithTx(func(ctx context.Context) {
+				err = notifier.Notify(ctx, payload)
+			})
+			Expect(err).ToNot(HaveOccurred())
+		})
+	})
+})


### PR DESCRIPTION
This patch adds utilities to simplify the usage of PostgreSQL's LISTEN/NOTIFIY mechanism. The `Listener` object takes care of keeping the connection to the database open, even if the database is restarted.

Both the `Listener` and `Notifier` object use protocol buffers messages, and they take care of encoding them so that they can be sent as payload of the LISTEN/NOTIFY mechanism.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a robust PostgreSQL notification system allowing the application to both send and listen for database notifications with configurable callbacks and error handling.
- **Tests**
	- Added comprehensive tests to ensure reliable creation, operation, and error handling of the new notification features.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->