### PR TITLE
Remove cluster order concept from access rules

### DIFF
--- a/manifests/base/service/files/rules.yaml
+++ b/manifests/base/service/files/rules.yaml
@@ -21,11 +21,6 @@
     subject.name == 'system:serviceaccount:innabox:client' &&
     method in [
       '/events.v1/Watch',
-      '/fulfillment.v1.ClusterOrders/Create',
-      '/fulfillment.v1.ClusterOrders/Delete',
-      '/fulfillment.v1.ClusterOrders/Get',
-      '/fulfillment.v1.ClusterOrders/List',
-      '/fulfillment.v1.ClusterOrders/Update',
       '/fulfillment.v1.ClusterTemplates/Get',
       '/fulfillment.v1.ClusterTemplates/List',
       '/fulfillment.v1.Clusters/Delete',


### PR DESCRIPTION
The previous merge of `ClusterOrder` and `Cluster` concepts made the access rules for the `ClusterOrders` service obsolete. This patch removes them to maintain an up-to-date configuration, even though their existence was inconsequential.