### PR TITLE
Update the base image

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/ubi:9.6-1753769805 AS builder
+FROM registry.access.redhat.com/ubi9/ubi:9.6-1758184894 AS builder
 
 # Install packages:
 RUN \


### PR DESCRIPTION
This patch updates the RHEL9 base image. The main reason is to get version 1.25.5 of Go, which is required by some of the new dependencies added as part of the change to use the `fulfillment-common` library.