### PR TITLE
Add support for installing CRDs in the integration tests cluster

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,6 @@
 *.patch
 *.rej
 *.test
+/dev.yaml
 /fulfillment-service
 __debug_bin*

--- a/it/crds/clusterorders.cloudkit.openshift.io.yaml
+++ b/it/crds/clusterorders.cloudkit.openshift.io.yaml
@@ -1,0 +1,37 @@
+#
+# Copyright (c) 2025 Red Hat Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+# the License. You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+# Note that this is a fake CRD, it can contain any thing, it is not validated. We use it just for tests.
+
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: clusterorders.cloudkit.openshift.io
+spec:
+  group: cloudkit.openshift.io
+  names:
+    kind: ClusterOrder
+    listKind: ClusterOrderList
+    plural: clusterorders
+    shortNames:
+    - cord
+    singular: clusterorder
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        type: object
+        x-kubernetes-preserve-unknown-fields: true

--- a/it/crds/hostedclusters.hypershift.openshift.io.yaml
+++ b/it/crds/hostedclusters.hypershift.openshift.io.yaml
@@ -1,0 +1,37 @@
+#
+# Copyright (c) 2025 Red Hat Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+# the License. You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+# Note that this is a fake CRD, it can contain any thing, it is not validated. We use it just for tests.
+
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: hostedclusters.hypershift.openshift.io
+spec:
+  group: hypershift.openshift.io
+  names:
+    kind: HostedCluster
+    listKind: HostedClusterList
+    plural: hostedclusters
+    shortNames:
+    - hc
+    singular: hostedcluster
+  scope: Namespaced
+  versions:
+  - name: v1beta1
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        type: object
+        x-kubernetes-preserve-unknown-fields: true

--- a/it/it_suite_test.go
+++ b/it/it_suite_test.go
@@ -140,6 +140,8 @@ var _ = BeforeSuite(func() {
 		kind, err = NewKind().
 			SetLogger(logger).
 			SetName("it").
+			AddCrdFile(filepath.Join("crds", "clusterorders.cloudkit.openshift.io.yaml")).
+			AddCrdFile(filepath.Join("crds", "hostedclusters.hypershift.openshift.io.yaml")).
 			Build()
 		Expect(err).ToNot(HaveOccurred())
 		err = kind.Start(ctx)


### PR DESCRIPTION
This patch adds a new `AddCrdFile` method to the builder of the kind cluster that can be used to add CRD files that will be installed in the cluster. This is used to install the `ClusterOrder` and `HostedCluster` CRDs that will be used (in other patches) to write tests that verify that `ClusterOrder` objects are created correctly.