### PR TITLE
Update to Go 1.24

### DIFF
--- a/.github/actions/setup-go/action.yaml
+++ b/.github/actions/setup-go/action.yaml
@@ -19,7 +19,7 @@ runs:
   steps:
   - uses: actions/setup-go@v5
     with:
-      go-version: '1.22.9'
+      go-version: '1.24.4'
   - shell: bash
     run: |
       go mod download

--- a/Containerfile
+++ b/Containerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/ubi:9.5-1739751568 AS builder
+FROM registry.access.redhat.com/ubi9/ubi:9.6-1753769805 AS builder
 
 # Install packages:
 RUN \
@@ -18,7 +18,7 @@ RUN go mod download
 COPY . /source
 RUN go build
 
-FROM registry.access.redhat.com/ubi9/ubi:9.5-1739751568 AS runtime
+FROM registry.access.redhat.com/ubi9/ubi:9.6-1753769805 AS runtime
 
 # Install the binary:
 COPY --from=builder /source/fulfillment-service /usr/local/bin

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/innabox/fulfillment-service
 
-go 1.22.9
+go 1.24.4
 
 require (
 	github.com/dustin/go-humanize v1.0.1


### PR DESCRIPTION
Why are currently using Go 1.22, which is already unsupported. This patch updates to Go 1.24 because that is the newest one supported in RHEL UBI (which we need to update to 9.6 as well).