### PR TITLE
Don't ignore marshal errors

### DIFF
--- a/internal/json/json_encoder.go
+++ b/internal/json/json_encoder.go
@@ -174,7 +174,7 @@ func (e *Encoder) marshalMessage(stream *jsoniter.Stream, message protoreflect.M
 			err = stream.Error
 			return false
 		}
-		err := e.marshalValue(stream, value, field)
+		err = e.marshalValue(stream, value, field)
 		if err != nil {
 			return false
 		}


### PR DESCRIPTION
Currently the `marshalMessage` method of the JSON encoder is ignoring some errors due to a typo in the assignment to the error variable. For example, in a related problem this results in the following error message when saving an object to the database:

```
{
  "time": "...",
  "level": "ERROR",
  "msg": "Failed to create",
  "error": {
    "message":"ERROR: invalid input syntax for type json (SQLSTATE 22P02)",
    ...
  },
  ...
}
```

But that is a side effect of the marshal error. The actual error, which is then visibile in the log when this patch is applied, is the following:

```
{
  "time": "...",
  "level": "ERROR",
  "msg": "Failed to create",
  "error": {
    "message": "proto: google.protobuf.Value: none of the oneof fields is set",
    ...
  }
}
```

Note that this doesn't fix the marshal error, just reports it correctly. The marshal error will be addressed in a separate patch.