### PR TITLE
Add logger to recovery tests

### DIFF
--- a/internal/recovery/grpc_panic_interceptor_test.go
+++ b/internal/recovery/grpc_panic_interceptor_test.go
@@ -15,8 +15,6 @@ package recovery
 
 import (
 	"context"
-	"log/slog"
-	"os"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -30,16 +28,15 @@ var _ = Describe("PanicInterceptor", func() {
 	var (
 		ctx         context.Context
 		interceptor *GrpcPanicInterceptor
-		logger      *slog.Logger
 	)
 
 	BeforeEach(func() {
-		ctx = context.Background()
-		logger = slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{
-			Level: slog.LevelDebug,
-		}))
-
 		var err error
+
+		// Create a context:
+		ctx = context.Background()
+
+		// Create the interceptor:
 		interceptor, err = NewGrpcPanicInterceptor().
 			SetLogger(logger).
 			Build()

--- a/internal/recovery/recovery_suite_test.go
+++ b/internal/recovery/recovery_suite_test.go
@@ -14,8 +14,10 @@ language governing permissions and limitations under the License.
 package recovery
 
 import (
+	"log/slog"
 	"testing"
 
+	"github.com/innabox/fulfillment-service/internal/logging"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
@@ -24,3 +26,19 @@ func TestRecovery(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Recovery")
 }
+
+// Logger used for tests:
+var logger *slog.Logger
+
+var _ = BeforeSuite(func() {
+	var err error
+
+	// Create a logger that writes to the Ginkgo writer, so that the log messages will be attached to the output of
+	// the right test:
+	logger, err = logging.NewLogger().
+		SetLevel(slog.LevelDebug.String()).
+		SetOut(GinkgoWriter).
+		SetErr(GinkgoWriter).
+		Build()
+	Expect(err).ToNot(HaveOccurred())
+})


### PR DESCRIPTION
Currently the logger used in the tests of the panic recovery interceptor writes to thes standard output stream directly. This mixes the output with the output of the `ginkgo` tool. To avoid that this patch uses a logger that writes to the `GinkgoWriter`, like in other tests in the project.