### PR TITLE
Hide generated files in GitHub pull requests

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+/internal/api/** linguist-generated=true


### PR DESCRIPTION
This patch adds a `.gitattributes` file to hide the generated files in GitHub pull requests.