### PR TITLE
Full sync of clusters on hub changes

### DIFF
--- a/internal/cmd/start_controller_cmd.go
+++ b/internal/cmd/start_controller_cmd.go
@@ -116,6 +116,7 @@ func (r *startControllerRunner) run(cmd *cobra.Command, argv []string) error {
 		SetLogger(r.logger).
 		SetClient(r.client).
 		SetFunction(clusterReconcilerFunction).
+		SetEventFilter("has(event.cluster) || (has(event.hub) && event.type == EVENT_TYPE_OBJECT_CREATED)").
 		Build()
 	if err != nil {
 		return fmt.Errorf("failed to create cluster reconciler: %w", err)


### PR DESCRIPTION
Currently a cluster is successfully created even if there is no hub yet. Later, when a hub is added nothing happens inmediatelly, instead the cluster will be re-evaluated during the next full sync, which happens every hour. In order to reduce that time this patch changes the cluster reconciler so that it will also watch for changes in hubs. When a new hub is added the reconciler will run the full sync again.

Related: https://github.com/innabox/issues/issues/181