### PR TITLE
Move validation logic to private server and implement delegation

### DIFF
--- a/internal/cmd/start_server_cmd.go
+++ b/internal/cmd/start_server_cmd.go
@@ -288,39 +288,6 @@ func (c *startServerCommandRunner) run(cmd *cobra.Command, argv []string) error 
 		return fmt.Errorf("failed to create notifier: %w", err)
 	}
 
-	// Create the cluster templates server:
-	c.logger.InfoContext(ctx, "Creating cluster templates server")
-	clusterTemplatesServer, err := servers.NewClusterTemplatesServer().
-		SetLogger(c.logger).
-		SetNotifier(notifier).
-		Build()
-	if err != nil {
-		return errors.Wrapf(err, "failed to create cluster templates server")
-	}
-	ffv1.RegisterClusterTemplatesServer(grpcServer, clusterTemplatesServer)
-
-	// Create the clusters server:
-	c.logger.InfoContext(ctx, "Creating clusters server")
-	clustersServer, err := servers.NewClustersServer().
-		SetLogger(c.logger).
-		SetNotifier(notifier).
-		Build()
-	if err != nil {
-		return errors.Wrapf(err, "failed to create clusters server")
-	}
-	ffv1.RegisterClustersServer(grpcServer, clustersServer)
-
-	// Create the host classes server:
-	c.logger.InfoContext(ctx, "Creating host classes server")
-	hostClassesServer, err := servers.NewHostClassesServer().
-		SetLogger(c.logger).
-		SetNotifier(notifier).
-		Build()
-	if err != nil {
-		return errors.Wrapf(err, "failed to create host classes server")
-	}
-	ffv1.RegisterHostClassesServer(grpcServer, hostClassesServer)
-
 	// Create the private cluster templates server:
 	c.logger.InfoContext(ctx, "Creating private cluster templates server")
 	privateClusterTemplatesServer, err := servers.NewPrivateClusterTemplatesServer().
@@ -331,6 +298,17 @@ func (c *startServerCommandRunner) run(cmd *cobra.Command, argv []string) error 
 		return errors.Wrapf(err, "failed to create private cluster templates server")
 	}
 	privatev1.RegisterClusterTemplatesServer(grpcServer, privateClusterTemplatesServer)
+
+	// Create the cluster templates server:
+	c.logger.InfoContext(ctx, "Creating cluster templates server")
+	clusterTemplatesServer, err := servers.NewClusterTemplatesServer().
+		SetLogger(c.logger).
+		SetPrivate(privateClusterTemplatesServer).
+		Build()
+	if err != nil {
+		return errors.Wrapf(err, "failed to create cluster templates server")
+	}
+	ffv1.RegisterClusterTemplatesServer(grpcServer, clusterTemplatesServer)
 
 	// Create the private clusters server:
 	c.logger.InfoContext(ctx, "Creating private clusters server")
@@ -343,6 +321,17 @@ func (c *startServerCommandRunner) run(cmd *cobra.Command, argv []string) error 
 	}
 	privatev1.RegisterClustersServer(grpcServer, privateClustersServer)
 
+	// Create the clusters server:
+	c.logger.InfoContext(ctx, "Creating clusters server")
+	clustersServer, err := servers.NewClustersServer().
+		SetLogger(c.logger).
+		SetPrivate(privateClustersServer).
+		Build()
+	if err != nil {
+		return errors.Wrapf(err, "failed to create clusters server")
+	}
+	ffv1.RegisterClustersServer(grpcServer, clustersServer)
+
 	// Create the private host classes server:
 	c.logger.InfoContext(ctx, "Creating private host classes server")
 	privateHostClassesServer, err := servers.NewPrivateHostClassesServer().
@@ -353,6 +342,17 @@ func (c *startServerCommandRunner) run(cmd *cobra.Command, argv []string) error 
 		return errors.Wrapf(err, "failed to create private host classes server")
 	}
 	privatev1.RegisterHostClassesServer(grpcServer, privateHostClassesServer)
+
+	// Create the host classes server:
+	c.logger.InfoContext(ctx, "Creating host classes server")
+	hostClassesServer, err := servers.NewHostClassesServer().
+		SetLogger(c.logger).
+		SetPrivate(privateHostClassesServer).
+		Build()
+	if err != nil {
+		return errors.Wrapf(err, "failed to create host classes server")
+	}
+	ffv1.RegisterHostClassesServer(grpcServer, hostClassesServer)
 
 	// Create the private hubs server:
 	c.logger.InfoContext(ctx, "Creating hubs server")

--- a/internal/servers/cluster_templates_server.go
+++ b/internal/servers/cluster_templates_server.go
@@ -18,14 +18,16 @@ import (
 	"errors"
 	"log/slog"
 
+	grpccodes "google.golang.org/grpc/codes"
+	grpcstatus "google.golang.org/grpc/status"
+
 	ffv1 "github.com/innabox/fulfillment-service/internal/api/fulfillment/v1"
 	privatev1 "github.com/innabox/fulfillment-service/internal/api/private/v1"
-	"github.com/innabox/fulfillment-service/internal/database"
 )
 
 type ClusterTemplatesServerBuilder struct {
-	logger   *slog.Logger
-	notifier *database.Notifier
+	logger  *slog.Logger
+	private privatev1.ClusterTemplatesServer
 }
 
 var _ ffv1.ClusterTemplatesServer = (*ClusterTemplatesServer)(nil)
@@ -33,21 +35,25 @@ var _ ffv1.ClusterTemplatesServer = (*ClusterTemplatesServer)(nil)
 type ClusterTemplatesServer struct {
 	ffv1.UnimplementedClusterTemplatesServer
 
-	logger  *slog.Logger
-	generic *GenericServer[*ffv1.ClusterTemplate, *privatev1.ClusterTemplate]
+	logger    *slog.Logger
+	private   privatev1.ClusterTemplatesServer
+	inMapper  *GenericMapper[*ffv1.ClusterTemplate, *privatev1.ClusterTemplate]
+	outMapper *GenericMapper[*privatev1.ClusterTemplate, *ffv1.ClusterTemplate]
 }
 
 func NewClusterTemplatesServer() *ClusterTemplatesServerBuilder {
 	return &ClusterTemplatesServerBuilder{}
 }
 
+// SetLogger sets the logger to use. This is mandatory.
 func (b *ClusterTemplatesServerBuilder) SetLogger(value *slog.Logger) *ClusterTemplatesServerBuilder {
 	b.logger = value
 	return b
 }
 
-func (b *ClusterTemplatesServerBuilder) SetNotifier(value *database.Notifier) *ClusterTemplatesServerBuilder {
-	b.notifier = value
+// SetPrivate sets the private server to use. This is mandatory.
+func (b *ClusterTemplatesServerBuilder) SetPrivate(value privatev1.ClusterTemplatesServer) *ClusterTemplatesServerBuilder {
+	b.private = value
 	return b
 }
 
@@ -57,13 +63,22 @@ func (b *ClusterTemplatesServerBuilder) Build() (result *ClusterTemplatesServer,
 		err = errors.New("logger is mandatory")
 		return
 	}
+	if b.private == nil {
+		err = errors.New("private server is mandatory")
+		return
+	}
 
-	// Create the generic server:
-	generic, err := NewGenericServer[*ffv1.ClusterTemplate, *privatev1.ClusterTemplate]().
+	// Create the mappers:
+	inMapper, err := NewGenericMapper[*ffv1.ClusterTemplate, *privatev1.ClusterTemplate]().
 		SetLogger(b.logger).
-		SetService(ffv1.ClusterTemplates_ServiceDesc.ServiceName).
-		SetTable("cluster_templates").
-		SetNotifier(b.notifier).
+		SetStrict(true).
+		Build()
+	if err != nil {
+		return
+	}
+	outMapper, err := NewGenericMapper[*privatev1.ClusterTemplate, *ffv1.ClusterTemplate]().
+		SetLogger(b.logger).
+		SetStrict(false).
 		Build()
 	if err != nil {
 		return
@@ -71,38 +86,208 @@ func (b *ClusterTemplatesServerBuilder) Build() (result *ClusterTemplatesServer,
 
 	// Create and populate the object:
 	result = &ClusterTemplatesServer{
-		logger:  b.logger,
-		generic: generic,
+		logger:    b.logger,
+		private:   b.private,
+		inMapper:  inMapper,
+		outMapper: outMapper,
 	}
 	return
 }
 
 func (s *ClusterTemplatesServer) List(ctx context.Context,
 	request *ffv1.ClusterTemplatesListRequest) (response *ffv1.ClusterTemplatesListResponse, err error) {
-	err = s.generic.List(ctx, request, &response)
+	// Create private request with same parameters:
+	privateRequest := &privatev1.ClusterTemplatesListRequest{}
+	privateRequest.SetOffset(request.GetOffset())
+	privateRequest.SetLimit(request.GetLimit())
+	privateRequest.SetFilter(request.GetFilter())
+
+	// Delegate to private server:
+	privateResponse, err := s.private.List(ctx, privateRequest)
+	if err != nil {
+		return nil, err
+	}
+
+	// Map private response to public format:
+	privateItems := privateResponse.GetItems()
+	publicItems := make([]*ffv1.ClusterTemplate, len(privateItems))
+	for i, privateItem := range privateItems {
+		publicItem := &ffv1.ClusterTemplate{}
+		err = s.outMapper.Copy(ctx, privateItem, publicItem)
+		if err != nil {
+			s.logger.ErrorContext(
+				ctx,
+				"Failed to map private cluster template to public",
+				slog.Any("error", err),
+			)
+			return nil, grpcstatus.Errorf(grpccodes.Internal, "failed to process cluster templates")
+		}
+		publicItems[i] = publicItem
+	}
+
+	// Create the public response:
+	response = &ffv1.ClusterTemplatesListResponse{}
+	response.SetSize(privateResponse.GetSize())
+	response.SetTotal(privateResponse.GetTotal())
+	response.SetItems(publicItems)
 	return
 }
 
 func (s *ClusterTemplatesServer) Get(ctx context.Context,
 	request *ffv1.ClusterTemplatesGetRequest) (response *ffv1.ClusterTemplatesGetResponse, err error) {
-	err = s.generic.Get(ctx, request, &response)
+	// Create private request:
+	privateRequest := &privatev1.ClusterTemplatesGetRequest{}
+	privateRequest.SetId(request.GetId())
+
+	// Delegate to private server:
+	privateResponse, err := s.private.Get(ctx, privateRequest)
+	if err != nil {
+		return nil, err
+	}
+
+	// Map private response to public format:
+	privateClusterTemplate := privateResponse.GetObject()
+	publicClusterTemplate := &ffv1.ClusterTemplate{}
+	err = s.outMapper.Copy(ctx, privateClusterTemplate, publicClusterTemplate)
+	if err != nil {
+		s.logger.ErrorContext(
+			ctx,
+			"Failed to map private cluster template to public",
+			slog.Any("error", err),
+		)
+		return nil, grpcstatus.Errorf(grpccodes.Internal, "failed to process cluster template")
+	}
+
+	// Create the public response:
+	response = &ffv1.ClusterTemplatesGetResponse{}
+	response.SetObject(publicClusterTemplate)
 	return
 }
 
 func (s *ClusterTemplatesServer) Create(ctx context.Context,
 	request *ffv1.ClusterTemplatesCreateRequest) (response *ffv1.ClusterTemplatesCreateResponse, err error) {
-	err = s.generic.Create(ctx, request, &response)
+	// Map the public cluster template to private format:
+	publicClusterTemplate := request.GetObject()
+	if publicClusterTemplate == nil {
+		err = grpcstatus.Errorf(grpccodes.InvalidArgument, "object is mandatory")
+		return
+	}
+	privateClusterTemplate := &privatev1.ClusterTemplate{}
+	err = s.inMapper.Copy(ctx, publicClusterTemplate, privateClusterTemplate)
+	if err != nil {
+		s.logger.ErrorContext(
+			ctx,
+			"Failed to map public cluster template to private",
+			slog.Any("error", err),
+		)
+		err = grpcstatus.Errorf(grpccodes.Internal, "failed to process cluster template")
+		return
+	}
+
+	// Delegate to the private server:
+	privateRequest := &privatev1.ClusterTemplatesCreateRequest{}
+	privateRequest.SetObject(privateClusterTemplate)
+	privateResponse, err := s.private.Create(ctx, privateRequest)
+	if err != nil {
+		return nil, err
+	}
+
+	// Map the private response back to public format:
+	createdPrivateClusterTemplate := privateResponse.GetObject()
+	createdPublicClusterTemplate := &ffv1.ClusterTemplate{}
+	err = s.outMapper.Copy(ctx, createdPrivateClusterTemplate, createdPublicClusterTemplate)
+	if err != nil {
+		s.logger.ErrorContext(
+			ctx,
+			"Failed to map private cluster template to public",
+			slog.Any("error", err),
+		)
+		err = grpcstatus.Errorf(grpccodes.Internal, "failed to process cluster template")
+		return
+	}
+
+	// Create the public response:
+	response = &ffv1.ClusterTemplatesCreateResponse{}
+	response.SetObject(createdPublicClusterTemplate)
 	return
 }
 
 func (s *ClusterTemplatesServer) Update(ctx context.Context,
 	request *ffv1.ClusterTemplatesUpdateRequest) (response *ffv1.ClusterTemplatesUpdateResponse, err error) {
-	err = s.generic.Update(ctx, request, &response)
+	// Validate the request:
+	publicClusterTemplate := request.GetObject()
+	if publicClusterTemplate == nil {
+		err = grpcstatus.Errorf(grpccodes.InvalidArgument, "object is mandatory")
+		return
+	}
+	id := publicClusterTemplate.GetId()
+	if id == "" {
+		err = grpcstatus.Errorf(grpccodes.InvalidArgument, "object identifier is mandatory")
+		return
+	}
+
+	// Get the existing object from the private server:
+	getRequest := &privatev1.ClusterTemplatesGetRequest{}
+	getRequest.SetId(id)
+	getResponse, err := s.private.Get(ctx, getRequest)
+	if err != nil {
+		return nil, err
+	}
+	existingPrivateClusterTemplate := getResponse.GetObject()
+
+	// Map the public changes to the existing private object (preserving private data):
+	err = s.inMapper.Copy(ctx, publicClusterTemplate, existingPrivateClusterTemplate)
+	if err != nil {
+		s.logger.ErrorContext(
+			ctx,
+			"Failed to map public cluster template to private",
+			slog.Any("error", err),
+		)
+		err = grpcstatus.Errorf(grpccodes.Internal, "failed to process cluster template")
+		return
+	}
+
+	// Delegate to the private server with the merged object:
+	privateRequest := &privatev1.ClusterTemplatesUpdateRequest{}
+	privateRequest.SetObject(existingPrivateClusterTemplate)
+	privateResponse, err := s.private.Update(ctx, privateRequest)
+	if err != nil {
+		return nil, err
+	}
+
+	// Map the private response back to public format:
+	updatedPrivateClusterTemplate := privateResponse.GetObject()
+	updatedPublicClusterTemplate := &ffv1.ClusterTemplate{}
+	err = s.outMapper.Copy(ctx, updatedPrivateClusterTemplate, updatedPublicClusterTemplate)
+	if err != nil {
+		s.logger.ErrorContext(
+			ctx,
+			"Failed to map private cluster template to public",
+			slog.Any("error", err),
+		)
+		err = grpcstatus.Errorf(grpccodes.Internal, "failed to process cluster template")
+		return
+	}
+
+	// Create the public response:
+	response = &ffv1.ClusterTemplatesUpdateResponse{}
+	response.SetObject(updatedPublicClusterTemplate)
 	return
 }
 
 func (s *ClusterTemplatesServer) Delete(ctx context.Context,
 	request *ffv1.ClusterTemplatesDeleteRequest) (response *ffv1.ClusterTemplatesDeleteResponse, err error) {
-	err = s.generic.Delete(ctx, request, &response)
+	// Create private request:
+	privateRequest := &privatev1.ClusterTemplatesDeleteRequest{}
+	privateRequest.SetId(request.GetId())
+
+	// Delegate to private server:
+	_, err = s.private.Delete(ctx, privateRequest)
+	if err != nil {
+		return nil, err
+	}
+
+	// Create the public response:
+	response = &ffv1.ClusterTemplatesDeleteResponse{}
 	return
 }

--- a/internal/servers/cluster_templates_server_test.go
+++ b/internal/servers/cluster_templates_server_test.go
@@ -87,17 +87,35 @@ var _ = Describe("Cluster templates server", func() {
 
 	Describe("Creation", func() {
 		It("Can be built if all the required parameters are set", func() {
+			privateServer, err := NewPrivateClusterTemplatesServer().
+				SetLogger(logger).
+				Build()
+			Expect(err).ToNot(HaveOccurred())
 			server, err := NewClusterTemplatesServer().
 				SetLogger(logger).
+				SetPrivate(privateServer).
 				Build()
 			Expect(err).ToNot(HaveOccurred())
 			Expect(server).ToNot(BeNil())
 		})
 
 		It("Fails if logger is not set", func() {
+			privateServer, err := NewPrivateClusterTemplatesServer().
+				SetLogger(logger).
+				Build()
+			Expect(err).ToNot(HaveOccurred())
 			server, err := NewClusterTemplatesServer().
+				SetPrivate(privateServer).
 				Build()
 			Expect(err).To(MatchError("logger is mandatory"))
+			Expect(server).To(BeNil())
+		})
+
+		It("Fails if private server is not set", func() {
+			server, err := NewClusterTemplatesServer().
+				SetLogger(logger).
+				Build()
+			Expect(err).To(MatchError("private server is mandatory"))
 			Expect(server).To(BeNil())
 		})
 	})
@@ -108,9 +126,16 @@ var _ = Describe("Cluster templates server", func() {
 		BeforeEach(func() {
 			var err error
 
+			// Create the private server:
+			privateServer, err := NewPrivateClusterTemplatesServer().
+				SetLogger(logger).
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+
 			// Create the server:
 			server, err = NewClusterTemplatesServer().
 				SetLogger(logger).
+				SetPrivate(privateServer).
 				Build()
 			Expect(err).ToNot(HaveOccurred())
 		})

--- a/internal/servers/clusters_server_test.go
+++ b/internal/servers/clusters_server_test.go
@@ -109,17 +109,35 @@ var _ = Describe("Clusters server", func() {
 
 	Describe("Creation", func() {
 		It("Can be built if all the required parameters are set", func() {
+			privateServer, err := NewPrivateClustersServer().
+				SetLogger(logger).
+				Build()
+			Expect(err).ToNot(HaveOccurred())
 			server, err := NewClustersServer().
 				SetLogger(logger).
+				SetPrivate(privateServer).
 				Build()
 			Expect(err).ToNot(HaveOccurred())
 			Expect(server).ToNot(BeNil())
 		})
 
 		It("Fails if logger is not set", func() {
+			privateServer, err := NewPrivateClustersServer().
+				SetLogger(logger).
+				Build()
+			Expect(err).ToNot(HaveOccurred())
 			server, err := NewClustersServer().
+				SetPrivate(privateServer).
 				Build()
 			Expect(err).To(MatchError("logger is mandatory"))
+			Expect(server).To(BeNil())
+		})
+
+		It("Fails if private server is not set", func() {
+			server, err := NewClustersServer().
+				SetLogger(logger).
+				Build()
+			Expect(err).To(MatchError("private server is mandatory"))
 			Expect(server).To(BeNil())
 		})
 	})
@@ -136,9 +154,16 @@ var _ = Describe("Clusters server", func() {
 		BeforeEach(func() {
 			var err error
 
+			// Create the private server:
+			privateServer, err := NewPrivateClustersServer().
+				SetLogger(logger).
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+
 			// Create the server:
 			server, err = NewClustersServer().
 				SetLogger(logger).
+				SetPrivate(privateServer).
 				Build()
 			Expect(err).ToNot(HaveOccurred())
 

--- a/internal/servers/generic_server.go
+++ b/internal/servers/generic_server.go
@@ -32,8 +32,8 @@ import (
 	"github.com/innabox/fulfillment-service/internal/database/dao"
 )
 
-// GenericServerBuilder contains the data and logic neede to create new generic servers.
-type GenericServerBuilder[Public, Private dao.Object] struct {
+// GenericServerBuilder contains the data and logic needed to create new generic servers.
+type GenericServerBuilder[O dao.Object] struct {
 	logger        *slog.Logger
 	service       string
 	table         string
@@ -43,46 +43,43 @@ type GenericServerBuilder[Public, Private dao.Object] struct {
 
 // GenericServer is a gRPC server that knows how to implement the List, Get, Create, Update and Delete operators for
 // any object that has identifier and metadata fields.
-type GenericServer[Public, Private dao.Object] struct {
-	logger          *slog.Logger
-	service         string
-	dao             *dao.GenericDAO[Private]
-	inMapper        *GenericMapper[Public, Private]
-	outMapper       *GenericMapper[Private, Public]
-	publicTemplate  proto.Message
-	privateTemplate proto.Message
-	listRequest     proto.Message
-	listResponse    proto.Message
-	getRequest      proto.Message
-	getResponse     proto.Message
-	createRequest   proto.Message
-	createResponse  proto.Message
-	updateRequest   proto.Message
-	updateResponse  proto.Message
-	deleteRequest   proto.Message
-	deleteResponse  proto.Message
-	notifier        *database.Notifier
+type GenericServer[O dao.Object] struct {
+	logger         *slog.Logger
+	service        string
+	dao            *dao.GenericDAO[O]
+	template       proto.Message
+	listRequest    proto.Message
+	listResponse   proto.Message
+	getRequest     proto.Message
+	getResponse    proto.Message
+	createRequest  proto.Message
+	createResponse proto.Message
+	updateRequest  proto.Message
+	updateResponse proto.Message
+	deleteRequest  proto.Message
+	deleteResponse proto.Message
+	notifier       *database.Notifier
 }
 
-// NewGeneric server creates a builder that can then be used to configure and create a new generic server.
-func NewGenericServer[Public, Private dao.Object]() *GenericServerBuilder[Public, Private] {
-	return &GenericServerBuilder[Public, Private]{}
+// NewGenericServer creates a builder that can then be used to configure and create a new generic server.
+func NewGenericServer[O dao.Object]() *GenericServerBuilder[O] {
+	return &GenericServerBuilder[O]{}
 }
 
 // SetLogger sets the logger. This is mandatory.
-func (b *GenericServerBuilder[Public, Private]) SetLogger(value *slog.Logger) *GenericServerBuilder[Public, Private] {
+func (b *GenericServerBuilder[O]) SetLogger(value *slog.Logger) *GenericServerBuilder[O] {
 	b.logger = value
 	return b
 }
 
 // SetService sets the service description. This is mandatory.
-func (b *GenericServerBuilder[Public, Private]) SetService(value string) *GenericServerBuilder[Public, Private] {
+func (b *GenericServerBuilder[O]) SetService(value string) *GenericServerBuilder[O] {
 	b.service = value
 	return b
 }
 
 // SetTable sets the name of the table where the objects will be stored. This is mandatory.
-func (b *GenericServerBuilder[Public, Private]) SetTable(value string) *GenericServerBuilder[Public, Private] {
+func (b *GenericServerBuilder[O]) SetTable(value string) *GenericServerBuilder[O] {
 	b.table = value
 	return b
 }
@@ -96,22 +93,21 @@ func (b *GenericServerBuilder[Public, Private]) SetTable(value string) *GenericS
 // protoreflect.Name - Like string.
 //
 // protoreflect.FullName - This indicates a field of a particular type. For example, if the value is
-// 'fulfillment.v1.Cluster.status' then only the 'status' field of the 'fulfillment.v1.Cluster' object will be ignored.
-func (b *GenericServerBuilder[Public, Private]) AddIgnoredFields(values ...any) *GenericServerBuilder[Public, Private] {
+// 'fulfillment.v1.Cluster.status' then the field 'status' of the 'fulfillment.v1.Cluster' type will be ignored, but
+// the 'status' field of other types will not be ignored.
+func (b *GenericServerBuilder[O]) AddIgnoredFields(values ...any) *GenericServerBuilder[O] {
 	b.ignoredFields = append(b.ignoredFields, values...)
 	return b
 }
 
-// SetNotifier sets the notifier that the server will use to send events when objects are created, updated or deleted.
-// This is optional.
-func (b *GenericServerBuilder[Public, Private]) SetNotifier(
-	value *database.Notifier) *GenericServerBuilder[Public, Private] {
+// SetNotifier sets the notifier that the server will use to send change notifications. This is optional.
+func (b *GenericServerBuilder[O]) SetNotifier(value *database.Notifier) *GenericServerBuilder[O] {
 	b.notifier = value
 	return b
 }
 
 // Build uses the configuration stored in the builder to create and configure a new generic server.
-func (b *GenericServerBuilder[Public, Private]) Build() (result *GenericServer[Public, Private], err error) {
+func (b *GenericServerBuilder[O]) Build() (result *GenericServer[O], err error) {
 	// Check parameters:
 	if b.logger == nil {
 		err = errors.New("logger is mandatory")
@@ -127,14 +123,14 @@ func (b *GenericServerBuilder[Public, Private]) Build() (result *GenericServer[P
 	}
 
 	// Create the object early so that we can use its methods as callbacks:
-	s := &GenericServer[Public, Private]{
+	s := &GenericServer[O]{
 		logger:   b.logger,
 		service:  b.service,
 		notifier: b.notifier,
 	}
 
 	// Create the DAO:
-	daoBuilder := dao.NewGenericDAO[Private]()
+	daoBuilder := dao.NewGenericDAO[O]()
 	daoBuilder.SetLogger(b.logger)
 	daoBuilder.SetTable(b.table)
 	if b.notifier != nil {
@@ -146,38 +142,15 @@ func (b *GenericServerBuilder[Public, Private]) Build() (result *GenericServer[P
 		return
 	}
 
-	// Create the mappers:
-	s.inMapper, err = NewGenericMapper[Public, Private]().
-		SetLogger(b.logger).
-		SetStrict(true).
-		AddIgnoredFields(b.ignoredFields...).
-		Build()
-	if err != nil {
-		err = fmt.Errorf("failed to create in mapper: %w", err)
-		return
-	}
-	s.outMapper, err = NewGenericMapper[Private, Public]().
-		SetLogger(b.logger).
-		SetStrict(false).
-		Build()
-	if err != nil {
-		err = fmt.Errorf("failed to create out mapper: %w", err)
-		return
-	}
-
 	// Find the descriptor:
 	service, err := b.findService()
 	if err != nil {
 		return
 	}
 
-	// Prepare the templates for the public and private objects:
-	var (
-		public  Public
-		private Private
-	)
-	s.publicTemplate = public.ProtoReflect().New().Interface()
-	s.privateTemplate = private.ProtoReflect().New().Interface()
+	// Prepare the template for the object:
+	var object O
+	s.template = object.ProtoReflect().New().Interface()
 
 	// Prepare templates for the request and response types. These are empty messages that will be cloned when
 	// it is necessary to create new instances.
@@ -206,60 +179,64 @@ func (b *GenericServerBuilder[Public, Private]) Build() (result *GenericServer[P
 	return
 }
 
-func (b *GenericServerBuilder[Public, Private]) findService() (result protoreflect.ServiceDescriptor, err error) {
-	serviceName := protoreflect.FullName(b.service)
-	packageName := serviceName.Parent()
-	protoregistry.GlobalFiles.RangeFilesByPackage(packageName, func(fileDesc protoreflect.FileDescriptor) bool {
-		serviceDescs := fileDesc.Services()
-		for i := range serviceDescs.Len() {
-			currentDesc := serviceDescs.Get(i)
-			if currentDesc.FullName() == serviceName {
-				result = currentDesc
+// findService finds the service descriptor using the service name given to the builder.
+func (b *GenericServerBuilder[O]) findService() (result protoreflect.ServiceDescriptor, err error) {
+	protoregistry.GlobalFiles.RangeFilesByPackage("private.v1", func(desc protoreflect.FileDescriptor) bool {
+		for i := range desc.Services().Len() {
+			serviceDesc := desc.Services().Get(i)
+			if string(serviceDesc.FullName()) == b.service {
+				result = serviceDesc
 				return false
 			}
 		}
 		return true
 	})
 	if result == nil {
-		err = fmt.Errorf("failed to find descriptor for service '%s'", serviceName)
+		err = fmt.Errorf("failed to find service '%s'", b.service)
 		return
 	}
 	return
 }
 
-func (b *GenericServerBuilder[Public, Private]) findRequestAndResponse(serviceDesc protoreflect.ServiceDescriptor,
-	methodName string) (request, response proto.Message, err error) {
-	methodDesc := serviceDesc.Methods().ByName(protoreflect.Name(methodName))
-	if methodDesc == nil {
-		err = fmt.Errorf("failed to find method '%s' for service '%s'", methodName, serviceDesc.FullName())
-		return
+// Names of gRPC methods:
+const (
+	listMethod   = "List"
+	getMethod    = "Get"
+	createMethod = "Create"
+	updateMethod = "Update"
+	deleteMethod = "Delete"
+)
+
+// findRequestAndResponse finds the request and response message types for the given method.
+func (b *GenericServerBuilder[O]) findRequestAndResponse(service protoreflect.ServiceDescriptor,
+	methodName string) (request proto.Message, response proto.Message, err error) {
+	for i := range service.Methods().Len() {
+		method := service.Methods().Get(i)
+		if string(method.Name()) == methodName {
+			requestType, err := protoregistry.GlobalTypes.FindMessageByName(method.Input().FullName())
+			if err != nil {
+				return nil, nil, fmt.Errorf(
+					"failed to find request message type '%s': %w",
+					method.Input().FullName(), err,
+				)
+			}
+			responseType, err := protoregistry.GlobalTypes.FindMessageByName(method.Output().FullName())
+			if err != nil {
+				return nil, nil, fmt.Errorf(
+					"failed to find response message type '%s': %w",
+					method.Output().FullName(), err,
+				)
+			}
+			request = requestType.New().Interface()
+			response = responseType.New().Interface()
+			return request, response, nil
+		}
 	}
-	requestDesc := methodDesc.Input()
-	requestName := requestDesc.FullName()
-	requestType, err := protoregistry.GlobalTypes.FindMessageByName(requestName)
-	if err != nil {
-		err = fmt.Errorf(
-			"failed to find request type '%s' for method '%s' of service '%s'",
-			requestName, methodName, serviceDesc.FullName(),
-		)
-		return
-	}
-	responseDesc := methodDesc.Output()
-	responseName := responseDesc.FullName()
-	responseType, err := protoregistry.GlobalTypes.FindMessageByName(responseName)
-	if err != nil {
-		err = fmt.Errorf(
-			"failed to find response type '%s' for method '%s' of service '%s'",
-			responseName, methodName, serviceDesc.FullName(),
-		)
-		return
-	}
-	request = requestType.New().Interface()
-	response = responseType.New().Interface()
+	err = fmt.Errorf("failed to find method '%s' in service '%s'", methodName, service.FullName())
 	return
 }
 
-func (s *GenericServer[Public, Private]) List(ctx context.Context, request any, response any) error {
+func (s *GenericServer[O]) List(ctx context.Context, request any, response any) error {
 	type requestIface interface {
 		GetOffset() int32
 		GetLimit() int32
@@ -268,7 +245,7 @@ func (s *GenericServer[Public, Private]) List(ctx context.Context, request any, 
 	type responseIface interface {
 		SetSize(int32)
 		SetTotal(int32)
-		SetItems([]Public)
+		SetItems([]O)
 	}
 	requestMsg := request.(requestIface)
 	daoRequest := dao.ListRequest{}
@@ -287,38 +264,24 @@ func (s *GenericServer[Public, Private]) List(ctx context.Context, request any, 
 	responseMsg := proto.Clone(s.listResponse).(responseIface)
 	responseMsg.SetSize(daoResponse.Size)
 	responseMsg.SetTotal(daoResponse.Total)
-	publicItems := make([]Public, len(daoResponse.Items))
-	for i, privateItem := range daoResponse.Items {
-		publicItem := proto.Clone(s.publicTemplate).(Public)
-		err = s.outMapper.Copy(ctx, privateItem, publicItem)
-		if err != nil {
-			s.logger.ErrorContext(
-				ctx,
-				"Failed to map item",
-				slog.Any("error", err),
-			)
-			return grpcstatus.Errorf(grpccodes.Internal, "failed to list")
-		}
-		publicItems[i] = publicItem
-	}
-	responseMsg.SetItems(publicItems)
+	responseMsg.SetItems(daoResponse.Items)
 	s.setPointer(response, responseMsg)
 	return nil
 }
 
-func (s *GenericServer[Public, Private]) Get(ctx context.Context, request any, response any) error {
+func (s *GenericServer[O]) Get(ctx context.Context, request any, response any) error {
 	type requestIface interface {
 		GetId() string
 	}
 	type responseIface interface {
-		SetObject(Public)
+		SetObject(O)
 	}
 	requestMsg := request.(requestIface)
 	id := requestMsg.GetId()
 	if id == "" {
 		return grpcstatus.Errorf(grpccodes.InvalidArgument, "identifier is mandatory")
 	}
-	private, err := s.dao.Get(ctx, id)
+	object, err := s.dao.Get(ctx, id)
 	if err != nil {
 		s.logger.ErrorContext(
 			ctx,
@@ -328,49 +291,28 @@ func (s *GenericServer[Public, Private]) Get(ctx context.Context, request any, r
 		)
 		return grpcstatus.Errorf(grpccodes.Internal, "failed to get object with identifier '%s'", id)
 	}
-	if s.isNil(private) {
+	if s.isNil(object) {
 		return grpcstatus.Errorf(grpccodes.NotFound, "object with identifier '%s' doesn't exist", id)
 	}
-	public := proto.Clone(s.publicTemplate).(Public)
-	err = s.outMapper.Copy(ctx, private, public)
-	if err != nil {
-		s.logger.ErrorContext(
-			ctx,
-			"Failed to map",
-			slog.String("id", id),
-			slog.Any("error", err),
-		)
-		return grpcstatus.Errorf(grpccodes.Internal, "failed to get object with identifier '%s'", id)
-	}
 	responseMsg := proto.Clone(s.getResponse).(responseIface)
-	responseMsg.SetObject(public)
+	responseMsg.SetObject(object)
 	s.setPointer(response, responseMsg)
 	return nil
 }
 
-func (s *GenericServer[Public, Private]) Create(ctx context.Context, request any, response any) error {
+func (s *GenericServer[O]) Create(ctx context.Context, request any, response any) error {
 	type requestIface interface {
-		GetObject() Public
+		GetObject() O
 	}
 	type responseIface interface {
-		SetObject(Public)
+		SetObject(O)
 	}
 	requestMsg := request.(requestIface)
-	public := requestMsg.GetObject()
-	if s.isNil(public) {
+	object := requestMsg.GetObject()
+	if s.isNil(object) {
 		return grpcstatus.Errorf(grpccodes.InvalidArgument, "object is mandatory")
 	}
-	private := proto.Clone(s.privateTemplate).(Private)
-	err := s.inMapper.Copy(ctx, public, private)
-	if err != nil {
-		s.logger.ErrorContext(
-			ctx,
-			"Failed to map",
-			slog.Any("error", err),
-		)
-		return grpcstatus.Errorf(grpccodes.Internal, "failed to create object")
-	}
-	private, err = s.dao.Create(ctx, private)
+	object, err := s.dao.Create(ctx, object)
 	if err != nil {
 		s.logger.ErrorContext(
 			ctx,
@@ -379,105 +321,40 @@ func (s *GenericServer[Public, Private]) Create(ctx context.Context, request any
 		)
 		return grpcstatus.Errorf(grpccodes.Internal, "failed to create object")
 	}
-	err = s.outMapper.Copy(ctx, private, public)
-	if err != nil {
-		s.logger.ErrorContext(
-			ctx,
-			"Failed to map",
-			slog.Any("error", err),
-		)
-		return grpcstatus.Errorf(grpccodes.Internal, "failed to create object")
-	}
 	responseMsg := proto.Clone(s.createResponse).(responseIface)
-	responseMsg.SetObject(public)
+	responseMsg.SetObject(object)
 	s.setPointer(response, responseMsg)
 	return nil
 }
 
-func (s *GenericServer[Public, Private]) Update(ctx context.Context, request any, response any) error {
+func (s *GenericServer[O]) Update(ctx context.Context, request any, response any) error {
 	type requestIface interface {
-		GetObject() Public
+		GetObject() O
 	}
 	type responseIface interface {
-		SetObject(Public)
+		SetObject(O)
 	}
 	requestMsg := request.(requestIface)
-	public := requestMsg.GetObject()
-	if s.isNil(public) {
+	object := requestMsg.GetObject()
+	if s.isNil(object) {
 		return grpcstatus.Errorf(grpccodes.InvalidArgument, "object is mandatory")
 	}
-	id := public.GetId()
-	if id == "" {
-		return grpcstatus.Errorf(grpccodes.Internal, "object identifier is mandatory")
-	}
-	private, err := s.dao.Get(ctx, id)
+	object, err := s.dao.Update(ctx, object)
 	if err != nil {
 		s.logger.ErrorContext(
 			ctx,
-			"Failed to get object",
-			slog.String("id", id),
+			"Failed to update",
 			slog.Any("error", err),
 		)
-		return grpcstatus.Errorf(
-			grpccodes.Internal,
-			"failed to get object with identifier '%s'",
-			id,
-		)
-	}
-	if s.isNil(private) {
-		return grpcstatus.Errorf(
-			grpccodes.InvalidArgument,
-			"object with identifier '%s' doesn't exist",
-			id,
-		)
-	}
-	err = s.inMapper.Copy(ctx, public, private)
-	if err != nil {
-		s.logger.ErrorContext(
-			ctx,
-			"Failed to copy object",
-			slog.Any("error", err),
-		)
-		return grpcstatus.Errorf(
-			grpccodes.Internal,
-			"failed to update object with identifier '%s'",
-			id,
-		)
-	}
-	private, err = s.dao.Update(ctx, private)
-	if err != nil {
-		s.logger.ErrorContext(
-			ctx,
-			"Failed to update object",
-			slog.String("id", id),
-			slog.Any("error", err),
-		)
-		return grpcstatus.Errorf(
-			grpccodes.Internal,
-			"failed to update object with identifier '%s'",
-			id,
-		)
-	}
-	err = s.outMapper.Copy(ctx, private, public)
-	if err != nil {
-		s.logger.ErrorContext(
-			ctx,
-			"Failed to map",
-			slog.Any("error", err),
-		)
-		return grpcstatus.Errorf(
-			grpccodes.Internal,
-			"failed to update object with identifier '%s'",
-			id,
-		)
+		return grpcstatus.Errorf(grpccodes.Internal, "failed to update object")
 	}
 	responseMsg := proto.Clone(s.updateResponse).(responseIface)
-	responseMsg.SetObject(public)
+	responseMsg.SetObject(object)
 	s.setPointer(response, responseMsg)
 	return nil
 }
 
-func (s *GenericServer[Public, Private]) Delete(ctx context.Context, request any, response any) error {
+func (s *GenericServer[O]) Delete(ctx context.Context, request any, response any) error {
 	type requestIface interface {
 		GetId() string
 	}
@@ -504,7 +381,7 @@ func (s *GenericServer[Public, Private]) Delete(ctx context.Context, request any
 }
 
 // notifyEvent converts the DAO event into an API event and publishes it using the PostgreSQL NOTIFY command.
-func (s *GenericServer[Public, Private]) notifyEvent(ctx context.Context, e dao.Event) error {
+func (s *GenericServer[O]) notifyEvent(ctx context.Context, e dao.Event) error {
 	// TODO: This is the only part of the generic server that depends on specific object types. Is there a way
 	// to avoid that?
 	event := &privatev1.Event{}
@@ -534,19 +411,10 @@ func (s *GenericServer[Public, Private]) notifyEvent(ctx context.Context, e dao.
 	return s.notifier.Notify(ctx, event)
 }
 
-func (s *GenericServer[Public, Private]) isNil(object proto.Message) bool {
+func (s *GenericServer[O]) isNil(object proto.Message) bool {
 	return reflect.ValueOf(object).IsNil()
 }
 
-func (s *GenericServer[Public, Private]) setPointer(pointer any, value any) {
+func (s *GenericServer[O]) setPointer(pointer any, value any) {
 	reflect.ValueOf(pointer).Elem().Set(reflect.ValueOf(value))
 }
-
-// Names of methods:
-const (
-	listMethod   = "List"
-	getMethod    = "Get"
-	createMethod = "Create"
-	updateMethod = "Update"
-	deleteMethod = "Delete"
-)

--- a/internal/servers/host_classes_server.go
+++ b/internal/servers/host_classes_server.go
@@ -18,14 +18,16 @@ import (
 	"errors"
 	"log/slog"
 
+	grpccodes "google.golang.org/grpc/codes"
+	grpcstatus "google.golang.org/grpc/status"
+
 	ffv1 "github.com/innabox/fulfillment-service/internal/api/fulfillment/v1"
 	privatev1 "github.com/innabox/fulfillment-service/internal/api/private/v1"
-	"github.com/innabox/fulfillment-service/internal/database"
 )
 
 type HostClassesServerBuilder struct {
-	logger   *slog.Logger
-	notifier *database.Notifier
+	logger  *slog.Logger
+	private privatev1.HostClassesServer
 }
 
 var _ ffv1.HostClassesServer = (*HostClassesServer)(nil)
@@ -33,21 +35,25 @@ var _ ffv1.HostClassesServer = (*HostClassesServer)(nil)
 type HostClassesServer struct {
 	ffv1.UnimplementedHostClassesServer
 
-	logger  *slog.Logger
-	generic *GenericServer[*ffv1.HostClass, *privatev1.HostClass]
+	logger    *slog.Logger
+	private   privatev1.HostClassesServer
+	inMapper  *GenericMapper[*ffv1.HostClass, *privatev1.HostClass]
+	outMapper *GenericMapper[*privatev1.HostClass, *ffv1.HostClass]
 }
 
 func NewHostClassesServer() *HostClassesServerBuilder {
 	return &HostClassesServerBuilder{}
 }
 
+// SetLogger sets the logger to use. This is mandatory.
 func (b *HostClassesServerBuilder) SetLogger(value *slog.Logger) *HostClassesServerBuilder {
 	b.logger = value
 	return b
 }
 
-func (b *HostClassesServerBuilder) SetNotifier(value *database.Notifier) *HostClassesServerBuilder {
-	b.notifier = value
+// SetPrivate sets the private server to use. This is mandatory.
+func (b *HostClassesServerBuilder) SetPrivate(value privatev1.HostClassesServer) *HostClassesServerBuilder {
+	b.private = value
 	return b
 }
 
@@ -57,13 +63,22 @@ func (b *HostClassesServerBuilder) Build() (result *HostClassesServer, err error
 		err = errors.New("logger is mandatory")
 		return
 	}
+	if b.private == nil {
+		err = errors.New("private server is mandatory")
+		return
+	}
 
-	// Create the generic server:
-	generic, err := NewGenericServer[*ffv1.HostClass, *privatev1.HostClass]().
+	// Create the mappers:
+	inMapper, err := NewGenericMapper[*ffv1.HostClass, *privatev1.HostClass]().
 		SetLogger(b.logger).
-		SetService(ffv1.HostClasses_ServiceDesc.ServiceName).
-		SetTable("host_classes").
-		SetNotifier(b.notifier).
+		SetStrict(true).
+		Build()
+	if err != nil {
+		return
+	}
+	outMapper, err := NewGenericMapper[*privatev1.HostClass, *ffv1.HostClass]().
+		SetLogger(b.logger).
+		SetStrict(false).
 		Build()
 	if err != nil {
 		return
@@ -71,38 +86,209 @@ func (b *HostClassesServerBuilder) Build() (result *HostClassesServer, err error
 
 	// Create and populate the object:
 	result = &HostClassesServer{
-		logger:  b.logger,
-		generic: generic,
+		logger:    b.logger,
+		private:   b.private,
+		inMapper:  inMapper,
+		outMapper: outMapper,
 	}
 	return
 }
 
 func (s *HostClassesServer) List(ctx context.Context,
 	request *ffv1.HostClassesListRequest) (response *ffv1.HostClassesListResponse, err error) {
-	err = s.generic.List(ctx, request, &response)
+	// Create private request with same parameters:
+	privateRequest := &privatev1.HostClassesListRequest{}
+	privateRequest.SetOffset(request.GetOffset())
+	privateRequest.SetLimit(request.GetLimit())
+	privateRequest.SetFilter(request.GetFilter())
+	privateRequest.SetOrder(request.GetOrder())
+
+	// Delegate to private server:
+	privateResponse, err := s.private.List(ctx, privateRequest)
+	if err != nil {
+		return nil, err
+	}
+
+	// Map private response to public format:
+	privateItems := privateResponse.GetItems()
+	publicItems := make([]*ffv1.HostClass, len(privateItems))
+	for i, privateItem := range privateItems {
+		publicItem := &ffv1.HostClass{}
+		err = s.outMapper.Copy(ctx, privateItem, publicItem)
+		if err != nil {
+			s.logger.ErrorContext(
+				ctx,
+				"Failed to map private host class to public",
+				slog.Any("error", err),
+			)
+			return nil, grpcstatus.Errorf(grpccodes.Internal, "failed to process host classes")
+		}
+		publicItems[i] = publicItem
+	}
+
+	// Create the public response:
+	response = &ffv1.HostClassesListResponse{}
+	response.SetSize(privateResponse.GetSize())
+	response.SetTotal(privateResponse.GetTotal())
+	response.SetItems(publicItems)
 	return
 }
 
 func (s *HostClassesServer) Get(ctx context.Context,
 	request *ffv1.HostClassesGetRequest) (response *ffv1.HostClassesGetResponse, err error) {
-	err = s.generic.Get(ctx, request, &response)
+	// Create private request:
+	privateRequest := &privatev1.HostClassesGetRequest{}
+	privateRequest.SetId(request.GetId())
+
+	// Delegate to private server:
+	privateResponse, err := s.private.Get(ctx, privateRequest)
+	if err != nil {
+		return nil, err
+	}
+
+	// Map private response to public format:
+	privateHostClass := privateResponse.GetObject()
+	publicHostClass := &ffv1.HostClass{}
+	err = s.outMapper.Copy(ctx, privateHostClass, publicHostClass)
+	if err != nil {
+		s.logger.ErrorContext(
+			ctx,
+			"Failed to map private host class to public",
+			slog.Any("error", err),
+		)
+		return nil, grpcstatus.Errorf(grpccodes.Internal, "failed to process host class")
+	}
+
+	// Create the public response:
+	response = &ffv1.HostClassesGetResponse{}
+	response.SetObject(publicHostClass)
 	return
 }
 
 func (s *HostClassesServer) Create(ctx context.Context,
 	request *ffv1.HostClassesCreateRequest) (response *ffv1.HostClassesCreateResponse, err error) {
-	err = s.generic.Create(ctx, request, &response)
+	// Map the public host class to private format:
+	publicHostClass := request.GetObject()
+	if publicHostClass == nil {
+		err = grpcstatus.Errorf(grpccodes.InvalidArgument, "object is mandatory")
+		return
+	}
+	privateHostClass := &privatev1.HostClass{}
+	err = s.inMapper.Copy(ctx, publicHostClass, privateHostClass)
+	if err != nil {
+		s.logger.ErrorContext(
+			ctx,
+			"Failed to map public host class to private",
+			slog.Any("error", err),
+		)
+		err = grpcstatus.Errorf(grpccodes.Internal, "failed to process host class")
+		return
+	}
+
+	// Delegate to the private server:
+	privateRequest := &privatev1.HostClassesCreateRequest{}
+	privateRequest.SetObject(privateHostClass)
+	privateResponse, err := s.private.Create(ctx, privateRequest)
+	if err != nil {
+		return nil, err
+	}
+
+	// Map the private response back to public format:
+	createdPrivateHostClass := privateResponse.GetObject()
+	createdPublicHostClass := &ffv1.HostClass{}
+	err = s.outMapper.Copy(ctx, createdPrivateHostClass, createdPublicHostClass)
+	if err != nil {
+		s.logger.ErrorContext(
+			ctx,
+			"Failed to map private host class to public",
+			slog.Any("error", err),
+		)
+		err = grpcstatus.Errorf(grpccodes.Internal, "failed to process host class")
+		return
+	}
+
+	// Create the public response:
+	response = &ffv1.HostClassesCreateResponse{}
+	response.SetObject(createdPublicHostClass)
 	return
 }
 
 func (s *HostClassesServer) Update(ctx context.Context,
 	request *ffv1.HostClassesUpdateRequest) (response *ffv1.HostClassesUpdateResponse, err error) {
-	err = s.generic.Update(ctx, request, &response)
+	// Validate the request:
+	publicHostClass := request.GetObject()
+	if publicHostClass == nil {
+		err = grpcstatus.Errorf(grpccodes.InvalidArgument, "object is mandatory")
+		return
+	}
+	id := publicHostClass.GetId()
+	if id == "" {
+		err = grpcstatus.Errorf(grpccodes.InvalidArgument, "object identifier is mandatory")
+		return
+	}
+
+	// Get the existing object from the private server:
+	getRequest := &privatev1.HostClassesGetRequest{}
+	getRequest.SetId(id)
+	getResponse, err := s.private.Get(ctx, getRequest)
+	if err != nil {
+		return nil, err
+	}
+	existingPrivateHostClass := getResponse.GetObject()
+
+	// Map the public changes to the existing private object (preserving private data):
+	err = s.inMapper.Copy(ctx, publicHostClass, existingPrivateHostClass)
+	if err != nil {
+		s.logger.ErrorContext(
+			ctx,
+			"Failed to map public host class to private",
+			slog.Any("error", err),
+		)
+		err = grpcstatus.Errorf(grpccodes.Internal, "failed to process host class")
+		return
+	}
+
+	// Delegate to the private server with the merged object:
+	privateRequest := &privatev1.HostClassesUpdateRequest{}
+	privateRequest.SetObject(existingPrivateHostClass)
+	privateResponse, err := s.private.Update(ctx, privateRequest)
+	if err != nil {
+		return nil, err
+	}
+
+	// Map the private response back to public format:
+	updatedPrivateHostClass := privateResponse.GetObject()
+	updatedPublicHostClass := &ffv1.HostClass{}
+	err = s.outMapper.Copy(ctx, updatedPrivateHostClass, updatedPublicHostClass)
+	if err != nil {
+		s.logger.ErrorContext(
+			ctx,
+			"Failed to map private host class to public",
+			slog.Any("error", err),
+		)
+		err = grpcstatus.Errorf(grpccodes.Internal, "failed to process host class")
+		return
+	}
+
+	// Create the public response:
+	response = &ffv1.HostClassesUpdateResponse{}
+	response.SetObject(updatedPublicHostClass)
 	return
 }
 
 func (s *HostClassesServer) Delete(ctx context.Context,
 	request *ffv1.HostClassesDeleteRequest) (response *ffv1.HostClassesDeleteResponse, err error) {
-	err = s.generic.Delete(ctx, request, &response)
+	// Create private request:
+	privateRequest := &privatev1.HostClassesDeleteRequest{}
+	privateRequest.SetId(request.GetId())
+
+	// Delegate to private server:
+	_, err = s.private.Delete(ctx, privateRequest)
+	if err != nil {
+		return nil, err
+	}
+
+	// Create the public response:
+	response = &ffv1.HostClassesDeleteResponse{}
 	return
 }

--- a/internal/servers/host_classes_server_test.go
+++ b/internal/servers/host_classes_server_test.go
@@ -87,17 +87,35 @@ var _ = Describe("Host classes server", func() {
 
 	Describe("Creation", func() {
 		It("Can be built if all the required parameters are set", func() {
+			privateServer, err := NewPrivateHostClassesServer().
+				SetLogger(logger).
+				Build()
+			Expect(err).ToNot(HaveOccurred())
 			server, err := NewHostClassesServer().
 				SetLogger(logger).
+				SetPrivate(privateServer).
 				Build()
 			Expect(err).ToNot(HaveOccurred())
 			Expect(server).ToNot(BeNil())
 		})
 
 		It("Fails if logger is not set", func() {
+			privateServer, err := NewPrivateHostClassesServer().
+				SetLogger(logger).
+				Build()
+			Expect(err).ToNot(HaveOccurred())
 			server, err := NewHostClassesServer().
+				SetPrivate(privateServer).
 				Build()
 			Expect(err).To(MatchError("logger is mandatory"))
+			Expect(server).To(BeNil())
+		})
+
+		It("Fails if private server is not set", func() {
+			server, err := NewHostClassesServer().
+				SetLogger(logger).
+				Build()
+			Expect(err).To(MatchError("private server is mandatory"))
 			Expect(server).To(BeNil())
 		})
 	})
@@ -108,9 +126,16 @@ var _ = Describe("Host classes server", func() {
 		BeforeEach(func() {
 			var err error
 
+			// Create the private server:
+			privateServer, err := NewPrivateHostClassesServer().
+				SetLogger(logger).
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+
 			// Create the server:
 			server, err = NewHostClassesServer().
 				SetLogger(logger).
+				SetPrivate(privateServer).
 				Build()
 			Expect(err).ToNot(HaveOccurred())
 		})

--- a/internal/servers/private_cluster_templates_server.go
+++ b/internal/servers/private_cluster_templates_server.go
@@ -32,7 +32,7 @@ var _ privatev1.ClusterTemplatesServer = (*PrivateClusterTemplatesServer)(nil)
 type PrivateClusterTemplatesServer struct {
 	privatev1.UnimplementedClusterTemplatesServer
 	logger  *slog.Logger
-	generic *GenericServer[*privatev1.ClusterTemplate, *privatev1.ClusterTemplate]
+	generic *GenericServer[*privatev1.ClusterTemplate]
 }
 
 func NewPrivateClusterTemplatesServer() *PrivateClusterTemplatesServerBuilder {
@@ -57,7 +57,7 @@ func (b *PrivateClusterTemplatesServerBuilder) Build() (result *PrivateClusterTe
 	}
 
 	// Create the generic server:
-	generic, err := NewGenericServer[*privatev1.ClusterTemplate, *privatev1.ClusterTemplate]().
+	generic, err := NewGenericServer[*privatev1.ClusterTemplate]().
 		SetLogger(b.logger).
 		SetService(privatev1.ClusterTemplates_ServiceDesc.ServiceName).
 		SetTable("cluster_templates").

--- a/internal/servers/private_clusters_server.go
+++ b/internal/servers/private_clusters_server.go
@@ -16,14 +16,20 @@ package servers
 import (
 	"context"
 	"errors"
+	"fmt"
 	"log/slog"
+	"sort"
 
 	"github.com/bits-and-blooms/bitset"
+	"github.com/dustin/go-humanize/english"
+	"golang.org/x/exp/maps"
 	grpccodes "google.golang.org/grpc/codes"
 	grpcstatus "google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/anypb"
 
 	privatev1 "github.com/innabox/fulfillment-service/internal/api/private/v1"
 	"github.com/innabox/fulfillment-service/internal/database"
+	"github.com/innabox/fulfillment-service/internal/database/dao"
 )
 
 type PrivateClustersServerBuilder struct {
@@ -35,8 +41,9 @@ var _ privatev1.ClustersServer = (*PrivateClustersServer)(nil)
 
 type PrivateClustersServer struct {
 	privatev1.UnimplementedClustersServer
-	logger  *slog.Logger
-	generic *GenericServer[*privatev1.Cluster, *privatev1.Cluster]
+	logger       *slog.Logger
+	templatesDao *dao.GenericDAO[*privatev1.ClusterTemplate]
+	generic      *GenericServer[*privatev1.Cluster]
 }
 
 func NewPrivateClustersServer() *PrivateClustersServerBuilder {
@@ -60,8 +67,17 @@ func (b *PrivateClustersServerBuilder) Build() (result *PrivateClustersServer, e
 		return
 	}
 
+	// Create the templates DAO:
+	templatesDao, err := dao.NewGenericDAO[*privatev1.ClusterTemplate]().
+		SetLogger(b.logger).
+		SetTable("cluster_templates").
+		Build()
+	if err != nil {
+		return
+	}
+
 	// Create the generic server:
-	generic, err := NewGenericServer[*privatev1.Cluster, *privatev1.Cluster]().
+	generic, err := NewGenericServer[*privatev1.Cluster]().
 		SetLogger(b.logger).
 		SetService(privatev1.Clusters_ServiceDesc.ServiceName).
 		SetTable("clusters").
@@ -73,8 +89,9 @@ func (b *PrivateClustersServerBuilder) Build() (result *PrivateClustersServer, e
 
 	// Create and populate the object:
 	result = &PrivateClustersServer{
-		logger:  b.logger,
-		generic: generic,
+		logger:       b.logger,
+		templatesDao: templatesDao,
+		generic:      generic,
 	}
 	return
 }
@@ -93,10 +110,18 @@ func (s *PrivateClustersServer) Get(ctx context.Context,
 
 func (s *PrivateClustersServer) Create(ctx context.Context,
 	request *privatev1.ClustersCreateRequest) (response *privatev1.ClustersCreateResponse, err error) {
+	// Validate duplicate conditions first:
 	err = s.validateNoDuplicateConditions(request.GetObject())
 	if err != nil {
 		return
 	}
+
+	// Validate template and perform transformations:
+	err = s.validateAndTransformCluster(ctx, request.GetObject())
+	if err != nil {
+		return
+	}
+
 	err = s.generic.Create(ctx, request, &response)
 	return
 }
@@ -134,5 +159,205 @@ func (s *PrivateClustersServer) validateNoDuplicateConditions(object *privatev1.
 		}
 		conditionTypes.Set(uint(conditionType))
 	}
+	return nil
+}
+
+func (s *PrivateClustersServer) validateAndTransformCluster(ctx context.Context, cluster *privatev1.Cluster) error {
+	// Check that the template is specified and that refers to a existing template:
+	if cluster == nil {
+		return grpcstatus.Errorf(grpccodes.InvalidArgument, "object is mandatory")
+	}
+	templateId := cluster.GetSpec().GetTemplate()
+	if templateId == "" {
+		return grpcstatus.Errorf(grpccodes.InvalidArgument, "template is mandatory")
+	}
+	template, err := s.templatesDao.Get(ctx, templateId)
+	if err != nil {
+		s.logger.ErrorContext(
+			ctx,
+			"Failed to get template",
+			slog.String("template", templateId),
+			slog.Any("error", err),
+		)
+		return grpcstatus.Errorf(grpccodes.Internal, "failed to get template '%s'", templateId)
+	}
+	if template == nil {
+		return grpcstatus.Errorf(grpccodes.InvalidArgument, "template '%s' doesn't exist", templateId)
+	}
+	if template.GetMetadata().HasDeletionTimestamp() {
+		return grpcstatus.Errorf(grpccodes.InvalidArgument, "template '%s' has been deleted", templateId)
+	}
+
+	// Check that all the node sets given in the cluster correspond to node sets that exist in the template:
+	templateNodeSets := template.GetNodeSets()
+	clusterNodeSets := cluster.GetSpec().GetNodeSets()
+	for clusterNodeSetKey := range clusterNodeSets {
+		templateNodeSet := templateNodeSets[clusterNodeSetKey]
+		if templateNodeSet == nil {
+			templateNodeSetKeys := maps.Keys(templateNodeSets)
+			sort.Strings(templateNodeSetKeys)
+			for i, templateNodeSetKey := range templateNodeSetKeys {
+				templateNodeSetKeys[i] = fmt.Sprintf("'%s'", templateNodeSetKey)
+			}
+			return grpcstatus.Errorf(
+				grpccodes.InvalidArgument,
+				"node set '%s' doesn't exist, valid values for template '%s' are %s",
+				clusterNodeSetKey, templateId, english.WordSeries(templateNodeSetKeys, "and"),
+			)
+		}
+	}
+
+	// Check that all the node sets given in the cluster specify the same host class that is specified in the
+	// template:
+	for clusterNodeSetKey, clusterNodeSet := range clusterNodeSets {
+		templateNodeSet := templateNodeSets[clusterNodeSetKey]
+		clusterHostClass := clusterNodeSet.GetHostClass()
+		if clusterHostClass == "" {
+			continue
+		}
+		templateHostClass := templateNodeSet.GetHostClass()
+		if clusterHostClass != templateHostClass {
+			return grpcstatus.Errorf(
+				grpccodes.InvalidArgument,
+				"host class for node set '%s' should be empty or '%s', like in template '%s', "+
+					"but it is '%s'",
+				clusterNodeSetKey, templateHostClass, templateId, clusterHostClass,
+			)
+		}
+	}
+
+	// Check that all the node sets given in the cluster have a positive size:
+	for clusterNodeSetKey, clusterNodeSet := range clusterNodeSets {
+		clusterNodeSetSize := clusterNodeSet.GetSize()
+		if clusterNodeSetSize <= 0 {
+			return grpcstatus.Errorf(
+				grpccodes.InvalidArgument,
+				"size for node set '%s' should be greater than zero, but it is %d",
+				clusterNodeSetKey, clusterNodeSetSize,
+			)
+		}
+	}
+
+	// Replace the node sets given in the cluster with those from the template, taking only the size from cluster:
+	actualNodeSets := map[string]*privatev1.ClusterNodeSet{}
+	for templateNodeSetKey, templateNodeSet := range templateNodeSets {
+		var actualNodeSetSize int32
+		clusterNodeSet := clusterNodeSets[templateNodeSetKey]
+		if clusterNodeSet != nil {
+			actualNodeSetSize = clusterNodeSet.GetSize()
+		} else {
+			actualNodeSetSize = templateNodeSet.GetSize()
+		}
+		actualNodeSets[templateNodeSetKey] = privatev1.ClusterNodeSet_builder{
+			HostClass: templateNodeSet.GetHostClass(),
+			Size:      actualNodeSetSize,
+		}.Build()
+	}
+	cluster.GetSpec().SetNodeSets(actualNodeSets)
+
+	// Check that all the specified template parameters are in the template:
+	templateParameters := template.GetParameters()
+	clusterParameters := cluster.GetSpec().GetTemplateParameters()
+	var invalidParameterNames []string
+	for clusterParameterName := range clusterParameters {
+		clusterParameterValid := false
+		for _, templateParameter := range templateParameters {
+			if templateParameter.GetName() == clusterParameterName {
+				clusterParameterValid = true
+				break
+			}
+		}
+		if !clusterParameterValid {
+			invalidParameterNames = append(invalidParameterNames, clusterParameterName)
+		}
+	}
+	if len(invalidParameterNames) > 0 {
+		templateParameterNames := make([]string, len(templateParameters))
+		for i, templateParameter := range templateParameters {
+			templateParameterNames[i] = templateParameter.GetName()
+		}
+		sort.Strings(templateParameterNames)
+		for i, templateParameterName := range templateParameterNames {
+			templateParameterNames[i] = fmt.Sprintf("'%s'", templateParameterName)
+		}
+		sort.Strings(invalidParameterNames)
+		for i, invalidParameterName := range invalidParameterNames {
+			invalidParameterNames[i] = fmt.Sprintf("'%s'", invalidParameterName)
+		}
+		if len(invalidParameterNames) == 1 {
+			return grpcstatus.Errorf(
+				grpccodes.InvalidArgument,
+				"template parameter %s doesn't exist, valid values for template '%s' are %s",
+				invalidParameterNames[0],
+				templateId,
+				english.WordSeries(templateParameterNames, "and"),
+			)
+		} else {
+			return grpcstatus.Errorf(
+				grpccodes.InvalidArgument,
+				"template parameters %s don't exist, valid values for template '%s' are %s",
+				english.WordSeries(invalidParameterNames, "and"),
+				templateId,
+				english.WordSeries(templateParameterNames, "and"),
+			)
+		}
+	}
+
+	// Check that all the mandatory parameters have a value:
+	for _, templateParameter := range templateParameters {
+		if !templateParameter.GetRequired() {
+			continue
+		}
+		templateParameterName := templateParameter.GetName()
+		clusterParameter := clusterParameters[templateParameterName]
+		if clusterParameter == nil {
+			return grpcstatus.Errorf(
+				grpccodes.InvalidArgument,
+				"parameter '%s' of template '%s' is mandatory",
+				templateParameterName, templateId,
+			)
+		}
+	}
+
+	// Check that the parameter values are compatible with the template:
+	for clusterParameterName, clusterParameter := range clusterParameters {
+		for _, templateParameter := range templateParameters {
+			templateParameterName := templateParameter.GetName()
+			if clusterParameterName != templateParameterName {
+				continue
+			}
+			clusterParameterType := clusterParameter.GetTypeUrl()
+			templateParameterType := templateParameter.GetType()
+			if clusterParameterType != templateParameterType {
+				return grpcstatus.Errorf(
+					grpccodes.InvalidArgument,
+					"type of parameter '%s' of template '%s' should be '%s', "+
+						"but it is '%s'",
+					clusterParameterName,
+					templateId,
+					templateParameterType,
+					clusterParameterType,
+				)
+			}
+		}
+	}
+
+	// Set default values for template parameters:
+	actualClusterParameters := make(map[string]*anypb.Any)
+	for _, templateParameter := range templateParameters {
+		templateParameterName := templateParameter.GetName()
+		clusterParameter := clusterParameters[templateParameterName]
+		actualClusterParameter := &anypb.Any{
+			TypeUrl: templateParameter.GetType(),
+		}
+		if clusterParameter != nil {
+			actualClusterParameter.Value = clusterParameter.Value
+		} else {
+			actualClusterParameter.Value = templateParameter.GetDefault().GetValue()
+		}
+		actualClusterParameters[templateParameterName] = actualClusterParameter
+	}
+	cluster.GetSpec().SetTemplateParameters(actualClusterParameters)
+
 	return nil
 }

--- a/internal/servers/private_host_classes_server.go
+++ b/internal/servers/private_host_classes_server.go
@@ -32,7 +32,7 @@ var _ privatev1.HostClassesServer = (*PrivateHostClassesServer)(nil)
 type PrivateHostClassesServer struct {
 	privatev1.UnimplementedHostClassesServer
 	logger  *slog.Logger
-	generic *GenericServer[*privatev1.HostClass, *privatev1.HostClass]
+	generic *GenericServer[*privatev1.HostClass]
 }
 
 func NewPrivateHostClassesServer() *PrivateHostClassesServerBuilder {
@@ -57,7 +57,7 @@ func (b *PrivateHostClassesServerBuilder) Build() (result *PrivateHostClassesSer
 	}
 
 	// Create the generic server:
-	generic, err := NewGenericServer[*privatev1.HostClass, *privatev1.HostClass]().
+	generic, err := NewGenericServer[*privatev1.HostClass]().
 		SetLogger(b.logger).
 		SetService(privatev1.HostClasses_ServiceDesc.ServiceName).
 		SetTable("host_classes").

--- a/internal/servers/private_hubs_server.go
+++ b/internal/servers/private_hubs_server.go
@@ -33,7 +33,7 @@ type PrivateHubsServer struct {
 	privatev1.UnimplementedHubsServer
 
 	logger  *slog.Logger
-	generic *GenericServer[*privatev1.Hub, *privatev1.Hub]
+	generic *GenericServer[*privatev1.Hub]
 }
 
 func NewPrivateHubsServer() *PrivateHubsServerBuilder {
@@ -58,7 +58,7 @@ func (b *PrivateHubsServerBuilder) Build() (result *PrivateHubsServer, err error
 	}
 
 	// Create the generic server:
-	generic, err := NewGenericServer[*privatev1.Hub, *privatev1.Hub]().
+	generic, err := NewGenericServer[*privatev1.Hub]().
 		SetLogger(b.logger).
 		SetService(privatev1.Hubs_ServiceDesc.ServiceName).
 		SetTable("hubs").


### PR DESCRIPTION
Currently validation is implemented only in public servers. But it is desirable to have them also in the private servers. This patch does that by moving the validations to the private servers, and changing the public servers so that they delegate almost everything to the private servers. A side effect of that is that the generic private server no longer needs to map private objects to private objects, and the other way around, so it no longer needs to have two generic parameters.