### PR TITLE
Add workflow to publish image

### DIFF
--- a/.github/workflows/publish-image.yaml
+++ b/.github/workflows/publish-image.yaml
@@ -1,0 +1,54 @@
+#
+# Copyright (c) 2025 Red Hat Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License. You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License
+# is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+# or implied. See the License for the specific language governing permissions and limitations under
+# the License.
+#
+
+name: Publish image
+
+on:
+  push:
+    branches:
+    - main
+    tags:
+    - 'v*'
+
+jobs:
+
+  publish-image:
+    name: Publish image
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+    - uses: actions/checkout@v4
+    - run: |
+        # Login to the registry:
+        registry="ghcr.io"
+        podman login --username "${{ github.actor}}" --password "${{ secrets.GITHUB_TOKEN }}" "${registry}"
+
+        # Build and push the image with the 'latest' tag:
+        image="${registry}/${{ github.repository }}"
+        podman build -t "${image}:latest" .
+        podman push "${image}:latest"
+
+        # Push the image again, but with the commit hash or version tag:
+        case "${{ github.ref_type }}" in
+          tag)
+            tag="${{ github.ref_name }}"
+            ;;
+          *)
+            tag=$(git rev-parse --short HEAD)
+            ;;
+        esac
+        podman tag "${image}:latest" "${image}:${tag}"
+        podman push "${image}:${tag}"


### PR DESCRIPTION
This patch adds a GitHub workflow that publishes the container image to the GitHub container image registry for each push to the main branch and for each version tag.

In addition to the `latest` tag, for pushes to the main branch add a tag containing the short commit hash, for example:

    ghcr.io/innabox/fulfillment-service:4719ed7

And for version tags like `v0.0.1` it will add the that version tag, for example:

    ghcr.io/innabox/fulfillment-service:v0.0.1