### PR TITLE
Don't send hub Kubeconfig in notifications

### DIFF
--- a/internal/servers/generic_server.go
+++ b/internal/servers/generic_server.go
@@ -527,6 +527,11 @@ func (s *GenericServer[Public, Private]) notifyEvent(ctx context.Context, e dao.
 	case *privatev1.HostClass:
 		event.SetHostClass(object)
 	case *privatev1.Hub:
+		// TODO: We need to remove the Kubeconfig from the payload of the notification because that usually
+		// exceeds the default limit of 8000 bytes of the PostgreSQL notification mechanism. A better way to
+		// do this would be to store the payloads in a separate table. We will do that later.
+		object = proto.Clone(object).(*privatev1.Hub)
+		object.SetKubeconfig(nil)
 		event.SetHub(object)
 	default:
 		return fmt.Errorf("unknown object type '%T'", object)


### PR DESCRIPTION
Sending the Kubeconfig of hubs in notifications usually exceeds the size max size of the PostgreSQL `NOTIFY ...` mechanism, which is 8000 bytes. To avoid that this patch changes the generic server so that it removes the Kubeconfig from notifications.

A more general way to solve this would be to store the payloads in a separate table, and send only the identifier of the event in the payload of the `NOTIFY` mechanism. We will do that later.

Related: https://github.com/innabox/fulfillment-service/issues/82
Related: https://www.postgresql.org/docs/current/sql-notify.html