### PR TITLE
Add IT_KEEP_KIND to preserve kind cluster used for integration tests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	k8s.io/apimachinery v0.31.0
 	k8s.io/client-go v0.31.0
 	k8s.io/klog/v2 v2.130.1
+	k8s.io/utils v0.0.0-20240711033017-18e509b52bc8
 	sigs.k8s.io/controller-runtime v0.19.7
 )
 
@@ -68,7 +69,6 @@ require (
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	k8s.io/kube-openapi v0.0.0-20240228011516-70dd3763d340 // indirect
-	k8s.io/utils v0.0.0-20240711033017-18e509b52bc8 // indirect
 	sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.4.1 // indirect
 	sigs.k8s.io/yaml v1.4.0 // indirect
@@ -83,6 +83,7 @@ require (
 	github.com/gorilla/handlers v1.5.2
 	github.com/itchyny/gojq v0.12.17
 	github.com/jackc/pgx/v5 v5.7.2
+	github.com/kelseyhightower/envconfig v1.4.0
 	github.com/onsi/ginkgo/v2 v2.22.2
 	github.com/onsi/gomega v1.36.2
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -104,6 +104,8 @@ github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8Hm
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
+github.com/kelseyhightower/envconfig v1.4.0 h1:Im6hONhd3pLkfDFsbRgu68RDNkGF1r3dvMUtDTo2cv8=
+github.com/kelseyhightower/envconfig v1.4.0/go.mod h1:cccZRl6mQpaq41TPp5QxidR+Sa3axMbJDNb//FQX6Gg=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=

--- a/it/it_suite_test.go
+++ b/it/it_suite_test.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
+	"github.com/kelseyhightower/envconfig"
 	. "github.com/onsi/ginkgo/v2/dsl/core"
 	. "github.com/onsi/gomega"
 	"google.golang.org/grpc"
@@ -42,8 +43,19 @@ import (
 	. "github.com/innabox/fulfillment-service/internal/testing"
 )
 
+// Config contains the settings for the integration tests. These will be loaded from the enviroment using the 'IT_'
+// prefix. For example, the 'KeepKind' setting will be loaded from the 'IT_KEEP_KIND' environment variable.
+type Config struct {
+	// KeepKind indicates if the kind cluster that is created to run the tests should be kept after running the
+	// tests. This is intended for the development environment, where it may be convenient to keep the kind cluster
+	// running in order to check the state after a test failure. By default the kind cluster is stopped after
+	// running the tests.
+	KeepKind bool `json:"keep_kind" envconfig:"keep_kind" default:"false"`
+}
+
 var (
 	logger     *slog.Logger
+	config     *Config
 	kind       *Kind
 	clientConn *grpc.ClientConn
 	adminConn  *grpc.ClientConn
@@ -67,6 +79,16 @@ var _ = BeforeSuite(func() {
 		Build()
 	Expect(err).ToNot(HaveOccurred())
 
+	// Load the configuration:
+	config = &Config{}
+	err = envconfig.Process("it", config)
+	Expect(err).ToNot(HaveOccurred())
+	logger.InfoContext(
+		ctx,
+		"Config",
+		slog.Any("values", config),
+	)
+
 	// Configure the Kubernetes libraries to use our logger:
 	logrLogger := logr.FromSlogHandler(logger.Handler())
 	crlog.SetLogger(logrLogger)
@@ -80,10 +102,12 @@ var _ = BeforeSuite(func() {
 	Expect(err).ToNot(HaveOccurred())
 	err = kind.Start(ctx)
 	Expect(err).ToNot(HaveOccurred())
-	DeferCleanup(func() {
-		err := kind.Stop(ctx)
-		Expect(err).ToNot(HaveOccurred())
-	})
+	if !config.KeepKind {
+		DeferCleanup(func() {
+			err := kind.Stop(ctx)
+			Expect(err).ToNot(HaveOccurred())
+		})
+	}
 
 	// Create a temporary directory:
 	tmpDir, err := os.MkdirTemp("", "*.it")


### PR DESCRIPTION
This patch adds a new `IT_KEEP_KIND` environment variable that can be used to preserve the kind cluster that is created for integration tests. This is convenient in the development environment, as it allows the developer to inspect the cluster, in particular the logs of the services and the contents of the database.