### PR TITLE
Replace dummy templates with a real one

### DIFF
--- a/internal/database/migrations/1_cluster_templates.up.sql
+++ b/internal/database/migrations/1_cluster_templates.up.sql
@@ -13,18 +13,10 @@
 
 insert into cluster_templates (id, data) values
 (
-  'my-template',
+  'ocp_4_17_small',
   '{
-    "id": "my-template",
-    "title": "My template",
-    "description": "My template is *nice*."
-  }'
-),
-(
-  'your-template',
-  '{
-    "id": "your-template",
-    "title": "Your template",
-    "description": "Your template is _ugly_."
+    "id": "ocp_4_17_small",
+    "title": "OpenShift 4.17 small",
+    "description": "OpenShift 4.17 with `small` instances as worker nodes."
   }'
 );


### PR DESCRIPTION
This patch replaces the dummy templates with one a bit more real.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - The available cluster template option has been refreshed.
  - A new “OpenShift 4.17 small” template now appears with updated title and description tailored for small worker node configurations.
  - Outdated template options have been removed, streamlining the selection process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->