### PR TITLE
Move cluster validation logic to private server and implement delegation

### DIFF
--- a/internal/cmd/start_server_cmd.go
+++ b/internal/cmd/start_server_cmd.go
@@ -299,28 +299,6 @@ func (c *startServerCommandRunner) run(cmd *cobra.Command, argv []string) error 
 	}
 	ffv1.RegisterClusterTemplatesServer(grpcServer, clusterTemplatesServer)
 
-	// Create the clusters server:
-	c.logger.InfoContext(ctx, "Creating clusters server")
-	clustersServer, err := servers.NewClustersServer().
-		SetLogger(c.logger).
-		SetNotifier(notifier).
-		Build()
-	if err != nil {
-		return errors.Wrapf(err, "failed to create clusters server")
-	}
-	ffv1.RegisterClustersServer(grpcServer, clustersServer)
-
-	// Create the host classes server:
-	c.logger.InfoContext(ctx, "Creating host classes server")
-	hostClassesServer, err := servers.NewHostClassesServer().
-		SetLogger(c.logger).
-		SetNotifier(notifier).
-		Build()
-	if err != nil {
-		return errors.Wrapf(err, "failed to create host classes server")
-	}
-	ffv1.RegisterHostClassesServer(grpcServer, hostClassesServer)
-
 	// Create the private cluster templates server:
 	c.logger.InfoContext(ctx, "Creating private cluster templates server")
 	privateClusterTemplatesServer, err := servers.NewPrivateClusterTemplatesServer().
@@ -342,6 +320,28 @@ func (c *startServerCommandRunner) run(cmd *cobra.Command, argv []string) error 
 		return errors.Wrapf(err, "failed to create private clusters server")
 	}
 	privatev1.RegisterClustersServer(grpcServer, privateClustersServer)
+
+	// Create the clusters server:
+	c.logger.InfoContext(ctx, "Creating clusters server")
+	clustersServer, err := servers.NewClustersServer().
+		SetLogger(c.logger).
+		SetPrivate(privateClustersServer).
+		Build()
+	if err != nil {
+		return errors.Wrapf(err, "failed to create clusters server")
+	}
+	ffv1.RegisterClustersServer(grpcServer, clustersServer)
+
+	// Create the host classes server:
+	c.logger.InfoContext(ctx, "Creating host classes server")
+	hostClassesServer, err := servers.NewHostClassesServer().
+		SetLogger(c.logger).
+		SetNotifier(notifier).
+		Build()
+	if err != nil {
+		return errors.Wrapf(err, "failed to create host classes server")
+	}
+	ffv1.RegisterHostClassesServer(grpcServer, hostClassesServer)
 
 	// Create the private host classes server:
 	c.logger.InfoContext(ctx, "Creating private host classes server")

--- a/internal/servers/clusters_server_test.go
+++ b/internal/servers/clusters_server_test.go
@@ -109,17 +109,35 @@ var _ = Describe("Clusters server", func() {
 
 	Describe("Creation", func() {
 		It("Can be built if all the required parameters are set", func() {
+			privateServer, err := NewPrivateClustersServer().
+				SetLogger(logger).
+				Build()
+			Expect(err).ToNot(HaveOccurred())
 			server, err := NewClustersServer().
 				SetLogger(logger).
+				SetPrivate(privateServer).
 				Build()
 			Expect(err).ToNot(HaveOccurred())
 			Expect(server).ToNot(BeNil())
 		})
 
 		It("Fails if logger is not set", func() {
+			privateServer, err := NewPrivateClustersServer().
+				SetLogger(logger).
+				Build()
+			Expect(err).ToNot(HaveOccurred())
 			server, err := NewClustersServer().
+				SetPrivate(privateServer).
 				Build()
 			Expect(err).To(MatchError("logger is mandatory"))
+			Expect(server).To(BeNil())
+		})
+
+		It("Fails if private server is not set", func() {
+			server, err := NewClustersServer().
+				SetLogger(logger).
+				Build()
+			Expect(err).To(MatchError("private server is mandatory"))
 			Expect(server).To(BeNil())
 		})
 	})
@@ -136,9 +154,16 @@ var _ = Describe("Clusters server", func() {
 		BeforeEach(func() {
 			var err error
 
+			// Create the private server:
+			privateServer, err := NewPrivateClustersServer().
+				SetLogger(logger).
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+
 			// Create the server:
 			server, err = NewClustersServer().
 				SetLogger(logger).
+				SetPrivate(privateServer).
 				Build()
 			Expect(err).ToNot(HaveOccurred())
 

--- a/internal/servers/private_clusters_server.go
+++ b/internal/servers/private_clusters_server.go
@@ -16,14 +16,20 @@ package servers
 import (
 	"context"
 	"errors"
+	"fmt"
 	"log/slog"
+	"sort"
 
 	"github.com/bits-and-blooms/bitset"
+	"github.com/dustin/go-humanize/english"
+	"golang.org/x/exp/maps"
 	grpccodes "google.golang.org/grpc/codes"
 	grpcstatus "google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/anypb"
 
 	privatev1 "github.com/innabox/fulfillment-service/internal/api/private/v1"
 	"github.com/innabox/fulfillment-service/internal/database"
+	"github.com/innabox/fulfillment-service/internal/database/dao"
 )
 
 type PrivateClustersServerBuilder struct {
@@ -35,8 +41,9 @@ var _ privatev1.ClustersServer = (*PrivateClustersServer)(nil)
 
 type PrivateClustersServer struct {
 	privatev1.UnimplementedClustersServer
-	logger  *slog.Logger
-	generic *GenericServer[*privatev1.Cluster, *privatev1.Cluster]
+	logger       *slog.Logger
+	templatesDao *dao.GenericDAO[*privatev1.ClusterTemplate]
+	generic      *GenericServer[*privatev1.Cluster, *privatev1.Cluster]
 }
 
 func NewPrivateClustersServer() *PrivateClustersServerBuilder {
@@ -60,6 +67,15 @@ func (b *PrivateClustersServerBuilder) Build() (result *PrivateClustersServer, e
 		return
 	}
 
+	// Create the templates DAO:
+	templatesDao, err := dao.NewGenericDAO[*privatev1.ClusterTemplate]().
+		SetLogger(b.logger).
+		SetTable("cluster_templates").
+		Build()
+	if err != nil {
+		return
+	}
+
 	// Create the generic server:
 	generic, err := NewGenericServer[*privatev1.Cluster, *privatev1.Cluster]().
 		SetLogger(b.logger).
@@ -73,8 +89,9 @@ func (b *PrivateClustersServerBuilder) Build() (result *PrivateClustersServer, e
 
 	// Create and populate the object:
 	result = &PrivateClustersServer{
-		logger:  b.logger,
-		generic: generic,
+		logger:       b.logger,
+		templatesDao: templatesDao,
+		generic:      generic,
 	}
 	return
 }
@@ -93,10 +110,18 @@ func (s *PrivateClustersServer) Get(ctx context.Context,
 
 func (s *PrivateClustersServer) Create(ctx context.Context,
 	request *privatev1.ClustersCreateRequest) (response *privatev1.ClustersCreateResponse, err error) {
+	// Validate duplicate conditions first:
 	err = s.validateNoDuplicateConditions(request.GetObject())
 	if err != nil {
 		return
 	}
+
+	// Validate template and perform transformations:
+	err = s.validateAndTransformCluster(ctx, request.GetObject())
+	if err != nil {
+		return
+	}
+
 	err = s.generic.Create(ctx, request, &response)
 	return
 }
@@ -134,5 +159,205 @@ func (s *PrivateClustersServer) validateNoDuplicateConditions(object *privatev1.
 		}
 		conditionTypes.Set(uint(conditionType))
 	}
+	return nil
+}
+
+func (s *PrivateClustersServer) validateAndTransformCluster(ctx context.Context, cluster *privatev1.Cluster) error {
+	// Check that the template is specified and that refers to a existing template:
+	if cluster == nil {
+		return grpcstatus.Errorf(grpccodes.InvalidArgument, "object is mandatory")
+	}
+	templateId := cluster.GetSpec().GetTemplate()
+	if templateId == "" {
+		return grpcstatus.Errorf(grpccodes.InvalidArgument, "template is mandatory")
+	}
+	template, err := s.templatesDao.Get(ctx, templateId)
+	if err != nil {
+		s.logger.ErrorContext(
+			ctx,
+			"Failed to get template",
+			slog.String("template", templateId),
+			slog.Any("error", err),
+		)
+		return grpcstatus.Errorf(grpccodes.Internal, "failed to get template '%s'", templateId)
+	}
+	if template == nil {
+		return grpcstatus.Errorf(grpccodes.InvalidArgument, "template '%s' doesn't exist", templateId)
+	}
+	if template.GetMetadata().HasDeletionTimestamp() {
+		return grpcstatus.Errorf(grpccodes.InvalidArgument, "template '%s' has been deleted", templateId)
+	}
+
+	// Check that all the node sets given in the cluster correspond to node sets that exist in the template:
+	templateNodeSets := template.GetNodeSets()
+	clusterNodeSets := cluster.GetSpec().GetNodeSets()
+	for clusterNodeSetKey := range clusterNodeSets {
+		templateNodeSet := templateNodeSets[clusterNodeSetKey]
+		if templateNodeSet == nil {
+			templateNodeSetKeys := maps.Keys(templateNodeSets)
+			sort.Strings(templateNodeSetKeys)
+			for i, templateNodeSetKey := range templateNodeSetKeys {
+				templateNodeSetKeys[i] = fmt.Sprintf("'%s'", templateNodeSetKey)
+			}
+			return grpcstatus.Errorf(
+				grpccodes.InvalidArgument,
+				"node set '%s' doesn't exist, valid values for template '%s' are %s",
+				clusterNodeSetKey, templateId, english.WordSeries(templateNodeSetKeys, "and"),
+			)
+		}
+	}
+
+	// Check that all the node sets given in the cluster specify the same host class that is specified in the
+	// template:
+	for clusterNodeSetKey, clusterNodeSet := range clusterNodeSets {
+		templateNodeSet := templateNodeSets[clusterNodeSetKey]
+		clusterHostClass := clusterNodeSet.GetHostClass()
+		if clusterHostClass == "" {
+			continue
+		}
+		templateHostClass := templateNodeSet.GetHostClass()
+		if clusterHostClass != templateHostClass {
+			return grpcstatus.Errorf(
+				grpccodes.InvalidArgument,
+				"host class for node set '%s' should be empty or '%s', like in template '%s', "+
+					"but it is '%s'",
+				clusterNodeSetKey, templateHostClass, templateId, clusterHostClass,
+			)
+		}
+	}
+
+	// Check that all the node sets given in the cluster have a positive size:
+	for clusterNodeSetKey, clusterNodeSet := range clusterNodeSets {
+		clusterNodeSetSize := clusterNodeSet.GetSize()
+		if clusterNodeSetSize <= 0 {
+			return grpcstatus.Errorf(
+				grpccodes.InvalidArgument,
+				"size for node set '%s' should be greater than zero, but it is %d",
+				clusterNodeSetKey, clusterNodeSetSize,
+			)
+		}
+	}
+
+	// Replace the node sets given in the cluster with those from the template, taking only the size from cluster:
+	actualNodeSets := map[string]*privatev1.ClusterNodeSet{}
+	for templateNodeSetKey, templateNodeSet := range templateNodeSets {
+		var actualNodeSetSize int32
+		clusterNodeSet := clusterNodeSets[templateNodeSetKey]
+		if clusterNodeSet != nil {
+			actualNodeSetSize = clusterNodeSet.GetSize()
+		} else {
+			actualNodeSetSize = templateNodeSet.GetSize()
+		}
+		actualNodeSets[templateNodeSetKey] = privatev1.ClusterNodeSet_builder{
+			HostClass: templateNodeSet.GetHostClass(),
+			Size:      actualNodeSetSize,
+		}.Build()
+	}
+	cluster.GetSpec().SetNodeSets(actualNodeSets)
+
+	// Check that all the specified template parameters are in the template:
+	templateParameters := template.GetParameters()
+	clusterParameters := cluster.GetSpec().GetTemplateParameters()
+	var invalidParameterNames []string
+	for clusterParameterName := range clusterParameters {
+		clusterParameterValid := false
+		for _, templateParameter := range templateParameters {
+			if templateParameter.GetName() == clusterParameterName {
+				clusterParameterValid = true
+				break
+			}
+		}
+		if !clusterParameterValid {
+			invalidParameterNames = append(invalidParameterNames, clusterParameterName)
+		}
+	}
+	if len(invalidParameterNames) > 0 {
+		templateParameterNames := make([]string, len(templateParameters))
+		for i, templateParameter := range templateParameters {
+			templateParameterNames[i] = templateParameter.GetName()
+		}
+		sort.Strings(templateParameterNames)
+		for i, templateParameterName := range templateParameterNames {
+			templateParameterNames[i] = fmt.Sprintf("'%s'", templateParameterName)
+		}
+		sort.Strings(invalidParameterNames)
+		for i, invalidParameterName := range invalidParameterNames {
+			invalidParameterNames[i] = fmt.Sprintf("'%s'", invalidParameterName)
+		}
+		if len(invalidParameterNames) == 1 {
+			return grpcstatus.Errorf(
+				grpccodes.InvalidArgument,
+				"template parameter %s doesn't exist, valid values for template '%s' are %s",
+				invalidParameterNames[0],
+				templateId,
+				english.WordSeries(templateParameterNames, "and"),
+			)
+		} else {
+			return grpcstatus.Errorf(
+				grpccodes.InvalidArgument,
+				"template parameters %s don't exist, valid values for template '%s' are %s",
+				english.WordSeries(invalidParameterNames, "and"),
+				templateId,
+				english.WordSeries(templateParameterNames, "and"),
+			)
+		}
+	}
+
+	// Check that all the mandatory parameters have a value:
+	for _, templateParameter := range templateParameters {
+		if !templateParameter.GetRequired() {
+			continue
+		}
+		templateParameterName := templateParameter.GetName()
+		clusterParameter := clusterParameters[templateParameterName]
+		if clusterParameter == nil {
+			return grpcstatus.Errorf(
+				grpccodes.InvalidArgument,
+				"parameter '%s' of template '%s' is mandatory",
+				templateParameterName, templateId,
+			)
+		}
+	}
+
+	// Check that the parameter values are compatible with the template:
+	for clusterParameterName, clusterParameter := range clusterParameters {
+		for _, templateParameter := range templateParameters {
+			templateParameterName := templateParameter.GetName()
+			if clusterParameterName != templateParameterName {
+				continue
+			}
+			clusterParameterType := clusterParameter.GetTypeUrl()
+			templateParameterType := templateParameter.GetType()
+			if clusterParameterType != templateParameterType {
+				return grpcstatus.Errorf(
+					grpccodes.InvalidArgument,
+					"type of parameter '%s' of template '%s' should be '%s', "+
+						"but it is '%s'",
+					clusterParameterName,
+					templateId,
+					templateParameterType,
+					clusterParameterType,
+				)
+			}
+		}
+	}
+
+	// Set default values for template parameters:
+	actualClusterParameters := make(map[string]*anypb.Any)
+	for _, templateParameter := range templateParameters {
+		templateParameterName := templateParameter.GetName()
+		clusterParameter := clusterParameters[templateParameterName]
+		actualClusterParameter := &anypb.Any{
+			TypeUrl: templateParameter.GetType(),
+		}
+		if clusterParameter != nil {
+			actualClusterParameter.Value = clusterParameter.Value
+		} else {
+			actualClusterParameter.Value = templateParameter.GetDefault().GetValue()
+		}
+		actualClusterParameters[templateParameterName] = actualClusterParameter
+	}
+	cluster.GetSpec().SetTemplateParameters(actualClusterParameters)
+
 	return nil
 }

--- a/it/it_cluster_reconciler_test.go
+++ b/it/it_cluster_reconciler_test.go
@@ -153,7 +153,8 @@ var _ = Describe("Cluster reconciler", func() {
 		Expect(err).ToNot(HaveOccurred())
 		Expect(ok).To(BeTrue())
 		Expect(templateParameters).To(MatchJSON(`{
-			"my": "my_value"
+			"my": "my_value",
+			"your": "your_default"
 		}`))
 	})
 


### PR DESCRIPTION
- Move node sets and template parameters validation from public ClustersServer.Create() to private PrivateClustersServer.Create()
- Add comprehensive validation logic to private server including template existence, node sets validation, host class validation, and template parameters validation
- Implement full delegation pattern in public ClustersServer - all CRUD operations now delegate to private server
- Add type mappers for converting between public (ffv1) and private (privatev1) cluster types
- Update ClustersServerBuilder to accept private server via SetPrivate() method for dependency injection
- Remove direct DAO usage from public server, centralizing all business logic in private server
- Update tests to create and inject private server instances
- Ensure backward compatibility of public API while centralizing validation logic