### PR TITLE
Add keep alive to gRPC client to prevent disconnections

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -52,7 +52,8 @@
                                 "--log-bodies=true",
                                 "--http-listener-address=localhost:8001",
                                 "--grpc-server-address=localhost:8000",
-                                "--grpc-server-plaintext"
+                                "--grpc-server-plaintext",
+                                "--grpc-keep-alive=5m"
                         ]
                 },
                 {
@@ -68,7 +69,8 @@
                                 "--log-headers=true",
                                 "--log-bodies=true",
                                 "--grpc-server-address=localhost:8000",
-                                "--grpc-server-plaintext"
+                                "--grpc-server-plaintext",
+                                "--grpc-keep-alive=5m"
                         ]
                 }
         ]

--- a/internal/controllers/reconciler.go
+++ b/internal/controllers/reconciler.go
@@ -344,6 +344,11 @@ func (c *Reconciler[O]) watchEvents(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
+	c.logger.DebugContext(
+		ctx,
+		"Started watching events",
+		slog.String("filter", c.eventFilter),
+	)
 	for {
 		response, err := stream.Recv()
 		if err != nil {

--- a/internal/network/grpc_client_flags.go
+++ b/internal/network/grpc_client_flags.go
@@ -16,6 +16,7 @@ package network
 import (
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/spf13/pflag"
 )
@@ -35,6 +36,7 @@ import (
 //	--api-ca-file               API trusted CA file.
 //	--api-token                 API token.
 //	--api-token-file            API token file.
+//	--api-keep-alive            API keep alive interval.
 func AddGrpcClientFlags(flags *pflag.FlagSet, name, addr string) {
 	_ = flags.String(
 		grpcClientFlagName(name, grpcClientServerNetworkFlagSuffix),
@@ -71,6 +73,11 @@ func AddGrpcClientFlags(flags *pflag.FlagSet, name, addr string) {
 		"",
 		fmt.Sprintf("%s authentication token file.", name),
 	)
+	_ = flags.Duration(
+		grpcClientFlagName(name, grpcClientKeepAliveFlagSuffix),
+		5*time.Minute,
+		fmt.Sprintf("%s keep alive interval.", name),
+	)
 }
 
 // Names of the flags:
@@ -82,6 +89,7 @@ const (
 	grpcClientCaFileFlagSuffix          = "ca-file"
 	grpcClientTokenFlagSuffix           = "token"
 	grpcClientTokenFileFlagSuffix       = "token-file"
+	grpcClientKeepAliveFlagSuffix       = "keep-alive"
 )
 
 // grpcClientFlagName calculates a complete flag name from a client name and a flag name suffix. For example, if the

--- a/manifests/base/controller/deployment.yaml
+++ b/manifests/base/controller/deployment.yaml
@@ -48,3 +48,4 @@ spec:
         - --grpc-server-address=fulfillment-api:8000
         - --grpc-token-file=/var/run/secrets/kubernetes.io/serviceaccount/token
         - --grpc-ca-file=/etc/fulfillment-service/tls/ca.crt
+        - --grpc-keep-alive=5m

--- a/manifests/base/service/deployment.yaml
+++ b/manifests/base/service/deployment.yaml
@@ -82,6 +82,7 @@ spec:
         - --grpc-server-network=unix
         - --grpc-server-address=/run/sockets/ingress.socket
         - --grpc-server-plaintext
+        - --grpc-keep-alive=5m
 
       - name: envoy
         image: envoy

--- a/manifests/base/service/files/envoy.yaml
+++ b/manifests/base/service/files/envoy.yaml
@@ -72,7 +72,26 @@ static_resources:
                     "@type": type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute
                     disabled: true
 
-              - name: server
+              # This route is for the gRPC streaming requests used to watch events. Those streams can last very long,
+              # so we don't want to set a timeout, as that would cause the connection to be closed and events to be
+              # potentially lost.
+              - name: watch
+                match:
+                  safe_regex:
+                    regex: ^.*/Watch$
+                route:
+                  cluster: server
+                  timeout: 0s
+                  idle_timeout: 0s
+                typed_per_filter_config:
+                  envoy.filters.http.header_mutation:
+                    "@type": type.googleapis.com/envoy.extensions.filters.http.header_mutation.v3.HeaderMutationPerRoute
+                    mutations:
+                      request_mutations:
+                      - remove: authorization
+
+              # This route is for gRPC unary requests, which should be quite fast, so we can safely set a timeout
+              - name: other
                 match:
                   prefix: /
                 route:


### PR DESCRIPTION
This change enables the gRPC keep alive functionality in an attempt to avoid connections being forcibly closed by proxies, particularly Envoy in our deployment environment. We have been experiencing intermittent connection issues that we haven't been able to fully identify, but they appear to be related to idle connection timeouts at the proxy layer.

The implementation adds a new `--grpc-keep-alive` command line flag allowing us to specify an interval for periodic keep alive events. When configured, the client will periodically ping the server to verify that the connection is alive. This should significantly reduce the chances of proxy-initiated connection drops during periods of low event activity.

In addition, in the Envoy configuration a new route is added specifically for the `Watch` method of the events service. This route is configured so that the total and idle timeouts are disabled.

Related: https://github.com/innabox/fulfillment-service/issues/111