### PR TITLE
Add Keycloak Helm chart for development and integration testing

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,3 +18,4 @@ repos:
       files: \.(yaml|yml)$
       types: [file, yaml]
       entry: yamllint --strict
+      exclude: ^charts/.*/templates/

--- a/charts/keycloak/Chart.yaml
+++ b/charts/keycloak/Chart.yaml
@@ -1,0 +1,19 @@
+#
+# Copyright (c) 2025 Red Hat Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+# the License. You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+apiVersion: v2
+name: keycloak
+description: A Helm chart for Keycloak for use in the Innabox project
+type: application
+version: 0.0.1
+appVersion: "26.3"

--- a/charts/keycloak/README.md
+++ b/charts/keycloak/README.md
@@ -1,0 +1,35 @@
+# Keycloak Helm chart
+
+This Keycloak Helm chart is intended for use in the integration tests of the
+fulfillment service inside a _kind_ cluster. It provides a pre-configured
+Keycloak instance with the necessary realm and client configurations for testing
+authentication and authorization workflows.
+
+## Installation
+
+To install the Keycloak chart, run the following command:
+
+```bash
+$ helm install keycloak charts/keycloak --namespace keycloak --create-namespace --wait
+```
+
+To uninstall it:
+
+```bash
+$ helm uninstall keycloak --namespace keycloak
+```
+
+## Accessing the console
+
+The Keycloak console will be available at
+`https://keycloak.keycloak.svc.cluster.local:8001`, but this address is not
+resolvable via DNS from outside the cluster. For external access, the console is
+available at the localhost IP address, and port 8001. To access it directly
+using the DNS name add the following to your `/etc/hosts` file:
+
+```
+127.0.0.1 keycloak.keycloak.svc.cluster.local
+```
+
+The go to `https://keycloak.keycloak.svc.cluster.local:8001` from your
+local machine.

--- a/charts/keycloak/files/realm.json
+++ b/charts/keycloak/files/realm.json
@@ -1,0 +1,2208 @@
+{
+  "id" : "01e6c34f-6906-4907-9cbd-2dec7a6a0e1d",
+  "realm" : "my_realm",
+  "notBefore" : 0,
+  "defaultSignatureAlgorithm" : "RS256",
+  "revokeRefreshToken" : false,
+  "refreshTokenMaxReuse" : 0,
+  "accessTokenLifespan" : 300,
+  "accessTokenLifespanForImplicitFlow" : 900,
+  "ssoSessionIdleTimeout" : 1800,
+  "ssoSessionMaxLifespan" : 36000,
+  "ssoSessionIdleTimeoutRememberMe" : 0,
+  "ssoSessionMaxLifespanRememberMe" : 0,
+  "offlineSessionIdleTimeout" : 2592000,
+  "offlineSessionMaxLifespanEnabled" : false,
+  "offlineSessionMaxLifespan" : 5184000,
+  "clientSessionIdleTimeout" : 0,
+  "clientSessionMaxLifespan" : 0,
+  "clientOfflineSessionIdleTimeout" : 0,
+  "clientOfflineSessionMaxLifespan" : 0,
+  "accessCodeLifespan" : 60,
+  "accessCodeLifespanUserAction" : 300,
+  "accessCodeLifespanLogin" : 1800,
+  "actionTokenGeneratedByAdminLifespan" : 43200,
+  "actionTokenGeneratedByUserLifespan" : 300,
+  "oauth2DeviceCodeLifespan" : 600,
+  "oauth2DevicePollingInterval" : 5,
+  "enabled" : true,
+  "sslRequired" : "external",
+  "registrationAllowed" : false,
+  "registrationEmailAsUsername" : false,
+  "rememberMe" : false,
+  "verifyEmail" : false,
+  "loginWithEmailAllowed" : true,
+  "duplicateEmailsAllowed" : false,
+  "resetPasswordAllowed" : false,
+  "editUsernameAllowed" : false,
+  "bruteForceProtected" : false,
+  "permanentLockout" : false,
+  "maxTemporaryLockouts" : 0,
+  "bruteForceStrategy" : "MULTIPLE",
+  "maxFailureWaitSeconds" : 900,
+  "minimumQuickLoginWaitSeconds" : 60,
+  "waitIncrementSeconds" : 60,
+  "quickLoginCheckMilliSeconds" : 1000,
+  "maxDeltaTimeSeconds" : 43200,
+  "failureFactor" : 30,
+  "roles" : {
+    "realm" : [ {
+      "id" : "ecc55bff-3667-427d-9326-764d76d99483",
+      "name" : "uma_authorization",
+      "description" : "${role_uma_authorization}",
+      "composite" : false,
+      "clientRole" : false,
+      "containerId" : "01e6c34f-6906-4907-9cbd-2dec7a6a0e1d",
+      "attributes" : { }
+    }, {
+      "id" : "69723bdf-7a37-471a-ae8d-d8fda6d0d119",
+      "name" : "default-roles-my realm",
+      "description" : "${role_default-roles}",
+      "composite" : true,
+      "composites" : {
+        "realm" : [ "offline_access", "uma_authorization" ],
+        "client" : {
+          "account" : [ "view-profile", "manage-account" ]
+        }
+      },
+      "clientRole" : false,
+      "containerId" : "01e6c34f-6906-4907-9cbd-2dec7a6a0e1d",
+      "attributes" : { }
+    }, {
+      "id" : "d0263b33-127a-41cc-a359-ce581f8f3fae",
+      "name" : "offline_access",
+      "description" : "${role_offline-access}",
+      "composite" : false,
+      "clientRole" : false,
+      "containerId" : "01e6c34f-6906-4907-9cbd-2dec7a6a0e1d",
+      "attributes" : { }
+    } ],
+    "client" : {
+      "fulfillment-cli" : [ ],
+      "realm-management" : [ {
+        "id" : "6a539c7b-9c68-499a-8eaf-ac1f5cca678b",
+        "name" : "query-groups",
+        "description" : "${role_query-groups}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "e37d4620-4ae2-432e-90d8-2b7f6a662f43",
+        "attributes" : { }
+      }, {
+        "id" : "d57bf948-75ab-41a6-ba57-63acea7fec96",
+        "name" : "view-identity-providers",
+        "description" : "${role_view-identity-providers}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "e37d4620-4ae2-432e-90d8-2b7f6a662f43",
+        "attributes" : { }
+      }, {
+        "id" : "8fba07c4-f659-4ccc-8416-a6d6f64fa6da",
+        "name" : "manage-clients",
+        "description" : "${role_manage-clients}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "e37d4620-4ae2-432e-90d8-2b7f6a662f43",
+        "attributes" : { }
+      }, {
+        "id" : "c5dd177c-82a5-4cea-bbe2-2f434deeda5d",
+        "name" : "query-clients",
+        "description" : "${role_query-clients}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "e37d4620-4ae2-432e-90d8-2b7f6a662f43",
+        "attributes" : { }
+      }, {
+        "id" : "5b3da028-41c7-4c83-b310-276fe1eea7a0",
+        "name" : "realm-admin",
+        "description" : "${role_realm-admin}",
+        "composite" : true,
+        "composites" : {
+          "client" : {
+            "realm-management" : [ "query-groups", "view-identity-providers", "manage-clients", "query-clients", "view-users", "impersonation", "manage-realm", "manage-identity-providers", "view-realm", "view-clients", "manage-events", "query-users", "manage-users", "create-client", "view-events", "view-authorization", "manage-authorization", "query-realms" ]
+          }
+        },
+        "clientRole" : true,
+        "containerId" : "e37d4620-4ae2-432e-90d8-2b7f6a662f43",
+        "attributes" : { }
+      }, {
+        "id" : "ec2e4475-05c8-46c3-808a-9ed58d5da015",
+        "name" : "view-users",
+        "description" : "${role_view-users}",
+        "composite" : true,
+        "composites" : {
+          "client" : {
+            "realm-management" : [ "query-groups", "query-users" ]
+          }
+        },
+        "clientRole" : true,
+        "containerId" : "e37d4620-4ae2-432e-90d8-2b7f6a662f43",
+        "attributes" : { }
+      }, {
+        "id" : "7ad226c6-f4b8-43d8-a7fe-30eb2daf61cf",
+        "name" : "impersonation",
+        "description" : "${role_impersonation}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "e37d4620-4ae2-432e-90d8-2b7f6a662f43",
+        "attributes" : { }
+      }, {
+        "id" : "b2a448e4-7469-4153-93a6-dcc7136e2ce8",
+        "name" : "manage-identity-providers",
+        "description" : "${role_manage-identity-providers}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "e37d4620-4ae2-432e-90d8-2b7f6a662f43",
+        "attributes" : { }
+      }, {
+        "id" : "ffd09670-3d1c-4cef-b408-6f650a6a22b2",
+        "name" : "manage-realm",
+        "description" : "${role_manage-realm}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "e37d4620-4ae2-432e-90d8-2b7f6a662f43",
+        "attributes" : { }
+      }, {
+        "id" : "9ca3d3d0-caa6-400e-b92b-f3090ddc70cd",
+        "name" : "view-clients",
+        "description" : "${role_view-clients}",
+        "composite" : true,
+        "composites" : {
+          "client" : {
+            "realm-management" : [ "query-clients" ]
+          }
+        },
+        "clientRole" : true,
+        "containerId" : "e37d4620-4ae2-432e-90d8-2b7f6a662f43",
+        "attributes" : { }
+      }, {
+        "id" : "bc134dee-52ed-4a92-b62b-16a85f1dbfef",
+        "name" : "view-realm",
+        "description" : "${role_view-realm}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "e37d4620-4ae2-432e-90d8-2b7f6a662f43",
+        "attributes" : { }
+      }, {
+        "id" : "b75ba6a6-776a-4298-b5ab-e47b2b408e04",
+        "name" : "manage-events",
+        "description" : "${role_manage-events}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "e37d4620-4ae2-432e-90d8-2b7f6a662f43",
+        "attributes" : { }
+      }, {
+        "id" : "41b7023d-0655-48e7-a31c-75ecccf2a3b6",
+        "name" : "query-users",
+        "description" : "${role_query-users}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "e37d4620-4ae2-432e-90d8-2b7f6a662f43",
+        "attributes" : { }
+      }, {
+        "id" : "8a4b016a-cd38-4271-b720-61bc6d967fa5",
+        "name" : "manage-users",
+        "description" : "${role_manage-users}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "e37d4620-4ae2-432e-90d8-2b7f6a662f43",
+        "attributes" : { }
+      }, {
+        "id" : "9c4d75ea-79d4-45dd-80bd-61dea84fd76a",
+        "name" : "create-client",
+        "description" : "${role_create-client}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "e37d4620-4ae2-432e-90d8-2b7f6a662f43",
+        "attributes" : { }
+      }, {
+        "id" : "e741b0ab-9b92-4ebe-9857-1de46b319c22",
+        "name" : "view-events",
+        "description" : "${role_view-events}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "e37d4620-4ae2-432e-90d8-2b7f6a662f43",
+        "attributes" : { }
+      }, {
+        "id" : "88e94a65-6f07-47f9-b4a5-36b5b72035e5",
+        "name" : "manage-authorization",
+        "description" : "${role_manage-authorization}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "e37d4620-4ae2-432e-90d8-2b7f6a662f43",
+        "attributes" : { }
+      }, {
+        "id" : "f0821013-ddd9-4c28-b33d-6838e44f3226",
+        "name" : "view-authorization",
+        "description" : "${role_view-authorization}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "e37d4620-4ae2-432e-90d8-2b7f6a662f43",
+        "attributes" : { }
+      }, {
+        "id" : "ffb70418-70dd-4d19-9844-2c6c12457ad1",
+        "name" : "query-realms",
+        "description" : "${role_query-realms}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "e37d4620-4ae2-432e-90d8-2b7f6a662f43",
+        "attributes" : { }
+      } ],
+      "fulfillment-controller" : [ ],
+      "security-admin-console" : [ ],
+      "admin-cli" : [ ],
+      "account-console" : [ ],
+      "broker" : [ {
+        "id" : "ff5ec66c-ba91-41e7-b4de-b5ac0457878b",
+        "name" : "read-token",
+        "description" : "${role_read-token}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "0e320650-41a8-4561-a026-92042d5f771c",
+        "attributes" : { }
+      } ],
+      "account" : [ {
+        "id" : "6f85d323-e6dc-4887-992b-eb44369ce826",
+        "name" : "view-profile",
+        "description" : "${role_view-profile}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "23cad6d9-db0b-43b2-9d20-63e90b1b571e",
+        "attributes" : { }
+      }, {
+        "id" : "21936607-e253-41ba-bd6e-dae4cb8c3f93",
+        "name" : "manage-account",
+        "description" : "${role_manage-account}",
+        "composite" : true,
+        "composites" : {
+          "client" : {
+            "account" : [ "manage-account-links" ]
+          }
+        },
+        "clientRole" : true,
+        "containerId" : "23cad6d9-db0b-43b2-9d20-63e90b1b571e",
+        "attributes" : { }
+      }, {
+        "id" : "15ad3c02-23c5-4ae2-929d-ca3f428ff7b9",
+        "name" : "manage-consent",
+        "description" : "${role_manage-consent}",
+        "composite" : true,
+        "composites" : {
+          "client" : {
+            "account" : [ "view-consent" ]
+          }
+        },
+        "clientRole" : true,
+        "containerId" : "23cad6d9-db0b-43b2-9d20-63e90b1b571e",
+        "attributes" : { }
+      }, {
+        "id" : "0432dc1f-787f-4114-b4c7-53df771a3528",
+        "name" : "manage-account-links",
+        "description" : "${role_manage-account-links}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "23cad6d9-db0b-43b2-9d20-63e90b1b571e",
+        "attributes" : { }
+      }, {
+        "id" : "855a8b36-b62b-4575-9ea9-8c25b672704b",
+        "name" : "view-consent",
+        "description" : "${role_view-consent}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "23cad6d9-db0b-43b2-9d20-63e90b1b571e",
+        "attributes" : { }
+      }, {
+        "id" : "5437fb4f-bd17-47e5-9606-ccbe9c4601a5",
+        "name" : "delete-account",
+        "description" : "${role_delete-account}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "23cad6d9-db0b-43b2-9d20-63e90b1b571e",
+        "attributes" : { }
+      }, {
+        "id" : "a7dd623c-4dbe-411c-be95-b4d5ae77beb9",
+        "name" : "view-applications",
+        "description" : "${role_view-applications}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "23cad6d9-db0b-43b2-9d20-63e90b1b571e",
+        "attributes" : { }
+      }, {
+        "id" : "89fc823e-9b1d-45b6-8700-bf9c623dc9d6",
+        "name" : "view-groups",
+        "description" : "${role_view-groups}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "23cad6d9-db0b-43b2-9d20-63e90b1b571e",
+        "attributes" : { }
+      } ]
+    }
+  },
+  "groups" : [ {
+    "id" : "4a0a8896-3d83-4327-b472-61d6880e4643",
+    "name" : "admins",
+    "description" : "Administrators",
+    "path" : "/admins",
+    "subGroups" : [ ],
+    "attributes" : { },
+    "realmRoles" : [ ],
+    "clientRoles" : { }
+  }, {
+    "id" : "eb89cecb-39cc-4e20-adb3-8661d9ffd592",
+    "name" : "my_group",
+    "description" : "My group",
+    "path" : "/my_group",
+    "subGroups" : [ ],
+    "attributes" : { },
+    "realmRoles" : [ ],
+    "clientRoles" : { }
+  }, {
+    "id" : "54cc5f3e-7a2d-47ab-942e-16010f087b98",
+    "name" : "your_group",
+    "description" : "Your group",
+    "path" : "/your_group",
+    "subGroups" : [ ],
+    "attributes" : { },
+    "realmRoles" : [ ],
+    "clientRoles" : { }
+  } ],
+  "defaultRole" : {
+    "id" : "69723bdf-7a37-471a-ae8d-d8fda6d0d119",
+    "name" : "default-roles-my realm",
+    "description" : "${role_default-roles}",
+    "composite" : true,
+    "clientRole" : false,
+    "containerId" : "01e6c34f-6906-4907-9cbd-2dec7a6a0e1d"
+  },
+  "requiredCredentials" : [ "password" ],
+  "otpPolicyType" : "totp",
+  "otpPolicyAlgorithm" : "HmacSHA1",
+  "otpPolicyInitialCounter" : 0,
+  "otpPolicyDigits" : 6,
+  "otpPolicyLookAheadWindow" : 1,
+  "otpPolicyPeriod" : 30,
+  "otpPolicyCodeReusable" : false,
+  "otpSupportedApplications" : [ "totpAppFreeOTPName", "totpAppGoogleName", "totpAppMicrosoftAuthenticatorName" ],
+  "localizationTexts" : { },
+  "webAuthnPolicyRpEntityName" : "keycloak",
+  "webAuthnPolicySignatureAlgorithms" : [ "ES256", "RS256" ],
+  "webAuthnPolicyRpId" : "",
+  "webAuthnPolicyAttestationConveyancePreference" : "not specified",
+  "webAuthnPolicyAuthenticatorAttachment" : "not specified",
+  "webAuthnPolicyRequireResidentKey" : "not specified",
+  "webAuthnPolicyUserVerificationRequirement" : "not specified",
+  "webAuthnPolicyCreateTimeout" : 0,
+  "webAuthnPolicyAvoidSameAuthenticatorRegister" : false,
+  "webAuthnPolicyAcceptableAaguids" : [ ],
+  "webAuthnPolicyExtraOrigins" : [ ],
+  "webAuthnPolicyPasswordlessRpEntityName" : "keycloak",
+  "webAuthnPolicyPasswordlessSignatureAlgorithms" : [ "ES256", "RS256" ],
+  "webAuthnPolicyPasswordlessRpId" : "",
+  "webAuthnPolicyPasswordlessAttestationConveyancePreference" : "not specified",
+  "webAuthnPolicyPasswordlessAuthenticatorAttachment" : "not specified",
+  "webAuthnPolicyPasswordlessRequireResidentKey" : "not specified",
+  "webAuthnPolicyPasswordlessUserVerificationRequirement" : "not specified",
+  "webAuthnPolicyPasswordlessCreateTimeout" : 0,
+  "webAuthnPolicyPasswordlessAvoidSameAuthenticatorRegister" : false,
+  "webAuthnPolicyPasswordlessAcceptableAaguids" : [ ],
+  "webAuthnPolicyPasswordlessExtraOrigins" : [ ],
+  "users" : [ {
+    "id" : "7aa83fea-6fcd-4167-a8cf-80ed4c3221b7",
+    "username" : "admin",
+    "firstName" : "Administrator",
+    "emailVerified" : true,
+    "enabled" : true,
+    "createdTimestamp" : 1757683803195,
+    "totp" : false,
+    "credentials" : [ {
+      "id" : "85ac82fc-bbcc-49a0-a709-1ac82d9fb37f",
+      "type" : "password",
+      "userLabel" : "My password",
+      "createdDate" : 1757683819334,
+      "secretData" : "{\"value\":\"ETe90wgj32P+Q1rPLulfMazdek0nF+op9EFkdZllsnE=\",\"salt\":\"QhTSTs3ZpWedDP/H7S7UCg==\",\"additionalParameters\":{}}",
+      "credentialData" : "{\"hashIterations\":5,\"algorithm\":\"argon2\",\"additionalParameters\":{\"hashLength\":[\"32\"],\"memory\":[\"7168\"],\"type\":[\"id\"],\"version\":[\"1.3\"],\"parallelism\":[\"1\"]}}"
+    } ],
+    "disableableCredentialTypes" : [ ],
+    "requiredActions" : [ ],
+    "realmRoles" : [ "default-roles-my realm" ],
+    "notBefore" : 0,
+    "groups" : [ "/admins" ]
+  }, {
+    "id" : "f81e5429-26ff-418e-bf67-c054e449e7b7",
+    "username" : "my_user",
+    "firstName" : "My user",
+    "emailVerified" : true,
+    "enabled" : true,
+    "createdTimestamp" : 1757683688569,
+    "totp" : false,
+    "credentials" : [ {
+      "id" : "600c5f73-bec9-4f00-8589-fb3d9cb73677",
+      "type" : "password",
+      "userLabel" : "My password",
+      "createdDate" : 1757683715233,
+      "secretData" : "{\"value\":\"O7P9Pg595LgKFL2nDOmNrRFg611i6OyTwPn1O17MNnM=\",\"salt\":\"2l9A8qWpE+OPfaPyfKQ9Cg==\",\"additionalParameters\":{}}",
+      "credentialData" : "{\"hashIterations\":5,\"algorithm\":\"argon2\",\"additionalParameters\":{\"hashLength\":[\"32\"],\"memory\":[\"7168\"],\"type\":[\"id\"],\"version\":[\"1.3\"],\"parallelism\":[\"1\"]}}"
+    } ],
+    "disableableCredentialTypes" : [ ],
+    "requiredActions" : [ ],
+    "realmRoles" : [ "default-roles-my realm" ],
+    "notBefore" : 0,
+    "groups" : [ "/my_group" ]
+  }, {
+    "id" : "bd0e8d6c-0095-4937-81a2-7f7c47caae59",
+    "username" : "your_user",
+    "firstName" : "Your user",
+    "emailVerified" : true,
+    "enabled" : true,
+    "createdTimestamp" : 1757683762187,
+    "totp" : false,
+    "credentials" : [ {
+      "id" : "b5c5c84b-c2f6-4641-ad60-a621b31e4f46",
+      "type" : "password",
+      "userLabel" : "My password",
+      "createdDate" : 1757683779283,
+      "secretData" : "{\"value\":\"GBNPTmZq4TYz5vknwZxmzkbv6UQxgYJtqQuFmFiKD6o=\",\"salt\":\"sHcs3g0Tz4wyU9pj8Wf8sQ==\",\"additionalParameters\":{}}",
+      "credentialData" : "{\"hashIterations\":5,\"algorithm\":\"argon2\",\"additionalParameters\":{\"hashLength\":[\"32\"],\"memory\":[\"7168\"],\"type\":[\"id\"],\"version\":[\"1.3\"],\"parallelism\":[\"1\"]}}"
+    } ],
+    "disableableCredentialTypes" : [ ],
+    "requiredActions" : [ ],
+    "realmRoles" : [ "default-roles-my realm" ],
+    "notBefore" : 0,
+    "groups" : [ "/your_group" ]
+  } ],
+  "scopeMappings" : [ {
+    "clientScope" : "offline_access",
+    "roles" : [ "offline_access" ]
+  } ],
+  "clientScopeMappings" : {
+    "account" : [ {
+      "client" : "account-console",
+      "roles" : [ "manage-account", "view-groups" ]
+    } ]
+  },
+  "clients" : [ {
+    "id" : "23cad6d9-db0b-43b2-9d20-63e90b1b571e",
+    "clientId" : "account",
+    "name" : "${client_account}",
+    "rootUrl" : "${authBaseUrl}",
+    "baseUrl" : "/realms/My%20realm/account/",
+    "surrogateAuthRequired" : false,
+    "enabled" : true,
+    "alwaysDisplayInConsole" : false,
+    "clientAuthenticatorType" : "client-secret",
+    "redirectUris" : [ "/realms/My%20realm/account/*" ],
+    "webOrigins" : [ ],
+    "notBefore" : 0,
+    "bearerOnly" : false,
+    "consentRequired" : false,
+    "standardFlowEnabled" : true,
+    "implicitFlowEnabled" : false,
+    "directAccessGrantsEnabled" : false,
+    "serviceAccountsEnabled" : false,
+    "publicClient" : true,
+    "frontchannelLogout" : false,
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "realm_client" : "false",
+      "post.logout.redirect.uris" : "+"
+    },
+    "authenticationFlowBindingOverrides" : { },
+    "fullScopeAllowed" : false,
+    "nodeReRegistrationTimeout" : 0,
+    "defaultClientScopes" : [ "web-origins", "acr", "profile", "roles", "basic", "email" ],
+    "optionalClientScopes" : [ "address", "phone", "organization", "offline_access", "microprofile-jwt" ]
+  }, {
+    "id" : "b3b07783-b506-4df2-a928-305b2e339502",
+    "clientId" : "account-console",
+    "name" : "${client_account-console}",
+    "rootUrl" : "${authBaseUrl}",
+    "baseUrl" : "/realms/My%20realm/account/",
+    "surrogateAuthRequired" : false,
+    "enabled" : true,
+    "alwaysDisplayInConsole" : false,
+    "clientAuthenticatorType" : "client-secret",
+    "redirectUris" : [ "/realms/My%20realm/account/*" ],
+    "webOrigins" : [ ],
+    "notBefore" : 0,
+    "bearerOnly" : false,
+    "consentRequired" : false,
+    "standardFlowEnabled" : true,
+    "implicitFlowEnabled" : false,
+    "directAccessGrantsEnabled" : false,
+    "serviceAccountsEnabled" : false,
+    "publicClient" : true,
+    "frontchannelLogout" : false,
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "realm_client" : "false",
+      "post.logout.redirect.uris" : "+",
+      "pkce.code.challenge.method" : "S256"
+    },
+    "authenticationFlowBindingOverrides" : { },
+    "fullScopeAllowed" : false,
+    "nodeReRegistrationTimeout" : 0,
+    "protocolMappers" : [ {
+      "id" : "690b8f4d-a61b-4a7b-a801-444323137349",
+      "name" : "audience resolve",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-audience-resolve-mapper",
+      "consentRequired" : false,
+      "config" : { }
+    } ],
+    "defaultClientScopes" : [ "web-origins", "acr", "profile", "roles", "basic", "email" ],
+    "optionalClientScopes" : [ "address", "phone", "organization", "offline_access", "microprofile-jwt" ]
+  }, {
+    "id" : "82884757-645c-45eb-a018-f2a7bdfdd554",
+    "clientId" : "admin-cli",
+    "name" : "${client_admin-cli}",
+    "surrogateAuthRequired" : false,
+    "enabled" : true,
+    "alwaysDisplayInConsole" : false,
+    "clientAuthenticatorType" : "client-secret",
+    "redirectUris" : [ ],
+    "webOrigins" : [ ],
+    "notBefore" : 0,
+    "bearerOnly" : false,
+    "consentRequired" : false,
+    "standardFlowEnabled" : false,
+    "implicitFlowEnabled" : false,
+    "directAccessGrantsEnabled" : true,
+    "serviceAccountsEnabled" : false,
+    "publicClient" : true,
+    "frontchannelLogout" : false,
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "realm_client" : "false",
+      "client.use.lightweight.access.token.enabled" : "true"
+    },
+    "authenticationFlowBindingOverrides" : { },
+    "fullScopeAllowed" : true,
+    "nodeReRegistrationTimeout" : 0,
+    "defaultClientScopes" : [ "web-origins", "acr", "profile", "roles", "basic", "email" ],
+    "optionalClientScopes" : [ "address", "phone", "organization", "offline_access", "microprofile-jwt" ]
+  }, {
+    "id" : "0e320650-41a8-4561-a026-92042d5f771c",
+    "clientId" : "broker",
+    "name" : "${client_broker}",
+    "surrogateAuthRequired" : false,
+    "enabled" : true,
+    "alwaysDisplayInConsole" : false,
+    "clientAuthenticatorType" : "client-secret",
+    "redirectUris" : [ ],
+    "webOrigins" : [ ],
+    "notBefore" : 0,
+    "bearerOnly" : true,
+    "consentRequired" : false,
+    "standardFlowEnabled" : true,
+    "implicitFlowEnabled" : false,
+    "directAccessGrantsEnabled" : false,
+    "serviceAccountsEnabled" : false,
+    "publicClient" : false,
+    "frontchannelLogout" : false,
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "realm_client" : "true"
+    },
+    "authenticationFlowBindingOverrides" : { },
+    "fullScopeAllowed" : false,
+    "nodeReRegistrationTimeout" : 0,
+    "defaultClientScopes" : [ "web-origins", "acr", "profile", "roles", "basic", "email" ],
+    "optionalClientScopes" : [ "address", "phone", "organization", "offline_access", "microprofile-jwt" ]
+  }, {
+    "id" : "75d02386-879f-4a5f-880f-eb59f4b3f19c",
+    "clientId" : "fulfillment-cli",
+    "name" : "Fulfillment CLI",
+    "description" : "Fulfillment command line interface",
+    "rootUrl" : "",
+    "adminUrl" : "",
+    "baseUrl" : "http://localhost",
+    "surrogateAuthRequired" : false,
+    "enabled" : true,
+    "alwaysDisplayInConsole" : false,
+    "clientAuthenticatorType" : "client-secret",
+    "redirectUris" : [ "/*" ],
+    "webOrigins" : [ "/*" ],
+    "notBefore" : 0,
+    "bearerOnly" : false,
+    "consentRequired" : false,
+    "standardFlowEnabled" : true,
+    "implicitFlowEnabled" : false,
+    "directAccessGrantsEnabled" : false,
+    "serviceAccountsEnabled" : false,
+    "publicClient" : true,
+    "frontchannelLogout" : true,
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "realm_client" : "false",
+      "oidc.ciba.grant.enabled" : "false",
+      "backchannel.logout.session.required" : "true",
+      "standard.token.exchange.enabled" : "false",
+      "oauth2.device.authorization.grant.enabled" : "true",
+      "pkce.code.challenge.method" : "S256",
+      "backchannel.logout.revoke.offline.tokens" : "false"
+    },
+    "authenticationFlowBindingOverrides" : { },
+    "fullScopeAllowed" : true,
+    "nodeReRegistrationTimeout" : -1,
+    "defaultClientScopes" : [ "web-origins", "acr", "profile", "roles", "basic", "email" ],
+    "optionalClientScopes" : [ "address", "phone", "organization", "offline_access", "microprofile-jwt" ]
+  }, {
+    "id" : "90e7d0e5-cac0-4de7-94cd-bcfe2cb1ae3c",
+    "clientId" : "fulfillment-controller",
+    "name" : "Fulfillment controller",
+    "description" : "Fulfillment controller",
+    "rootUrl" : "",
+    "adminUrl" : "",
+    "baseUrl" : "",
+    "surrogateAuthRequired" : false,
+    "enabled" : true,
+    "alwaysDisplayInConsole" : false,
+    "clientAuthenticatorType" : "client-secret",
+    "secret" : "t2N7qNiOYZzt6InsHOVsV5AzcZZbA7Sg",
+    "redirectUris" : [ "/*" ],
+    "webOrigins" : [ "/*" ],
+    "notBefore" : 0,
+    "bearerOnly" : false,
+    "consentRequired" : false,
+    "standardFlowEnabled" : false,
+    "implicitFlowEnabled" : false,
+    "directAccessGrantsEnabled" : true,
+    "serviceAccountsEnabled" : false,
+    "publicClient" : false,
+    "frontchannelLogout" : true,
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "realm_client" : "false",
+      "oidc.ciba.grant.enabled" : "false",
+      "client.secret.creation.time" : "1757684016",
+      "backchannel.logout.session.required" : "true",
+      "standard.token.exchange.enabled" : "false",
+      "oauth2.device.authorization.grant.enabled" : "false",
+      "backchannel.logout.revoke.offline.tokens" : "false"
+    },
+    "authenticationFlowBindingOverrides" : { },
+    "fullScopeAllowed" : true,
+    "nodeReRegistrationTimeout" : -1,
+    "defaultClientScopes" : [ "web-origins", "acr", "profile", "roles", "basic", "email" ],
+    "optionalClientScopes" : [ "address", "phone", "organization", "offline_access", "microprofile-jwt" ]
+  }, {
+    "id" : "e37d4620-4ae2-432e-90d8-2b7f6a662f43",
+    "clientId" : "realm-management",
+    "name" : "${client_realm-management}",
+    "surrogateAuthRequired" : false,
+    "enabled" : true,
+    "alwaysDisplayInConsole" : false,
+    "clientAuthenticatorType" : "client-secret",
+    "redirectUris" : [ ],
+    "webOrigins" : [ ],
+    "notBefore" : 0,
+    "bearerOnly" : true,
+    "consentRequired" : false,
+    "standardFlowEnabled" : true,
+    "implicitFlowEnabled" : false,
+    "directAccessGrantsEnabled" : false,
+    "serviceAccountsEnabled" : false,
+    "publicClient" : false,
+    "frontchannelLogout" : false,
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "realm_client" : "true"
+    },
+    "authenticationFlowBindingOverrides" : { },
+    "fullScopeAllowed" : false,
+    "nodeReRegistrationTimeout" : 0,
+    "defaultClientScopes" : [ "web-origins", "acr", "profile", "roles", "basic", "email" ],
+    "optionalClientScopes" : [ "address", "phone", "organization", "offline_access", "microprofile-jwt" ]
+  }, {
+    "id" : "88d75990-993f-4c55-a166-67041a6b3377",
+    "clientId" : "security-admin-console",
+    "name" : "${client_security-admin-console}",
+    "rootUrl" : "${authAdminUrl}",
+    "baseUrl" : "/admin/My%20realm/console/",
+    "surrogateAuthRequired" : false,
+    "enabled" : true,
+    "alwaysDisplayInConsole" : false,
+    "clientAuthenticatorType" : "client-secret",
+    "redirectUris" : [ "/admin/My%20realm/console/*" ],
+    "webOrigins" : [ "+" ],
+    "notBefore" : 0,
+    "bearerOnly" : false,
+    "consentRequired" : false,
+    "standardFlowEnabled" : true,
+    "implicitFlowEnabled" : false,
+    "directAccessGrantsEnabled" : false,
+    "serviceAccountsEnabled" : false,
+    "publicClient" : true,
+    "frontchannelLogout" : false,
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "realm_client" : "false",
+      "client.use.lightweight.access.token.enabled" : "true",
+      "post.logout.redirect.uris" : "+",
+      "pkce.code.challenge.method" : "S256"
+    },
+    "authenticationFlowBindingOverrides" : { },
+    "fullScopeAllowed" : true,
+    "nodeReRegistrationTimeout" : 0,
+    "protocolMappers" : [ {
+      "id" : "a7f78d53-a9a9-4323-92a2-d1744824e1ef",
+      "name" : "locale",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "introspection.token.claim" : "true",
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "locale",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "locale",
+        "jsonType.label" : "String"
+      }
+    } ],
+    "defaultClientScopes" : [ "web-origins", "acr", "profile", "roles", "basic", "email" ],
+    "optionalClientScopes" : [ "address", "phone", "organization", "offline_access", "microprofile-jwt" ]
+  } ],
+  "clientScopes" : [ {
+    "id" : "2d4feb76-fd87-46d5-9eca-b7471da62403",
+    "name" : "service_account",
+    "description" : "Specific scope for a client enabled for service accounts",
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "include.in.token.scope" : "false",
+      "display.on.consent.screen" : "false"
+    },
+    "protocolMappers" : [ {
+      "id" : "3b28a355-d2f4-40b5-b89d-4e631d3cccd5",
+      "name" : "Client IP Address",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usersessionmodel-note-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "user.session.note" : "clientAddress",
+        "id.token.claim" : "true",
+        "introspection.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "clientAddress",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "5993f2c5-3230-4337-844d-e204f5177eaf",
+      "name" : "Client ID",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usersessionmodel-note-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "user.session.note" : "client_id",
+        "id.token.claim" : "true",
+        "introspection.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "client_id",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "f2a27232-2096-4e88-b5a8-46e9c276b937",
+      "name" : "Client Host",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usersessionmodel-note-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "user.session.note" : "clientHost",
+        "id.token.claim" : "true",
+        "introspection.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "clientHost",
+        "jsonType.label" : "String"
+      }
+    } ]
+  }, {
+    "id" : "031c6268-83a2-4445-90f3-3a773beb1077",
+    "name" : "phone",
+    "description" : "OpenID Connect built-in scope: phone",
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "include.in.token.scope" : "true",
+      "consent.screen.text" : "${phoneScopeConsentText}",
+      "display.on.consent.screen" : "true"
+    },
+    "protocolMappers" : [ {
+      "id" : "f3291e1d-b1e9-4ca7-8d2a-7336f9b52e66",
+      "name" : "phone number verified",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "introspection.token.claim" : "true",
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "phoneNumberVerified",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "phone_number_verified",
+        "jsonType.label" : "boolean"
+      }
+    }, {
+      "id" : "99e7228a-c2a6-47ef-959b-38f759997452",
+      "name" : "phone number",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "introspection.token.claim" : "true",
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "phoneNumber",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "phone_number",
+        "jsonType.label" : "String"
+      }
+    } ]
+  }, {
+    "id" : "26c93a2a-6291-4ba0-bbfe-3821617c6713",
+    "name" : "role_list",
+    "description" : "SAML role list",
+    "protocol" : "saml",
+    "attributes" : {
+      "consent.screen.text" : "${samlRoleListScopeConsentText}",
+      "display.on.consent.screen" : "true"
+    },
+    "protocolMappers" : [ {
+      "id" : "d808154b-75f9-4310-93a1-4b385df0045a",
+      "name" : "role list",
+      "protocol" : "saml",
+      "protocolMapper" : "saml-role-list-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "single" : "false",
+        "attribute.nameformat" : "Basic",
+        "attribute.name" : "Role"
+      }
+    } ]
+  }, {
+    "id" : "1c7c7b64-1801-4c15-9cbc-b60aaeec89bb",
+    "name" : "organization",
+    "description" : "Additional claims about the organization a subject belongs to",
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "include.in.token.scope" : "true",
+      "consent.screen.text" : "${organizationScopeConsentText}",
+      "display.on.consent.screen" : "true"
+    },
+    "protocolMappers" : [ {
+      "id" : "bfbb0aab-8730-4488-b0f9-6be8ceede468",
+      "name" : "organization",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-organization-membership-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "id.token.claim" : "true",
+        "introspection.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "organization",
+        "jsonType.label" : "String",
+        "multivalued" : "true"
+      }
+    } ]
+  }, {
+    "id" : "ced65214-50b1-4c1b-9775-18fcbf5c27a6",
+    "name" : "saml_organization",
+    "description" : "Organization Membership",
+    "protocol" : "saml",
+    "attributes" : {
+      "display.on.consent.screen" : "false"
+    },
+    "protocolMappers" : [ {
+      "id" : "865cc3fa-7e7c-4921-a059-e4cde1a485f2",
+      "name" : "organization",
+      "protocol" : "saml",
+      "protocolMapper" : "saml-organization-membership-mapper",
+      "consentRequired" : false,
+      "config" : { }
+    } ]
+  }, {
+    "id" : "8e0c0caa-cc2c-46a8-b0a1-e6f4bc8d5564",
+    "name" : "microprofile-jwt",
+    "description" : "Microprofile - JWT built-in scope",
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "include.in.token.scope" : "true",
+      "display.on.consent.screen" : "false"
+    },
+    "protocolMappers" : [ {
+      "id" : "bd8abc7c-6dcd-4d9b-bd3f-d35eb1971302",
+      "name" : "upn",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "introspection.token.claim" : "true",
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "username",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "upn",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "06afb588-d617-4795-ba94-48f944db6eef",
+      "name" : "groups",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-realm-role-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "introspection.token.claim" : "true",
+        "multivalued" : "true",
+        "user.attribute" : "foo",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "groups",
+        "jsonType.label" : "String"
+      }
+    } ]
+  }, {
+    "id" : "1b4c4f6d-3fb6-4fe5-8220-e508f5b92cb5",
+    "name" : "offline_access",
+    "description" : "OpenID Connect built-in scope: offline_access",
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "consent.screen.text" : "${offlineAccessScopeConsentText}",
+      "display.on.consent.screen" : "true"
+    }
+  }, {
+    "id" : "3b2c7544-9751-4cc5-999a-02d291bcc336",
+    "name" : "acr",
+    "description" : "OpenID Connect scope for add acr (authentication context class reference) to the token",
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "include.in.token.scope" : "false",
+      "display.on.consent.screen" : "false"
+    },
+    "protocolMappers" : [ {
+      "id" : "7a9ad13d-ff78-4535-9e2c-b68ad155d94f",
+      "name" : "acr loa level",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-acr-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "id.token.claim" : "true",
+        "introspection.token.claim" : "true",
+        "access.token.claim" : "true"
+      }
+    } ]
+  }, {
+    "id" : "d5232a06-84cb-4d4a-9676-33968d98eecc",
+    "name" : "roles",
+    "description" : "OpenID Connect scope for add user roles to the access token",
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "include.in.token.scope" : "false",
+      "consent.screen.text" : "${rolesScopeConsentText}",
+      "display.on.consent.screen" : "true"
+    },
+    "protocolMappers" : [ {
+      "id" : "00224eba-ca73-4459-b2dc-f82334ce9b03",
+      "name" : "realm roles",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-realm-role-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "user.attribute" : "foo",
+        "introspection.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "realm_access.roles",
+        "jsonType.label" : "String",
+        "multivalued" : "true"
+      }
+    }, {
+      "id" : "5fb5d5c5-26eb-4faa-9bb0-be1401592078",
+      "name" : "client roles",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-client-role-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "user.attribute" : "foo",
+        "introspection.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "resource_access.${client_id}.roles",
+        "jsonType.label" : "String",
+        "multivalued" : "true"
+      }
+    }, {
+      "id" : "9e768141-a8df-4415-b26d-f41883612650",
+      "name" : "audience resolve",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-audience-resolve-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "introspection.token.claim" : "true",
+        "access.token.claim" : "true"
+      }
+    } ]
+  }, {
+    "id" : "0f46869e-5a98-4ab0-92c7-2cf3f46318c1",
+    "name" : "web-origins",
+    "description" : "OpenID Connect scope for add allowed web origins to the access token",
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "include.in.token.scope" : "false",
+      "consent.screen.text" : "",
+      "display.on.consent.screen" : "false"
+    },
+    "protocolMappers" : [ {
+      "id" : "9e455861-2c3c-457b-8a6d-6454e69122d6",
+      "name" : "allowed web origins",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-allowed-origins-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "introspection.token.claim" : "true",
+        "access.token.claim" : "true"
+      }
+    } ]
+  }, {
+    "id" : "4a8ef1f3-6531-415f-8972-a52eed55d837",
+    "name" : "basic",
+    "description" : "OpenID Connect scope for add all basic claims to the token",
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "include.in.token.scope" : "false",
+      "display.on.consent.screen" : "false"
+    },
+    "protocolMappers" : [ {
+      "id" : "f64a29f0-28c0-43f1-a9ee-7513ecb22476",
+      "name" : "auth_time",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usersessionmodel-note-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "user.session.note" : "AUTH_TIME",
+        "id.token.claim" : "true",
+        "introspection.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "auth_time",
+        "jsonType.label" : "long"
+      }
+    }, {
+      "id" : "f20a3a6a-6451-4715-b3f1-07c38f5d616f",
+      "name" : "sub",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-sub-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "introspection.token.claim" : "true",
+        "access.token.claim" : "true"
+      }
+    } ]
+  }, {
+    "id" : "cd025712-64b4-4221-8b27-e18c1a452ddb",
+    "name" : "email",
+    "description" : "OpenID Connect built-in scope: email",
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "include.in.token.scope" : "true",
+      "consent.screen.text" : "${emailScopeConsentText}",
+      "display.on.consent.screen" : "true"
+    },
+    "protocolMappers" : [ {
+      "id" : "6c7fcd01-f651-444f-af02-f78339124c32",
+      "name" : "email",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "introspection.token.claim" : "true",
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "email",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "email",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "7e9ef7ff-21a4-4e21-9f69-d6a56a210bc7",
+      "name" : "email verified",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-property-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "introspection.token.claim" : "true",
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "emailVerified",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "email_verified",
+        "jsonType.label" : "boolean"
+      }
+    } ]
+  }, {
+    "id" : "21cbca22-12c1-4269-ad95-38b6117f8ef2",
+    "name" : "profile",
+    "description" : "OpenID Connect built-in scope: profile",
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "include.in.token.scope" : "true",
+      "consent.screen.text" : "${profileScopeConsentText}",
+      "display.on.consent.screen" : "true"
+    },
+    "protocolMappers" : [ {
+      "id" : "05afc1ea-8386-42de-abb3-5221f87f29bd",
+      "name" : "locale",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "introspection.token.claim" : "true",
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "locale",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "locale",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "d9e0bd40-7150-45df-ae8d-99d37085c702",
+      "name" : "updated at",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "introspection.token.claim" : "true",
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "updatedAt",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "updated_at",
+        "jsonType.label" : "long"
+      }
+    }, {
+      "id" : "2d0ede4e-a15d-4fcf-b5e8-6b463cecbe64",
+      "name" : "full name",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-full-name-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "id.token.claim" : "true",
+        "introspection.token.claim" : "true",
+        "access.token.claim" : "true",
+        "userinfo.token.claim" : "true"
+      }
+    }, {
+      "id" : "0ed542d4-bcc8-41be-911f-29d946549b41",
+      "name" : "username",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "introspection.token.claim" : "true",
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "username",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "preferred_username",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "9a7b4f77-0dd1-4392-96e6-a8ac2c436d9f",
+      "name" : "middle name",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "introspection.token.claim" : "true",
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "middleName",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "middle_name",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "bc285e5b-34e5-4788-939b-a08aef53197b",
+      "name" : "picture",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "introspection.token.claim" : "true",
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "picture",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "picture",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "5294a6a5-7652-4335-9065-074c69f28aa5",
+      "name" : "profile",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "introspection.token.claim" : "true",
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "profile",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "profile",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "4d7419cd-b239-4c60-a301-9a6605a47b67",
+      "name" : "zoneinfo",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "introspection.token.claim" : "true",
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "zoneinfo",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "zoneinfo",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "a69b3a4b-f4e7-4794-a3a5-dd81ff004def",
+      "name" : "website",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "introspection.token.claim" : "true",
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "website",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "website",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "b4ff110f-b1a9-4780-a07d-96778c059410",
+      "name" : "gender",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "introspection.token.claim" : "true",
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "gender",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "gender",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "39f120f3-f06c-4b69-bf4f-b6caec540830",
+      "name" : "family name",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "introspection.token.claim" : "true",
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "lastName",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "family_name",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "886679e1-205d-4836-a2a4-d05d6a693d0d",
+      "name" : "birthdate",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "introspection.token.claim" : "true",
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "birthdate",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "birthdate",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "ee282633-004f-44d0-915d-f28879e29cca",
+      "name" : "nickname",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "introspection.token.claim" : "true",
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "nickname",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "nickname",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "3c7db46b-84bb-45ec-991d-d4105e56bd9c",
+      "name" : "given name",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "introspection.token.claim" : "true",
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "firstName",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "given_name",
+        "jsonType.label" : "String"
+      }
+    } ]
+  }, {
+    "id" : "c20c7864-23e4-4866-8a2c-889d0a55c568",
+    "name" : "address",
+    "description" : "OpenID Connect built-in scope: address",
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "include.in.token.scope" : "true",
+      "consent.screen.text" : "${addressScopeConsentText}",
+      "display.on.consent.screen" : "true"
+    },
+    "protocolMappers" : [ {
+      "id" : "67294e3e-594e-4b55-9fd3-1e42bcaf539c",
+      "name" : "address",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-address-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "user.attribute.formatted" : "formatted",
+        "user.attribute.country" : "country",
+        "introspection.token.claim" : "true",
+        "user.attribute.postal_code" : "postal_code",
+        "userinfo.token.claim" : "true",
+        "user.attribute.street" : "street",
+        "id.token.claim" : "true",
+        "user.attribute.region" : "region",
+        "access.token.claim" : "true",
+        "user.attribute.locality" : "locality"
+      }
+    } ]
+  } ],
+  "defaultDefaultClientScopes" : [ "role_list", "saml_organization", "profile", "email", "roles", "web-origins", "acr", "basic" ],
+  "defaultOptionalClientScopes" : [ "offline_access", "address", "phone", "microprofile-jwt", "organization" ],
+  "browserSecurityHeaders" : {
+    "contentSecurityPolicyReportOnly" : "",
+    "xContentTypeOptions" : "nosniff",
+    "referrerPolicy" : "no-referrer",
+    "xRobotsTag" : "none",
+    "xFrameOptions" : "SAMEORIGIN",
+    "contentSecurityPolicy" : "frame-src 'self'; frame-ancestors 'self'; object-src 'none';",
+    "strictTransportSecurity" : "max-age=31536000; includeSubDomains"
+  },
+  "smtpServer" : { },
+  "eventsEnabled" : false,
+  "eventsListeners" : [ "jboss-logging" ],
+  "enabledEventTypes" : [ ],
+  "adminEventsEnabled" : false,
+  "adminEventsDetailsEnabled" : false,
+  "identityProviders" : [ ],
+  "identityProviderMappers" : [ ],
+  "components" : {
+    "org.keycloak.services.clientregistration.policy.ClientRegistrationPolicy" : [ {
+      "id" : "ea92b85a-adc1-4876-a642-064a1828a57a",
+      "name" : "Allowed Protocol Mapper Types",
+      "providerId" : "allowed-protocol-mappers",
+      "subType" : "authenticated",
+      "subComponents" : { },
+      "config" : {
+        "allowed-protocol-mapper-types" : [ "oidc-address-mapper", "saml-user-attribute-mapper", "oidc-usermodel-attribute-mapper", "saml-user-property-mapper", "oidc-full-name-mapper", "oidc-usermodel-property-mapper", "saml-role-list-mapper", "oidc-sha256-pairwise-sub-mapper" ]
+      }
+    }, {
+      "id" : "3f236ec1-309c-48fb-96cd-08c03ae45271",
+      "name" : "Allowed Protocol Mapper Types",
+      "providerId" : "allowed-protocol-mappers",
+      "subType" : "anonymous",
+      "subComponents" : { },
+      "config" : {
+        "allowed-protocol-mapper-types" : [ "oidc-usermodel-attribute-mapper", "oidc-full-name-mapper", "oidc-sha256-pairwise-sub-mapper", "oidc-address-mapper", "saml-user-attribute-mapper", "oidc-usermodel-property-mapper", "saml-role-list-mapper", "saml-user-property-mapper" ]
+      }
+    }, {
+      "id" : "5f50bd47-344d-48f8-b2b3-ee4128dde1cc",
+      "name" : "Full Scope Disabled",
+      "providerId" : "scope",
+      "subType" : "anonymous",
+      "subComponents" : { },
+      "config" : { }
+    }, {
+      "id" : "043cceff-34b8-4773-ac85-6ede7790ac35",
+      "name" : "Allowed Client Scopes",
+      "providerId" : "allowed-client-templates",
+      "subType" : "anonymous",
+      "subComponents" : { },
+      "config" : {
+        "allow-default-scopes" : [ "true" ]
+      }
+    }, {
+      "id" : "9426b168-c499-41c8-b83c-b8fb05e3ba71",
+      "name" : "Allowed Client Scopes",
+      "providerId" : "allowed-client-templates",
+      "subType" : "authenticated",
+      "subComponents" : { },
+      "config" : {
+        "allow-default-scopes" : [ "true" ]
+      }
+    }, {
+      "id" : "98212f83-0629-4a54-b8a8-8a209a406094",
+      "name" : "Trusted Hosts",
+      "providerId" : "trusted-hosts",
+      "subType" : "anonymous",
+      "subComponents" : { },
+      "config" : {
+        "host-sending-registration-request-must-match" : [ "true" ],
+        "client-uris-must-match" : [ "true" ]
+      }
+    }, {
+      "id" : "2bd57be1-f269-4340-bf87-e9b07240097c",
+      "name" : "Consent Required",
+      "providerId" : "consent-required",
+      "subType" : "anonymous",
+      "subComponents" : { },
+      "config" : { }
+    }, {
+      "id" : "0d34872b-1a14-442a-8b3c-eea811b9853e",
+      "name" : "Max Clients Limit",
+      "providerId" : "max-clients",
+      "subType" : "anonymous",
+      "subComponents" : { },
+      "config" : {
+        "max-clients" : [ "200" ]
+      }
+    } ],
+    "org.keycloak.keys.KeyProvider" : [ {
+      "id" : "bc4fe42f-0ee1-4884-9ba5-df5dfd7f8f40",
+      "name" : "hmac-generated-hs512",
+      "providerId" : "hmac-generated",
+      "subComponents" : { },
+      "config" : {
+        "kid" : [ "513d15f5-06ec-4a5b-b60c-be0150e08772" ],
+        "secret" : [ "aJUl8piIHK_97LD9LbkCSVQdKundPvfxlCE3HfUOABgo2AO5RNPcPrhtWbatKJdn_8zTlssAvbgOGc3JK1nioGgJC4CEEGST5eB6zW0c5c_QV_Da5YnUNND8x1xx5QA5V_B_gemD3vNM2ETgrF2cAuww8RFxFz5Wj8JLH5RTCJw" ],
+        "priority" : [ "100" ],
+        "algorithm" : [ "HS512" ]
+      }
+    }, {
+      "id" : "b40479fb-88db-4c4c-9c0a-cf6cf0c402b3",
+      "name" : "aes-generated",
+      "providerId" : "aes-generated",
+      "subComponents" : { },
+      "config" : {
+        "kid" : [ "a7dd0fed-b89b-4c8a-8d23-a0f49c41360e" ],
+        "secret" : [ "1mm6DQuQwmXRWssonexIrQ" ],
+        "priority" : [ "100" ]
+      }
+    }, {
+      "id" : "7565d549-7fb3-4165-a55c-b9a48688b379",
+      "name" : "rsa-enc-generated",
+      "providerId" : "rsa-enc-generated",
+      "subComponents" : { },
+      "config" : {
+        "privateKey" : [ "MIIEogIBAAKCAQEA3GbyIS5fpV/NQsruZIrQfDtQl6SBt0k3C+zCn45L/O/Pyn/ikY9EelFnL+9jVsXp1j8CxTgOBNdGRdad0WvwjZOaer1oxM6R7ZvkqHsjctdesz+RYgZRraGVEMgvrnO+JD8jvuiY+91j5F1ieWJIjX28ck990DSNauZxH5A0Ik3imYoZ+PRj5fkkocxzUwrftST17lEfykxsHYEJb9Tpx7LRT6qW2qZgLXWBZSa1oNT6Z1zi5DbrGaiBdRgxE/adSWdAPgy+Eq4ZjjRBUIP90cZB7POGPPE5nWjlHnAQk1tv/o4kELNhPz3FZ/08eG4an6iaPjOUonAdP+F7cwDBtwIDAQABAoH/KNDnwGvhvvitc0hnUfF6ZM0i5X36WTFBgHPYIrRDGHF/WyPfaM+fXtkRfSCGln+cCJEuWuNAzKS0O/TriuiVUlzgeQkPDHqpLpHTGBqegZpg46KQm1x48l1LjzjJPqhH350XmNp6YxMFj627mnlHmUl1kPub/6Fevad7BcYXhHEEPQDyGEtb9uGgyRfeZ7aP+gSICHShMAkwC1K5oNDVN+wSsOHCzgqbEd1hYlx0aAfhY1SfyOf+Cbs6SnTZ5H6kxQb2kR+2/9J5YOWbJjvQVAv9qSpw2MwVf9J/gZrK3jgwoP/jfd2Q/0+yelsPrgBTn/+PhglulyF8yF/5KfPhAoGBAPy6xuSO3fnCq0YLl6HEzrkW8tDZO6mIGloF2Okp9Fbf5eu2WlW1jwTiLHl0T4UFtdmqbBf6HEaFhxz+aw5zGEyWPDhqAtOGxO+BFQyNv6ifNrElVJpBDlQvyvX8/UmZTcTQxWMqwMn54kvKKy1oSSEY1i6YYeWfZDMd/RLIVTdXAoGBAN9BE7QF4Gsx9YArtw2y2uJXUgJyLZ55gkS2ZtsTGEE7l8eI3eQYKvvzky3eHAxO3cNqjwobhSSC9/MxcrBUYqkbDQ5wKcaJgICXg25vsKaYrrtZD4YOPJyl1uRGcmQ1odmmgH9pXI4xpUksoT+3M2v1e0RCIfBZmGFlJsT9iiyhAoGBAO7+Vc2XyRRCYiM4HSluaqsfp3mWpFP6kCjndKtx8E0jKFNSO3Tn35qXo8UrF3PM5Z40CkpWS9zoss/ZTDX641SxkbsrjQapYJy47cXUWhVEkrzMd4fz03ALThx3JLMv1Ro07ySLLosR0k0nntMu1lEFIq4njhROObwZNNRJPES7AoGBAKzDNFccMRVi3MMpkQdVv9Jllj30U18OUoOPzzp6pUtdrU+ol2U6WpEMZXmaJoRTx4LAhB5jO34Mp4mXW1QeiRapq0nf/EP6Ben81aVxYvcYsiaifcPUYo0qPIf8B+uKIUxHb6qpQwl6W5iro8ClqXJCzff9YTwYaTX9S6onNXThAoGAWonGqH4AuHkb+fDGLNfeUKLB8UxK3IznFyEohfp7W7htYAa9HH/11P+pBbn7iVR4qcSBHCZ4qL1dENmmZNrQk5TKRaM0b+mOBRMgEjpYYXCSud07W1IQlu8KRBcqDKO9zEZGJa4LGtCiA48R9KUimWtUW0ld0JNJH+2jC1P8Q3k=" ],
+        "keyUse" : [ "ENC" ],
+        "certificate" : [ "MIICnzCCAYcCBgGZPhwHiDANBgkqhkiG9w0BAQsFADATMREwDwYDVQQDDAhNeSByZWFsbTAeFw0yNTA5MTIxMzI1NDhaFw0zNTA5MTIxMzI3MjhaMBMxETAPBgNVBAMMCE15IHJlYWxtMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA3GbyIS5fpV/NQsruZIrQfDtQl6SBt0k3C+zCn45L/O/Pyn/ikY9EelFnL+9jVsXp1j8CxTgOBNdGRdad0WvwjZOaer1oxM6R7ZvkqHsjctdesz+RYgZRraGVEMgvrnO+JD8jvuiY+91j5F1ieWJIjX28ck990DSNauZxH5A0Ik3imYoZ+PRj5fkkocxzUwrftST17lEfykxsHYEJb9Tpx7LRT6qW2qZgLXWBZSa1oNT6Z1zi5DbrGaiBdRgxE/adSWdAPgy+Eq4ZjjRBUIP90cZB7POGPPE5nWjlHnAQk1tv/o4kELNhPz3FZ/08eG4an6iaPjOUonAdP+F7cwDBtwIDAQABMA0GCSqGSIb3DQEBCwUAA4IBAQBdML7IQdmKK/MDXqI0pc5XD/+gYFzQL+AzHpZQjCngfqBD4SNqK2DWW9/v9gFxwdxVd6O5VQjr9xi7RFgxk7g5GBYc3bm/PZWPmStTDADAQ+zm4N1dwapnvr7r6q7MBkZK1isegRGaxzn7tm2o7GMIQMjb2lsVsApj9oReCYCZlUsaSnJj7l98FBe93Cp0S9bQPPlI3t6MwnZfxMGANyJWb7nX6ghYkN9QnhnHu8UENcuZgCP2WuBOiacHFmBRTzYcybx2JCciOdlx9TzLh+amcD4erJZWwblEF7F4kL/SKe4tThV4eZ4dn740cTS8KPycWpM0+bi7XN22lgD+cM1h" ],
+        "priority" : [ "100" ],
+        "algorithm" : [ "RSA-OAEP" ]
+      }
+    }, {
+      "id" : "ea153e2b-b510-4f1b-a996-3ded2268213b",
+      "name" : "rsa-generated",
+      "providerId" : "rsa-generated",
+      "subComponents" : { },
+      "config" : {
+        "privateKey" : [ "MIIEoQIBAAKCAQEA1ItS1Phk91AWxXW88NiO1vL7juMBmIArT0RuJWb7F/HIHJAokeYoxPEjlqfoNtIR++G7N02RbQGr7SYdbZqiAcO52Yu3VMVilyshjCHn4f4yXnLQUZhLFRiDn9k2ctiCkfCzTMX0y+NYlic2vLM3pn0PxCYfavyMB/szRM13YBI7lXjajvfkyxdC8oLipE+WyMJ4IIbi1r94lR9N1Q/XpYffjtcb+ChO2R7ByO6sL7crq4MmvjpyvqqiPGG+huuMCjYezf2iibiJF1HsfFxqzElPYbzxGGyIOaWmnyNBMUNgi5D6ZO5UVmVZP9mBujAg6DrtFsVT8LB2uPTI3tzNGQIDAQABAoH/F8ZQ+kl94lSUN3/+JeC+Ipc/GdZsY58++hcPKR2k0nx/5wLfSAJl+xrnr+zgHaSIGNdOfbwcaftEw2CKL8cG8yTX1Wz1Bk91TRv5o5Bhvz57J0AjFAH2LjNj/xCBzWsgcz3q2X2XhzKDJWgS2i7ugs9dQZcGlRPi/VblAU5YvFwMF/Z3iFXmfCwSyPHbwvABTI418ne7WqSyVR5V2irTXjxUeEa1J95UqisOk054hg8FqhKBwsqyUQDqvmXjs++QLpqeKZeijVc5zUxFApNm7+SnXbXQs6SDe1qt+uVrE3LSC7A8R0zkXWWn9SvLFMrJq+Hga6XlPxUyNcp2uojBAoGBAOo2AfyALihtsP8c62QO+oRa6FN6IuKvl5NNjrvQ46J98OGeX3Vi0JJmsxniGvtsUkTyc0jeIOs7RyADipN+EqXOzZB3PO4eNCaDS7RyZqcvNbCKsxLXWjAx7wP6i3SN6TEE2VLKnkLJ5WPx3Eqv7ETIEu/FSHmhvHqDu7o2eWShAoGBAOhRTHNK29K/866D6aadljVJ+4p0LOsfSuNWyL9Kc7RPEx+gUJRpD6IJWSrDJrcuuNT3gJfPFDlrpGRyVEWKT7e8DPylQQGMUVHks6uo2QZFyIGBzA+BKfvLQepZVrfo9tAaTShPYGJVfdmWbOohJRM6Myp8b99eemZbX1bxVh15AoGACbA4PtCymBuJgdQZbKct98Gm8KURwlzPIVnI+L34XKVnDH43pqxywkubRwvSX+ooMQ/ycuY1aGWoWIus9NL3RIKcgEhebd8z+w/dVtaQpoPObcIfDD16TpoSMBDyKd0g81UnBES7bTna0lqT6UcDuAiqt95qVBW7rTm7z0UnmmECgYEAqF5rYs9pG4dkSyFtUAS73SkeNYzXFRxbwQGfgguqaY45lN0yKS0vWEcgKX6/61jgOfCacOtyg98AiI/XhYKlHcsbOmtl/oI8WXa/xHQdvY8LrthsFPyOed8oiXhwAd/EKLQ3ITTN7NZ63BxKGTEmVpYCiRMgXSly2gX0xeUofTkCgYASzRe1cnKp8xUj830CTYBcKtmRZcMHCDqxwsuw3l+2ZEdXAG72BkXEDnyt9seRAc8XtP4/ICa/2Decglxyt4+UCTKP6daf0K92yRo4QbzWPOw/7txWkmWZ/NBrASo34vyle3RBqXfMc95CbHDLYEuA6BMO9nFNw71M6aoE0raXxQ==" ],
+        "keyUse" : [ "SIG" ],
+        "certificate" : [ "MIICnzCCAYcCBgGZPhwGOjANBgkqhkiG9w0BAQsFADATMREwDwYDVQQDDAhNeSByZWFsbTAeFw0yNTA5MTIxMzI1NDhaFw0zNTA5MTIxMzI3MjhaMBMxETAPBgNVBAMMCE15IHJlYWxtMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA1ItS1Phk91AWxXW88NiO1vL7juMBmIArT0RuJWb7F/HIHJAokeYoxPEjlqfoNtIR++G7N02RbQGr7SYdbZqiAcO52Yu3VMVilyshjCHn4f4yXnLQUZhLFRiDn9k2ctiCkfCzTMX0y+NYlic2vLM3pn0PxCYfavyMB/szRM13YBI7lXjajvfkyxdC8oLipE+WyMJ4IIbi1r94lR9N1Q/XpYffjtcb+ChO2R7ByO6sL7crq4MmvjpyvqqiPGG+huuMCjYezf2iibiJF1HsfFxqzElPYbzxGGyIOaWmnyNBMUNgi5D6ZO5UVmVZP9mBujAg6DrtFsVT8LB2uPTI3tzNGQIDAQABMA0GCSqGSIb3DQEBCwUAA4IBAQAwSlrrdXAn+y9uXgKtIutWJ+m4wW5hCDmQNSS0XkcsAdLUNGp8fjrJKQV6CUiQCh+0tXHu9iybGiQfc5A73VgzNUDtrGplqEPWG3z3rTjfo+gTwvev7izMwU+5/lF2/aMPdYTM7E/RgGW+Phb+wBvTNzc9glhFzQQQLV81HHt907UvTfKonjeMnCUOn/92YR6Y6Kz3WuIVmOjNWwB1TpjWRxiiJ1kRsEgbWt368K3eY1CKkStDAYlpV2Nenzbbgk3hrZq7+JT3ZxMXUqrnScI/SA8/FRt9mld8J4/fnLWe++HiPGDpRKjphFCJLyk31VceMXlvxg+8zUZt4ZIcaoEU" ],
+        "priority" : [ "100" ]
+      }
+    } ]
+  },
+  "internationalizationEnabled" : false,
+  "authenticationFlows" : [ {
+    "id" : "6a92f886-b04d-4b9d-b9eb-dfcaade20688",
+    "alias" : "Account verification options",
+    "description" : "Method with which to verity the existing account",
+    "providerId" : "basic-flow",
+    "topLevel" : false,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "idp-email-verification",
+      "authenticatorFlow" : false,
+      "requirement" : "ALTERNATIVE",
+      "priority" : 10,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticatorFlow" : true,
+      "requirement" : "ALTERNATIVE",
+      "priority" : 20,
+      "autheticatorFlow" : true,
+      "flowAlias" : "Verify Existing Account by Re-authentication",
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "dc925463-8f79-4325-b901-e409847cad23",
+    "alias" : "Browser - Conditional 2FA",
+    "description" : "Flow to determine if any 2FA is required for the authentication",
+    "providerId" : "basic-flow",
+    "topLevel" : false,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "conditional-user-configured",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticator" : "auth-otp-form",
+      "authenticatorFlow" : false,
+      "requirement" : "ALTERNATIVE",
+      "priority" : 20,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticator" : "webauthn-authenticator",
+      "authenticatorFlow" : false,
+      "requirement" : "DISABLED",
+      "priority" : 30,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticator" : "auth-recovery-authn-code-form",
+      "authenticatorFlow" : false,
+      "requirement" : "DISABLED",
+      "priority" : 40,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "035628ad-a4d1-4b90-b15d-788015c09f1b",
+    "alias" : "Browser - Conditional Organization",
+    "description" : "Flow to determine if the organization identity-first login is to be used",
+    "providerId" : "basic-flow",
+    "topLevel" : false,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "conditional-user-configured",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticator" : "organization",
+      "authenticatorFlow" : false,
+      "requirement" : "ALTERNATIVE",
+      "priority" : 20,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "be3c906d-c54a-4964-b7bc-96b8282facb4",
+    "alias" : "Direct Grant - Conditional OTP",
+    "description" : "Flow to determine if the OTP is required for the authentication",
+    "providerId" : "basic-flow",
+    "topLevel" : false,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "conditional-user-configured",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticator" : "direct-grant-validate-otp",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 20,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "52c841e3-65d5-4cce-a2f5-046852f6c0b6",
+    "alias" : "First Broker Login - Conditional Organization",
+    "description" : "Flow to determine if the authenticator that adds organization members is to be used",
+    "providerId" : "basic-flow",
+    "topLevel" : false,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "conditional-user-configured",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticator" : "idp-add-organization-member",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 20,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "8449f292-7782-4e9a-93bf-ab11a96f4290",
+    "alias" : "First broker login - Conditional 2FA",
+    "description" : "Flow to determine if any 2FA is required for the authentication",
+    "providerId" : "basic-flow",
+    "topLevel" : false,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "conditional-user-configured",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticator" : "auth-otp-form",
+      "authenticatorFlow" : false,
+      "requirement" : "ALTERNATIVE",
+      "priority" : 20,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticator" : "webauthn-authenticator",
+      "authenticatorFlow" : false,
+      "requirement" : "DISABLED",
+      "priority" : 30,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticator" : "auth-recovery-authn-code-form",
+      "authenticatorFlow" : false,
+      "requirement" : "DISABLED",
+      "priority" : 40,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "7132a5f2-112c-4971-b8d7-eeaf562994f5",
+    "alias" : "Handle Existing Account",
+    "description" : "Handle what to do if there is existing account with same email/username like authenticated identity provider",
+    "providerId" : "basic-flow",
+    "topLevel" : false,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "idp-confirm-link",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticatorFlow" : true,
+      "requirement" : "REQUIRED",
+      "priority" : 20,
+      "autheticatorFlow" : true,
+      "flowAlias" : "Account verification options",
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "84a03f33-a69a-4031-a59d-6f540df66ec2",
+    "alias" : "Organization",
+    "providerId" : "basic-flow",
+    "topLevel" : false,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticatorFlow" : true,
+      "requirement" : "CONDITIONAL",
+      "priority" : 10,
+      "autheticatorFlow" : true,
+      "flowAlias" : "Browser - Conditional Organization",
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "937e3a93-722c-468b-bd13-dd797c330ff7",
+    "alias" : "Reset - Conditional OTP",
+    "description" : "Flow to determine if the OTP should be reset or not. Set to REQUIRED to force.",
+    "providerId" : "basic-flow",
+    "topLevel" : false,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "conditional-user-configured",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticator" : "reset-otp",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 20,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "f5e03dc1-6e73-4b3b-84ec-abd522db7bff",
+    "alias" : "User creation or linking",
+    "description" : "Flow for the existing/non-existing user alternatives",
+    "providerId" : "basic-flow",
+    "topLevel" : false,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticatorConfig" : "create unique user config",
+      "authenticator" : "idp-create-user-if-unique",
+      "authenticatorFlow" : false,
+      "requirement" : "ALTERNATIVE",
+      "priority" : 10,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticatorFlow" : true,
+      "requirement" : "ALTERNATIVE",
+      "priority" : 20,
+      "autheticatorFlow" : true,
+      "flowAlias" : "Handle Existing Account",
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "c54a7183-59ea-4487-a088-c917e6916b68",
+    "alias" : "Verify Existing Account by Re-authentication",
+    "description" : "Reauthentication of existing account",
+    "providerId" : "basic-flow",
+    "topLevel" : false,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "idp-username-password-form",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticatorFlow" : true,
+      "requirement" : "CONDITIONAL",
+      "priority" : 20,
+      "autheticatorFlow" : true,
+      "flowAlias" : "First broker login - Conditional 2FA",
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "766e3d62-3553-49c7-be01-f26fddce40e2",
+    "alias" : "browser",
+    "description" : "Browser based authentication",
+    "providerId" : "basic-flow",
+    "topLevel" : true,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "auth-cookie",
+      "authenticatorFlow" : false,
+      "requirement" : "ALTERNATIVE",
+      "priority" : 10,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticator" : "auth-spnego",
+      "authenticatorFlow" : false,
+      "requirement" : "DISABLED",
+      "priority" : 20,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticator" : "identity-provider-redirector",
+      "authenticatorFlow" : false,
+      "requirement" : "ALTERNATIVE",
+      "priority" : 25,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticatorFlow" : true,
+      "requirement" : "ALTERNATIVE",
+      "priority" : 26,
+      "autheticatorFlow" : true,
+      "flowAlias" : "Organization",
+      "userSetupAllowed" : false
+    }, {
+      "authenticatorFlow" : true,
+      "requirement" : "ALTERNATIVE",
+      "priority" : 30,
+      "autheticatorFlow" : true,
+      "flowAlias" : "forms",
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "a9a859e5-e2d9-486e-b4a6-10c5f8e443d5",
+    "alias" : "clients",
+    "description" : "Base authentication for clients",
+    "providerId" : "client-flow",
+    "topLevel" : true,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "client-secret",
+      "authenticatorFlow" : false,
+      "requirement" : "ALTERNATIVE",
+      "priority" : 10,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticator" : "client-jwt",
+      "authenticatorFlow" : false,
+      "requirement" : "ALTERNATIVE",
+      "priority" : 20,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticator" : "client-secret-jwt",
+      "authenticatorFlow" : false,
+      "requirement" : "ALTERNATIVE",
+      "priority" : 30,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticator" : "client-x509",
+      "authenticatorFlow" : false,
+      "requirement" : "ALTERNATIVE",
+      "priority" : 40,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "defe543d-d145-4781-b5f2-ce07b21f9258",
+    "alias" : "direct grant",
+    "description" : "OpenID Connect Resource Owner Grant",
+    "providerId" : "basic-flow",
+    "topLevel" : true,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "direct-grant-validate-username",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticator" : "direct-grant-validate-password",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 20,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticatorFlow" : true,
+      "requirement" : "CONDITIONAL",
+      "priority" : 30,
+      "autheticatorFlow" : true,
+      "flowAlias" : "Direct Grant - Conditional OTP",
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "ee72847f-04d5-4eed-bb8b-c576fcc4bd6b",
+    "alias" : "docker auth",
+    "description" : "Used by Docker clients to authenticate against the IDP",
+    "providerId" : "basic-flow",
+    "topLevel" : true,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "docker-http-basic-authenticator",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "602e1d5f-ffda-4c40-8adc-b0ae640b4574",
+    "alias" : "first broker login",
+    "description" : "Actions taken after first broker login with identity provider account, which is not yet linked to any Keycloak account",
+    "providerId" : "basic-flow",
+    "topLevel" : true,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticatorConfig" : "review profile config",
+      "authenticator" : "idp-review-profile",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticatorFlow" : true,
+      "requirement" : "REQUIRED",
+      "priority" : 20,
+      "autheticatorFlow" : true,
+      "flowAlias" : "User creation or linking",
+      "userSetupAllowed" : false
+    }, {
+      "authenticatorFlow" : true,
+      "requirement" : "CONDITIONAL",
+      "priority" : 50,
+      "autheticatorFlow" : true,
+      "flowAlias" : "First Broker Login - Conditional Organization",
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "014fdbfb-fa59-4e60-95a4-986e932c50e4",
+    "alias" : "forms",
+    "description" : "Username, password, otp and other auth forms.",
+    "providerId" : "basic-flow",
+    "topLevel" : false,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "auth-username-password-form",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticatorFlow" : true,
+      "requirement" : "CONDITIONAL",
+      "priority" : 20,
+      "autheticatorFlow" : true,
+      "flowAlias" : "Browser - Conditional 2FA",
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "1f78bafd-0862-4e6b-b7eb-b7e64c51a088",
+    "alias" : "registration",
+    "description" : "Registration flow",
+    "providerId" : "basic-flow",
+    "topLevel" : true,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "registration-page-form",
+      "authenticatorFlow" : true,
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "autheticatorFlow" : true,
+      "flowAlias" : "registration form",
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "6f823485-723b-42e0-8c59-80d52377180a",
+    "alias" : "registration form",
+    "description" : "Registration form",
+    "providerId" : "form-flow",
+    "topLevel" : false,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "registration-user-creation",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 20,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticator" : "registration-password-action",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 50,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticator" : "registration-recaptcha-action",
+      "authenticatorFlow" : false,
+      "requirement" : "DISABLED",
+      "priority" : 60,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticator" : "registration-terms-and-conditions",
+      "authenticatorFlow" : false,
+      "requirement" : "DISABLED",
+      "priority" : 70,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "12e57c09-0562-4a9e-8bff-a397c9ebf704",
+    "alias" : "reset credentials",
+    "description" : "Reset credentials for a user if they forgot their password or something",
+    "providerId" : "basic-flow",
+    "topLevel" : true,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "reset-credentials-choose-user",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticator" : "reset-credential-email",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 20,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticator" : "reset-password",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 30,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticatorFlow" : true,
+      "requirement" : "CONDITIONAL",
+      "priority" : 40,
+      "autheticatorFlow" : true,
+      "flowAlias" : "Reset - Conditional OTP",
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "488caeea-1408-4008-b43b-e6f96f5eef6e",
+    "alias" : "saml ecp",
+    "description" : "SAML ECP Profile Authentication Flow",
+    "providerId" : "basic-flow",
+    "topLevel" : true,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "http-basic-authenticator",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    } ]
+  } ],
+  "authenticatorConfig" : [ {
+    "id" : "06643ecc-b0de-4373-8232-ee1ccaddb999",
+    "alias" : "create unique user config",
+    "config" : {
+      "require.password.update.after.registration" : "false"
+    }
+  }, {
+    "id" : "c77cb09c-5416-4f21-b3c1-4a1928c08777",
+    "alias" : "review profile config",
+    "config" : {
+      "update.profile.on.first.login" : "missing"
+    }
+  } ],
+  "requiredActions" : [ {
+    "alias" : "CONFIGURE_TOTP",
+    "name" : "Configure OTP",
+    "providerId" : "CONFIGURE_TOTP",
+    "enabled" : true,
+    "defaultAction" : false,
+    "priority" : 10,
+    "config" : { }
+  }, {
+    "alias" : "TERMS_AND_CONDITIONS",
+    "name" : "Terms and Conditions",
+    "providerId" : "TERMS_AND_CONDITIONS",
+    "enabled" : false,
+    "defaultAction" : false,
+    "priority" : 20,
+    "config" : { }
+  }, {
+    "alias" : "UPDATE_PASSWORD",
+    "name" : "Update Password",
+    "providerId" : "UPDATE_PASSWORD",
+    "enabled" : true,
+    "defaultAction" : false,
+    "priority" : 30,
+    "config" : { }
+  }, {
+    "alias" : "UPDATE_PROFILE",
+    "name" : "Update Profile",
+    "providerId" : "UPDATE_PROFILE",
+    "enabled" : true,
+    "defaultAction" : false,
+    "priority" : 40,
+    "config" : { }
+  }, {
+    "alias" : "VERIFY_EMAIL",
+    "name" : "Verify Email",
+    "providerId" : "VERIFY_EMAIL",
+    "enabled" : true,
+    "defaultAction" : false,
+    "priority" : 50,
+    "config" : { }
+  }, {
+    "alias" : "delete_account",
+    "name" : "Delete Account",
+    "providerId" : "delete_account",
+    "enabled" : false,
+    "defaultAction" : false,
+    "priority" : 60,
+    "config" : { }
+  }, {
+    "alias" : "webauthn-register",
+    "name" : "Webauthn Register",
+    "providerId" : "webauthn-register",
+    "enabled" : true,
+    "defaultAction" : false,
+    "priority" : 70,
+    "config" : { }
+  }, {
+    "alias" : "webauthn-register-passwordless",
+    "name" : "Webauthn Register Passwordless",
+    "providerId" : "webauthn-register-passwordless",
+    "enabled" : true,
+    "defaultAction" : false,
+    "priority" : 80,
+    "config" : { }
+  }, {
+    "alias" : "VERIFY_PROFILE",
+    "name" : "Verify Profile",
+    "providerId" : "VERIFY_PROFILE",
+    "enabled" : true,
+    "defaultAction" : false,
+    "priority" : 90,
+    "config" : { }
+  }, {
+    "alias" : "delete_credential",
+    "name" : "Delete Credential",
+    "providerId" : "delete_credential",
+    "enabled" : true,
+    "defaultAction" : false,
+    "priority" : 100,
+    "config" : { }
+  }, {
+    "alias" : "idp_link",
+    "name" : "Linking Identity Provider",
+    "providerId" : "idp_link",
+    "enabled" : true,
+    "defaultAction" : false,
+    "priority" : 110,
+    "config" : { }
+  }, {
+    "alias" : "CONFIGURE_RECOVERY_AUTHN_CODES",
+    "name" : "Recovery Authentication Codes",
+    "providerId" : "CONFIGURE_RECOVERY_AUTHN_CODES",
+    "enabled" : true,
+    "defaultAction" : false,
+    "priority" : 120,
+    "config" : { }
+  }, {
+    "alias" : "update_user_locale",
+    "name" : "Update User Locale",
+    "providerId" : "update_user_locale",
+    "enabled" : true,
+    "defaultAction" : false,
+    "priority" : 1000,
+    "config" : { }
+  } ],
+  "browserFlow" : "browser",
+  "registrationFlow" : "registration",
+  "directGrantFlow" : "direct grant",
+  "resetCredentialsFlow" : "reset credentials",
+  "clientAuthenticationFlow" : "clients",
+  "dockerAuthenticationFlow" : "docker auth",
+  "firstBrokerLoginFlow" : "first broker login",
+  "attributes" : {
+    "cibaBackchannelTokenDeliveryMode" : "poll",
+    "cibaExpiresIn" : "120",
+    "cibaAuthRequestedUserHint" : "login_hint",
+    "oauth2DeviceCodeLifespan" : "600",
+    "oauth2DevicePollingInterval" : "5",
+    "parRequestUriLifespan" : "60",
+    "cibaInterval" : "5",
+    "realmReusableOtpCode" : "false"
+  },
+  "keycloakVersion" : "26.3.3",
+  "userManagedAccessAllowed" : false,
+  "organizationsEnabled" : false,
+  "verifiableCredentialsEnabled" : false,
+  "adminPermissionsEnabled" : false,
+  "clientProfiles" : {
+    "profiles" : [ ]
+  },
+  "clientPolicies" : {
+    "policies" : [ ]
+  }
+}

--- a/charts/keycloak/templates/ca/ca-certificate.yaml
+++ b/charts/keycloak/templates/ca/ca-certificate.yaml
@@ -1,0 +1,25 @@
+{{/*
+Copyright (c) 2025 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+the License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+*/}}
+
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  namespace: {{ .Release.Namespace }}
+  name: keycloak-ca-certificate
+spec:
+  commonName: "Keycloak CA"
+  isCA: true
+  issuerRef:
+    kind: Issuer
+    name: keycloak-ca-issuer
+  secretName: keycloak-ca-key

--- a/charts/keycloak/templates/ca/ca-issuer.yaml
+++ b/charts/keycloak/templates/ca/ca-issuer.yaml
@@ -1,0 +1,22 @@
+{{/*
+Copyright (c) 2025 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+the License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+
+This issuer is used to generate the self signed certificate of our CA.
+*/}}
+
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  namespace: {{ .Release.Namespace }}
+  name: keycloak-ca-issuer
+spec:
+  selfSigned: {}

--- a/charts/keycloak/templates/ca/issuer.yaml
+++ b/charts/keycloak/templates/ca/issuer.yaml
@@ -1,0 +1,21 @@
+{{/*
+Copyright (c) 2025 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+the License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+*/}}
+
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  namespace: {{ .Release.Namespace }}
+  name: keycloak-issuer
+spec:
+  ca:
+    secretName: keycloak-ca-key

--- a/charts/keycloak/templates/database/client-cert.yaml
+++ b/charts/keycloak/templates/database/client-cert.yaml
@@ -1,0 +1,29 @@
+{{/*
+Copyright (c) 2025 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+the License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+*/}}
+
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  namespace: {{ .Release.Namespace }}
+  name: keycloak-database-client
+spec:
+  issuerRef:
+    name: keycloak-issuer
+  usages:
+  - client auth
+  commonName: keycloak
+  secretName: keycloak-database-client-cert
+  privateKey:
+    encoding: PKCS8
+  additionalOutputFormats:
+  - type: DER

--- a/charts/keycloak/templates/database/configmap.yaml
+++ b/charts/keycloak/templates/database/configmap.yaml
@@ -1,0 +1,35 @@
+{{/*
+Copyright (c) 2025 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+the License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+*/}}
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: keycloak-database-config
+  namespace: {{ .Release.Namespace }}
+data:
+  server.conf: |
+    # Enable TLS:
+    ssl = on
+    ssl_ca_file = '/secrets/cert/ca.crt'
+    ssl_cert_file = '/secrets/cert/tls.crt'
+    ssl_key_file = '/secrets/cert/tls.key'
+
+    # Use our custom access file:
+    hba_file = '/config/access/access.conf'
+  access.conf: |
+    # This is needed by the scripts that setup the database.
+    local all all peer
+
+    # For any other user we only allow access with certificates.
+    hostssl all all 0.0.0.0/0 cert
+    hostssl all all ::0/0 cert

--- a/charts/keycloak/templates/database/pvc.yaml
+++ b/charts/keycloak/templates/database/pvc.yaml
@@ -1,0 +1,24 @@
+{{/*
+Copyright (c) 2025 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+the License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+*/}}
+
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: keycloak-database
+  namespace: {{ .Release.Namespace }}
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi

--- a/charts/keycloak/templates/database/server-cert.yaml
+++ b/charts/keycloak/templates/database/server-cert.yaml
@@ -1,0 +1,27 @@
+{{/*
+Copyright (c) 2025 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+the License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+*/}}
+
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: keycloak-database-server
+  namespace: {{ .Release.Namespace }}
+spec:
+  issuerRef:
+    name: keycloak-issuer
+  dnsNames:
+  - localhost
+  - keycloak-database
+  - keycloak-database.{{ .Release.Namespace }}
+  - keycloak-database.{{ .Release.Namespace }}.svc.cluster.local
+  secretName: keycloak-database-server-cert

--- a/charts/keycloak/templates/database/service.yaml
+++ b/charts/keycloak/templates/database/service.yaml
@@ -1,0 +1,25 @@
+{{/*
+Copyright (c) 2025 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+the License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+*/}}
+
+apiVersion: v1
+kind: Service
+metadata:
+  namespace: {{ .Release.Namespace }}
+  name: keycloak-database
+spec:
+  selector:
+    app: keycloak-database
+  ports:
+  - name: postgres
+    port: 5432
+    targetPort: postgres

--- a/charts/keycloak/templates/database/statefulset.yaml
+++ b/charts/keycloak/templates/database/statefulset.yaml
@@ -1,0 +1,66 @@
+{{/*
+Copyright (c) 2025 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+the License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+*/}}
+
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  namespace: {{ .Release.Namespace }}
+  name: keycloak-database
+spec:
+  replicas: 1
+  serviceName: keycloak-database
+  selector:
+    matchLabels:
+      app: keycloak-database
+  template:
+    metadata:
+      labels:
+        app: keycloak-database
+    spec:
+      volumes:
+      - name: server-cert
+        secret:
+          secretName: keycloak-database-server-cert
+          defaultMode: 0440
+      - name: config
+        configMap:
+          name: keycloak-database-config
+      - name: data
+        persistentVolumeClaim:
+          claimName: keycloak-database
+      containers:
+      - name: server
+        image: "quay.io/sclorg/postgresql-15-c9s:latest"
+        imagePullPolicy: IfNotPresent
+        env:
+        - name: POSTGRESQL_USER
+          value: keycloak
+        - name: POSTGRESQL_PASSWORD
+          value: ""
+        - name: POSTGRESQL_DATABASE
+          value: keycloak
+        volumeMounts:
+        - name: data
+          mountPath: /var/lib/pgsql/data
+        - name: server-cert
+          mountPath: /secrets/cert
+        - name: config
+          mountPath: /opt/app-root/src/postgresql-cfg/server.conf
+          subPath: server.conf
+        - name: config
+          mountPath: /config/access/access.conf
+          subPath: access.conf
+        ports:
+        - name: postgres
+          protocol: TCP
+          containerPort: 5432

--- a/charts/keycloak/templates/service/deployment.yaml
+++ b/charts/keycloak/templates/service/deployment.yaml
@@ -1,0 +1,119 @@
+{{/*
+Copyright (c) 2025 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+the License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+*/}}
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  namespace: {{ .Release.Namespace }}
+  name: keycloak-service
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: keycloak-service
+  template:
+    metadata:
+      labels:
+        app: keycloak-service
+    spec:
+      volumes:
+      - name: realm
+        configMap:
+          name: keycloak-realm
+      - name: database-client-cert
+        secret:
+          secretName: keycloak-database-client-cert
+      - name: tls-cert
+        secret:
+          secretName: keycloak-tls-cert
+      initContainers:
+      - name: wait-for-database
+        image: "quay.io/sclorg/postgresql-15-c9s:latest"
+        imagePullPolicy: IfNotPresent
+        command:
+        - /bin/bash
+        - -c
+        - |
+          set -e
+          until pg_isready --host keycloak-database --timeout 1; do
+            sleep 1
+          done
+      containers:
+      - name: keycloak
+        image: "quay.io/keycloak/keycloak:26.3"
+        imagePullPolicy: IfNotPresent
+        volumeMounts:
+        - name: realm
+          mountPath: /opt/keycloak/data/import
+          readOnly: true
+        - name: database-client-cert
+          mountPath: /secrets/database-client
+          readOnly: true
+        - name: tls-cert
+          mountPath: /secrets/tls
+          readOnly: true
+        env:
+        - name: KEYCLOAK_ADMIN
+          value: admin
+        - name: KEYCLOAK_ADMIN_PASSWORD
+          value: admin
+        - name: KC_HOSTNAME_STRICT
+          value: "true"
+        - name: KC_HOSTNAME_STRICT_HTTPS
+          value: "true"
+        - name: KC_HTTP_ENABLED
+          value: "false"
+        - name: KC_HTTPS_ENABLED
+          value: "true"
+        - name: KC_HTTPS_PORT
+          value: "8001"
+        - name: KC_HTTPS_CERTIFICATE_FILE
+          value: "/secrets/tls/tls.crt"
+        - name: KC_HTTPS_CERTIFICATE_KEY_FILE
+          value: "/secrets/tls/tls.key"
+        - name: KC_HOSTNAME
+          value: "keycloak.{{ .Release.Namespace }}.svc.cluster.local"
+        - name: KC_HOSTNAME_PORT
+          value: "8001"
+        - name: KC_DB
+          value: "postgres"
+        - name: KC_DB_URL
+          value: "jdbc:postgresql://keycloak-database:5432/keycloak?\
+          sslmode=require&\
+          sslcert=/secrets/database-client/tls.crt&\
+          sslkey=/secrets/database-client/key.der&\
+          sslrootcert=/secrets/database-client/ca.crt"
+        - name: KC_DB_USERNAME
+          value: keycloak
+        - name: KC_DB_PASSWORD
+          value: ""
+        args:
+        - start
+        - --import-realm
+        ports:
+        - name: https
+          containerPort: 8001
+        readinessProbe:
+          httpGet:
+            path: /realms/master
+            port: 8001
+            scheme: HTTPS
+          initialDelaySeconds: 30
+          periodSeconds: 10
+        livenessProbe:
+          httpGet:
+            path: /realms/master
+            port: 8001
+            scheme: HTTPS
+          initialDelaySeconds: 60
+          periodSeconds: 30

--- a/charts/keycloak/templates/service/realm-configmap.yaml
+++ b/charts/keycloak/templates/service/realm-configmap.yaml
@@ -1,0 +1,20 @@
+{{/*
+Copyright (c) 2025 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+the License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+*/}}
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  namespace: {{ .Release.Namespace }}
+  name: keycloak-realm
+data:
+  realm.json: {{ .Files.Get "files/realm.json" | quote }}

--- a/charts/keycloak/templates/service/server-cert.yaml
+++ b/charts/keycloak/templates/service/server-cert.yaml
@@ -1,0 +1,27 @@
+{{/*
+Copyright (c) 2025 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+the License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+*/}}
+
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  namespace: {{ .Release.Namespace }}
+  name: keycloak-tls
+spec:
+  issuerRef:
+    name: keycloak-issuer
+  dnsNames:
+  - localhost
+  - keycloak
+  - keycloak.{{ .Release.Namespace }}
+  - keycloak.{{ .Release.Namespace }}.svc.cluster.local
+  secretName: keycloak-tls-cert

--- a/charts/keycloak/templates/service/service.yaml
+++ b/charts/keycloak/templates/service/service.yaml
@@ -1,0 +1,33 @@
+{{/*
+Copyright (c) 2025 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+the License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+*/}}
+
+apiVersion: v1
+kind: Service
+metadata:
+  namespace: {{ .Release.Namespace }}
+  name: keycloak
+  labels:
+    app: keycloak-service
+spec:
+  {{ if eq .Values.variant "kind" }}
+  type: NodePort
+  {{ end }}
+  selector:
+    app: keycloak-service
+  ports:
+  - name: https
+    port: 8001
+    targetPort: 8001
+    {{ if eq .Values.variant "kind" }}
+    nodePort: 30001
+    {{ end }}

--- a/charts/keycloak/values.yaml
+++ b/charts/keycloak/values.yaml
@@ -1,0 +1,15 @@
+#
+# Copyright (c) 2025 Red Hat Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+# the License. You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+# This indicates if the chart is being deployed to an OpenShift or Kind cluster. Valid values are `openshift` and `kind`
+variant: kind

--- a/internal/testing/kind.go
+++ b/internal/testing/kind.go
@@ -96,6 +96,11 @@ func (b *KindBuilder) Build() (result *Kind, err error) {
 	)
 
 	// Check that the command line tools that we need are available:
+	_, err = exec.LookPath(helmCmd)
+	if err != nil {
+		err = fmt.Errorf("command line tool '%s' isn't available: %w", helmCmd, err)
+		return
+	}
 	_, err = exec.LookPath(kindCmd)
 	if err != nil {
 		err = fmt.Errorf("command line tool '%s' isn't available: %w", kindCmd, err)
@@ -367,6 +372,11 @@ func (k *Kind) createCluster(ctx context.Context) error {
 					map[string]any{
 						"containerPort": 30000,
 						"hostPort":      8000,
+						"listenAddress": "0.0.0.0",
+					},
+					map[string]any{
+						"containerPort": 30001,
+						"hostPort":      8001,
 						"listenAddress": "0.0.0.0",
 					},
 				},
@@ -663,6 +673,7 @@ func (k *Kind) installCrdFiles(ctx context.Context) error {
 
 // Names of commands:
 const (
+	helmCmd    = "helm"
 	kindCmd    = "kind"
 	kubectlCmd = "kubectl"
 )

--- a/manifests/README.md
+++ b/manifests/README.md
@@ -76,6 +76,9 @@ nodes:
   - containerPort: 30000
     hostPort: 8000
     listenAddress: "0.0.0.0"
+  - containerPort: 30001
+    hostPort: 8001
+    listenAddress: "0.0.0.0"
 .
 ```
 


### PR DESCRIPTION
This commit introduces a comprehensive Keycloak Helm chart specifically designed for development and integration testing purposes within the fulfillment service project. The chart provides a complete Keycloak deployment that includes both the authentication service and its required PostgreSQL database, along with all necessary TLS certificates and configuration.

The Keycloak instance comes pre-configured with a test realm containing sample users, roles, and client configurations that will support authentication and authorization testing scenarios. The chart is designed to run efficiently in Kind clusters and includes all the infrastructure components needed for a functional identity provider setup, including certificate authorities, database persistence, and service networking.

Integration with the existing test infrastructure has been enhanced to automatically deploy this Keycloak instance during the test suite initialization process. The deployment is orchestrated through Helm and integrates seamlessly with the current Kind-based testing environment, ensuring that authentication services are available before any tests that require them begin execution.

It's important to note that this Keycloak chart is explicitly intended for development and testing environments only and should not be used in production deployments. The configuration prioritizes ease of testing over security hardening, and the pre-configured credentials and settings are designed for convenience in automated testing scenarios rather than production security requirements.

Currently, while the Keycloak infrastructure is deployed during test setup, it is not yet actively utilized by the test suites. The integration of actual authentication testing workflows will be implemented in subsequent patches, allowing for a gradual rollout of authentication-dependent test scenarios.