### PR TITLE
Discard private events in public event server

### DIFF
--- a/internal/servers/events_server.go
+++ b/internal/servers/events_server.go
@@ -293,6 +293,9 @@ func (s *EventsServer) processPayload(ctx context.Context, payload proto.Message
 		)
 		return nil
 	}
+	if private.HasHub() {
+		return nil
+	}
 	public := &eventsv1.Event{}
 	err := s.mapper.Copy(ctx, private, public)
 	if err != nil {


### PR DESCRIPTION
Currently the public event server tries to transform all the private events into public events, but that results in empty events for objects that are only for private use, like hubs. To avoid that this patch changes the public event server so that it explicitly discards those private objects.