### PR TITLE
Store notifications payload in a table

### DIFF
--- a/internal/database/database_listener_test.go
+++ b/internal/database/database_listener_test.go
@@ -136,6 +136,19 @@ var _ = Describe("Listener", func() {
 			Expect(err).ToNot(HaveOccurred())
 			DeferCleanup(pool.Close)
 
+			// Create the notifications table:
+			_, err = pool.Exec(
+				ctx,
+				`
+				create table notifications (
+					id text not null primary key,
+					creation_timestamp timestamp with time zone default now(),
+					payload bytea
+				);
+				`,
+			)
+			Expect(err).ToNot(HaveOccurred())
+
 			// Create the payloads channel:
 			payloads = make(chan proto.Message)
 

--- a/internal/database/migrations/7_add_notifications_table.up.sql
+++ b/internal/database/migrations/7_add_notifications_table.up.sql
@@ -1,0 +1,18 @@
+--
+-- Copyright (c) 2025 Red Hat Inc.
+--
+-- Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+-- the License. You may obtain a copy of the License at
+--
+--   http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+-- an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+-- specific language governing permissions and limitations under the License.
+--
+
+create table notifications (
+  id text not null primary key,
+  creation_timestamp timestamp with time zone not null default now(),
+  payload bytea not null
+);


### PR DESCRIPTION
Currently the payload of notifications are sent using the PostgreSQL `NOTIFY` mechanism, but that mechanism has a limit of 8000 bytes, which is very easy to exceed. For example, it is exceeded for hub notifications that contain large Kubeconfigs. To address that issue this patch adds an unique identifier to each notification, and stores the payload in a new `notifications` table. The payload of the `NOTIFY` mechanism will now be only the identifer, and the listener will fetch the payload from the table.

Related: https://github.com/innabox/fulfillment-service/issues/82
Related: https://www.postgresql.org/docs/current/sql-notify.html