### PR TITLE
Explain how to enable HTTP2 in OpenShift

### DIFF
--- a/manifests/README.md
+++ b/manifests/README.md
@@ -7,6 +7,12 @@ for Kind, intended for development and testing environments.
 
 ## OpenShift
 
+The gRPC protocol is based on HTTP2, which isn't enabled by default in OpenShift. To enable it run this command:
+
+```shell
+$ oc annotate ingresses.config/cluster ingress.operator.openshift.io/default-enable-http2=true
+```
+
 Install the _cert-manager_ operator:
 
 ```shell


### PR DESCRIPTION
This patch adds to the documentation of the manifests the command that is used to enable HTTP2 in OpenShift, as that is required for gRPC to work correctly.