### PR TITLE
Add kind cluster as hub for integration tests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	k8s.io/apimachinery v0.31.0
 	k8s.io/client-go v0.31.0
 	k8s.io/klog/v2 v2.130.1
+	k8s.io/utils v0.0.0-20240711033017-18e509b52bc8
 	sigs.k8s.io/controller-runtime v0.19.7
 )
 
@@ -68,7 +69,6 @@ require (
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	k8s.io/kube-openapi v0.0.0-20240228011516-70dd3763d340 // indirect
-	k8s.io/utils v0.0.0-20240711033017-18e509b52bc8 // indirect
 	sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.4.1 // indirect
 	sigs.k8s.io/yaml v1.4.0 // indirect

--- a/it/it_suite_test.go
+++ b/it/it_suite_test.go
@@ -32,11 +32,13 @@ import (
 	authenticationv1 "k8s.io/api/authentication/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/klog/v2"
 	"k8s.io/utils/ptr"
 	crclient "sigs.k8s.io/controller-runtime/pkg/client"
 	crlog "sigs.k8s.io/controller-runtime/pkg/log"
 
+	privatev1 "github.com/innabox/fulfillment-service/internal/api/private/v1"
 	"github.com/innabox/fulfillment-service/internal/logging"
 	"github.com/innabox/fulfillment-service/internal/network"
 	. "github.com/innabox/fulfillment-service/internal/testing"
@@ -249,6 +251,35 @@ var _ = BeforeSuite(func() {
 		time.Minute,
 		5*time.Second,
 	).Should(Succeed())
+
+	// Create the namespace for the hub:
+	hubNamespaceObject := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: hubNamespace,
+		},
+	}
+	err = kubeClient.Create(ctx, hubNamespaceObject)
+	Expect(err).ToNot(HaveOccurred())
+
+	// Register the kind cluster as a hub. Note that in order to do this we need to replace the 127.0.0.1 IP
+	// with the internal DNS name of the API server, as otherwise the controller will not be able to connect.
+	hubKubeconfigBytes := kind.Kubeconfig()
+	hubKubeconfigObject, err := clientcmd.Load(hubKubeconfigBytes)
+	Expect(err).ToNot(HaveOccurred())
+	for clusterKey := range hubKubeconfigObject.Clusters {
+		hubKubeconfigObject.Clusters[clusterKey].Server = "https://kubernetes.default.svc"
+	}
+	hubKubeconfigBytes, err = clientcmd.Write(*hubKubeconfigObject)
+	Expect(err).ToNot(HaveOccurred())
+	hubsClient := privatev1.NewHubsClient(adminConn)
+	_, err = hubsClient.Create(ctx, privatev1.HubsCreateRequest_builder{
+		Object: privatev1.Hub_builder{
+			Id:         hubId,
+			Kubeconfig: hubKubeconfigBytes,
+			Namespace:  hubNamespace,
+		}.Build(),
+	}.Build())
+	Expect(err).ToNot(HaveOccurred())
 })
 
 // Names of the command line tools:
@@ -256,6 +287,10 @@ const (
 	kubectlPath = "kubectl"
 	kindPath    = "podman"
 )
+
+// Name and namespace of the hub:
+const hubId = "local"
+const hubNamespace = "cloudkit-operator-system"
 
 // Image details:
 const imageName = "ghcr.io/innabox/fulfillment-service"


### PR DESCRIPTION
Currently the environment for integration tests doesn't have any hub, so it isn't possible to test anything related to it, like the creation of the Kubernetes `ClusterOrder` object. This patch changes the test suite so that the kind cluster used to run the service is also used as a hub.