### PR TITLE
Add feedback controller permissions

### DIFF
--- a/manifests/service/files/rules.yaml
+++ b/manifests/service/files/rules.yaml
@@ -42,4 +42,5 @@
     subject.name in [
       'system:serviceaccount:innabox:admin',
       'system:serviceaccount:innabox:controller',
+      'system:serviceaccount:cloudkit-operator-system:cloudkit-operator-controller-manager',
     ]


### PR DESCRIPTION
The feedback controller (part of the CloudKit operator) needs full permissions in order to create and update objects.