### PR TITLE
Use context logger in processEvent

### DIFF
--- a/internal/servers/events_server.go
+++ b/internal/servers/events_server.go
@@ -330,7 +330,7 @@ func (s *EventsServer) processEvent(ctx context.Context, event *eventsv1.Event) 
 			logger.DebugContext(ctx, "Event accepted by filter")
 			sub.eventsChan <- event
 		} else {
-			s.logger.DebugContext(ctx, "Event rejected by filter")
+			logger.DebugContext(ctx, "Event rejected by filter")
 		}
 	}
 	return nil

--- a/internal/servers/private_events_server.go
+++ b/internal/servers/private_events_server.go
@@ -310,7 +310,7 @@ func (s *PrivateEventsServer) processEvent(ctx context.Context, event *privatev1
 			logger.DebugContext(ctx, "Event accepted by filter")
 			sub.eventsChan <- event
 		} else {
-			s.logger.DebugContext(ctx, "Event rejected by filter")
+			logger.DebugContext(ctx, "Event rejected by filter")
 		}
 	}
 	return nil


### PR DESCRIPTION
Replace a call to `s.logger` with a call to the contextualized `logger` so
that the `Event rejected by filter` message includes context information.
