### PR TITLE
Avoid creating incorrect `Any` messages

### DIFF
--- a/internal/utils/template_parameters_test.go
+++ b/internal/utils/template_parameters_test.go
@@ -442,6 +442,22 @@ var _ = Describe("ProcessTemplateParametersWithDefaults", func() {
 			Expect(resultInt.Value).To(Equal(int32(3)))
 		})
 	})
+
+	It("Ignores optional parameter that has no default value", func() {
+		template = &mockTemplate{
+			id: "my_template",
+			parameters: []TemplateParameterDefinition{
+				&mockParameter{
+					name:         "my_parameter",
+					paramType:    "type.googleapis.com/google.protobuf.StringValue",
+					required:     false,
+					defaultValue: nil,
+				},
+			},
+		}
+		result := ProcessTemplateParametersWithDefaults(template, nil)
+		Expect(result).To(BeEmpty())
+	})
 })
 
 var _ = Describe("ConvertTemplateParametersToJSON", func() {


### PR DESCRIPTION
Currently when we calculate the actual parameters of a template we create `Any` messages with `TypeUrl` but no `Value` if the parameter is optional but doesn't have a default value in the definition of the template. These are invalid protobuf messages, and later result in JSON conversion errors like this when trying to save the object to the database:

```
 {
   "time": "...",
   "level": "ERROR",
   "msg": "Failed to create",
   "error": {
     "message": "proto: google.protobuf.Value: none of the oneof fields is set",
     ...
   }
 }
```

To avoid that this patch changes the code that does the calculation so that it will just skip the parameters that are optional and don't have a default value.

Resolves: https://github.com/innabox/issues/issues/214