### PR TITLE
Save selected hub

### DIFF
--- a/internal/controllers/clusterorder/cluster_order_function.go
+++ b/internal/controllers/clusterorder/cluster_order_function.go
@@ -169,6 +169,9 @@ func (t *task) update(ctx context.Context) error {
 		return err
 	}
 
+	// Save the selected hub in the private data of the order:
+	t.private.SetHubId(t.hubId)
+
 	// Prepare the template parameters:
 	templateParameters, err := t.prepareTemplateParameters()
 	if err != nil {

--- a/internal/servers/clusters_server.go
+++ b/internal/servers/clusters_server.go
@@ -287,7 +287,7 @@ func (s *ClustersServer) getKubeconfig(ctx context.Context, clusterId string) (r
 	}
 	logger = logger.With(
 		slog.String("co_namespace", order.GetNamespace()),
-		slog.String("co_name", order.GetNamespace()),
+		slog.String("co_name", order.GetName()),
 	)
 	logger.DebugContext(ctx, "Got cluster order from hub")
 


### PR DESCRIPTION
When a order is created it is necessary to save the identifier of the selected hub, so that future operations on the order know which hub to use. This was already done, but accidentally lost in a previous change.