### PR TITLE
Revert "Create non-expiring token for controller service account (#37)"

### DIFF
--- a/manifests/controller/deployment.yaml
+++ b/manifests/controller/deployment.yaml
@@ -26,21 +26,11 @@ spec:
         app: fulfillment-controller
     spec:
       serviceAccountName: controller
-
-      volumes:
-
-      - name: controller-token
-        secret:
-          secretName: controller-token
-
       containers:
 
       - name: controller
         image: fulfillment-service
         imagePullPolicy: IfNotPresent
-        volumeMounts:
-        - name: controller-token
-          mountPath: /run/secrets/token
         env:
         - name: NAMESPACE
           valueFrom:
@@ -57,6 +47,6 @@ spec:
           --log-bodies="true" \
           --grpc-server-network="tcp" \
           --grpc-server-address="fulfillment-api.${NAMESPACE}.svc:8000" \
-          --grpc-ca-file="/run/secrets/token/ca.crt" \
-          --grpc-ca-file="/run/secrets/token/service-ca.crt" \
-          --grpc-token-file="/run/secrets/token/token"
+          --grpc-ca-file="/var/run/secrets/kubernetes.io/serviceaccount/ca.crt" \
+          --grpc-ca-file="/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt" \
+          --grpc-token-file="/var/run/secrets/kubernetes.io/serviceaccount/token"

--- a/manifests/controller/kustomization.yaml
+++ b/manifests/controller/kustomization.yaml
@@ -7,5 +7,4 @@ labels:
 
 resources:
 - sa.yaml
-- sa-token.yaml
 - deployment.yaml

--- a/manifests/controller/sa-token.yaml
+++ b/manifests/controller/sa-token.yaml
@@ -1,7 +1,0 @@
-apiVersion: v1
-kind: Secret
-metadata:
-  name: controller-token
-  annotations:
-    kubernetes.io/service-account.name: controller
-type: kubernetes.io/service-account-token


### PR DESCRIPTION
This reverts commit 69a3ef5eb4f81b5d2b04b725ff1c123b81690e9d.

This is necessary because the tokens created using this mechanism don't have an `iat` claim. For example:

```json
{
  "iss": "kubernetes/serviceaccount",
  "kubernetes.io/serviceaccount/namespace": "innabox",
  "kubernetes.io/serviceaccount/secret.name": "controller-token",
  "kubernetes.io/serviceaccount/service-account.name": "controller",
  "kubernetes.io/serviceaccount/service-account.uid": "abec75cc-021a-4e2f-8a3f-d6e37a28c650"
  "sub": "system:serviceaccount:innabox:controller"
}
```

And our JWT authenticator rejects that with the following error message:

```json
{
  "time": "2025-05-07T17:31:25Z",
  "level": "ERROR",
  "msg": "Watch failed",
  "error": {
    "message": "rpc error: code = Unauthenticated desc = Bearer token doesn't contain required claim 'iat'",
    "goroutine": 15,
    "stack": [
      {
        "function": "github.com/innabox/fulfillment-service/internal/controllers.(*Reconciler[...]).watchLoop",
        "source": "/source/internal/controllers/reconciler.go:320"
      }
    ]
  }
}
```

Instead of that non-expiring token we will change the gRPC client so that it always reads the latest token from the file.