### PR TITLE
Add VM reconciler

### DIFF
--- a/internal/kubernetes/gvks/kubernetes_gkvs.go
+++ b/internal/kubernetes/gvks/kubernetes_gkvs.go
@@ -31,6 +31,14 @@ var HostedCluster = schema.GroupVersionKind{
 
 var HostedClusterList = listGVK(HostedCluster)
 
+var VirtualMachine = schema.GroupVersionKind{
+	Group:   "cloudkit.openshift.io",
+	Version: "v1alpha1",
+	Kind:    "VirtualMachine",
+}
+
+var VirtualMachineList = listGVK(VirtualMachine)
+
 func listGVK(gvk schema.GroupVersionKind) schema.GroupVersionKind {
 	gvk.Kind = gvk.Kind + "List"
 	return gvk

--- a/internal/kubernetes/labels/kubernetes_labels.go
+++ b/internal/kubernetes/labels/kubernetes_labels.go
@@ -21,3 +21,6 @@ import (
 
 // ClusterOrderUuid is the label where the fulfillment API will write the identifier of the order.
 var ClusterOrderUuid = fmt.Sprintf("%s/%s", gvks.ClusterOrder.Group, "clusterorder-uuid")
+
+// VirtualMachineUuid is the label where the fulfillment API will write the identifier of the virtual machine.
+var VirtualMachineUuid = fmt.Sprintf("%s/%s", gvks.VirtualMachine.Group, "virtualmachine-uuid")


### PR DESCRIPTION
- Add VM reconciler function following cluster reconciler patterns
- Create VirtualMachine GVK and labels for Kubernetes resources
- Extract template parameter conversion to reusable utility function
- Update both VM and cluster reconcilers to use shared utility
- Add comprehensive tests for ConvertTemplateParametersToJSON function
- Integrate VM reconciler into controller startup process

The VM reconciler handles VirtualMachine lifecycle management by:
- Creating/updating/deleting VirtualMachine Kubernetes objects
- Selecting hubs for VM placement
- Processing template parameters for Kubernetes controllers
- Managing VM status and conditions
