### PR TITLE
Update channel for installing Authorino on OpenShift

### DIFF
--- a/manifests/README.md
+++ b/manifests/README.md
@@ -50,7 +50,7 @@ spec:
   name: authorino-operator
   sourceNamespace: openshift-marketplace
   source: redhat-operators
-  channel: tech-preview-v1
+  channel: stable
   installPlanApproval: Automatic
 .
 ```


### PR DESCRIPTION
We are currently using version `v1beta3` of the `AuthConfig` CRD, but that is not supported in the version of Authorino available in the `tech-preview-v1` channel that we are using for the OpenShift installation: we need to use channel `stable`.