### PR TITLE
Use time-sortable UUIDs

### DIFF
--- a/internal/database/dao/generic_dao.go
+++ b/internal/database/dao/generic_dao.go
@@ -23,7 +23,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/proto"
@@ -33,6 +32,7 @@ import (
 	"github.com/innabox/fulfillment-service/internal/auth"
 	"github.com/innabox/fulfillment-service/internal/database"
 	"github.com/innabox/fulfillment-service/internal/json"
+	"github.com/innabox/fulfillment-service/internal/uuid"
 )
 
 // Object is the interface that should be satisfied by objects to be managed by the generic DAO.
@@ -648,7 +648,7 @@ func (d *GenericDAO[O]) create(ctx context.Context, tx database.Tx, object O) (r
 	// Generate an identifier if needed:
 	id := object.GetId()
 	if id == "" {
-		id = d.newId()
+		id = uuid.New()
 	}
 
 	// Get the metadata:
@@ -972,10 +972,6 @@ func (d *GenericDAO[O]) fireEvent(ctx context.Context, event Event) error {
 		}
 	}
 	return nil
-}
-
-func (d *GenericDAO[O]) newId() string {
-	return uuid.NewString()
 }
 
 func (d *GenericDAO[O]) newObject() O {

--- a/internal/database/dao/generic_dao_test.go
+++ b/internal/database/dao/generic_dao_test.go
@@ -21,7 +21,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgxpool"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -31,6 +30,7 @@ import (
 	testsv1 "github.com/innabox/fulfillment-service/internal/api/tests/v1"
 	"github.com/innabox/fulfillment-service/internal/auth"
 	"github.com/innabox/fulfillment-service/internal/database"
+	"github.com/innabox/fulfillment-service/internal/uuid"
 )
 
 var _ = Describe("Generic DAO", func() {
@@ -619,7 +619,7 @@ var _ = Describe("Generic DAO", func() {
 				objects = make([]*testsv1.Object, objectCount)
 				for i := range len(objects) {
 					objects[i] = &testsv1.Object{
-						Id: uuid.NewString(),
+						Id: uuid.New(),
 					}
 					_, err := generic.Create(ctx, objects[i])
 					Expect(err).ToNot(HaveOccurred())
@@ -731,7 +731,7 @@ var _ = Describe("Generic DAO", func() {
 			})
 
 			It("Returns false if the object doesn't exist", func() {
-				exists, err := generic.Exists(ctx, uuid.NewString())
+				exists, err := generic.Exists(ctx, uuid.New())
 				Expect(err).ToNot(HaveOccurred())
 				Expect(exists).To(BeFalse())
 			})

--- a/internal/database/database_notifier.go
+++ b/internal/database/database_notifier.go
@@ -18,9 +18,10 @@ import (
 	"errors"
 	"log/slog"
 
-	"github.com/google/uuid"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/anypb"
+
+	"github.com/innabox/fulfillment-service/internal/uuid"
 )
 
 // NotifierBuilder contains the data and logic needed to build a notifier.
@@ -105,7 +106,7 @@ func (n *Notifier) Notify(ctx context.Context, payload proto.Message) (err error
 	}
 
 	// Generate an identifier:
-	id := uuid.NewString()
+	id := uuid.New()
 
 	// Save the payload to the database:
 	_, err = tx.Exec(ctx, "insert into notifications (id, payload) values ($1, $2)", id, data)

--- a/internal/servers/events_server.go
+++ b/internal/servers/events_server.go
@@ -23,7 +23,6 @@ import (
 
 	"github.com/google/cel-go/cel"
 	"github.com/google/cel-go/common/types"
-	"github.com/google/uuid"
 	"github.com/spf13/pflag"
 	"google.golang.org/grpc"
 	grpccodes "google.golang.org/grpc/codes"
@@ -36,6 +35,7 @@ import (
 	privatev1 "github.com/innabox/fulfillment-service/internal/api/private/v1"
 	"github.com/innabox/fulfillment-service/internal/auth"
 	"github.com/innabox/fulfillment-service/internal/database"
+	"github.com/innabox/fulfillment-service/internal/uuid"
 )
 
 type EventsServerBuilder struct {
@@ -231,7 +231,7 @@ func (s *EventsServer) Watch(request *eventsv1.EventsWatchRequest,
 	}
 
 	// Create a subscription and remember to remove it when done:
-	subId := uuid.NewString()
+	subId := uuid.New()
 	logger := s.logger.With(
 		slog.String("subscription", subId),
 	)

--- a/internal/servers/generic_server.go
+++ b/internal/servers/generic_server.go
@@ -21,7 +21,6 @@ import (
 	"reflect"
 	"sync"
 
-	"github.com/google/uuid"
 	grpccodes "google.golang.org/grpc/codes"
 	grpcstatus "google.golang.org/grpc/status"
 	"google.golang.org/protobuf/proto"
@@ -34,6 +33,7 @@ import (
 	"github.com/innabox/fulfillment-service/internal/database"
 	"github.com/innabox/fulfillment-service/internal/database/dao"
 	"github.com/innabox/fulfillment-service/internal/masks"
+	"github.com/innabox/fulfillment-service/internal/uuid"
 )
 
 // GenericServerBuilder contains the data and logic needed to create new generic servers.
@@ -507,7 +507,7 @@ func (s *GenericServer[O]) notifyEvent(ctx context.Context, e dao.Event) error {
 	// TODO: This is the only part of the generic server that depends on specific object types. Is there a way
 	// to avoid that?
 	event := &privatev1.Event{}
-	event.SetId(uuid.NewString())
+	event.SetId(uuid.New())
 	switch e.Type {
 	case dao.EventTypeCreated:
 		event.SetType(privatev1.EventType_EVENT_TYPE_OBJECT_CREATED)

--- a/internal/servers/private_events_server.go
+++ b/internal/servers/private_events_server.go
@@ -22,7 +22,6 @@ import (
 
 	"github.com/google/cel-go/cel"
 	"github.com/google/cel-go/common/types"
-	"github.com/google/uuid"
 	"github.com/spf13/pflag"
 	"google.golang.org/grpc"
 	grpccodes "google.golang.org/grpc/codes"
@@ -33,6 +32,7 @@ import (
 
 	privatev1 "github.com/innabox/fulfillment-service/internal/api/private/v1"
 	"github.com/innabox/fulfillment-service/internal/database"
+	"github.com/innabox/fulfillment-service/internal/uuid"
 )
 
 type PrivateEventsServerBuilder struct {
@@ -197,7 +197,7 @@ func (s *PrivateEventsServer) Watch(request *privatev1.EventsWatchRequest,
 	}
 
 	// Create a subscription and remember to remove it when done:
-	subId := uuid.NewString()
+	subId := uuid.New()
 	logger := s.logger.With(
 		slog.String("subscription", subId),
 	)

--- a/internal/testing/database.go
+++ b/internal/testing/database.go
@@ -21,10 +21,11 @@ import (
 	"os/exec"
 	"strings"
 
-	"github.com/google/uuid"
 	_ "github.com/jackc/pgx/v5/stdlib"
 	. "github.com/onsi/ginkgo/v2/dsl/core"
 	. "github.com/onsi/gomega"
+
+	"github.com/innabox/fulfillment-service/internal/uuid"
 )
 
 // DatabaseServer knows how to start a PostgreSQL database server inside a container, and how to create databases to be
@@ -73,7 +74,7 @@ func MakeDatabaseServer() *DatabaseServer {
 	}
 
 	// Generate a random password for the database admnistrator:
-	password := uuid.NewString()
+	password := uuid.New()
 
 	// Start the database server:
 	runOut := &bytes.Buffer{}
@@ -162,7 +163,7 @@ func (s *DatabaseServer) MakeDatabase() *Database {
 	// Generate the database name and password:
 	name := fmt.Sprintf("test_%d", s.count)
 	user := fmt.Sprintf("test_%d", s.count)
-	password := uuid.NewString()
+	password := uuid.New()
 	s.count++
 
 	// Create the user:

--- a/internal/uuid/uuid.go
+++ b/internal/uuid/uuid.go
@@ -1,0 +1,28 @@
+/*
+Copyright (c) 2025 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package uuid
+
+import (
+	"fmt"
+
+	"github.com/google/uuid"
+)
+
+func New() string {
+	id, err := uuid.NewV7()
+	if err != nil {
+		panic(fmt.Sprintf("failed to generate UUID: %s", err))
+	}
+	return id.String()
+}

--- a/internal/uuid/uuid_suite_test.go
+++ b/internal/uuid/uuid_suite_test.go
@@ -1,0 +1,26 @@
+/*
+Copyright (c) 2025 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package uuid
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2/dsl/core"
+	. "github.com/onsi/gomega"
+)
+
+func TestUUID(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "UUID")
+}

--- a/internal/uuid/uuid_test.go
+++ b/internal/uuid/uuid_test.go
@@ -1,0 +1,47 @@
+/*
+Copyright (c) 2025 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package uuid
+
+import (
+	"sort"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2/dsl/core"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("UUID generation", func() {
+	It("Generates unique identifiers", func() {
+		const count = 1000
+		seen := make(map[string]bool)
+		for range count {
+			id := New()
+			Expect(seen[id]).To(BeFalse())
+			seen[id] = true
+		}
+	})
+
+	It("Generates identifiers sorted by generation time", func() {
+		const count = 100
+		ids := make([]string, count)
+		for i := range count {
+			ids[i] = New()
+			time.Sleep(time.Microsecond)
+		}
+		sorted := make([]string, count)
+		copy(sorted, ids)
+		sort.Strings(sorted)
+		Expect(ids).To(Equal(sorted))
+	})
+})

--- a/it/it_cluster_reconciler_test.go
+++ b/it/it_cluster_reconciler_test.go
@@ -18,7 +18,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/google/uuid"
 	. "github.com/onsi/ginkgo/v2/dsl/core"
 	. "github.com/onsi/gomega"
 	"google.golang.org/protobuf/proto"
@@ -32,6 +31,7 @@ import (
 	privatev1 "github.com/innabox/fulfillment-service/internal/api/private/v1"
 	"github.com/innabox/fulfillment-service/internal/kubernetes/gvks"
 	"github.com/innabox/fulfillment-service/internal/kubernetes/labels"
+	"github.com/innabox/fulfillment-service/internal/uuid"
 )
 
 var _ = Describe("Cluster reconciler", func() {
@@ -57,7 +57,7 @@ var _ = Describe("Cluster reconciler", func() {
 		templatesClient = privatev1.NewClusterTemplatesClient(adminConn)
 
 		// Create a template for testing:
-		templateId = fmt.Sprintf("my_template_%s", uuid.NewString())
+		templateId = fmt.Sprintf("my_template_%s", uuid.New())
 		_, err := templatesClient.Create(ctx, privatev1.ClusterTemplatesCreateRequest_builder{
 			Object: privatev1.ClusterTemplate_builder{
 				Id:          templateId,

--- a/it/it_private_cluster_templates_test.go
+++ b/it/it_private_cluster_templates_test.go
@@ -17,13 +17,13 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/google/uuid"
 	. "github.com/onsi/ginkgo/v2/dsl/core"
 	. "github.com/onsi/gomega"
-
-	privatev1 "github.com/innabox/fulfillment-service/internal/api/private/v1"
 	grpccodes "google.golang.org/grpc/codes"
 	grpcstatus "google.golang.org/grpc/status"
+
+	privatev1 "github.com/innabox/fulfillment-service/internal/api/private/v1"
+	"github.com/innabox/fulfillment-service/internal/uuid"
 )
 
 var _ = Describe("Private cluster templates", func() {
@@ -47,7 +47,7 @@ var _ = Describe("Private cluster templates", func() {
 
 	It("Can get a specific template", func() {
 		// Create the template:
-		id := fmt.Sprintf("my_template_%s", uuid.NewString())
+		id := fmt.Sprintf("my_template_%s", uuid.New())
 		_, err := client.Create(ctx, privatev1.ClusterTemplatesCreateRequest_builder{
 			Object: privatev1.ClusterTemplate_builder{
 				Id:          id,
@@ -75,7 +75,7 @@ var _ = Describe("Private cluster templates", func() {
 	})
 
 	It("Can create a template", func() {
-		id := fmt.Sprintf("my_template_%s", uuid.NewString())
+		id := fmt.Sprintf("my_template_%s", uuid.New())
 		response, err := client.Create(ctx, privatev1.ClusterTemplatesCreateRequest_builder{
 			Object: privatev1.ClusterTemplate_builder{
 				Id:          id,
@@ -98,7 +98,7 @@ var _ = Describe("Private cluster templates", func() {
 
 	It("Can update a template", func() {
 		// Create a template::
-		id := fmt.Sprintf("my_template_%s", uuid.NewString())
+		id := fmt.Sprintf("my_template_%s", uuid.New())
 		_, err := client.Create(ctx, privatev1.ClusterTemplatesCreateRequest_builder{
 			Object: privatev1.ClusterTemplate_builder{
 				Id:          id,
@@ -147,7 +147,7 @@ var _ = Describe("Private cluster templates", func() {
 
 	It("Can delete a template", func() {
 		// Create a template::
-		id := fmt.Sprintf("my_template_%s", uuid.NewString())
+		id := fmt.Sprintf("my_template_%s", uuid.New())
 		_, err := client.Create(ctx, privatev1.ClusterTemplatesCreateRequest_builder{
 			Object: privatev1.ClusterTemplate_builder{
 				Id:          id,

--- a/it/it_private_host_classes_test.go
+++ b/it/it_private_host_classes_test.go
@@ -17,11 +17,11 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/google/uuid"
 	. "github.com/onsi/ginkgo/v2/dsl/core"
 	. "github.com/onsi/gomega"
 
 	privatev1 "github.com/innabox/fulfillment-service/internal/api/private/v1"
+	"github.com/innabox/fulfillment-service/internal/uuid"
 )
 
 var _ = Describe("Priate host classes", func() {
@@ -37,7 +37,7 @@ var _ = Describe("Priate host classes", func() {
 
 	It("Can get the list of host classes", func() {
 		// Create the host class:
-		id := fmt.Sprintf("my_host_class_%s", uuid.NewString())
+		id := fmt.Sprintf("my_host_class_%s", uuid.New())
 		_, err := client.Create(ctx, privatev1.HostClassesCreateRequest_builder{
 			Object: privatev1.HostClass_builder{
 				Id:          id,
@@ -57,7 +57,7 @@ var _ = Describe("Priate host classes", func() {
 
 	It("Can get a specific host class", func() {
 		// Create the host class:
-		id := fmt.Sprintf("my_host_class_%s", uuid.NewString())
+		id := fmt.Sprintf("my_host_class_%s", uuid.New())
 		_, err := client.Create(ctx, privatev1.HostClassesCreateRequest_builder{
 			Object: privatev1.HostClass_builder{
 				Id:          id,
@@ -85,7 +85,7 @@ var _ = Describe("Priate host classes", func() {
 	})
 
 	It("Can create a host class", func() {
-		id := fmt.Sprintf("my_template_%s", uuid.NewString())
+		id := fmt.Sprintf("my_template_%s", uuid.New())
 		response, err := client.Create(ctx, privatev1.HostClassesCreateRequest_builder{
 			Object: privatev1.HostClass_builder{
 				Id:          id,
@@ -108,7 +108,7 @@ var _ = Describe("Priate host classes", func() {
 
 	It("Can update a host class", func() {
 		// Create a host class::
-		id := fmt.Sprintf("my_host_class_%s", uuid.NewString())
+		id := fmt.Sprintf("my_host_class_%s", uuid.New())
 		_, err := client.Create(ctx, privatev1.HostClassesCreateRequest_builder{
 			Object: privatev1.HostClass_builder{
 				Id:          id,
@@ -157,7 +157,7 @@ var _ = Describe("Priate host classes", func() {
 
 	It("Can delete a host class", func() {
 		// Create a host class::
-		id := fmt.Sprintf("my_host_class_%s", uuid.NewString())
+		id := fmt.Sprintf("my_host_class_%s", uuid.New())
 		_, err := client.Create(ctx, privatev1.HostClassesCreateRequest_builder{
 			Object: privatev1.HostClass_builder{
 				Metadata: privatev1.Metadata_builder{

--- a/it/it_public_clusters_test.go
+++ b/it/it_public_clusters_test.go
@@ -18,7 +18,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/google/uuid"
 	. "github.com/onsi/ginkgo/v2/dsl/core"
 	. "github.com/onsi/gomega"
 	grpccodes "google.golang.org/grpc/codes"
@@ -32,6 +31,7 @@ import (
 	privatev1 "github.com/innabox/fulfillment-service/internal/api/private/v1"
 	"github.com/innabox/fulfillment-service/internal/kubernetes/gvks"
 	"github.com/innabox/fulfillment-service/internal/kubernetes/labels"
+	"github.com/innabox/fulfillment-service/internal/uuid"
 )
 
 var _ = Describe("Public clusters", func() {
@@ -51,7 +51,7 @@ var _ = Describe("Public clusters", func() {
 		templatesClient = privatev1.NewClusterTemplatesClient(adminConn)
 
 		// Create a template for testing:
-		templateId = fmt.Sprintf("my_template_%s", uuid.NewString())
+		templateId = fmt.Sprintf("my_template_%s", uuid.New())
 		_, err := templatesClient.Create(ctx, privatev1.ClusterTemplatesCreateRequest_builder{
 			Object: privatev1.ClusterTemplate_builder{
 				Id:          templateId,

--- a/it/it_rest_gateway_test.go
+++ b/it/it_rest_gateway_test.go
@@ -20,11 +20,11 @@ import (
 	"io"
 	"net/http"
 
-	"github.com/google/uuid"
 	. "github.com/onsi/ginkgo/v2/dsl/core"
 	. "github.com/onsi/gomega"
 
 	privatev1 "github.com/innabox/fulfillment-service/internal/api/private/v1"
+	"github.com/innabox/fulfillment-service/internal/uuid"
 )
 
 var _ = Describe("REST gateway", func() {
@@ -42,8 +42,8 @@ var _ = Describe("REST gateway", func() {
 
 	It("Should use protobuf field names in JSON representation", func() {
 		// Create a couple of host classes for the node sets:
-		computeHostClassID := fmt.Sprintf("compute_%s", uuid.NewString())
-		gpuHostClassID := fmt.Sprintf("gpus_%s", uuid.NewString())
+		computeHostClassID := fmt.Sprintf("compute_%s", uuid.New())
+		gpuHostClassID := fmt.Sprintf("gpus_%s", uuid.New())
 		_, err := hostClassesClient.Create(ctx, privatev1.HostClassesCreateRequest_builder{
 			Object: privatev1.HostClass_builder{
 				Id:          computeHostClassID,
@@ -74,7 +74,7 @@ var _ = Describe("REST gateway", func() {
 		})
 
 		// Create a cluster template:
-		templateID := fmt.Sprintf("my_%s", uuid.NewString())
+		templateID := fmt.Sprintf("my_%s", uuid.New())
 		nodeSets := map[string]*privatev1.ClusterTemplateNodeSet{
 			"compute": privatev1.ClusterTemplateNodeSet_builder{
 				HostClass: computeHostClassID,


### PR DESCRIPTION
This patch changes the service so that it uses `UUID7` to generate unique identifiers. The advantage of this is that these identifiers are time-sortable.

The implementation uses the same Google UUID library that we used in the past, only that it uses the `uuid.NewV7` method.

All the places in the project that generate UUIDs have been changed to use the new `uuid.New` function, so that if we decide to use some other mechanism to generate identifiers we will only have to change that function.

Related: https://github.com/innabox/issues/issues/223