### PR TITLE
Use TLS for PostgreSQL communication

### DIFF
--- a/manifests/ca/ca-certificate.yaml
+++ b/manifests/ca/ca-certificate.yaml
@@ -11,31 +11,14 @@
 # specific language governing permissions and limitations under the License.
 #
 
-apiVersion: kustomize.config.k8s.io/v1beta1
-kind: Kustomization
-namespace: innabox
-labels:
-- includeSelectors: true
-  pairs:
-    app: fulfillment-service
-
-resources:
-- namespace.yaml
-- ca
-- database
-- service
-- client
-
-generatorOptions:
-  disableNameSuffixHash: true
-
-images:
-- name: envoy
-  newName: docker.io/envoyproxy/envoy
-  newTag: v1.33.0
-- name: fulfillment-service
-  newName: quay.io/innabox/fulfillment-service
-  newTag: latest
-- name: postgres
-  newName: quay.io/sclorg/postgresql-15-c9s
-  newTag: latest
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: ca-certificate
+spec:
+  commonName: Innabox CA
+  isCA: true
+  issuerRef:
+    kind: Issuer
+    name: ca-issuer
+  secretName: ca-key

--- a/manifests/ca/ca-issuer.yaml
+++ b/manifests/ca/ca-issuer.yaml
@@ -11,31 +11,11 @@
 # specific language governing permissions and limitations under the License.
 #
 
-apiVersion: kustomize.config.k8s.io/v1beta1
-kind: Kustomization
-namespace: innabox
-labels:
-- includeSelectors: true
-  pairs:
-    app: fulfillment-service
+# This issuer is used to generate the the self signed certificate our our CA.
 
-resources:
-- namespace.yaml
-- ca
-- database
-- service
-- client
-
-generatorOptions:
-  disableNameSuffixHash: true
-
-images:
-- name: envoy
-  newName: docker.io/envoyproxy/envoy
-  newTag: v1.33.0
-- name: fulfillment-service
-  newName: quay.io/innabox/fulfillment-service
-  newTag: latest
-- name: postgres
-  newName: quay.io/sclorg/postgresql-15-c9s
-  newTag: latest
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: ca-issuer
+spec:
+  selfSigned: {}

--- a/manifests/ca/issuer.yaml
+++ b/manifests/ca/issuer.yaml
@@ -11,31 +11,10 @@
 # specific language governing permissions and limitations under the License.
 #
 
-apiVersion: kustomize.config.k8s.io/v1beta1
-kind: Kustomization
-namespace: innabox
-labels:
-- includeSelectors: true
-  pairs:
-    app: fulfillment-service
-
-resources:
-- namespace.yaml
-- ca
-- database
-- service
-- client
-
-generatorOptions:
-  disableNameSuffixHash: true
-
-images:
-- name: envoy
-  newName: docker.io/envoyproxy/envoy
-  newTag: v1.33.0
-- name: fulfillment-service
-  newName: quay.io/innabox/fulfillment-service
-  newTag: latest
-- name: postgres
-  newName: quay.io/sclorg/postgresql-15-c9s
-  newTag: latest
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: issuer
+spec:
+  ca:
+    secretName: ca-key

--- a/manifests/ca/kustomization.yaml
+++ b/manifests/ca/kustomization.yaml
@@ -13,29 +13,8 @@
 
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-namespace: innabox
-labels:
-- includeSelectors: true
-  pairs:
-    app: fulfillment-service
 
 resources:
-- namespace.yaml
-- ca
-- database
-- service
-- client
-
-generatorOptions:
-  disableNameSuffixHash: true
-
-images:
-- name: envoy
-  newName: docker.io/envoyproxy/envoy
-  newTag: v1.33.0
-- name: fulfillment-service
-  newName: quay.io/innabox/fulfillment-service
-  newTag: latest
-- name: postgres
-  newName: quay.io/sclorg/postgresql-15-c9s
-  newTag: latest
+- ca-issuer.yaml
+- ca-certificate.yaml
+- issuer.yaml

--- a/manifests/database/client-cert.yaml
+++ b/manifests/database/client-cert.yaml
@@ -11,31 +11,14 @@
 # specific language governing permissions and limitations under the License.
 #
 
-apiVersion: kustomize.config.k8s.io/v1beta1
-kind: Kustomization
-namespace: innabox
-labels:
-- includeSelectors: true
-  pairs:
-    app: fulfillment-service
-
-resources:
-- namespace.yaml
-- ca
-- database
-- service
-- client
-
-generatorOptions:
-  disableNameSuffixHash: true
-
-images:
-- name: envoy
-  newName: docker.io/envoyproxy/envoy
-  newTag: v1.33.0
-- name: fulfillment-service
-  newName: quay.io/innabox/fulfillment-service
-  newTag: latest
-- name: postgres
-  newName: quay.io/sclorg/postgresql-15-c9s
-  newTag: latest
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: fulfillment-database-client
+spec:
+  issuerRef:
+    name: issuer
+  usages:
+  - client auth
+  commonName: client
+  secretName: fulfillment-database-client-cert

--- a/manifests/database/files/access.conf
+++ b/manifests/database/files/access.conf
@@ -11,31 +11,9 @@
 # specific language governing permissions and limitations under the License.
 #
 
-apiVersion: kustomize.config.k8s.io/v1beta1
-kind: Kustomization
-namespace: innabox
-labels:
-- includeSelectors: true
-  pairs:
-    app: fulfillment-service
+# This is needed by the scripts that setup the database.
+local all all peer
 
-resources:
-- namespace.yaml
-- ca
-- database
-- service
-- client
-
-generatorOptions:
-  disableNameSuffixHash: true
-
-images:
-- name: envoy
-  newName: docker.io/envoyproxy/envoy
-  newTag: v1.33.0
-- name: fulfillment-service
-  newName: quay.io/innabox/fulfillment-service
-  newTag: latest
-- name: postgres
-  newName: quay.io/sclorg/postgresql-15-c9s
-  newTag: latest
+# For any other user we only allow access with certificates.
+hostssl all all 0.0.0.0/0 cert
+hostssl all all ::0/0 cert

--- a/manifests/database/files/server.conf
+++ b/manifests/database/files/server.conf
@@ -11,31 +11,11 @@
 # specific language governing permissions and limitations under the License.
 #
 
-apiVersion: kustomize.config.k8s.io/v1beta1
-kind: Kustomization
-namespace: innabox
-labels:
-- includeSelectors: true
-  pairs:
-    app: fulfillment-service
+# Enable TLS:
+ssl = on
+ssl_ca_file = '/secrets/cert/ca.crt'
+ssl_cert_file = '/secrets/cert/tls.crt'
+ssl_key_file = '/secrets/cert/tls.key'
 
-resources:
-- namespace.yaml
-- ca
-- database
-- service
-- client
-
-generatorOptions:
-  disableNameSuffixHash: true
-
-images:
-- name: envoy
-  newName: docker.io/envoyproxy/envoy
-  newTag: v1.33.0
-- name: fulfillment-service
-  newName: quay.io/innabox/fulfillment-service
-  newTag: latest
-- name: postgres
-  newName: quay.io/sclorg/postgresql-15-c9s
-  newTag: latest
+# Use our custom access file:
+hba_file = '/config/access/access.conf'

--- a/manifests/database/kustomization.yaml
+++ b/manifests/database/kustomization.yaml
@@ -9,3 +9,13 @@ resources:
 - pvc.yaml
 - service.yaml
 - statefulset.yaml
+- server-cert.yaml
+- client-cert.yaml
+
+configMapGenerator:
+- name: fulfillment-database-server
+  files:
+  - files/server.conf
+- name: fulfillment-database-access
+  files:
+  - files/access.conf

--- a/manifests/database/server-cert.yaml
+++ b/manifests/database/server-cert.yaml
@@ -11,31 +11,13 @@
 # specific language governing permissions and limitations under the License.
 #
 
-apiVersion: kustomize.config.k8s.io/v1beta1
-kind: Kustomization
-namespace: innabox
-labels:
-- includeSelectors: true
-  pairs:
-    app: fulfillment-service
-
-resources:
-- namespace.yaml
-- ca
-- database
-- service
-- client
-
-generatorOptions:
-  disableNameSuffixHash: true
-
-images:
-- name: envoy
-  newName: docker.io/envoyproxy/envoy
-  newTag: v1.33.0
-- name: fulfillment-service
-  newName: quay.io/innabox/fulfillment-service
-  newTag: latest
-- name: postgres
-  newName: quay.io/sclorg/postgresql-15-c9s
-  newTag: latest
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: fulfillment-database-server
+spec:
+  issuerRef:
+    name: issuer
+  dnsNames:
+  - fulfillment-database
+  secretName: fulfillment-database-server-cert

--- a/manifests/database/statefulset.yaml
+++ b/manifests/database/statefulset.yaml
@@ -20,6 +20,16 @@ spec:
   template:
     spec:
       volumes:
+      - name: server-cert
+        secret:
+          secretName: fulfillment-database-server-cert
+          defaultMode: 0400
+      - name: server-config
+        configMap:
+          name: fulfillment-database-server
+      - name: access-config
+        configMap:
+          name: fulfillment-database-access
       - name: data
         persistentVolumeClaim:
           claimName: fulfillment-database
@@ -29,14 +39,20 @@ spec:
         imagePullPolicy: IfNotPresent
         env:
         - name: POSTGRESQL_USER
-          value: service
+          value: client
         - name: POSTGRESQL_PASSWORD
-          value: service123
+          value: ''
         - name: POSTGRESQL_DATABASE
           value: service
         volumeMounts:
         - name: data
           mountPath: /var/lib/pgsql/data
+        - name: server-cert
+          mountPath: /secrets/cert
+        - name: server-config
+          mountPath: /opt/app-root/src/postgresql-cfg
+        - name: access-config
+          mountPath: /config/access
         ports:
         - name: postgres
           protocol: TCP

--- a/manifests/service/deployment.yaml
+++ b/manifests/service/deployment.yaml
@@ -32,6 +32,9 @@ spec:
       - name: config
         configMap:
           name: fulfillment-service-config
+      - name: cert
+        secret:
+          secretName: fulfillment-database-client-cert
       - name: envoy
         configMap:
           name: fulfillment-service-envoy
@@ -48,6 +51,8 @@ spec:
           mountPath: /run/sockets
         - name: config
           mountPath: /etc/fulfillment-service
+        - name: cert
+          mountPath: /secrets/cert
         command:
         - /usr/local/bin/fulfillment-service
         - start
@@ -55,7 +60,11 @@ spec:
         - --log-level=debug
         - --log-headers=true
         - --log-bodies=true
-        - --db-url=postgres://service:service123@fulfillment-database:5432/service
+        - "--db-url=postgres://client@fulfillment-database:5432/service?\
+          sslmode=verify-full&\
+          sslcert=/secrets/cert/tls.crt&\
+          sslkey=/secrets/cert/tls.key&\
+          sslrootcert=/secrets/cert/ca.crt"
         - --grpc-listener-network=unix
         - --grpc-listener-address=/run/sockets/server.socket
         - --grpc-authn-type=jwks


### PR DESCRIPTION
This patch changes the configuration of the PostgreSQL database so that TLS is enabled, and configured to require client certificates. The certificates for the database server and client are genered using [cert-manager](https://cert-manager.io).