### PR TITLE
Add `Authorization` header to Envoy CORS filter

### DIFF
--- a/manifests/service/files/envoy.yaml
+++ b/manifests/service/files/envoy.yaml
@@ -51,7 +51,7 @@ static_resources:
                   - safe_regex:
                       regex: ".*"
                   allow_methods: "POST"
-                  allow_headers: "Content-Type, X-User-Agent, X-Grpc-Web"
+                  allow_headers: "Authorization, Content-Type, X-User-Agent, X-Grpc-Web"
                   allow_credentials: true
                   max_age: "86400"
               routes:


### PR DESCRIPTION
Currently the CORS configuration of the Envoy proxy doesn't explicitly list `Authorization` as an allowed header. This seems to work fine with Firefox, but not with Chrome. This patch adds it.