### PR TITLE
Add module name for the private API

### DIFF
--- a/buf.yaml
+++ b/buf.yaml
@@ -26,6 +26,7 @@ breaking:
 
 modules:
 - path: proto
+  name: buf.build/innabox/private-api
 
 deps:
 - buf.build/googleapis/googleapis


### PR DESCRIPTION
In order to push the private API to the buf schema registry it is necessary to give a name to the module.