### PR TITLE
Make tenancy logic mandatory

### DIFF
--- a/internal/cmd/start_server_cmd.go
+++ b/internal/cmd/start_server_cmd.go
@@ -272,6 +272,7 @@ func (c *startServerCommandRunner) run(cmd *cobra.Command, argv []string) error 
 	clusterTemplatesServer, err := servers.NewClusterTemplatesServer().
 		SetLogger(c.logger).
 		SetPrivate(privateClusterTemplatesServer).
+		SetTenancyLogic(tenancyLogic).
 		Build()
 	if err != nil {
 		return errors.Wrapf(err, "failed to create cluster templates server")
@@ -296,6 +297,7 @@ func (c *startServerCommandRunner) run(cmd *cobra.Command, argv []string) error 
 	clustersServer, err := servers.NewClustersServer().
 		SetLogger(c.logger).
 		SetPrivate(privateClustersServer).
+		SetTenancyLogic(tenancyLogic).
 		Build()
 	if err != nil {
 		return errors.Wrapf(err, "failed to create clusters server")
@@ -320,6 +322,7 @@ func (c *startServerCommandRunner) run(cmd *cobra.Command, argv []string) error 
 	hostClassesServer, err := servers.NewHostClassesServer().
 		SetLogger(c.logger).
 		SetPrivate(privateHostClassesServer).
+		SetTenancyLogic(tenancyLogic).
 		Build()
 	if err != nil {
 		return errors.Wrapf(err, "failed to create host classes server")
@@ -344,6 +347,7 @@ func (c *startServerCommandRunner) run(cmd *cobra.Command, argv []string) error 
 	hostsServer, err := servers.NewHostsServer().
 		SetLogger(c.logger).
 		SetPrivate(privateHostsServer).
+		SetTenancyLogic(tenancyLogic).
 		Build()
 	if err != nil {
 		return errors.Wrapf(err, "failed to create hosts server")
@@ -368,6 +372,7 @@ func (c *startServerCommandRunner) run(cmd *cobra.Command, argv []string) error 
 	hostPoolsServer, err := servers.NewHostPoolsServer().
 		SetLogger(c.logger).
 		SetPrivate(privateHostPoolsServer).
+		SetTenancyLogic(tenancyLogic).
 		Build()
 	if err != nil {
 		return errors.Wrapf(err, "failed to create host pools server")
@@ -392,6 +397,7 @@ func (c *startServerCommandRunner) run(cmd *cobra.Command, argv []string) error 
 	virtualMachineTemplatesServer, err := servers.NewVirtualMachineTemplatesServer().
 		SetLogger(c.logger).
 		SetPrivate(privateVirtualMachineTemplatesServer).
+		SetTenancyLogic(tenancyLogic).
 		Build()
 	if err != nil {
 		return errors.Wrapf(err, "failed to create virtual machine templates server")
@@ -416,6 +422,7 @@ func (c *startServerCommandRunner) run(cmd *cobra.Command, argv []string) error 
 	virtualMachinesServer, err := servers.NewVirtualMachinesServer().
 		SetLogger(c.logger).
 		SetPrivate(privateVirtualMachinesServer).
+		SetTenancyLogic(tenancyLogic).
 		Build()
 	if err != nil {
 		return errors.Wrapf(err, "failed to create virtual machines server")

--- a/internal/database/dao/generic_dao.go
+++ b/internal/database/dao/generic_dao.go
@@ -182,6 +182,10 @@ func (b *GenericDAOBuilder[O]) Build() (result *GenericDAO[O], err error) {
 		)
 		return
 	}
+	if b.tenancyLogic == nil {
+		err = errors.New("tenancy logic is mandatory")
+		return
+	}
 
 	// Get descriptors of well known types:
 	var timestamp *timestamppb.Timestamp
@@ -256,16 +260,6 @@ func (b *GenericDAOBuilder[O]) Build() (result *GenericDAO[O], err error) {
 		}
 	}
 
-	// Set the default tenancy logic so that it will never be nil:
-	tenancyLogic := b.tenancyLogic
-	if tenancyLogic == nil {
-		tenancyLogic, err = auth.NewEmptyTenancyLogic().Build()
-		if err != nil {
-			err = fmt.Errorf("failed to create default tenancy logic: %w", err)
-			return
-		}
-	}
-
 	// Create and populate the object:
 	result = &GenericDAO[O]{
 		logger:           b.logger,
@@ -282,7 +276,7 @@ func (b *GenericDAOBuilder[O]) Build() (result *GenericDAO[O], err error) {
 		unmarshalOptions: unmarshalOptions,
 		filterTranslator: filterTranslator,
 		attributionLogic: attributionLogic,
-		tenancyLogic:     tenancyLogic,
+		tenancyLogic:     b.tenancyLogic,
 	}
 	return
 }

--- a/internal/database/dao/generic_dao_events_test.go
+++ b/internal/database/dao/generic_dao_events_test.go
@@ -22,14 +22,16 @@ import (
 	. "github.com/onsi/gomega"
 
 	privatev1 "github.com/innabox/fulfillment-service/internal/api/private/v1"
+	"github.com/innabox/fulfillment-service/internal/auth"
 	"github.com/innabox/fulfillment-service/internal/database"
 )
 
 var _ = Describe("Generic DAO events", func() {
 	var (
-		ctx  context.Context
-		pool *pgxpool.Pool
-		tm   database.TxManager
+		ctx     context.Context
+		pool    *pgxpool.Pool
+		tm      database.TxManager
+		tenancy auth.TenancyLogic
 	)
 
 	BeforeEach(func() {
@@ -37,6 +39,12 @@ var _ = Describe("Generic DAO events", func() {
 
 		// Create a context:
 		ctx = context.Background()
+
+		// Create the tenancy logic:
+		tenancy, err = auth.NewEmptyTenancyLogic().
+			SetLogger(logger).
+			Build()
+		Expect(err).ToNot(HaveOccurred())
 
 		// Prepare the database connection pool:
 		db := server.MakeDatabase()
@@ -95,6 +103,7 @@ var _ = Describe("Generic DAO events", func() {
 		generic, err := NewGenericDAO[*privatev1.Cluster]().
 			SetLogger(logger).
 			SetTable("clusters").
+			SetTenancyLogic(tenancy).
 			AddEventCallback(func(_ context.Context, e Event) error {
 				event = &e
 				return nil
@@ -117,6 +126,7 @@ var _ = Describe("Generic DAO events", func() {
 		generic, err := NewGenericDAO[*privatev1.Cluster]().
 			SetLogger(logger).
 			SetTable("clusters").
+			SetTenancyLogic(tenancy).
 			AddEventCallback(func(_ context.Context, e Event) error {
 				event = &e
 				return nil
@@ -149,6 +159,7 @@ var _ = Describe("Generic DAO events", func() {
 		generic, err := NewGenericDAO[*privatev1.Cluster]().
 			SetLogger(logger).
 			SetTable("clusters").
+			SetTenancyLogic(tenancy).
 			AddEventCallback(func(_ context.Context, e Event) error {
 				event = &e
 				return nil
@@ -174,6 +185,7 @@ var _ = Describe("Generic DAO events", func() {
 		generic, err := NewGenericDAO[*privatev1.Cluster]().
 			SetLogger(logger).
 			SetTable("clusters").
+			SetTenancyLogic(tenancy).
 			AddEventCallback(func(context.Context, Event) error {
 				return errors.New("my error")
 			}).
@@ -197,6 +209,7 @@ var _ = Describe("Generic DAO events", func() {
 		generic, err := NewGenericDAO[*privatev1.Cluster]().
 			SetLogger(logger).
 			SetTable("clusters").
+			SetTenancyLogic(tenancy).
 			Build()
 		Expect(err).ToNot(HaveOccurred())
 		var object *privatev1.Cluster
@@ -209,6 +222,7 @@ var _ = Describe("Generic DAO events", func() {
 		generic, err = NewGenericDAO[*privatev1.Cluster]().
 			SetLogger(logger).
 			SetTable("clusters").
+			SetTenancyLogic(tenancy).
 			AddEventCallback(func(context.Context, Event) error {
 				return errors.New("my error")
 			}).
@@ -234,6 +248,7 @@ var _ = Describe("Generic DAO events", func() {
 		generic, err := NewGenericDAO[*privatev1.Cluster]().
 			SetLogger(logger).
 			SetTable("clusters").
+			SetTenancyLogic(tenancy).
 			AddEventCallback(func(_ context.Context, event Event) error {
 				if event.Type == EventTypeUpdated {
 					called = true
@@ -263,6 +278,7 @@ var _ = Describe("Generic DAO events", func() {
 		generic, err := NewGenericDAO[*privatev1.Cluster]().
 			SetLogger(logger).
 			SetTable("clusters").
+			SetTenancyLogic(tenancy).
 			Build()
 		Expect(err).ToNot(HaveOccurred())
 		var object *privatev1.Cluster
@@ -279,6 +295,7 @@ var _ = Describe("Generic DAO events", func() {
 		generic, err = NewGenericDAO[*privatev1.Cluster]().
 			SetLogger(logger).
 			SetTable("clusters").
+			SetTenancyLogic(tenancy).
 			AddEventCallback(func(_ context.Context, _ Event) error {
 				return errors.New("my error")
 			}).
@@ -310,6 +327,7 @@ var _ = Describe("Generic DAO events", func() {
 		generic, err := NewGenericDAO[*privatev1.Cluster]().
 			SetLogger(logger).
 			SetTable("clusters").
+			SetTenancyLogic(tenancy).
 			AddEventCallback(func(context.Context, Event) error {
 				called1 = true
 				return nil
@@ -335,6 +353,7 @@ var _ = Describe("Generic DAO events", func() {
 		generic, err := NewGenericDAO[*privatev1.Cluster]().
 			SetLogger(logger).
 			SetTable("clusters").
+			SetTenancyLogic(tenancy).
 			AddEventCallback(func(context.Context, Event) error {
 				called1 = true
 				return errors.New("my error 1")

--- a/internal/database/dao/generic_dao_test.go
+++ b/internal/database/dao/generic_dao_test.go
@@ -41,9 +41,10 @@ var _ = Describe("Generic DAO", func() {
 	)
 
 	var (
-		ctrl *gomock.Controller
-		ctx  context.Context
-		tx   database.Tx
+		ctrl    *gomock.Controller
+		ctx     context.Context
+		tx      database.Tx
+		tenancy auth.TenancyLogic
 	)
 
 	sort := func(objects []*testsv1.Object) {
@@ -61,6 +62,12 @@ var _ = Describe("Generic DAO", func() {
 
 		// Create a context:
 		ctx = context.Background()
+
+		// Create the tenancy logic:
+		tenancy, err = auth.NewEmptyTenancyLogic().
+			SetLogger(logger).
+			Build()
+		Expect(err).ToNot(HaveOccurred())
 
 		// Prepare the database pool:
 		db := server.MakeDatabase()
@@ -91,6 +98,7 @@ var _ = Describe("Generic DAO", func() {
 			generic, err := NewGenericDAO[*testsv1.Object]().
 				SetLogger(logger).
 				SetTable("objects").
+				SetTenancyLogic(tenancy).
 				Build()
 			Expect(err).ToNot(HaveOccurred())
 			Expect(generic).ToNot(BeNil())
@@ -112,10 +120,20 @@ var _ = Describe("Generic DAO", func() {
 			Expect(generic).To(BeNil())
 		})
 
+		It("Fails if tenancy logic is not set", func() {
+			generic, err := NewGenericDAO[*testsv1.Object]().
+				SetLogger(logger).
+				SetTable("objects").
+				Build()
+			Expect(err).To(MatchError("tenancy logic is mandatory"))
+			Expect(generic).To(BeNil())
+		})
+
 		It("Fails if default limit is zero", func() {
 			generic, err := NewGenericDAO[*testsv1.Object]().
 				SetLogger(logger).
 				SetTable("objects").
+				SetTenancyLogic(tenancy).
 				SetDefaultLimit(0).
 				Build()
 			Expect(err).To(MatchError("default limit must be a possitive integer, but it is 0"))
@@ -126,6 +144,7 @@ var _ = Describe("Generic DAO", func() {
 			generic, err := NewGenericDAO[*testsv1.Object]().
 				SetLogger(logger).
 				SetTable("objects").
+				SetTenancyLogic(tenancy).
 				SetDefaultLimit(-1).
 				Build()
 			Expect(err).To(MatchError("default limit must be a possitive integer, but it is -1"))
@@ -136,6 +155,7 @@ var _ = Describe("Generic DAO", func() {
 			generic, err := NewGenericDAO[*testsv1.Object]().
 				SetLogger(logger).
 				SetTable("objects").
+				SetTenancyLogic(tenancy).
 				SetMaxLimit(0).
 				Build()
 			Expect(err).To(MatchError("max limit must be a possitive integer, but it is 0"))
@@ -146,6 +166,7 @@ var _ = Describe("Generic DAO", func() {
 			generic, err := NewGenericDAO[*testsv1.Object]().
 				SetLogger(logger).
 				SetTable("objects").
+				SetTenancyLogic(tenancy).
 				SetMaxLimit(-1).
 				Build()
 			Expect(err).To(MatchError("max limit must be a possitive integer, but it is -1"))
@@ -156,6 +177,7 @@ var _ = Describe("Generic DAO", func() {
 			generic, err := NewGenericDAO[*testsv1.Object]().
 				SetLogger(logger).
 				SetTable("objects").
+				SetTenancyLogic(tenancy).
 				SetMaxLimit(100).
 				SetDefaultLimit(1000).
 				Build()

--- a/internal/servers/cluster_templates_server.go
+++ b/internal/servers/cluster_templates_server.go
@@ -23,11 +23,13 @@ import (
 
 	ffv1 "github.com/innabox/fulfillment-service/internal/api/fulfillment/v1"
 	privatev1 "github.com/innabox/fulfillment-service/internal/api/private/v1"
+	"github.com/innabox/fulfillment-service/internal/auth"
 )
 
 type ClusterTemplatesServerBuilder struct {
-	logger  *slog.Logger
-	private privatev1.ClusterTemplatesServer
+	logger       *slog.Logger
+	private      privatev1.ClusterTemplatesServer
+	tenancyLogic auth.TenancyLogic
 }
 
 var _ ffv1.ClusterTemplatesServer = (*ClusterTemplatesServer)(nil)
@@ -57,6 +59,12 @@ func (b *ClusterTemplatesServerBuilder) SetPrivate(value privatev1.ClusterTempla
 	return b
 }
 
+// SetTenancyLogic sets the tenancy logic to use. This is mandatory.
+func (b *ClusterTemplatesServerBuilder) SetTenancyLogic(value auth.TenancyLogic) *ClusterTemplatesServerBuilder {
+	b.tenancyLogic = value
+	return b
+}
+
 func (b *ClusterTemplatesServerBuilder) Build() (result *ClusterTemplatesServer, err error) {
 	// Check parameters:
 	if b.logger == nil {
@@ -65,6 +73,10 @@ func (b *ClusterTemplatesServerBuilder) Build() (result *ClusterTemplatesServer,
 	}
 	if b.private == nil {
 		err = errors.New("private server is mandatory")
+		return
+	}
+	if b.tenancyLogic == nil {
+		err = errors.New("tenancy logic is mandatory")
 		return
 	}
 

--- a/internal/servers/cluster_templates_server_test.go
+++ b/internal/servers/cluster_templates_server_test.go
@@ -23,13 +23,15 @@ import (
 	"google.golang.org/protobuf/proto"
 
 	ffv1 "github.com/innabox/fulfillment-service/internal/api/fulfillment/v1"
+	"github.com/innabox/fulfillment-service/internal/auth"
 	"github.com/innabox/fulfillment-service/internal/database"
 )
 
 var _ = Describe("Cluster templates server", func() {
 	var (
-		ctx context.Context
-		tx  database.Tx
+		ctx     context.Context
+		tx      database.Tx
+		tenancy auth.TenancyLogic
 	)
 
 	BeforeEach(func() {
@@ -37,6 +39,12 @@ var _ = Describe("Cluster templates server", func() {
 
 		// Create a context:
 		ctx = context.Background()
+
+		// Create the tenancy logic:
+		tenancy, err = auth.NewEmptyTenancyLogic().
+			SetLogger(logger).
+			Build()
+		Expect(err).ToNot(HaveOccurred())
 
 		// Prepare the database pool:
 		db := server.MakeDatabase()
@@ -93,11 +101,13 @@ var _ = Describe("Cluster templates server", func() {
 		It("Can be built if all the required parameters are set", func() {
 			privateServer, err := NewPrivateClusterTemplatesServer().
 				SetLogger(logger).
+				SetTenancyLogic(tenancy).
 				Build()
 			Expect(err).ToNot(HaveOccurred())
 			server, err := NewClusterTemplatesServer().
 				SetLogger(logger).
 				SetPrivate(privateServer).
+				SetTenancyLogic(tenancy).
 				Build()
 			Expect(err).ToNot(HaveOccurred())
 			Expect(server).ToNot(BeNil())
@@ -106,10 +116,12 @@ var _ = Describe("Cluster templates server", func() {
 		It("Fails if logger is not set", func() {
 			privateServer, err := NewPrivateClusterTemplatesServer().
 				SetLogger(logger).
+				SetTenancyLogic(tenancy).
 				Build()
 			Expect(err).ToNot(HaveOccurred())
 			server, err := NewClusterTemplatesServer().
 				SetPrivate(privateServer).
+				SetTenancyLogic(tenancy).
 				Build()
 			Expect(err).To(MatchError("logger is mandatory"))
 			Expect(server).To(BeNil())
@@ -118,8 +130,23 @@ var _ = Describe("Cluster templates server", func() {
 		It("Fails if private server is not set", func() {
 			server, err := NewClusterTemplatesServer().
 				SetLogger(logger).
+				SetTenancyLogic(tenancy).
 				Build()
 			Expect(err).To(MatchError("private server is mandatory"))
+			Expect(server).To(BeNil())
+		})
+
+		It("Fails if tenancy logic is not set", func() {
+			privateServer, err := NewPrivateClusterTemplatesServer().
+				SetLogger(logger).
+				SetTenancyLogic(tenancy).
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+			server, err := NewClusterTemplatesServer().
+				SetLogger(logger).
+				SetPrivate(privateServer).
+				Build()
+			Expect(err).To(MatchError("tenancy logic is mandatory"))
 			Expect(server).To(BeNil())
 		})
 	})
@@ -133,6 +160,7 @@ var _ = Describe("Cluster templates server", func() {
 			// Create the private server:
 			privateServer, err := NewPrivateClusterTemplatesServer().
 				SetLogger(logger).
+				SetTenancyLogic(tenancy).
 				Build()
 			Expect(err).ToNot(HaveOccurred())
 
@@ -140,6 +168,7 @@ var _ = Describe("Cluster templates server", func() {
 			server, err = NewClusterTemplatesServer().
 				SetLogger(logger).
 				SetPrivate(privateServer).
+				SetTenancyLogic(tenancy).
 				Build()
 			Expect(err).ToNot(HaveOccurred())
 		})

--- a/internal/servers/host_classes_server.go
+++ b/internal/servers/host_classes_server.go
@@ -23,11 +23,13 @@ import (
 
 	ffv1 "github.com/innabox/fulfillment-service/internal/api/fulfillment/v1"
 	privatev1 "github.com/innabox/fulfillment-service/internal/api/private/v1"
+	"github.com/innabox/fulfillment-service/internal/auth"
 )
 
 type HostClassesServerBuilder struct {
-	logger  *slog.Logger
-	private privatev1.HostClassesServer
+	logger       *slog.Logger
+	private      privatev1.HostClassesServer
+	tenancyLogic auth.TenancyLogic
 }
 
 var _ ffv1.HostClassesServer = (*HostClassesServer)(nil)
@@ -57,6 +59,12 @@ func (b *HostClassesServerBuilder) SetPrivate(value privatev1.HostClassesServer)
 	return b
 }
 
+// SetTenancyLogic sets the tenancy logic to use. This is mandatory.
+func (b *HostClassesServerBuilder) SetTenancyLogic(value auth.TenancyLogic) *HostClassesServerBuilder {
+	b.tenancyLogic = value
+	return b
+}
+
 func (b *HostClassesServerBuilder) Build() (result *HostClassesServer, err error) {
 	// Check parameters:
 	if b.logger == nil {
@@ -65,6 +73,10 @@ func (b *HostClassesServerBuilder) Build() (result *HostClassesServer, err error
 	}
 	if b.private == nil {
 		err = errors.New("private server is mandatory")
+		return
+	}
+	if b.tenancyLogic == nil {
+		err = errors.New("tenancy logic is mandatory")
 		return
 	}
 

--- a/internal/servers/host_classes_server_test.go
+++ b/internal/servers/host_classes_server_test.go
@@ -23,13 +23,15 @@ import (
 	"google.golang.org/protobuf/proto"
 
 	ffv1 "github.com/innabox/fulfillment-service/internal/api/fulfillment/v1"
+	"github.com/innabox/fulfillment-service/internal/auth"
 	"github.com/innabox/fulfillment-service/internal/database"
 )
 
 var _ = Describe("Host classes server", func() {
 	var (
-		ctx context.Context
-		tx  database.Tx
+		ctx     context.Context
+		tx      database.Tx
+		tenancy auth.TenancyLogic
 	)
 
 	BeforeEach(func() {
@@ -37,6 +39,12 @@ var _ = Describe("Host classes server", func() {
 
 		// Create a context:
 		ctx = context.Background()
+
+		// Create the tenancy logic:
+		tenancy, err = auth.NewEmptyTenancyLogic().
+			SetLogger(logger).
+			Build()
+		Expect(err).ToNot(HaveOccurred())
 
 		// Prepare the database pool:
 		db := server.MakeDatabase()
@@ -93,11 +101,13 @@ var _ = Describe("Host classes server", func() {
 		It("Can be built if all the required parameters are set", func() {
 			privateServer, err := NewPrivateHostClassesServer().
 				SetLogger(logger).
+				SetTenancyLogic(tenancy).
 				Build()
 			Expect(err).ToNot(HaveOccurred())
 			server, err := NewHostClassesServer().
 				SetLogger(logger).
 				SetPrivate(privateServer).
+				SetTenancyLogic(tenancy).
 				Build()
 			Expect(err).ToNot(HaveOccurred())
 			Expect(server).ToNot(BeNil())
@@ -106,6 +116,7 @@ var _ = Describe("Host classes server", func() {
 		It("Fails if logger is not set", func() {
 			privateServer, err := NewPrivateHostClassesServer().
 				SetLogger(logger).
+				SetTenancyLogic(tenancy).
 				Build()
 			Expect(err).ToNot(HaveOccurred())
 			server, err := NewHostClassesServer().
@@ -133,6 +144,7 @@ var _ = Describe("Host classes server", func() {
 			// Create the private server:
 			privateServer, err := NewPrivateHostClassesServer().
 				SetLogger(logger).
+				SetTenancyLogic(tenancy).
 				Build()
 			Expect(err).ToNot(HaveOccurred())
 
@@ -140,6 +152,7 @@ var _ = Describe("Host classes server", func() {
 			server, err = NewHostClassesServer().
 				SetLogger(logger).
 				SetPrivate(privateServer).
+				SetTenancyLogic(tenancy).
 				Build()
 			Expect(err).ToNot(HaveOccurred())
 		})

--- a/internal/servers/host_pools_server.go
+++ b/internal/servers/host_pools_server.go
@@ -24,11 +24,13 @@ import (
 
 	ffv1 "github.com/innabox/fulfillment-service/internal/api/fulfillment/v1"
 	privatev1 "github.com/innabox/fulfillment-service/internal/api/private/v1"
+	"github.com/innabox/fulfillment-service/internal/auth"
 )
 
 type HostPoolsServerBuilder struct {
-	logger  *slog.Logger
-	private privatev1.HostPoolsServer
+	logger       *slog.Logger
+	private      privatev1.HostPoolsServer
+	tenancyLogic auth.TenancyLogic
 }
 
 var _ ffv1.HostPoolsServer = (*HostPoolsServer)(nil)
@@ -58,6 +60,12 @@ func (b *HostPoolsServerBuilder) SetPrivate(value privatev1.HostPoolsServer) *Ho
 	return b
 }
 
+// SetTenancyLogic sets the tenancy logic to use. This is mandatory.
+func (b *HostPoolsServerBuilder) SetTenancyLogic(value auth.TenancyLogic) *HostPoolsServerBuilder {
+	b.tenancyLogic = value
+	return b
+}
+
 func (b *HostPoolsServerBuilder) Build() (result *HostPoolsServer, err error) {
 	// Check parameters:
 	if b.logger == nil {
@@ -66,6 +74,10 @@ func (b *HostPoolsServerBuilder) Build() (result *HostPoolsServer, err error) {
 	}
 	if b.private == nil {
 		err = errors.New("private server is mandatory")
+		return
+	}
+	if b.tenancyLogic == nil {
+		err = errors.New("tenancy logic is mandatory")
 		return
 	}
 

--- a/internal/servers/host_pools_server_test.go
+++ b/internal/servers/host_pools_server_test.go
@@ -23,13 +23,15 @@ import (
 	"google.golang.org/protobuf/proto"
 
 	ffv1 "github.com/innabox/fulfillment-service/internal/api/fulfillment/v1"
+	"github.com/innabox/fulfillment-service/internal/auth"
 	"github.com/innabox/fulfillment-service/internal/database"
 )
 
 var _ = Describe("Host pools server", func() {
 	var (
-		ctx context.Context
-		tx  database.Tx
+		ctx     context.Context
+		tx      database.Tx
+		tenancy auth.TenancyLogic
 	)
 
 	BeforeEach(func() {
@@ -37,6 +39,12 @@ var _ = Describe("Host pools server", func() {
 
 		// Create a context:
 		ctx = context.Background()
+
+		// Create the tenancy logic:
+		tenancy, err = auth.NewEmptyTenancyLogic().
+			SetLogger(logger).
+			Build()
+		Expect(err).ToNot(HaveOccurred())
 
 		// Prepare the database pool:
 		db := server.MakeDatabase()
@@ -93,11 +101,13 @@ var _ = Describe("Host pools server", func() {
 		It("Can be built if all the required parameters are set", func() {
 			privateServer, err := NewPrivateHostPoolsServer().
 				SetLogger(logger).
+				SetTenancyLogic(tenancy).
 				Build()
 			Expect(err).ToNot(HaveOccurred())
 			server, err := NewHostPoolsServer().
 				SetLogger(logger).
 				SetPrivate(privateServer).
+				SetTenancyLogic(tenancy).
 				Build()
 			Expect(err).ToNot(HaveOccurred())
 			Expect(server).ToNot(BeNil())
@@ -106,10 +116,12 @@ var _ = Describe("Host pools server", func() {
 		It("Fails if logger is not set", func() {
 			privateServer, err := NewPrivateHostPoolsServer().
 				SetLogger(logger).
+				SetTenancyLogic(tenancy).
 				Build()
 			Expect(err).ToNot(HaveOccurred())
 			server, err := NewHostPoolsServer().
 				SetPrivate(privateServer).
+				SetTenancyLogic(tenancy).
 				Build()
 			Expect(err).To(MatchError("logger is mandatory"))
 			Expect(server).To(BeNil())
@@ -118,8 +130,23 @@ var _ = Describe("Host pools server", func() {
 		It("Fails if private server is not set", func() {
 			server, err := NewHostPoolsServer().
 				SetLogger(logger).
+				SetTenancyLogic(tenancy).
 				Build()
 			Expect(err).To(MatchError("private server is mandatory"))
+			Expect(server).To(BeNil())
+		})
+
+		It("Fails if tenancy logic is not set", func() {
+			privateServer, err := NewPrivateHostPoolsServer().
+				SetLogger(logger).
+				SetTenancyLogic(tenancy).
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+			server, err := NewHostPoolsServer().
+				SetLogger(logger).
+				SetPrivate(privateServer).
+				Build()
+			Expect(err).To(MatchError("tenancy logic is mandatory"))
 			Expect(server).To(BeNil())
 		})
 	})
@@ -133,6 +160,7 @@ var _ = Describe("Host pools server", func() {
 			// Create the private server:
 			privateServer, err := NewPrivateHostPoolsServer().
 				SetLogger(logger).
+				SetTenancyLogic(tenancy).
 				Build()
 			Expect(err).ToNot(HaveOccurred())
 
@@ -140,6 +168,7 @@ var _ = Describe("Host pools server", func() {
 			server, err = NewHostPoolsServer().
 				SetLogger(logger).
 				SetPrivate(privateServer).
+				SetTenancyLogic(tenancy).
 				Build()
 			Expect(err).ToNot(HaveOccurred())
 		})

--- a/internal/servers/hosts_server.go
+++ b/internal/servers/hosts_server.go
@@ -24,11 +24,13 @@ import (
 
 	ffv1 "github.com/innabox/fulfillment-service/internal/api/fulfillment/v1"
 	privatev1 "github.com/innabox/fulfillment-service/internal/api/private/v1"
+	"github.com/innabox/fulfillment-service/internal/auth"
 )
 
 type HostsServerBuilder struct {
-	logger  *slog.Logger
-	private privatev1.HostsServer
+	logger       *slog.Logger
+	private      privatev1.HostsServer
+	tenancyLogic auth.TenancyLogic
 }
 
 var _ ffv1.HostsServer = (*HostsServer)(nil)
@@ -58,6 +60,12 @@ func (b *HostsServerBuilder) SetPrivate(value privatev1.HostsServer) *HostsServe
 	return b
 }
 
+// SetTenancyLogic sets the tenancy logic to use. This is mandatory.
+func (b *HostsServerBuilder) SetTenancyLogic(value auth.TenancyLogic) *HostsServerBuilder {
+	b.tenancyLogic = value
+	return b
+}
+
 func (b *HostsServerBuilder) Build() (result *HostsServer, err error) {
 	// Check parameters:
 	if b.logger == nil {
@@ -66,6 +74,10 @@ func (b *HostsServerBuilder) Build() (result *HostsServer, err error) {
 	}
 	if b.private == nil {
 		err = errors.New("private server is mandatory")
+		return
+	}
+	if b.tenancyLogic == nil {
+		err = errors.New("tenancy logic is mandatory")
 		return
 	}
 

--- a/internal/servers/hosts_server_test.go
+++ b/internal/servers/hosts_server_test.go
@@ -23,13 +23,15 @@ import (
 	"google.golang.org/protobuf/proto"
 
 	ffv1 "github.com/innabox/fulfillment-service/internal/api/fulfillment/v1"
+	"github.com/innabox/fulfillment-service/internal/auth"
 	"github.com/innabox/fulfillment-service/internal/database"
 )
 
 var _ = Describe("Hosts server", func() {
 	var (
-		ctx context.Context
-		tx  database.Tx
+		ctx     context.Context
+		tx      database.Tx
+		tenancy auth.TenancyLogic
 	)
 
 	BeforeEach(func() {
@@ -37,6 +39,12 @@ var _ = Describe("Hosts server", func() {
 
 		// Create a context:
 		ctx = context.Background()
+
+		// Create the tenancy logic:
+		tenancy, err = auth.NewEmptyTenancyLogic().
+			SetLogger(logger).
+			Build()
+		Expect(err).ToNot(HaveOccurred())
 
 		// Prepare the database pool:
 		db := server.MakeDatabase()
@@ -93,11 +101,13 @@ var _ = Describe("Hosts server", func() {
 		It("Can be built if all the required parameters are set", func() {
 			privateServer, err := NewPrivateHostsServer().
 				SetLogger(logger).
+				SetTenancyLogic(tenancy).
 				Build()
 			Expect(err).ToNot(HaveOccurred())
 			server, err := NewHostsServer().
 				SetLogger(logger).
 				SetPrivate(privateServer).
+				SetTenancyLogic(tenancy).
 				Build()
 			Expect(err).ToNot(HaveOccurred())
 			Expect(server).ToNot(BeNil())
@@ -106,10 +116,12 @@ var _ = Describe("Hosts server", func() {
 		It("Fails if logger is not set", func() {
 			privateServer, err := NewPrivateHostsServer().
 				SetLogger(logger).
+				SetTenancyLogic(tenancy).
 				Build()
 			Expect(err).ToNot(HaveOccurred())
 			server, err := NewHostsServer().
 				SetPrivate(privateServer).
+				SetTenancyLogic(tenancy).
 				Build()
 			Expect(err).To(MatchError("logger is mandatory"))
 			Expect(server).To(BeNil())
@@ -118,8 +130,23 @@ var _ = Describe("Hosts server", func() {
 		It("Fails if private server is not set", func() {
 			server, err := NewHostsServer().
 				SetLogger(logger).
+				SetTenancyLogic(tenancy).
 				Build()
 			Expect(err).To(MatchError("private server is mandatory"))
+			Expect(server).To(BeNil())
+		})
+
+		It("Fails if tenancy logic is not set", func() {
+			privateServer, err := NewPrivateHostsServer().
+				SetLogger(logger).
+				SetTenancyLogic(tenancy).
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+			server, err := NewHostsServer().
+				SetLogger(logger).
+				SetPrivate(privateServer).
+				Build()
+			Expect(err).To(MatchError("tenancy logic is mandatory"))
 			Expect(server).To(BeNil())
 		})
 	})
@@ -133,6 +160,7 @@ var _ = Describe("Hosts server", func() {
 			// Create the private server:
 			privateServer, err := NewPrivateHostsServer().
 				SetLogger(logger).
+				SetTenancyLogic(tenancy).
 				Build()
 			Expect(err).ToNot(HaveOccurred())
 
@@ -140,6 +168,7 @@ var _ = Describe("Hosts server", func() {
 			server, err = NewHostsServer().
 				SetLogger(logger).
 				SetPrivate(privateServer).
+				SetTenancyLogic(tenancy).
 				Build()
 			Expect(err).ToNot(HaveOccurred())
 		})

--- a/internal/servers/private_cluster_templates_server.go
+++ b/internal/servers/private_cluster_templates_server.go
@@ -69,6 +69,10 @@ func (b *PrivateClusterTemplatesServerBuilder) Build() (result *PrivateClusterTe
 		err = errors.New("logger is mandatory")
 		return
 	}
+	if b.tenancyLogic == nil {
+		err = errors.New("tenancy logic is mandatory")
+		return
+	}
 
 	// Create the generic server:
 	generic, err := NewGenericServer[*privatev1.ClusterTemplate]().

--- a/internal/servers/private_cluster_templates_server_test.go
+++ b/internal/servers/private_cluster_templates_server_test.go
@@ -24,13 +24,15 @@ import (
 	"google.golang.org/protobuf/types/known/fieldmaskpb"
 
 	privatev1 "github.com/innabox/fulfillment-service/internal/api/private/v1"
+	"github.com/innabox/fulfillment-service/internal/auth"
 	"github.com/innabox/fulfillment-service/internal/database"
 )
 
 var _ = Describe("Private cluster templates server", func() {
 	var (
-		ctx context.Context
-		tx  database.Tx
+		ctx     context.Context
+		tx      database.Tx
+		tenancy auth.TenancyLogic
 	)
 
 	BeforeEach(func() {
@@ -38,6 +40,12 @@ var _ = Describe("Private cluster templates server", func() {
 
 		// Create a context:
 		ctx = context.Background()
+
+		// Create the tenancy logic:
+		tenancy, err = auth.NewEmptyTenancyLogic().
+			SetLogger(logger).
+			Build()
+		Expect(err).ToNot(HaveOccurred())
 
 		// Prepare the database pool:
 		db := server.MakeDatabase()
@@ -94,6 +102,7 @@ var _ = Describe("Private cluster templates server", func() {
 		It("Can be built if all the required parameters are set", func() {
 			server, err := NewPrivateClusterTemplatesServer().
 				SetLogger(logger).
+				SetTenancyLogic(tenancy).
 				Build()
 			Expect(err).ToNot(HaveOccurred())
 			Expect(server).ToNot(BeNil())
@@ -101,8 +110,17 @@ var _ = Describe("Private cluster templates server", func() {
 
 		It("Fails if logger is not set", func() {
 			server, err := NewPrivateClusterTemplatesServer().
+				SetTenancyLogic(tenancy).
 				Build()
 			Expect(err).To(MatchError("logger is mandatory"))
+			Expect(server).To(BeNil())
+		})
+
+		It("Fails if tenancy logic is not set", func() {
+			server, err := NewPrivateClusterTemplatesServer().
+				SetLogger(logger).
+				Build()
+			Expect(err).To(MatchError("tenancy logic is mandatory"))
 			Expect(server).To(BeNil())
 		})
 	})
@@ -116,6 +134,7 @@ var _ = Describe("Private cluster templates server", func() {
 			// Create the server:
 			server, err = NewPrivateClusterTemplatesServer().
 				SetLogger(logger).
+				SetTenancyLogic(tenancy).
 				Build()
 			Expect(err).ToNot(HaveOccurred())
 		})

--- a/internal/servers/private_clusters_server.go
+++ b/internal/servers/private_clusters_server.go
@@ -79,6 +79,10 @@ func (b *PrivateClustersServerBuilder) Build() (result *PrivateClustersServer, e
 		err = errors.New("logger is mandatory")
 		return
 	}
+	if b.tenancyLogic == nil {
+		err = errors.New("tenancy logic is mandatory")
+		return
+	}
 
 	// Create the templates DAO:
 	templatesDao, err := dao.NewGenericDAO[*privatev1.ClusterTemplate]().

--- a/internal/servers/private_host_classes_server.go
+++ b/internal/servers/private_host_classes_server.go
@@ -68,6 +68,10 @@ func (b *PrivateHostClassesServerBuilder) Build() (result *PrivateHostClassesSer
 		err = errors.New("logger is mandatory")
 		return
 	}
+	if b.tenancyLogic == nil {
+		err = errors.New("tenancy logic is mandatory")
+		return
+	}
 
 	// Create the generic server:
 	generic, err := NewGenericServer[*privatev1.HostClass]().

--- a/internal/servers/private_host_classes_server_test.go
+++ b/internal/servers/private_host_classes_server_test.go
@@ -23,13 +23,15 @@ import (
 	"google.golang.org/protobuf/proto"
 
 	privatev1 "github.com/innabox/fulfillment-service/internal/api/private/v1"
+	"github.com/innabox/fulfillment-service/internal/auth"
 	"github.com/innabox/fulfillment-service/internal/database"
 )
 
 var _ = Describe("Private host classes server", func() {
 	var (
-		ctx context.Context
-		tx  database.Tx
+		ctx     context.Context
+		tx      database.Tx
+		tenancy auth.TenancyLogic
 	)
 
 	BeforeEach(func() {
@@ -37,6 +39,12 @@ var _ = Describe("Private host classes server", func() {
 
 		// Create a context:
 		ctx = context.Background()
+
+		// Create the tenancy logic:
+		tenancy, err = auth.NewEmptyTenancyLogic().
+			SetLogger(logger).
+			Build()
+		Expect(err).ToNot(HaveOccurred())
 
 		// Prepare the database pool:
 		db := server.MakeDatabase()
@@ -93,6 +101,7 @@ var _ = Describe("Private host classes server", func() {
 		It("Can be built if all the required parameters are set", func() {
 			server, err := NewPrivateHostClassesServer().
 				SetLogger(logger).
+				SetTenancyLogic(tenancy).
 				Build()
 			Expect(err).ToNot(HaveOccurred())
 			Expect(server).ToNot(BeNil())
@@ -100,8 +109,17 @@ var _ = Describe("Private host classes server", func() {
 
 		It("Fails if logger is not set", func() {
 			server, err := NewPrivateHostClassesServer().
+				SetTenancyLogic(tenancy).
 				Build()
 			Expect(err).To(MatchError("logger is mandatory"))
+			Expect(server).To(BeNil())
+		})
+
+		It("Fails if tenancy logic is not set", func() {
+			server, err := NewPrivateHostClassesServer().
+				SetLogger(logger).
+				Build()
+			Expect(err).To(MatchError("tenancy logic is mandatory"))
 			Expect(server).To(BeNil())
 		})
 	})
@@ -115,6 +133,7 @@ var _ = Describe("Private host classes server", func() {
 			// Create the server:
 			server, err = NewPrivateHostClassesServer().
 				SetLogger(logger).
+				SetTenancyLogic(tenancy).
 				Build()
 			Expect(err).ToNot(HaveOccurred())
 		})

--- a/internal/servers/private_host_pools_server.go
+++ b/internal/servers/private_host_pools_server.go
@@ -69,6 +69,10 @@ func (b *PrivateHostPoolsServerBuilder) Build() (result *PrivateHostPoolsServer,
 		err = errors.New("logger is mandatory")
 		return
 	}
+	if b.tenancyLogic == nil {
+		err = errors.New("tenancy logic is mandatory")
+		return
+	}
 
 	// Create the generic server:
 	generic, err := NewGenericServer[*privatev1.HostPool]().

--- a/internal/servers/private_host_pools_server_test.go
+++ b/internal/servers/private_host_pools_server_test.go
@@ -23,13 +23,15 @@ import (
 	"google.golang.org/protobuf/proto"
 
 	privatev1 "github.com/innabox/fulfillment-service/internal/api/private/v1"
+	"github.com/innabox/fulfillment-service/internal/auth"
 	"github.com/innabox/fulfillment-service/internal/database"
 )
 
 var _ = Describe("Private host pools server", func() {
 	var (
-		ctx context.Context
-		tx  database.Tx
+		ctx     context.Context
+		tx      database.Tx
+		tenancy auth.TenancyLogic
 	)
 
 	BeforeEach(func() {
@@ -37,6 +39,12 @@ var _ = Describe("Private host pools server", func() {
 
 		// Create a context:
 		ctx = context.Background()
+
+		// Create the tenancy logic:
+		tenancy, err = auth.NewEmptyTenancyLogic().
+			SetLogger(logger).
+			Build()
+		Expect(err).ToNot(HaveOccurred())
 
 		// Prepare the database pool:
 		db := server.MakeDatabase()
@@ -93,6 +101,7 @@ var _ = Describe("Private host pools server", func() {
 		It("Can be built if all the required parameters are set", func() {
 			server, err := NewPrivateHostPoolsServer().
 				SetLogger(logger).
+				SetTenancyLogic(tenancy).
 				Build()
 			Expect(err).ToNot(HaveOccurred())
 			Expect(server).ToNot(BeNil())
@@ -100,8 +109,17 @@ var _ = Describe("Private host pools server", func() {
 
 		It("Fails if logger is not set", func() {
 			server, err := NewPrivateHostPoolsServer().
+				SetTenancyLogic(tenancy).
 				Build()
 			Expect(err).To(MatchError("logger is mandatory"))
+			Expect(server).To(BeNil())
+		})
+
+		It("Fails if tenancy logic is not set", func() {
+			server, err := NewPrivateHostPoolsServer().
+				SetLogger(logger).
+				Build()
+			Expect(err).To(MatchError("tenancy logic is mandatory"))
 			Expect(server).To(BeNil())
 		})
 	})
@@ -115,6 +133,7 @@ var _ = Describe("Private host pools server", func() {
 			// Create the server:
 			server, err = NewPrivateHostPoolsServer().
 				SetLogger(logger).
+				SetTenancyLogic(tenancy).
 				Build()
 			Expect(err).ToNot(HaveOccurred())
 		})

--- a/internal/servers/private_hosts_server.go
+++ b/internal/servers/private_hosts_server.go
@@ -69,6 +69,10 @@ func (b *PrivateHostsServerBuilder) Build() (result *PrivateHostsServer, err err
 		err = errors.New("logger is mandatory")
 		return
 	}
+	if b.tenancyLogic == nil {
+		err = errors.New("tenancy logic is mandatory")
+		return
+	}
 
 	// Create the generic server:
 	generic, err := NewGenericServer[*privatev1.Host]().

--- a/internal/servers/private_hosts_server_test.go
+++ b/internal/servers/private_hosts_server_test.go
@@ -23,13 +23,15 @@ import (
 	"google.golang.org/protobuf/proto"
 
 	privatev1 "github.com/innabox/fulfillment-service/internal/api/private/v1"
+	"github.com/innabox/fulfillment-service/internal/auth"
 	"github.com/innabox/fulfillment-service/internal/database"
 )
 
 var _ = Describe("Private hosts server", func() {
 	var (
-		ctx context.Context
-		tx  database.Tx
+		ctx     context.Context
+		tx      database.Tx
+		tenancy auth.TenancyLogic
 	)
 
 	BeforeEach(func() {
@@ -37,6 +39,12 @@ var _ = Describe("Private hosts server", func() {
 
 		// Create a context:
 		ctx = context.Background()
+
+		// Create the tenancy logic:
+		tenancy, err = auth.NewEmptyTenancyLogic().
+			SetLogger(logger).
+			Build()
+		Expect(err).ToNot(HaveOccurred())
 
 		// Prepare the database pool:
 		db := server.MakeDatabase()
@@ -93,6 +101,7 @@ var _ = Describe("Private hosts server", func() {
 		It("Can be built if all the required parameters are set", func() {
 			server, err := NewPrivateHostsServer().
 				SetLogger(logger).
+				SetTenancyLogic(tenancy).
 				Build()
 			Expect(err).ToNot(HaveOccurred())
 			Expect(server).ToNot(BeNil())
@@ -100,6 +109,7 @@ var _ = Describe("Private hosts server", func() {
 
 		It("Fails if logger is not set", func() {
 			server, err := NewPrivateHostsServer().
+				SetTenancyLogic(tenancy).
 				Build()
 			Expect(err).To(MatchError("logger is mandatory"))
 			Expect(server).To(BeNil())
@@ -115,6 +125,7 @@ var _ = Describe("Private hosts server", func() {
 			// Create the server:
 			server, err = NewPrivateHostsServer().
 				SetLogger(logger).
+				SetTenancyLogic(tenancy).
 				Build()
 			Expect(err).ToNot(HaveOccurred())
 		})

--- a/internal/servers/private_hubs_server.go
+++ b/internal/servers/private_hubs_server.go
@@ -69,6 +69,10 @@ func (b *PrivateHubsServerBuilder) Build() (result *PrivateHubsServer, err error
 		err = errors.New("logger is mandatory")
 		return
 	}
+	if b.tenancyLogic == nil {
+		err = errors.New("tenancy logic is mandatory")
+		return
+	}
 
 	// Create the generic server:
 	generic, err := NewGenericServer[*privatev1.Hub]().

--- a/internal/servers/private_virtual_machine_templates_server.go
+++ b/internal/servers/private_virtual_machine_templates_server.go
@@ -68,6 +68,10 @@ func (b *PrivateVirtualMachineTemplatesServerBuilder) Build() (result *PrivateVi
 		err = errors.New("logger is mandatory")
 		return
 	}
+	if b.tenancyLogic == nil {
+		err = errors.New("tenancy logic is mandatory")
+		return
+	}
 
 	// Create the generic server:
 	generic, err := NewGenericServer[*privatev1.VirtualMachineTemplate]().

--- a/internal/servers/private_virtual_machine_templates_server_test.go
+++ b/internal/servers/private_virtual_machine_templates_server_test.go
@@ -24,13 +24,15 @@ import (
 	"google.golang.org/protobuf/types/known/fieldmaskpb"
 
 	privatev1 "github.com/innabox/fulfillment-service/internal/api/private/v1"
+	"github.com/innabox/fulfillment-service/internal/auth"
 	"github.com/innabox/fulfillment-service/internal/database"
 )
 
 var _ = Describe("Private virtual machine templates server", func() {
 	var (
-		ctx context.Context
-		tx  database.Tx
+		ctx     context.Context
+		tx      database.Tx
+		tenancy auth.TenancyLogic
 	)
 
 	BeforeEach(func() {
@@ -38,6 +40,12 @@ var _ = Describe("Private virtual machine templates server", func() {
 
 		// Create a context:
 		ctx = context.Background()
+
+		// Create the tenancy logic:
+		tenancy, err = auth.NewEmptyTenancyLogic().
+			SetLogger(logger).
+			Build()
+		Expect(err).ToNot(HaveOccurred())
 
 		// Prepare the database pool:
 		db := server.MakeDatabase()
@@ -94,6 +102,7 @@ var _ = Describe("Private virtual machine templates server", func() {
 		It("Creates server with logger", func() {
 			server, err := NewPrivateVirtualMachineTemplatesServer().
 				SetLogger(logger).
+				SetTenancyLogic(tenancy).
 				Build()
 			Expect(err).ToNot(HaveOccurred())
 			Expect(server).ToNot(BeNil())
@@ -101,6 +110,7 @@ var _ = Describe("Private virtual machine templates server", func() {
 
 		It("Doesn't create server without logger", func() {
 			server, err := NewPrivateVirtualMachineTemplatesServer().
+				SetTenancyLogic(tenancy).
 				Build()
 			Expect(err).To(HaveOccurred())
 			Expect(server).To(BeNil())
@@ -116,6 +126,7 @@ var _ = Describe("Private virtual machine templates server", func() {
 			// Create the server:
 			server, err = NewPrivateVirtualMachineTemplatesServer().
 				SetLogger(logger).
+				SetTenancyLogic(tenancy).
 				Build()
 			Expect(err).ToNot(HaveOccurred())
 		})

--- a/internal/servers/private_virtual_machines_server.go
+++ b/internal/servers/private_virtual_machines_server.go
@@ -75,6 +75,10 @@ func (b *PrivateVirtualMachinesServerBuilder) Build() (result *PrivateVirtualMac
 		err = errors.New("logger is mandatory")
 		return
 	}
+	if b.tenancyLogic == nil {
+		err = errors.New("tenancy logic is mandatory")
+		return
+	}
 
 	// Create the templates DAO:
 	templatesDao, err := dao.NewGenericDAO[*privatev1.VirtualMachineTemplate]().

--- a/internal/servers/virtual_machine_templates_server.go
+++ b/internal/servers/virtual_machine_templates_server.go
@@ -23,11 +23,13 @@ import (
 
 	ffv1 "github.com/innabox/fulfillment-service/internal/api/fulfillment/v1"
 	privatev1 "github.com/innabox/fulfillment-service/internal/api/private/v1"
+	"github.com/innabox/fulfillment-service/internal/auth"
 )
 
 type VirtualMachineTemplatesServerBuilder struct {
-	logger  *slog.Logger
-	private privatev1.VirtualMachineTemplatesServer
+	logger       *slog.Logger
+	private      privatev1.VirtualMachineTemplatesServer
+	tenancyLogic auth.TenancyLogic
 }
 
 var _ ffv1.VirtualMachineTemplatesServer = (*VirtualMachineTemplatesServer)(nil)
@@ -57,6 +59,12 @@ func (b *VirtualMachineTemplatesServerBuilder) SetPrivate(value privatev1.Virtua
 	return b
 }
 
+// SetTenancyLogic sets the tenancy logic to use. This is mandatory.
+func (b *VirtualMachineTemplatesServerBuilder) SetTenancyLogic(value auth.TenancyLogic) *VirtualMachineTemplatesServerBuilder {
+	b.tenancyLogic = value
+	return b
+}
+
 func (b *VirtualMachineTemplatesServerBuilder) Build() (result *VirtualMachineTemplatesServer, err error) {
 	// Check parameters:
 	if b.logger == nil {
@@ -65,6 +73,10 @@ func (b *VirtualMachineTemplatesServerBuilder) Build() (result *VirtualMachineTe
 	}
 	if b.private == nil {
 		err = errors.New("private server is mandatory")
+		return
+	}
+	if b.tenancyLogic == nil {
+		err = errors.New("tenancy logic is mandatory")
 		return
 	}
 

--- a/internal/servers/virtual_machines_server.go
+++ b/internal/servers/virtual_machines_server.go
@@ -23,11 +23,13 @@ import (
 
 	ffv1 "github.com/innabox/fulfillment-service/internal/api/fulfillment/v1"
 	privatev1 "github.com/innabox/fulfillment-service/internal/api/private/v1"
+	"github.com/innabox/fulfillment-service/internal/auth"
 )
 
 type VirtualMachinesServerBuilder struct {
-	logger  *slog.Logger
-	private privatev1.VirtualMachinesServer
+	logger       *slog.Logger
+	private      privatev1.VirtualMachinesServer
+	tenancyLogic auth.TenancyLogic
 }
 
 var _ ffv1.VirtualMachinesServer = (*VirtualMachinesServer)(nil)
@@ -57,6 +59,12 @@ func (b *VirtualMachinesServerBuilder) SetPrivate(value privatev1.VirtualMachine
 	return b
 }
 
+// SetTenancyLogic sets the tenancy logic to use. This is mandatory.
+func (b *VirtualMachinesServerBuilder) SetTenancyLogic(value auth.TenancyLogic) *VirtualMachinesServerBuilder {
+	b.tenancyLogic = value
+	return b
+}
+
 func (b *VirtualMachinesServerBuilder) Build() (result *VirtualMachinesServer, err error) {
 	// Check parameters:
 	if b.logger == nil {
@@ -65,6 +73,10 @@ func (b *VirtualMachinesServerBuilder) Build() (result *VirtualMachinesServer, e
 	}
 	if b.private == nil {
 		err = errors.New("private server is mandatory")
+		return
+	}
+	if b.tenancyLogic == nil {
+		err = errors.New("tenancy logic is mandatory")
 		return
 	}
 


### PR DESCRIPTION
Currently the storage layer uses the empty tenancy logic by default. This is to avoid setting it explicily in unit tests that aren't about tenancy. A potential side effect of that is that if some code path forgets to explicitly set it can result in a security vulnerability. To avoid that this patch changes the storage layer so that the the tenancy logic is required, and is explicitly set in all the places where it is needed.

Note that this doesn't change the behaviour of the system, as the tenancy logic was already explicitly set when the server was started.