### PR TITLE
Add integration tests

### DIFF
--- a/.github/actions/setup-go/action.yaml
+++ b/.github/actions/setup-go/action.yaml
@@ -1,0 +1,36 @@
+#
+# Copyright (c) 2025 Red Hat Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License. You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License
+# is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+# or implied. See the License for the specific language governing permissions and limitations under
+# the License.
+#
+
+name: Setup Go
+description: Install and Go and Ginkgo
+runs:
+  using: composite
+  steps:
+  - uses: actions/setup-go@v5
+    with:
+      go-version: '1.22.9'
+  - shell: bash
+    run: |
+      go mod download
+  - id: ginkgo-cache
+    uses: actions/cache@v4
+    with:
+      key: ginkgo
+      path: ~/go/bin/ginkgo
+  - if: steps.ginkgo-cache.outputs.cache-hit != 'true'
+    shell: bash
+    run: |
+      module="github.com/onsi/ginkgo/v2"
+      version=$(go list -f '{{ .Version }}' -m "${module}")
+      go install "${module}/ginkgo@${version}"

--- a/.github/workflows/check-pull-request.yaml
+++ b/.github/workflows/check-pull-request.yaml
@@ -34,9 +34,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-    - uses: actions/setup-go@v5
-      with:
-        go-version: '1.22.9'
+    - uses: ./.github/actions/setup-go
     - run: |
         gofmt -s -l -w .
         git diff --exit-code
@@ -59,25 +57,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-    - uses: actions/setup-go@v5
-      with:
-        go-version: '1.22.9'
+    - uses: ./.github/actions/setup-go
     - run: |
-        module="github.com/onsi/ginkgo/v2"
-        version=$(go list -f '{{ .Version }}' -m "${module}")
-        go install "${module}/ginkgo@${version}"
-        ginkgo run -r
-
-  build-binary:
-    name: Build binary
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v4
-    - uses: actions/setup-go@v5
-      with:
-        go-version: '1.22.9'
-    - run: |
-        go build
+        ginkgo run -r internal
 
   build-image:
     name: Build image
@@ -85,4 +67,25 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - run: |
-        podman build .
+        image="ghcr.io/innabox/fulfillment-service:latest"
+        podman build --tag "${image}" .
+        podman save --output image.tar "${image}"
+    - uses: actions/upload-artifact@v4
+      with:
+        name: image
+        path: image.tar
+
+  run-integration-tests:
+    name: Run integration tests
+    runs-on: ubuntu-latest
+    needs:
+    - build-image
+    steps:
+    - uses: actions/checkout@v4
+    - uses: ./.github/actions/setup-go
+    - uses: actions/download-artifact@v4
+      with:
+        name: image
+        path: .
+    - run: |
+        ginkgo run -v it

--- a/Containerfile
+++ b/Containerfile
@@ -7,9 +7,15 @@ RUN \
   && \
   dnf clean all -y
 
-# Copy the source and build the binary:
-COPY . /source
+
+# Copy only the 'go.mod' and 'go.sum' files and try to download the required modules, so that hopefully this will be
+# in a layer that can be cached reused for builds that don't change the dependencies.
 WORKDIR /source
+COPY go.mod go.sum /source
+RUN go mod download
+
+# Copy the rest of the source and build the binary:
+COPY . /source
 RUN go build
 
 FROM registry.access.redhat.com/ubi9/ubi:9.5-1739751568 AS runtime

--- a/internal/logging/logger.go
+++ b/internal/logging/logger.go
@@ -117,7 +117,7 @@ func (b *LoggerBuilder) SetFile(value string) *LoggerBuilder {
 	return b
 }
 
-// Set redact sets the flag that indicates if security sensitive data should be removed from the log. These fields are
+// SetRedact sets the flag that indicates if security sensitive data should be removed from the log. These fields are
 // indicated by adding an exlamation mark in front of the field name. For example, to write a message with a `public`
 // field that isn't sensitive and another `private` field that is:
 //

--- a/internal/logging/logging_writer.go
+++ b/internal/logging/logging_writer.go
@@ -1,0 +1,92 @@
+/*
+Copyright (c) 2025 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package logging
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+)
+
+// WriterBuilder contains the data and logic needed to create a writer that writes messages to a logger. Don't create
+// instances of this type directly, use the NewWriterBuilder function instead.
+type WriterBuilder struct {
+	logger  *slog.Logger
+	level   slog.Level
+	context context.Context
+}
+
+// Writer is an implementation of an io.Writer that writes messages to a slog.Logger. Don't create instances of this
+// type directly, use the NewWriterBuilder function instead.
+type Writer struct {
+	logger  *slog.Logger
+	level   slog.Level
+	context context.Context
+}
+
+// NewWriter creates a builder that can then be used to configure and create a new logging writer.
+func NewWriter() *WriterBuilder {
+	return &WriterBuilder{
+		level: slog.LevelInfo,
+	}
+}
+
+// SetLogger sets the logger. This is mandatory.
+func (b *WriterBuilder) SetLogger(value *slog.Logger) *WriterBuilder {
+	b.logger = value
+	return b
+}
+
+// SetLevel sets the level. This is optional, if not set the 'info' level will be used.
+func (b *WriterBuilder) SetLevel(value slog.Level) *WriterBuilder {
+	b.level = value
+	return b
+}
+
+// SetContext sets the context that will be passed to the logger from the Write method. This is optional, if not set no
+// context will be passed to the logger.
+func (b *WriterBuilder) SetContext(value context.Context) *WriterBuilder {
+	b.context = value
+	return b
+}
+
+// Build uses the configuration stored in the builder to create a new logging writer.
+func (b *WriterBuilder) Build() (result *Writer, err error) {
+	// Check arguments:
+	if b.logger == nil {
+		err = errors.New("logger is mandatory")
+		return
+	}
+
+	// Create and populate the object:
+	result = &Writer{
+		logger:  b.logger,
+		level:   b.level,
+		context: b.context,
+	}
+	return
+}
+
+// Write implements the io.Writer interface.
+func (w *Writer) Write(p []byte) (n int, err error) {
+	n = len(p)
+	w.logger.LogAttrs(
+		w.context,
+		w.level,
+		"Write",
+		slog.Int("size", n),
+		slog.String("data", string(p)),
+	)
+	return
+}

--- a/internal/testing/command.go
+++ b/internal/testing/command.go
@@ -1,0 +1,223 @@
+/*
+Copyright (c) 2025 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package testing
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"os/exec"
+	"slices"
+
+	"github.com/innabox/fulfillment-service/internal/logging"
+)
+
+// CommandBuilder contains the data and logic needed to create an object that helps execute a command line tool. Don't
+// create instances of this type directly, use the NewCommand function instead.
+type CommandBuilder struct {
+	logger *slog.Logger
+	name   string
+	args   []string
+	dir    string
+}
+
+// Command helps manage execute a command line tool. Don't create instances of this type directly, use the NewCommand
+// function instead.
+type Command struct {
+	logger *slog.Logger
+	name   string
+	args   []string
+	dir    string
+}
+
+// NewCommand creates a builder that can then be used to configure and create a new command.
+func NewCommand() *CommandBuilder {
+	return &CommandBuilder{}
+}
+
+// SetLogger sets the logger. This is mandatory.
+func (b *CommandBuilder) SetLogger(value *slog.Logger) *CommandBuilder {
+	b.logger = value
+	return b
+}
+
+// SetName sets the name of the command. This is mandatory.
+func (b *CommandBuilder) SetName(name string) *CommandBuilder {
+	b.name = name
+	return b
+}
+
+// SetArgs sets the arguments for the command. Note that this replaces any previously arguments added with the AddArgs
+// /method. Arguments are optional, if not set no arguments will be used.
+func (b *CommandBuilder) SetArgs(args ...string) *CommandBuilder {
+	b.args = args
+	return b
+}
+
+// AddArgs adds the arguments for the command. Note that this appends to any previously set arguments with the SetArgs
+// method. Arguments are optional, if not set no arguments will be used.
+func (b *CommandBuilder) AddArgs(args ...string) *CommandBuilder {
+	b.args = append(b.args, args...)
+	return b
+}
+
+// SetDir sets the directory where the command will be executed. This is optional, if not set the current working
+// directory will be used.
+func (b *CommandBuilder) SetDir(value string) *CommandBuilder {
+	b.dir = value
+	return b
+}
+
+// Build creates the command object.
+func (b *CommandBuilder) Build() (result *Command, err error) {
+	// Check parameters:
+	if b.logger == nil {
+		err = fmt.Errorf("logger is mandatory")
+		return
+	}
+	if b.name == "" {
+		err = fmt.Errorf("name is mandatory")
+		return
+	}
+
+	// Use the current working directory if no directory is set:
+	dir := b.dir
+	if dir == "" {
+		dir, err = os.Getwd()
+		if err != nil {
+			return
+		}
+	}
+
+	// Add some details to the logger:
+	logger := b.logger.With(
+		slog.String("cmd", b.name),
+		slog.String("dir", dir),
+	)
+
+	// Create and populate the object:
+	result = &Command{
+		logger: logger,
+		name:   b.name,
+		args:   slices.Clone(b.args),
+		dir:    dir,
+	}
+	return
+}
+
+// Execute executes the commands. It returns an error if the command fails.
+func (c *Command) Execute(ctx context.Context) error {
+	logger := c.logger.With(
+		slog.Any("args", c.args),
+	)
+	cmd := exec.Command(c.name, c.args...)
+	cmd.Dir = c.dir
+	err := c.setupLogging(ctx, cmd)
+	if err != nil {
+		return err
+	}
+	logger.DebugContext(ctx, "Executing command")
+	err = cmd.Run()
+	if logger.Enabled(ctx, slog.LevelDebug) {
+		var attrs []slog.Attr
+		c.appendStateAttrs(cmd, &attrs)
+		logger.LogAttrs(ctx, slog.LevelDebug, "Executed command", attrs...)
+	}
+	return err
+}
+
+// Evaluate evalutes the command and returns the standard output and error as byte slices. It returns an error if the
+// command fails.
+func (c *Command) Evaluate(ctx context.Context) (stdoutBytes, stderrBytes []byte, err error) {
+	logger := c.logger.With(
+		slog.Any("args", c.args),
+	)
+	outBuffer := &bytes.Buffer{}
+	errBuffer := &bytes.Buffer{}
+	cmd := exec.Command(c.name, c.args...)
+	cmd.Dir = c.dir
+	cmd.Stdout = outBuffer
+	cmd.Stderr = errBuffer
+	err = c.setupLogging(ctx, cmd)
+	if err != nil {
+		return
+	}
+	logger.DebugContext(ctx, "Evaluating command")
+	err = cmd.Run()
+	if logger.Enabled(ctx, slog.LevelDebug) {
+		stdoutBytes = outBuffer.Bytes()
+		stderrBytes = errBuffer.Bytes()
+		attrs := []slog.Attr{
+			slog.String("stdout", string(stdoutBytes)),
+			slog.String("stderr", string(stderrBytes)),
+		}
+		c.appendStateAttrs(cmd, &attrs)
+		logger.LogAttrs(ctx, slog.LevelDebug, "Evaluated command", attrs...)
+	}
+	return
+}
+
+func (c *Command) setupLogging(ctx context.Context, cmd *exec.Cmd) error {
+	stdoutLogger := c.logger.With(
+		slog.String("stream", "stdout"),
+	)
+	stdoutWriter, err := logging.NewWriter().
+		SetLogger(stdoutLogger).
+		SetLevel(slog.LevelDebug).
+		SetContext(ctx).
+		Build()
+	if err != nil {
+		return fmt.Errorf("failed to create stdout logger for command '%s': %w", c.name, err)
+	}
+	stderrLogger := c.logger.With(
+		slog.String("stream", "stderr"),
+	)
+	stderrWriter, err := logging.NewWriter().
+		SetLogger(stderrLogger).
+		SetLevel(slog.LevelDebug).
+		SetContext(ctx).
+		Build()
+	if err != nil {
+		return fmt.Errorf("failed to create stderr logger for command '%s': %w", c.name, err)
+	}
+	if cmd.Stdout != nil {
+		cmd.Stdout = io.MultiWriter(cmd.Stdout, stdoutWriter)
+	} else {
+		cmd.Stdout = stdoutWriter
+	}
+	if cmd.Stderr != nil {
+		cmd.Stderr = io.MultiWriter(cmd.Stderr, stderrWriter)
+	} else {
+		cmd.Stderr = stderrWriter
+	}
+	return nil
+}
+
+func (c *Command) appendStateAttrs(cmd *exec.Cmd, attrs *[]slog.Attr) {
+	if cmd == nil {
+		return
+	}
+	state := cmd.ProcessState
+	if state == nil {
+		return
+	}
+	*attrs = append(
+		*attrs,
+		slog.Int("code", state.ExitCode()),
+		slog.Int("pid", state.Pid()),
+	)
+}

--- a/internal/testing/kind.go
+++ b/internal/testing/kind.go
@@ -1,0 +1,533 @@
+/*
+Copyright (c) 2025 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package testing
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"slices"
+	"strings"
+	"time"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/clientcmd"
+	crclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// KindBuilder contains the data and logic needed to create an object that helps manage a Kind cluster used for
+// integration tests. Don't create instances of this type directly, use the NewKind function instead.
+type KindBuilder struct {
+	logger *slog.Logger
+	name   string
+}
+
+// Kind helps manage a Kind cluster used for integration tests. Don't create instances of this type directly, use the
+// NewKind function instead.
+type Kind struct {
+	logger          *slog.Logger
+	name            string
+	kubeconfigBytes []byte
+	kubeconfigFile  string
+	kubeClient      crclient.WithWatch
+	kubeClientSet   *kubernetes.Clientset
+}
+
+// NewKind creates a builder that can then be used to configure and create a new Kind cluster used for integration
+// tests.
+func NewKind() *KindBuilder {
+	return &KindBuilder{}
+}
+
+// SetLogger sets the logger. This is mandatory.
+func (b *KindBuilder) SetLogger(value *slog.Logger) *KindBuilder {
+	b.logger = value
+	return b
+}
+
+// SetName sets the name of the Kind cluster. This is mandatory.
+func (b *KindBuilder) SetName(name string) *KindBuilder {
+	b.name = name
+	return b
+}
+
+// Build uses the configuration stored in the builder to create a new Kind cluster
+func (b *KindBuilder) Build() (result *Kind, err error) {
+	// Check parameters:
+	if b.logger == nil {
+		err = fmt.Errorf("logger is mandatory")
+		return
+	}
+	if b.name == "" {
+		err = fmt.Errorf("name is mandatory")
+		return
+	}
+
+	// Add the name to the logger:
+	logger := b.logger.With(
+		slog.String("kind", b.name),
+	)
+
+	// Check that the command line tools that we need are available:
+	_, err = exec.LookPath(kindCmd)
+	if err != nil {
+		err = fmt.Errorf("command line tool '%s' isn't available: %w", kindCmd, err)
+		return
+	}
+	_, err = exec.LookPath(kubectlCmd)
+	if err != nil {
+		err = fmt.Errorf("command line tool '%s' isn't available: %w", kubectlCmd, err)
+		return
+	}
+
+	// Create and populate the object:
+	result = &Kind{
+		logger: logger,
+		name:   b.name,
+	}
+	return
+}
+
+// Start makes sure that the cluster is created and ready to use. It will remove the cluster if it already exists and
+// will create a new one if it doesn't exist.
+func (k *Kind) Start(ctx context.Context) error {
+	// Check if the cluster already exists. If it does, delete it. Then create a new one.
+	names, err := k.getClusters(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to get existing clusters: %w", err)
+	}
+	if slices.Contains(names, k.name) {
+		k.logger.LogAttrs(
+			ctx,
+			slog.LevelDebug,
+			"Deleting existing kind cluster",
+		)
+		err = k.deleteCluster(ctx)
+		if err != nil {
+			return fmt.Errorf("failed to delete existing kind cluster '%s': %w", k.name, err)
+		}
+	}
+	k.logger.LogAttrs(
+		ctx,
+		slog.LevelDebug,
+		"Creating new kind cluster",
+	)
+	err = k.createCluster(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to create kind cluster '%s': %w", k.name, err)
+	}
+	k.logger.LogAttrs(
+		ctx,
+		slog.LevelDebug,
+		"Created new kind cluster",
+	)
+
+	// Create the kubeconfig and the Kubernetes client:
+	err = k.createKubeconfig(ctx)
+	if err != nil {
+		return err
+	}
+	err = k.createKubeClient(ctx)
+	if err != nil {
+		return err
+	}
+	err = k.createKubeClientSet(ctx)
+	if err != nil {
+		return err
+	}
+
+	// Install other components:
+	err = k.installCertManager(ctx)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Stop removes the Kind cluster.
+func (k *Kind) Stop(ctx context.Context) error {
+	k.logger.DebugContext(ctx, "Stopping kind cluster")
+	var errs []error
+	err := k.deleteCluster(ctx)
+	if err != nil {
+		errs = append(errs, fmt.Errorf("failed to delete kind cluster '%s': %w", k.name, err))
+	}
+	err = os.Remove(k.kubeconfigFile)
+	if err != nil {
+		errs = append(errs, fmt.Errorf("failed to remove kubeconfig file '%s': %w", k.kubeconfigFile, err))
+	}
+	if len(errs) > 0 {
+		return fmt.Errorf("failed to stop kind cluster '%s': %v", k.name, errs)
+	}
+	k.logger.DebugContext(ctx, "Stopped kind cluster")
+	return nil
+}
+
+// LoadImage loads the specified image into the Kind cluster.
+//
+// Note that this will take the image from the local Docker daemon, regardless of what provider was used to create the
+// cluster. For example, if the cluster was created with the Podman provider this wills still load the image from
+// Docker.
+func (k *Kind) LoadImage(ctx context.Context, image string) error {
+	if image == "" {
+		return fmt.Errorf("image is mandatory")
+	}
+	logger := k.logger.With(
+		slog.String("image", image),
+	)
+	logger.DebugContext(ctx, "Loading image into kind cluster")
+	loadCmd, err := NewCommand().
+		SetLogger(k.logger).
+		SetName(kindCmd).
+		SetArgs("load", "docker-image", "--name", k.name, image).
+		Build()
+	if err != nil {
+		return fmt.Errorf(
+			"failed to create command to load image '%s' into kind cluster '%s': %w",
+			image, k.name, err,
+		)
+	}
+	err = loadCmd.Execute(ctx)
+	if err != nil {
+		return fmt.Errorf(
+			"failed to load image '%s' into kind cluster '%s': %w",
+			image, k.name, err,
+		)
+	}
+	logger.DebugContext(ctx, "Loaded image into kind cluster")
+	return nil
+}
+
+// LoadArchive loads the specified image archive into the Kind cluster.
+func (k *Kind) LoadArchive(ctx context.Context, archive string) error {
+	if archive == "" {
+		return fmt.Errorf("archive is mandatory")
+	}
+	logger := k.logger.With(
+		slog.String("archive", archive),
+	)
+	logger.DebugContext(ctx, "Loading image archive into kind cluster")
+	loadCmd, err := NewCommand().
+		SetLogger(k.logger).
+		SetName(kindCmd).
+		SetArgs("load", "image-archive", "--name", k.name, archive).
+		Build()
+	if err != nil {
+		return fmt.Errorf(
+			"failed to create command to load image archive '%s' into kind cluster '%s': %w",
+			archive, k.name, err,
+		)
+	}
+	err = loadCmd.Execute(ctx)
+	if err != nil {
+		return fmt.Errorf(
+			"failed to load image archive '%s' into kind cluster '%s': %w",
+			archive, k.name, err,
+		)
+	}
+	logger.DebugContext(ctx, "Loaded image archive into kind cluster")
+	return nil
+}
+
+// Kubeconfig returns the kubeconfig bytes.
+func (k *Kind) Kubeconfig() []byte {
+	return slices.Clone(k.kubeconfigBytes)
+}
+
+// Client returns the controller runtime client for the cluster.
+func (k *Kind) Client() crclient.WithWatch {
+	return k.kubeClient
+}
+
+// ClientSet returns the Kubernetes set client for the cluster.
+func (k *Kind) ClientSet() *kubernetes.Clientset {
+	return k.kubeClientSet
+}
+
+func (k *Kind) getClusters(ctx context.Context) (result []string, err error) {
+	getCmd, err := NewCommand().
+		SetLogger(k.logger).
+		SetName(kindCmd).
+		SetArgs("get", "clusters").
+		Build()
+	if err != nil {
+		err = fmt.Errorf(
+			"failed to create command to get existing kind clusters: %w",
+			err,
+		)
+		return
+	}
+	getOut, _, err := getCmd.Evaluate(ctx)
+	if err != nil {
+		err = fmt.Errorf(
+			"failed to get existing kind clusters: %w",
+			err,
+		)
+		return
+	}
+	names := strings.Split(string(getOut), "\n")
+	for len(names) > 0 && names[len(names)-1] == "" {
+		names = names[:len(names)-1]
+	}
+	result = names
+	return
+}
+
+func (k *Kind) createCluster(ctx context.Context) error {
+	// Create a temporary directory to store the configuration file for the kind cluster:
+	tmpDir, err := os.MkdirTemp("", "*.kind")
+	if err != nil {
+		return fmt.Errorf(
+			"failed to create temporary directory for configuration of kind cluster '%s': %w",
+			k.name, err,
+		)
+	}
+	defer func() {
+		err := os.RemoveAll(tmpDir)
+		if err != nil {
+			k.logger.LogAttrs(
+				ctx,
+				slog.LevelError,
+				"Failed to remove temporary directory for configuration of kind cluster",
+				slog.String("tmp", tmpDir),
+				slog.Any("error", err),
+			)
+		}
+	}()
+	configData := map[string]any{
+		"apiVersion": "kind.x-k8s.io/v1alpha4",
+		"kind":       "Cluster",
+		"name":       k.name,
+		"nodes": []any{
+			map[string]any{
+				"role": "control-plane",
+				"extraPortMappings": []any{
+					map[string]any{
+						"containerPort": 30000,
+						"hostPort":      8000,
+						"listenAddress": "0.0.0.0",
+					},
+				},
+			},
+		},
+	}
+	configBytes, err := json.Marshal(configData)
+	if err != nil {
+		return fmt.Errorf("failed to marshal configuration for kind cluster '%s': %w", k.name, err)
+	}
+	configFile := filepath.Join(tmpDir, "config.yaml")
+	err = os.WriteFile(configFile, configBytes, 0644)
+	if err != nil {
+		return fmt.Errorf(
+			"failed to write configuration for kind cluster '%s' to file '%s': %w",
+			k.name, configFile, err,
+		)
+	}
+	k.logger.LogAttrs(
+		ctx,
+		slog.LevelDebug,
+		"Creating kind cluster",
+		slog.Any("config", configData),
+	)
+
+	// Create the cluster:
+	createCmd, err := NewCommand().
+		SetLogger(k.logger).
+		SetName(kindCmd).
+		SetArgs("create", "cluster", "--name", k.name, "--config", configFile).
+		Build()
+	if err != nil {
+		return fmt.Errorf("failed to create command to create kind cluster '%s': %w", k.name, err)
+	}
+	err = createCmd.Execute(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to create kind cluster '%s': %w", k.name, err)
+	}
+	k.logger.DebugContext(ctx, "Created kind cluster")
+	return nil
+}
+
+func (k *Kind) deleteCluster(ctx context.Context) error {
+	k.logger.DebugContext(ctx, "Deleting kind cluster")
+	deleteCmd, err := NewCommand().
+		SetLogger(k.logger).
+		SetName(kindCmd).
+		SetArgs("delete", "cluster", "--name", k.name).
+		Build()
+	if err != nil {
+		return fmt.Errorf("failed to create command to delete kind cluster '%s': %w", k.name, err)
+	}
+	err = deleteCmd.Execute(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to delete kind cluster '%s': %w", k.name, err)
+	}
+	k.logger.DebugContext(ctx, "Deleted kind cluster")
+	return err
+}
+
+func (k *Kind) createKubeconfig(ctx context.Context) error {
+	k.logger.DebugContext(ctx, "Creating kubeconfig")
+	getCmd, err := NewCommand().
+		SetLogger(k.logger).
+		SetName(kindCmd).
+		SetArgs("get", "kubeconfig", "--name", k.name).
+		Build()
+	if err != nil {
+		return fmt.Errorf("failed to create command to get kubeconfig for kind cluster '%s': %w", k.name, err)
+	}
+	k.kubeconfigBytes, _, err = getCmd.Evaluate(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to get kubeconfig for kind cluster '%s': %w", k.name, err)
+	}
+	err = func() error {
+		tmpFile, err := os.CreateTemp("", "*.kubeconfig")
+		if err != nil {
+			return fmt.Errorf("failed to create kubeconfig file for kind cluster '%s': %w", k.name, err)
+		}
+		defer func() {
+			err := tmpFile.Close()
+			if err != nil {
+				k.logger.LogAttrs(
+					ctx,
+					slog.LevelError,
+					"Failed to close kubeconfig file",
+					slog.String("file", tmpFile.Name()),
+					slog.Any("error", err),
+				)
+			}
+		}()
+		_, err = tmpFile.Write(k.kubeconfigBytes)
+		if err != nil {
+			return fmt.Errorf(
+				"failed to write kubeconfig file '%s' for kind cluster '%s': %w",
+				tmpFile.Name(), k.name, err,
+			)
+		}
+		k.kubeconfigFile = tmpFile.Name()
+		return nil
+	}()
+	if err != nil {
+		return err
+	}
+	k.logger.LogAttrs(
+		ctx,
+		slog.LevelDebug,
+		"Created kubeconfig",
+		slog.String("file", k.kubeconfigFile),
+		slog.Int("size", len(k.kubeconfigBytes)),
+	)
+	return nil
+}
+
+func (k *Kind) createKubeClient(ctx context.Context) error {
+	k.logger.DebugContext(ctx, "Creating Kubernetes client")
+	restConfig, err := clientcmd.RESTConfigFromKubeConfig(k.kubeconfigBytes)
+	if err != nil {
+		return fmt.Errorf("failed to create REST config for kind cluster '%s': %w", k.name, err)
+	}
+	k.kubeClient, err = crclient.NewWithWatch(restConfig, crclient.Options{})
+	if err != nil {
+		return fmt.Errorf("failed to create client for kind cluster '%s': %w", k.name, err)
+	}
+	k.logger.DebugContext(ctx, "Created Kubernetes client")
+	return nil
+}
+
+func (k *Kind) createKubeClientSet(ctx context.Context) error {
+	k.logger.DebugContext(ctx, "Creating Kubernetes client set")
+	restConfig, err := clientcmd.RESTConfigFromKubeConfig(k.kubeconfigBytes)
+	if err != nil {
+		return fmt.Errorf("failed to create REST config for kind cluster '%s': %w", k.name, err)
+	}
+	k.kubeClientSet, err = kubernetes.NewForConfig(restConfig)
+	if err != nil {
+		return fmt.Errorf("failed to create client set for kind cluster '%s': %w", k.name, err)
+	}
+	k.logger.DebugContext(ctx, "Created Kubernetes client")
+	return nil
+}
+
+func (k *Kind) installCertManager(ctx context.Context) (err error) {
+	// Apply the cert-manager manifest:
+	k.logger.DebugContext(ctx, "Applying cert-manager manifests")
+	applyCmd, err := NewCommand().
+		SetLogger(k.logger).
+		SetName(kubectlCmd).
+		SetArgs(
+			"apply",
+			"--kubeconfig", k.kubeconfigFile,
+			"--filename", cmManifests,
+		).
+		Build()
+	if err != nil {
+		return fmt.Errorf("failed to create command to apply cert-manager manifests: %w", err)
+	}
+	err = applyCmd.Execute(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to apply cert-manager manifests: %w", err)
+	}
+	k.logger.DebugContext(ctx, "Applied cert-manager manifests")
+
+	// Wait till it is possible to create cert-manager objects. Any other way to check this has proven to be
+	// unreliable. The fact that the apply worked doesn't mean that the CRDs are established already, and the fact
+	// that the CRDs are established doesn't mean that the webhooks are already running.
+	k.logger.DebugContext(ctx, "Waiting for cert-manager to be ready")
+	object := &unstructured.Unstructured{}
+	object.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   "cert-manager.io",
+		Version: "v1",
+		Kind:    "Issuer",
+	})
+	object.SetNamespace("default")
+	object.SetName("default")
+	object.Object["spec"] = map[string]any{
+		"selfSigned": map[string]any{},
+	}
+	start := time.Now()
+	for {
+		err = k.kubeClient.Create(ctx, object, crclient.DryRunAll)
+		if err == nil {
+			break
+		}
+		k.logger.LogAttrs(
+			ctx,
+			slog.LevelDebug,
+			"Cert-manager not ready yet",
+			slog.Any("error", err),
+		)
+		if time.Since(start) > time.Minute {
+			return fmt.Errorf("failed to create cert-manager object after 1 minute: %w", err)
+		}
+		time.Sleep(5 * time.Second)
+	}
+	k.logger.DebugContext(ctx, "Cert-manager is ready")
+
+	return nil
+}
+
+// Names of commands:
+const (
+	kindCmd    = "kind"
+	kubectlCmd = "kubectl"
+)
+
+// Location of cert-manager manifests:
+const cmManifests = "https://github.com/cert-manager/cert-manager/releases/download/v1.17.2/cert-manager.yaml"

--- a/it/it_cluster_templates_test.go
+++ b/it/it_cluster_templates_test.go
@@ -1,0 +1,177 @@
+/*
+Copyright (c) 2025 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package it
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/google/uuid"
+	. "github.com/onsi/ginkgo/v2/dsl/core"
+	. "github.com/onsi/gomega"
+
+	ffv1 "github.com/innabox/fulfillment-service/internal/api/fulfillment/v1"
+)
+
+var _ = Describe("Cluster templates", func() {
+	var (
+		ctx    context.Context
+		client ffv1.ClusterTemplatesClient
+	)
+
+	BeforeEach(func() {
+		ctx = context.Background()
+		client = ffv1.NewClusterTemplatesClient(adminConn)
+	})
+
+	It("Can get the list of templates", func() {
+		listResponse, err := client.List(ctx, ffv1.ClusterTemplatesListRequest_builder{}.Build())
+		Expect(err).ToNot(HaveOccurred())
+		Expect(listResponse).ToNot(BeNil())
+		items := listResponse.GetItems()
+		Expect(items).ToNot(BeEmpty())
+	})
+
+	It("Can get a specific template", func() {
+		// Create the template:
+		id := fmt.Sprintf("my_template_%s", uuid.NewString())
+		_, err := client.Create(ctx, ffv1.ClusterTemplatesCreateRequest_builder{
+			Object: ffv1.ClusterTemplate_builder{
+				Id:          id,
+				Title:       "My title",
+				Description: "My description.",
+			}.Build(),
+		}.Build())
+		Expect(err).ToNot(HaveOccurred())
+
+		// Get the template and verify that the returned object is correct:
+		response, err := client.Get(ctx, ffv1.ClusterTemplatesGetRequest_builder{
+			Id: id,
+		}.Build())
+		Expect(err).ToNot(HaveOccurred())
+		Expect(response).ToNot(BeNil())
+		object := response.GetObject()
+		Expect(object).ToNot(BeNil())
+		Expect(object.GetId()).To(Equal(id))
+		metadata := object.GetMetadata()
+		Expect(metadata).ToNot(BeNil())
+		Expect(metadata.HasCreationTimestamp()).To(BeTrue())
+		Expect(metadata.HasDeletionTimestamp()).To(BeFalse())
+		Expect(object.GetTitle()).To(Equal("My title"))
+		Expect(object.GetDescription()).To(Equal("My description."))
+	})
+
+	It("Can create a template", func() {
+		id := fmt.Sprintf("my_template_%s", uuid.NewString())
+		response, err := client.Create(ctx, ffv1.ClusterTemplatesCreateRequest_builder{
+			Object: ffv1.ClusterTemplate_builder{
+				Id:          id,
+				Title:       "My title",
+				Description: "My description.",
+			}.Build(),
+		}.Build())
+		Expect(err).ToNot(HaveOccurred())
+		Expect(response).ToNot(BeNil())
+		object := response.GetObject()
+		Expect(object).ToNot(BeNil())
+		Expect(object.GetId()).To(Equal(id))
+		metadata := object.GetMetadata()
+		Expect(metadata).ToNot(BeNil())
+		Expect(metadata.HasCreationTimestamp()).To(BeTrue())
+		Expect(metadata.HasDeletionTimestamp()).To(BeFalse())
+		Expect(object.GetTitle()).To(Equal("My title"))
+		Expect(object.GetDescription()).To(Equal("My description."))
+	})
+
+	It("Can update a template", func() {
+		// Create a template::
+		id := fmt.Sprintf("my_template_%s", uuid.NewString())
+		_, err := client.Create(ctx, ffv1.ClusterTemplatesCreateRequest_builder{
+			Object: ffv1.ClusterTemplate_builder{
+				Id:          id,
+				Title:       "My title",
+				Description: "My description.",
+			}.Build(),
+		}.Build())
+		Expect(err).ToNot(HaveOccurred())
+
+		// Update it and verify that the returned object is correct:
+		updateResponse, err := client.Update(ctx, ffv1.ClusterTemplatesUpdateRequest_builder{
+			Object: ffv1.ClusterTemplate_builder{
+				Id:          id,
+				Title:       "My updated title",
+				Description: "My updated description.",
+			}.Build(),
+		}.Build())
+		Expect(err).ToNot(HaveOccurred())
+		Expect(updateResponse).ToNot(BeNil())
+		object := updateResponse.GetObject()
+		Expect(object).ToNot(BeNil())
+		Expect(object.GetId()).To(Equal(id))
+		metadata := object.GetMetadata()
+		Expect(metadata).ToNot(BeNil())
+		Expect(metadata.HasCreationTimestamp()).To(BeTrue())
+		Expect(metadata.HasDeletionTimestamp()).To(BeFalse())
+		Expect(object.GetTitle()).To(Equal("My updated title"))
+		Expect(object.GetDescription()).To(Equal("My updated description."))
+
+		// Get the template and verify that the returned object is correct:
+		getResponse, err := client.Get(ctx, ffv1.ClusterTemplatesGetRequest_builder{
+			Id: id,
+		}.Build())
+		Expect(err).ToNot(HaveOccurred())
+		Expect(getResponse).ToNot(BeNil())
+		object = getResponse.GetObject()
+		Expect(object).ToNot(BeNil())
+		Expect(object.GetId()).To(Equal(id))
+		metadata = object.GetMetadata()
+		Expect(metadata).ToNot(BeNil())
+		Expect(metadata.HasCreationTimestamp()).To(BeTrue())
+		Expect(metadata.HasDeletionTimestamp()).To(BeFalse())
+		Expect(object.GetTitle()).To(Equal("My updated title"))
+		Expect(object.GetDescription()).To(Equal("My updated description."))
+	})
+
+	It("Can delete a template", func() {
+		// Create a template::
+		id := fmt.Sprintf("my_template_%s", uuid.NewString())
+		_, err := client.Create(ctx, ffv1.ClusterTemplatesCreateRequest_builder{
+			Object: ffv1.ClusterTemplate_builder{
+				Id:          id,
+				Title:       "My title",
+				Description: "My description.",
+			}.Build(),
+		}.Build())
+		Expect(err).ToNot(HaveOccurred())
+
+		// Delete it:
+		deleteResponse, err := client.Delete(ctx, ffv1.ClusterTemplatesDeleteRequest_builder{
+			Id: id,
+		}.Build())
+		Expect(err).ToNot(HaveOccurred())
+		Expect(deleteResponse).ToNot(BeNil())
+
+		// Verify that the template has the deletion timestamp set:
+		getResponse, err := client.Get(ctx, ffv1.ClusterTemplatesGetRequest_builder{
+			Id: id,
+		}.Build())
+		Expect(err).ToNot(HaveOccurred())
+		Expect(getResponse).ToNot(BeNil())
+		object := getResponse.GetObject()
+		Expect(object).ToNot(BeNil())
+		metadata := object.GetMetadata()
+		Expect(metadata).ToNot(BeNil())
+		Expect(metadata.HasDeletionTimestamp()).To(BeTrue())
+	})
+})

--- a/it/it_suite_test.go
+++ b/it/it_suite_test.go
@@ -1,0 +1,264 @@
+/*
+Copyright (c) 2025 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package it
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/go-logr/logr"
+	. "github.com/onsi/ginkgo/v2/dsl/core"
+	. "github.com/onsi/gomega"
+	"google.golang.org/grpc"
+	healthv1 "google.golang.org/grpc/health/grpc_health_v1"
+	authenticationv1 "k8s.io/api/authentication/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/klog/v2"
+	"k8s.io/utils/ptr"
+	crclient "sigs.k8s.io/controller-runtime/pkg/client"
+	crlog "sigs.k8s.io/controller-runtime/pkg/log"
+
+	"github.com/innabox/fulfillment-service/internal/logging"
+	"github.com/innabox/fulfillment-service/internal/network"
+	. "github.com/innabox/fulfillment-service/internal/testing"
+)
+
+var (
+	logger     *slog.Logger
+	kind       *Kind
+	clientConn *grpc.ClientConn
+	adminConn  *grpc.ClientConn
+)
+
+func TestIntegration(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Integration")
+}
+
+var _ = BeforeSuite(func() {
+	var err error
+
+	// Create a context:
+	ctx := context.Background()
+
+	// Create the logger:
+	logger, err = logging.NewLogger().
+		SetWriter(GinkgoWriter).
+		SetLevel(slog.LevelDebug.String()).
+		Build()
+	Expect(err).ToNot(HaveOccurred())
+
+	// Configure the Kubernetes libraries to use our logger:
+	logrLogger := logr.FromSlogHandler(logger.Handler())
+	crlog.SetLogger(logrLogger)
+	klog.SetLogger(logrLogger)
+
+	// Ensure that the kind cluster is ready:
+	kind, err = NewKind().
+		SetLogger(logger).
+		SetName("it").
+		Build()
+	Expect(err).ToNot(HaveOccurred())
+	err = kind.Start(ctx)
+	Expect(err).ToNot(HaveOccurred())
+	DeferCleanup(func() {
+		err := kind.Stop(ctx)
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	// Create a temporary directory:
+	tmpDir, err := os.MkdirTemp("", "*.it")
+	Expect(err).ToNot(HaveOccurred())
+	DeferCleanup(func() {
+		err := os.RemoveAll(tmpDir)
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	// Get the project directory:
+	currentDir, err := os.Getwd()
+	Expect(err).ToNot(HaveOccurred())
+	for {
+		modFile := filepath.Join(currentDir, "go.mod")
+		_, err := os.Stat(modFile)
+		if err == nil {
+			break
+		}
+		if !errors.Is(err, os.ErrNotExist) {
+			Expect(err).ToNot(HaveOccurred())
+		}
+		parentDir := filepath.Dir(currentDir)
+		Expect(parentDir).ToNot(Equal(currentDir))
+		currentDir = parentDir
+	}
+	projectDir := currentDir
+
+	// Check that the required tools are available:
+	_, err = exec.LookPath(kubectlPath)
+	Expect(err).ToNot(HaveOccurred())
+	_, err = exec.LookPath(kindPath)
+	Expect(err).ToNot(HaveOccurred())
+
+	// Get the kubeconfig:
+	kcFile := filepath.Join(tmpDir, "kubeconfig")
+	err = os.WriteFile(kcFile, kind.Kubeconfig(), 0400)
+	Expect(err).ToNot(HaveOccurred())
+
+	// Get the client:
+	kubeClient := kind.Client()
+	kubeClientSet := kind.ClientSet()
+
+	// In the GitHub actions environment, the image is already built and available in the 'imag.tar' file in the
+	// project directory. If it is not there, we build it and save it to the temporary directory.
+	imageTar := filepath.Join(projectDir, "image.tar")
+	_, err = os.Stat(imageTar)
+	if err != nil {
+		imageTar = filepath.Join(tmpDir, "image.tar")
+		DeferCleanup(func() {
+			err := os.Remove(imageTar)
+			Expect(err).ToNot(HaveOccurred())
+		})
+		buildCmd, err := NewCommand().
+			SetLogger(logger).
+			SetDir(projectDir).
+			SetName("podman").
+			SetArgs(
+				"build",
+				"--tag", fmt.Sprintf("%s:%s", imageName, imageTag),
+				"--file", "Containerfile",
+			).
+			Build()
+		Expect(err).ToNot(HaveOccurred())
+		err = buildCmd.Execute(ctx)
+		Expect(err).ToNot(HaveOccurred())
+		saveCmd, err := NewCommand().
+			SetLogger(logger).
+			SetDir(projectDir).
+			SetName("podman").
+			SetArgs(
+				"save",
+				"--output", imageTar,
+				imageRef,
+			).
+			Build()
+		Expect(err).ToNot(HaveOccurred())
+		err = saveCmd.Execute(ctx)
+		Expect(err).ToNot(HaveOccurred())
+	}
+
+	// Load the image:
+	err = kind.LoadArchive(ctx, imageTar)
+	Expect(err).ToNot(HaveOccurred())
+
+	// Deploy the application:
+	applyCmd, err := NewCommand().
+		SetLogger(logger).
+		SetDir(projectDir).
+		SetName(kubectlPath).
+		SetArgs(
+			"apply",
+			"--kubeconfig", kcFile,
+			"--kustomize", filepath.Join("manifests", "overlays", "kind"),
+		).
+		Build()
+	Expect(err).ToNot(HaveOccurred())
+	err = applyCmd.Execute(ctx)
+	Expect(err).ToNot(HaveOccurred())
+
+	// Wait till the CA certificate has been issued, and fetch it. We need it to configure gRPC and HTTP clients
+	// so that they trust it.
+	caKey := crclient.ObjectKey{
+		Namespace: "innabox",
+		Name:      "ca-key",
+	}
+	caSecret := &corev1.Secret{}
+	Eventually(
+		func(g Gomega) {
+			err := kubeClient.Get(ctx, caKey, caSecret)
+			g.Expect(err).ToNot(HaveOccurred())
+		},
+		time.Minute,
+		time.Second,
+	).Should(Succeed())
+	caBytes := caSecret.Data["ca.crt"]
+	Expect(caBytes).ToNot(BeEmpty())
+	caFile := filepath.Join(tmpDir, "ca.crt")
+	err = os.WriteFile(caFile, caBytes, 0400)
+	Expect(err).ToNot(HaveOccurred())
+
+	// Create a client token:
+	makeToken := func(sa string) string {
+		response, err := kubeClientSet.CoreV1().ServiceAccounts("innabox").CreateToken(
+			ctx,
+			sa,
+			&authenticationv1.TokenRequest{
+				Spec: authenticationv1.TokenRequestSpec{
+					ExpirationSeconds: ptr.To(int64(3600)),
+				},
+			},
+			metav1.CreateOptions{},
+		)
+		Expect(err).ToNot(HaveOccurred())
+		return response.Status.Token
+	}
+	clientToken := makeToken("client")
+	adminToken := makeToken("admin")
+
+	// Create the gRPC clients:
+	makeConn := func(token string) *grpc.ClientConn {
+		conn, err := network.NewClient().
+			SetLogger(logger).
+			SetServerNetwork("tcp").
+			SetServerAddress("localhost:8000").
+			AddCaFile(caFile).
+			SetToken(token).
+			Build()
+		Expect(err).ToNot(HaveOccurred())
+		return conn
+	}
+	clientConn = makeConn(clientToken)
+	adminConn = makeConn(adminToken)
+
+	// Wait till the application is healthy:
+	healthClient := healthv1.NewHealthClient(adminConn)
+	healthRequest := &healthv1.HealthCheckRequest{}
+	Eventually(
+		func(g Gomega) {
+			healthResponse, err := healthClient.Check(ctx, healthRequest)
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(healthResponse.Status).To(Equal(healthv1.HealthCheckResponse_SERVING))
+		},
+		time.Minute,
+		5*time.Second,
+	).Should(Succeed())
+})
+
+// Names of the command line tools:
+const (
+	kubectlPath = "kubectl"
+	kindPath    = "podman"
+)
+
+// Image details:
+const imageName = "ghcr.io/innabox/fulfillment-service"
+const imageTag = "latest"
+
+var imageRef = fmt.Sprintf("%s:%s", imageName, imageTag)

--- a/manifests/README.md
+++ b/manifests/README.md
@@ -50,6 +50,7 @@ To create the Kind cluster create a `kind.yaml` file with the following content:
 ```yaml
 apiVersion: kind.x-k8s.io/v1alpha4
 kind: Cluster
+name: innabox
 nodes:
 - role: control-plane
   extraPortMappings:

--- a/manifests/base/service/certificate.yaml
+++ b/manifests/base/service/certificate.yaml
@@ -19,5 +19,6 @@ spec:
   issuerRef:
     name: issuer
   dnsNames:
+  - localhost
   - fulfillment-api
   secretName: fulfillment-service-tls

--- a/manifests/base/service/files/rules.yaml
+++ b/manifests/base/service/files/rules.yaml
@@ -11,9 +11,9 @@
 # specific language governing permissions and limitations under the License.
 #
 
-- name: Allow reflection to everyone
+- name: Allow reflection and health to everyone
   action: allow
-  condition: method.startsWith('/grpc.reflection.')
+  condition: method.startsWith('/grpc.reflection.') || method.startsWith('/grpc.health.')
 
 - name: Allow specific methods to client
   action: allow


### PR DESCRIPTION
This patch adds a collection of integration tests inside the `it` directory. These tests deploy the application to a _Kind_ cluster, and then check the behaviour using the API.