### PR TITLE
Add system tenancy and attribution logic for private API

### DIFF
--- a/internal/auth/system_attribution_logic.go
+++ b/internal/auth/system_attribution_logic.go
@@ -1,0 +1,60 @@
+/*
+Copyright (c) 2025 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package auth
+
+import (
+	"context"
+	"log/slog"
+)
+
+// SystemAttributionLogicBuilder contains the data and logic needed to create system attribution logic.
+type SystemAttributionLogicBuilder struct {
+	logger *slog.Logger
+}
+
+// SystemAttributionLogic is an attribution logic implementation intended exclusively for the private API, where all
+// objects are attributed to the "system" creator. This implementation should NOT be used for the public API.
+type SystemAttributionLogic struct {
+	logger *slog.Logger
+}
+
+// NewSystemAttributionLogic creates a new builder for system attribution logic.
+func NewSystemAttributionLogic() *SystemAttributionLogicBuilder {
+	return &SystemAttributionLogicBuilder{}
+}
+
+// SetLogger sets the logger that will be used by the attribution logic.
+func (b *SystemAttributionLogicBuilder) SetLogger(value *slog.Logger) *SystemAttributionLogicBuilder {
+	b.logger = value
+	return b
+}
+
+// Build creates the system attribution logic.
+func (b *SystemAttributionLogicBuilder) Build() (result *SystemAttributionLogic, err error) {
+	// Create the attribution logic:
+	result = &SystemAttributionLogic{
+		logger: b.logger,
+	}
+	return
+}
+
+// DetermineAssignedCreators returns "system" as the creator for objects created through the private API.
+func (l *SystemAttributionLogic) DetermineAssignedCreators(_ context.Context) (result []string, err error) {
+	result = systemCreators
+	return
+}
+
+var systemCreators = []string{
+	"system",
+}

--- a/internal/auth/system_attribution_logic_test.go
+++ b/internal/auth/system_attribution_logic_test.go
@@ -1,0 +1,58 @@
+/*
+Copyright (c) 2025 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package auth
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2/dsl/core"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("System attribution logic", func() {
+	var ctx context.Context
+
+	BeforeEach(func() {
+		ctx = context.Background()
+	})
+
+	Describe("Creation", func() {
+		It("Succeeds without logger", func() {
+			logic, err := NewSystemAttributionLogic().
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(logic).ToNot(BeNil())
+		})
+
+		It("Succeeds with logger", func() {
+			logic, err := NewSystemAttributionLogic().
+				SetLogger(logger).
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(logic).ToNot(BeNil())
+		})
+	})
+
+	Describe("Behavior", func() {
+		It("Returns system as the creator", func() {
+			logic, err := NewSystemAttributionLogic().
+				SetLogger(logger).
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+			creators, err := logic.DetermineAssignedCreators(ctx)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(creators).To(ConsistOf("system"))
+		})
+	})
+})

--- a/internal/auth/system_tenancy_logic.go
+++ b/internal/auth/system_tenancy_logic.go
@@ -1,0 +1,68 @@
+/*
+Copyright (c) 2025 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package auth
+
+import (
+	"context"
+	"log/slog"
+)
+
+// SystemTenancyLogicBuilder contains the data and logic needed to create system tenancy logic.
+type SystemTenancyLogicBuilder struct {
+	logger *slog.Logger
+}
+
+// SystemTenancyLogic is a tenancy logic implementation intended exclusively for the private API, where tenancy
+// filtering is effectively disabled. It assigns objects to the "shared" tenant while returning an empty list of
+// visible tenants, which allows the private API to access all objects regardless of their tenant assignment.
+// This implementation should NOT be used for the public API.
+type SystemTenancyLogic struct {
+	logger *slog.Logger
+}
+
+// NewSystemTenancyLogic creates a new builder for system tenancy logic.
+func NewSystemTenancyLogic() *SystemTenancyLogicBuilder {
+	return &SystemTenancyLogicBuilder{}
+}
+
+// SetLogger sets the logger that will be used by the tenancy logic.
+func (b *SystemTenancyLogicBuilder) SetLogger(value *slog.Logger) *SystemTenancyLogicBuilder {
+	b.logger = value
+	return b
+}
+
+// Build creates the system tenancy logic.
+func (b *SystemTenancyLogicBuilder) Build() (result *SystemTenancyLogic, err error) {
+	// Create the tenancy logic:
+	result = &SystemTenancyLogic{
+		logger: b.logger,
+	}
+	return
+}
+
+// DetermineAssignedTenants returns the "shared" tenant for objects created through the private API.
+func (p *SystemTenancyLogic) DetermineAssignedTenants(_ context.Context) (result []string, err error) {
+	result = systemTenants
+	return
+}
+
+// DetermineVisibleTenants returns an empty list of tenants, which disables tenant filtering and allows the private
+// API to access all objects regardless of their tenant assignment.
+func (p *SystemTenancyLogic) DetermineVisibleTenants(_ context.Context) (result []string, err error) {
+	return
+}
+
+var systemTenants = []string{
+	"shared",
+}

--- a/internal/auth/system_tenancy_logic_test.go
+++ b/internal/auth/system_tenancy_logic_test.go
@@ -1,0 +1,54 @@
+/*
+Copyright (c) 2025 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package auth
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("System tenancy logic", func() {
+	var (
+		ctx   context.Context
+		logic *SystemTenancyLogic
+	)
+
+	BeforeEach(func() {
+		var err error
+
+		// Create the context:
+		ctx = context.Background()
+
+		// Create the tenancy logic:
+		logic, err = NewSystemTenancyLogic().
+			SetLogger(logger).
+			Build()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(logic).ToNot(BeNil())
+	})
+
+	It("Returns the shared tenant for assigned tenants", func() {
+		result, err := logic.DetermineAssignedTenants(ctx)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(result).To(ConsistOf("shared"))
+	})
+
+	It("Returns an empty list of visible tenants to disable filtering", func() {
+		result, err := logic.DetermineVisibleTenants(ctx)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(result).To(BeEmpty())
+	})
+})

--- a/internal/servers/cluster_templates_server_test.go
+++ b/internal/servers/cluster_templates_server_test.go
@@ -99,14 +99,8 @@ var _ = Describe("Cluster templates server", func() {
 
 	Describe("Creation", func() {
 		It("Can be built if all the required parameters are set", func() {
-			privateServer, err := NewPrivateClusterTemplatesServer().
-				SetLogger(logger).
-				SetTenancyLogic(tenancy).
-				Build()
-			Expect(err).ToNot(HaveOccurred())
 			server, err := NewClusterTemplatesServer().
 				SetLogger(logger).
-				SetPrivate(privateServer).
 				SetTenancyLogic(tenancy).
 				Build()
 			Expect(err).ToNot(HaveOccurred())
@@ -114,37 +108,16 @@ var _ = Describe("Cluster templates server", func() {
 		})
 
 		It("Fails if logger is not set", func() {
-			privateServer, err := NewPrivateClusterTemplatesServer().
-				SetLogger(logger).
-				SetTenancyLogic(tenancy).
-				Build()
-			Expect(err).ToNot(HaveOccurred())
 			server, err := NewClusterTemplatesServer().
-				SetPrivate(privateServer).
 				SetTenancyLogic(tenancy).
 				Build()
 			Expect(err).To(MatchError("logger is mandatory"))
 			Expect(server).To(BeNil())
 		})
 
-		It("Fails if private server is not set", func() {
-			server, err := NewClusterTemplatesServer().
-				SetLogger(logger).
-				SetTenancyLogic(tenancy).
-				Build()
-			Expect(err).To(MatchError("private server is mandatory"))
-			Expect(server).To(BeNil())
-		})
-
 		It("Fails if tenancy logic is not set", func() {
-			privateServer, err := NewPrivateClusterTemplatesServer().
-				SetLogger(logger).
-				SetTenancyLogic(tenancy).
-				Build()
-			Expect(err).ToNot(HaveOccurred())
 			server, err := NewClusterTemplatesServer().
 				SetLogger(logger).
-				SetPrivate(privateServer).
 				Build()
 			Expect(err).To(MatchError("tenancy logic is mandatory"))
 			Expect(server).To(BeNil())
@@ -157,17 +130,9 @@ var _ = Describe("Cluster templates server", func() {
 		BeforeEach(func() {
 			var err error
 
-			// Create the private server:
-			privateServer, err := NewPrivateClusterTemplatesServer().
-				SetLogger(logger).
-				SetTenancyLogic(tenancy).
-				Build()
-			Expect(err).ToNot(HaveOccurred())
-
 			// Create the server:
 			server, err = NewClusterTemplatesServer().
 				SetLogger(logger).
-				SetPrivate(privateServer).
 				SetTenancyLogic(tenancy).
 				Build()
 			Expect(err).ToNot(HaveOccurred())

--- a/internal/servers/clusters_server_test.go
+++ b/internal/servers/clusters_server_test.go
@@ -126,14 +126,8 @@ var _ = Describe("Clusters server", func() {
 
 	Describe("Creation", func() {
 		It("Can be built if all the required parameters are set", func() {
-			privateServer, err := NewPrivateClustersServer().
-				SetLogger(logger).
-				SetTenancyLogic(tenancy).
-				Build()
-			Expect(err).ToNot(HaveOccurred())
 			server, err := NewClustersServer().
 				SetLogger(logger).
-				SetPrivate(privateServer).
 				SetTenancyLogic(tenancy).
 				Build()
 			Expect(err).ToNot(HaveOccurred())
@@ -141,37 +135,16 @@ var _ = Describe("Clusters server", func() {
 		})
 
 		It("Fails if logger is not set", func() {
-			privateServer, err := NewPrivateClustersServer().
-				SetLogger(logger).
-				SetTenancyLogic(tenancy).
-				Build()
-			Expect(err).ToNot(HaveOccurred())
 			server, err := NewClustersServer().
-				SetPrivate(privateServer).
 				SetTenancyLogic(tenancy).
 				Build()
 			Expect(err).To(MatchError("logger is mandatory"))
 			Expect(server).To(BeNil())
 		})
 
-		It("Fails if private server is not set", func() {
-			server, err := NewClustersServer().
-				SetLogger(logger).
-				SetTenancyLogic(tenancy).
-				Build()
-			Expect(err).To(MatchError("private server is mandatory"))
-			Expect(server).To(BeNil())
-		})
-
 		It("Fails if tenancy logic is not set", func() {
-			privateServer, err := NewPrivateClustersServer().
-				SetLogger(logger).
-				SetTenancyLogic(tenancy).
-				Build()
-			Expect(err).ToNot(HaveOccurred())
 			server, err := NewClustersServer().
 				SetLogger(logger).
-				SetPrivate(privateServer).
 				Build()
 			Expect(err).To(MatchError("tenancy logic is mandatory"))
 			Expect(server).To(BeNil())
@@ -190,25 +163,9 @@ var _ = Describe("Clusters server", func() {
 		BeforeEach(func() {
 			var err error
 
-			// Create the private server:
-			privateServer, err := NewPrivateClustersServer().
-				SetLogger(logger).
-				SetTenancyLogic(tenancy).
-				Build()
-			Expect(err).ToNot(HaveOccurred())
-
 			// Create the server:
 			server, err = NewClustersServer().
 				SetLogger(logger).
-				SetPrivate(privateServer).
-				SetTenancyLogic(tenancy).
-				Build()
-			Expect(err).ToNot(HaveOccurred())
-
-			// Create the server:
-			server, err = NewClustersServer().
-				SetLogger(logger).
-				SetPrivate(privateServer).
 				SetTenancyLogic(tenancy).
 				Build()
 			Expect(err).ToNot(HaveOccurred())

--- a/internal/servers/host_classes_server_test.go
+++ b/internal/servers/host_classes_server_test.go
@@ -99,14 +99,8 @@ var _ = Describe("Host classes server", func() {
 
 	Describe("Creation", func() {
 		It("Can be built if all the required parameters are set", func() {
-			privateServer, err := NewPrivateHostClassesServer().
-				SetLogger(logger).
-				SetTenancyLogic(tenancy).
-				Build()
-			Expect(err).ToNot(HaveOccurred())
 			server, err := NewHostClassesServer().
 				SetLogger(logger).
-				SetPrivate(privateServer).
 				SetTenancyLogic(tenancy).
 				Build()
 			Expect(err).ToNot(HaveOccurred())
@@ -114,23 +108,18 @@ var _ = Describe("Host classes server", func() {
 		})
 
 		It("Fails if logger is not set", func() {
-			privateServer, err := NewPrivateHostClassesServer().
-				SetLogger(logger).
-				SetTenancyLogic(tenancy).
-				Build()
-			Expect(err).ToNot(HaveOccurred())
 			server, err := NewHostClassesServer().
-				SetPrivate(privateServer).
+				SetTenancyLogic(tenancy).
 				Build()
 			Expect(err).To(MatchError("logger is mandatory"))
 			Expect(server).To(BeNil())
 		})
 
-		It("Fails if private server is not set", func() {
+		It("Fails if tenancy logic is not set", func() {
 			server, err := NewHostClassesServer().
 				SetLogger(logger).
 				Build()
-			Expect(err).To(MatchError("private server is mandatory"))
+			Expect(err).To(MatchError("tenancy logic is mandatory"))
 			Expect(server).To(BeNil())
 		})
 	})
@@ -141,17 +130,9 @@ var _ = Describe("Host classes server", func() {
 		BeforeEach(func() {
 			var err error
 
-			// Create the private server:
-			privateServer, err := NewPrivateHostClassesServer().
-				SetLogger(logger).
-				SetTenancyLogic(tenancy).
-				Build()
-			Expect(err).ToNot(HaveOccurred())
-
 			// Create the server:
 			server, err = NewHostClassesServer().
 				SetLogger(logger).
-				SetPrivate(privateServer).
 				SetTenancyLogic(tenancy).
 				Build()
 			Expect(err).ToNot(HaveOccurred())

--- a/internal/servers/host_pools_server_test.go
+++ b/internal/servers/host_pools_server_test.go
@@ -99,14 +99,8 @@ var _ = Describe("Host pools server", func() {
 
 	Describe("Creation", func() {
 		It("Can be built if all the required parameters are set", func() {
-			privateServer, err := NewPrivateHostPoolsServer().
-				SetLogger(logger).
-				SetTenancyLogic(tenancy).
-				Build()
-			Expect(err).ToNot(HaveOccurred())
 			server, err := NewHostPoolsServer().
 				SetLogger(logger).
-				SetPrivate(privateServer).
 				SetTenancyLogic(tenancy).
 				Build()
 			Expect(err).ToNot(HaveOccurred())
@@ -114,37 +108,16 @@ var _ = Describe("Host pools server", func() {
 		})
 
 		It("Fails if logger is not set", func() {
-			privateServer, err := NewPrivateHostPoolsServer().
-				SetLogger(logger).
-				SetTenancyLogic(tenancy).
-				Build()
-			Expect(err).ToNot(HaveOccurred())
 			server, err := NewHostPoolsServer().
-				SetPrivate(privateServer).
 				SetTenancyLogic(tenancy).
 				Build()
 			Expect(err).To(MatchError("logger is mandatory"))
 			Expect(server).To(BeNil())
 		})
 
-		It("Fails if private server is not set", func() {
-			server, err := NewHostPoolsServer().
-				SetLogger(logger).
-				SetTenancyLogic(tenancy).
-				Build()
-			Expect(err).To(MatchError("private server is mandatory"))
-			Expect(server).To(BeNil())
-		})
-
 		It("Fails if tenancy logic is not set", func() {
-			privateServer, err := NewPrivateHostPoolsServer().
-				SetLogger(logger).
-				SetTenancyLogic(tenancy).
-				Build()
-			Expect(err).ToNot(HaveOccurred())
 			server, err := NewHostPoolsServer().
 				SetLogger(logger).
-				SetPrivate(privateServer).
 				Build()
 			Expect(err).To(MatchError("tenancy logic is mandatory"))
 			Expect(server).To(BeNil())
@@ -157,17 +130,9 @@ var _ = Describe("Host pools server", func() {
 		BeforeEach(func() {
 			var err error
 
-			// Create the private server:
-			privateServer, err := NewPrivateHostPoolsServer().
-				SetLogger(logger).
-				SetTenancyLogic(tenancy).
-				Build()
-			Expect(err).ToNot(HaveOccurred())
-
 			// Create the server:
 			server, err = NewHostPoolsServer().
 				SetLogger(logger).
-				SetPrivate(privateServer).
 				SetTenancyLogic(tenancy).
 				Build()
 			Expect(err).ToNot(HaveOccurred())

--- a/internal/servers/hosts_server_test.go
+++ b/internal/servers/hosts_server_test.go
@@ -99,14 +99,8 @@ var _ = Describe("Hosts server", func() {
 
 	Describe("Creation", func() {
 		It("Can be built if all the required parameters are set", func() {
-			privateServer, err := NewPrivateHostsServer().
-				SetLogger(logger).
-				SetTenancyLogic(tenancy).
-				Build()
-			Expect(err).ToNot(HaveOccurred())
 			server, err := NewHostsServer().
 				SetLogger(logger).
-				SetPrivate(privateServer).
 				SetTenancyLogic(tenancy).
 				Build()
 			Expect(err).ToNot(HaveOccurred())
@@ -114,37 +108,16 @@ var _ = Describe("Hosts server", func() {
 		})
 
 		It("Fails if logger is not set", func() {
-			privateServer, err := NewPrivateHostsServer().
-				SetLogger(logger).
-				SetTenancyLogic(tenancy).
-				Build()
-			Expect(err).ToNot(HaveOccurred())
 			server, err := NewHostsServer().
-				SetPrivate(privateServer).
 				SetTenancyLogic(tenancy).
 				Build()
 			Expect(err).To(MatchError("logger is mandatory"))
 			Expect(server).To(BeNil())
 		})
 
-		It("Fails if private server is not set", func() {
-			server, err := NewHostsServer().
-				SetLogger(logger).
-				SetTenancyLogic(tenancy).
-				Build()
-			Expect(err).To(MatchError("private server is mandatory"))
-			Expect(server).To(BeNil())
-		})
-
 		It("Fails if tenancy logic is not set", func() {
-			privateServer, err := NewPrivateHostsServer().
-				SetLogger(logger).
-				SetTenancyLogic(tenancy).
-				Build()
-			Expect(err).ToNot(HaveOccurred())
 			server, err := NewHostsServer().
 				SetLogger(logger).
-				SetPrivate(privateServer).
 				Build()
 			Expect(err).To(MatchError("tenancy logic is mandatory"))
 			Expect(server).To(BeNil())
@@ -157,17 +130,9 @@ var _ = Describe("Hosts server", func() {
 		BeforeEach(func() {
 			var err error
 
-			// Create the private server:
-			privateServer, err := NewPrivateHostsServer().
-				SetLogger(logger).
-				SetTenancyLogic(tenancy).
-				Build()
-			Expect(err).ToNot(HaveOccurred())
-
 			// Create the server:
 			server, err = NewHostsServer().
 				SetLogger(logger).
-				SetPrivate(privateServer).
 				SetTenancyLogic(tenancy).
 				Build()
 			Expect(err).ToNot(HaveOccurred())

--- a/internal/servers/virtual_machine_templates_server_test.go
+++ b/internal/servers/virtual_machine_templates_server_test.go
@@ -99,18 +99,10 @@ var _ = Describe("Virtual machine templates server", func() {
 	})
 
 	Describe("Builder", func() {
-		It("Creates server with logger and private server", func() {
-			// Create the private server:
-			privateServer, err := NewPrivateVirtualMachineTemplatesServer().
-				SetLogger(logger).
-				SetTenancyLogic(tenancy).
-				Build()
-			Expect(err).ToNot(HaveOccurred())
-
+		It("Creates server with logger and tenancy logic", func() {
 			// Create the public server:
 			server, err := NewVirtualMachineTemplatesServer().
 				SetLogger(logger).
-				SetPrivate(privateServer).
 				SetTenancyLogic(tenancy).
 				Build()
 			Expect(err).ToNot(HaveOccurred())
@@ -118,26 +110,8 @@ var _ = Describe("Virtual machine templates server", func() {
 		})
 
 		It("Doesn't create server without logger", func() {
-			// Create the private server:
-			privateServer, err := NewPrivateVirtualMachineTemplatesServer().
-				SetLogger(logger).
-				SetTenancyLogic(tenancy).
-				Build()
-			Expect(err).ToNot(HaveOccurred())
-
 			// Try to create the public server without logger:
 			server, err := NewVirtualMachineTemplatesServer().
-				SetPrivate(privateServer).
-				SetTenancyLogic(tenancy).
-				Build()
-			Expect(err).To(HaveOccurred())
-			Expect(server).To(BeNil())
-		})
-
-		It("Doesn't create server without private server", func() {
-			// Try to create the public server without private server:
-			server, err := NewVirtualMachineTemplatesServer().
-				SetLogger(logger).
 				SetTenancyLogic(tenancy).
 				Build()
 			Expect(err).To(HaveOccurred())
@@ -145,14 +119,8 @@ var _ = Describe("Virtual machine templates server", func() {
 		})
 
 		It("Fails if tenancy logic is not set", func() {
-			privateServer, err := NewPrivateVirtualMachineTemplatesServer().
-				SetLogger(logger).
-				SetTenancyLogic(tenancy).
-				Build()
-			Expect(err).ToNot(HaveOccurred())
 			server, err := NewVirtualMachineTemplatesServer().
 				SetLogger(logger).
-				SetPrivate(privateServer).
 				Build()
 			Expect(err).To(MatchError("tenancy logic is mandatory"))
 			Expect(server).To(BeNil())
@@ -165,17 +133,9 @@ var _ = Describe("Virtual machine templates server", func() {
 		BeforeEach(func() {
 			var err error
 
-			// Create the private server:
-			privateServer, err := NewPrivateVirtualMachineTemplatesServer().
-				SetLogger(logger).
-				SetTenancyLogic(tenancy).
-				Build()
-			Expect(err).ToNot(HaveOccurred())
-
 			// Create the public server:
 			server, err = NewVirtualMachineTemplatesServer().
 				SetLogger(logger).
-				SetPrivate(privateServer).
 				SetTenancyLogic(tenancy).
 				Build()
 			Expect(err).ToNot(HaveOccurred())

--- a/internal/servers/virtual_machines_server_test.go
+++ b/internal/servers/virtual_machines_server_test.go
@@ -123,18 +123,10 @@ var _ = Describe("Virtual machines server", func() {
 	})
 
 	Describe("Builder", func() {
-		It("Creates server with logger and private server", func() {
-			// Create a private server:
-			privateServer, err := NewPrivateVirtualMachinesServer().
-				SetLogger(logger).
-				SetTenancyLogic(tenancy).
-				Build()
-			Expect(err).ToNot(HaveOccurred())
-
+		It("Creates server with logger and tenancy logic", func() {
 			// Create the public server:
 			server, err := NewVirtualMachinesServer().
 				SetLogger(logger).
-				SetPrivate(privateServer).
 				SetTenancyLogic(tenancy).
 				Build()
 			Expect(err).ToNot(HaveOccurred())
@@ -142,26 +134,8 @@ var _ = Describe("Virtual machines server", func() {
 		})
 
 		It("Doesn't create server without logger", func() {
-			// Create a private server:
-			privateServer, err := NewPrivateVirtualMachinesServer().
-				SetLogger(logger).
-				SetTenancyLogic(tenancy).
-				Build()
-			Expect(err).ToNot(HaveOccurred())
-
 			// Try to create the public server without logger:
 			server, err := NewVirtualMachinesServer().
-				SetPrivate(privateServer).
-				SetTenancyLogic(tenancy).
-				Build()
-			Expect(err).To(HaveOccurred())
-			Expect(server).To(BeNil())
-		})
-
-		It("Doesn't create server without private server", func() {
-			// Try to create the public server without private server:
-			server, err := NewVirtualMachinesServer().
-				SetLogger(logger).
 				SetTenancyLogic(tenancy).
 				Build()
 			Expect(err).To(HaveOccurred())
@@ -169,14 +143,8 @@ var _ = Describe("Virtual machines server", func() {
 		})
 
 		It("Fails if tenancy logic is not set", func() {
-			privateServer, err := NewPrivateVirtualMachinesServer().
-				SetLogger(logger).
-				SetTenancyLogic(tenancy).
-				Build()
-			Expect(err).ToNot(HaveOccurred())
 			server, err := NewVirtualMachinesServer().
 				SetLogger(logger).
-				SetPrivate(privateServer).
 				Build()
 			Expect(err).To(MatchError("tenancy logic is mandatory"))
 			Expect(server).To(BeNil())
@@ -185,24 +153,15 @@ var _ = Describe("Virtual machines server", func() {
 
 	Describe("Behaviour", func() {
 		var (
-			server        *VirtualMachinesServer
-			privateServer *PrivateVirtualMachinesServer
+			server *VirtualMachinesServer
 		)
 
 		BeforeEach(func() {
 			var err error
 
-			// Create the private server:
-			privateServer, err = NewPrivateVirtualMachinesServer().
-				SetLogger(logger).
-				SetTenancyLogic(tenancy).
-				Build()
-			Expect(err).ToNot(HaveOccurred())
-
 			// Create the public server:
 			server, err = NewVirtualMachinesServer().
 				SetLogger(logger).
-				SetPrivate(privateServer).
 				SetTenancyLogic(tenancy).
 				Build()
 			Expect(err).ToNot(HaveOccurred())


### PR DESCRIPTION
This change introduces specialized tenancy and attribution logic implementations designed exclusively for the private API, enabling service accounts to operate across tenant boundaries while maintaining proper security controls for the public API.

Previously, the private API used the same tenancy logic as the public API, which meant that even administrative service accounts were constrained by tenant filtering. This prevented operations that needed to see or manage resources across multiple tenants, such as listing all clusters in the system regardless of which tenant created them.

The new **SystemTenancyLogic** implementation solves this by returning an empty list from the `DetermineVisibleTenants` method, which effectively disables tenant-based filtering for queries. Objects created through the private API are still assigned to the "shared" tenant to maintain consistency, but visibility is no longer restricted. This allows administrative operations to work across the entire resource space.

Similarly, the new **SystemAttributionLogic** assigns "system" as the creator for all objects created through the private API, providing clear attribution that distinguishes system-level operations from user-initiated actions.

The public API servers continue to use the configurable tenancy logic (default or service account based) and the default attribution logic that extracts user information from the authentication context. This ensures that regular users remain properly isolated within their tenant boundaries while administrative service accounts gain the necessary visibility to manage the entire system.

Related: https://github.com/innabox/fulfillment-service/issues/136