### PR TITLE
Add test to verify names of SQL migration files

### DIFF
--- a/internal/database/database_migrations_test.go
+++ b/internal/database/database_migrations_test.go
@@ -1,0 +1,32 @@
+/*
+Copyright (c) 2025 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package database
+
+import (
+	"path/filepath"
+
+	. "github.com/onsi/ginkgo/v2/dsl/core"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Migrations", func() {
+	It("All migrations have the '.up.sql' suffix", func() {
+		files, err := filepath.Glob("migrations/*.sql")
+		Expect(err).ToNot(HaveOccurred())
+		Expect(files).ToNot(BeEmpty())
+		for _, file := range files {
+			Expect(file).To(MatchRegexp(`\.up\.sql$`))
+		}
+	})
+})


### PR DESCRIPTION
Names of migration files must end with `.up.sql`, but it is very easy to forget that and name them just `.sql`. This results in silently ignoring the migration. To avoid that this patch introduces a new test that verifies that all migration files end with `.up.sql`.