### PR TITLE
Grant users permission to get cluster password

### DIFF
--- a/manifests/base/service/files/rules.yaml
+++ b/manifests/base/service/files/rules.yaml
@@ -27,6 +27,8 @@
       '/fulfillment.v1.Clusters/Get',
       '/fulfillment.v1.Clusters/GetKubeconfig',
       '/fulfillment.v1.Clusters/GetKubeconfigViaHttp',
+      '/fulfillment.v1.Clusters/GetPassword',
+      '/fulfillment.v1.Clusters/GetPasswordViaHttp',
       '/fulfillment.v1.Clusters/List',
       '/fulfillment.v1.Clusters/Update',
       '/fulfillment.v1.HostClasses/Get',


### PR DESCRIPTION
This changes the authorization rules to grant regular users permission to get the administrator password of clusters.