### PR TITLE
Add `git` to builder image

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -3,6 +3,7 @@ FROM registry.access.redhat.com/ubi9/ubi:9.6-1758184894 AS builder
 # Install packages:
 RUN \
   dnf install -y \
+  git \
   golang \
   && \
   dnf clean all -y


### PR DESCRIPTION
Currently the `git` command isn't available in the container image that is used to build the service. As a result the `go build` command isn't able to find the value for the `vcs.revision` build setting, and therefore the `version` command prints `unknown`:

```
$ podman run ... /usr/local/bin/fulfillment-service version | jq
{
  "time": "2025-10-08T08:31:40Z",
  "level": "INFO",
  "msg": "Command",
  "args": [
    "/usr/local/bin/fulfillment-service",
    "version"
  ]
}
{
  "time": "2025-10-08T08:31:40Z",
  "level": "INFO",
  "msg": "Build",
  "go": "go1.24.6 (Red Hat 1.24.6-1.el9_6)",
  "os": "linux",
  "arch": "amd64"
}
{
  "time": "unknown",
  "level": "INFO",
  "msg": "Version",
  "commit": "unknown"
}
```

To avoid that this patch adds the `git` command to the container image. The `version` command will now print this:

```
$ podman run ... /usr/local/bin/fulfillment-service version | jq
{
  "time": "2025-10-08T08:35:26Z",
  "level": "INFO",
  "msg": "Command",
  "args": [
    "/usr/local/bin/fulfillment-service",
    "version"
  ]
}
{
  "time": "2025-10-08T08:31:53Z",
  "level": "INFO",
  "msg": "Build",
  "go": "go1.24.6 (Red Hat 1.24.6-1.el9_6)",
  "os": "linux",
  "arch": "amd64",
  "revision": "aa42608940968dd8bd9089d137a3b4004a0013d2"
}
{
  "time": "2025-10-08T08:31:53Z",
  "level": "INFO",
  "msg": "Version",
  "commit": "aa42608940968dd8bd9089d137a3b4004a0013d2"
}
```

Resolves: https://github.com/innabox/fulfillment-service/issues/129