### PR TITLE
Copy template parameters to K8S cluster order

### DIFF
--- a/internal/database/migrations/1_cluster_templates.up.sql
+++ b/internal/database/migrations/1_cluster_templates.up.sql
@@ -17,6 +17,32 @@ insert into cluster_templates (id, data) values
   '{
     "id": "ocp_4_17_small",
     "title": "OpenShift 4.17 small",
-    "description": "OpenShift 4.17 with `small` instances as worker nodes."
+    "description": "OpenShift 4.17 with `small` instances as worker nodes.",
+    "parameters": [
+      {
+        "type": "type.googleapis.com/google.protobuf.BoolValue",
+        "name": "my_bool",
+        "default": {
+          "@type": "type.googleapis.com/google.protobuf.BoolValue",
+          "value": true
+        }
+      },
+      {
+        "type": "type.googleapis.com/google.protobuf.Int32Value",
+        "name": "my_int",
+        "default": {
+          "@type": "type.googleapis.com/google.protobuf.Int32Value",
+          "value": 42
+        }
+      },
+      {
+        "type": "type.googleapis.com/google.protobuf.StringValue",
+        "name": "my_string",
+        "default": {
+          "@type": "type.googleapis.com/google.protobuf.StringValue",
+          "value": "my_value"
+        }
+      }
+    ]
   }'
 );


### PR DESCRIPTION
This patch changes the part of the server that creates the K8S cluster orders so that it also puts the template parameters in the `spec.templateParameters` field. For example, for a cluster order like this:

```json
{
  "object": {
    "id": "e465dfad-e8af-4703-a37c-b115d1beb1a9",
    "spec": {
      "template_id": "ocp_4_17_small",
      "template_parameters": {
        "my_bool": {
          "@type": "type.googleapis.com/google.protobuf.BoolValue",
          "value": true
        },
        "my_int": {
          "@type": "type.googleapis.com/google.protobuf.Int32Value",
          "value": 42
        },
        "my_string": {
          "@type": "type.googleapis.com/google.protobuf.StringValue",
          "value": "my_value"
        }
      }
    }
  }
}
```

It creates a Kubernetes `ClusterOrder` like this:

```yaml
piVersion: cloudkit.openshift.io/v1alpha1
kind: ClusterOrder
metadata:
  namespace: cloudkit-operator-system
  name: order-r6rg9
  labels:
    cloudkit.openshift.io/clusterorder-uuid: e465dfad-e8af-4703-a37c-b115d1beb1a9
spec:
  templateID: ocp_4_17_small
  templateParameters: '{"my_bool":true,"my_int":42,"my_string":"my_value"}'
```

Note that this is on top of #25, focus on the last commit when reviewing.
