### PR TITLE
Allow clients to create cluster

### DIFF
--- a/manifests/base/service/files/rules.yaml
+++ b/manifests/base/service/files/rules.yaml
@@ -23,6 +23,7 @@
       '/events.v1/Watch',
       '/fulfillment.v1.ClusterTemplates/Get',
       '/fulfillment.v1.ClusterTemplates/List',
+      '/fulfillment.v1.Clusters/Create',
       '/fulfillment.v1.Clusters/Delete',
       '/fulfillment.v1.Clusters/Get',
       '/fulfillment.v1.Clusters/GetKubeconfig',


### PR DESCRIPTION
In the previous changes to merge the `ClusterOrder` and `Cluster` concepts we forgot to add an authorization rule that gives regular users permission to create clusters. This patch fixes that.