### PR TITLE
Don't use int32 in unstructured objects

### DIFF
--- a/internal/controllers/cluster/cluster_function.go
+++ b/internal/controllers/cluster/cluster_function.go
@@ -160,7 +160,7 @@ func (t *task) update(ctx context.Context) error {
 	for _, nodeSet := range t.public.GetSpec().GetNodeSets() {
 		nodeRequests = append(nodeRequests, map[string]any{
 			"resourceClass": nodeSet.GetHostClass(),
-			"numberOfNodes": nodeSet.GetSize(),
+			"numberOfNodes": int64(nodeSet.GetSize()),
 		})
 	}
 	spec := map[string]any{


### PR DESCRIPTION
We use the `Unstructured` type of the Kubernetes client package to interact with the `ClusterOrder` object. That type doesn't support the `int32` type, but we use it because it is what the gRPC returns. To avoid the issue we need to explicitly convert it to `int64`.