### PR TITLE
Return not found error when deleting non-existent objects

### DIFF
--- a/internal/database/dao/dao_errors.go
+++ b/internal/database/dao/dao_errors.go
@@ -1,0 +1,29 @@
+/*
+Copyright (c) 2025 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package dao
+
+import (
+	"fmt"
+)
+
+// ErrNotFound is an error type that indicates that a requested object doesn't exist.
+type ErrNotFound struct {
+	// ID is the identifier of the object that was not found.
+	ID string
+}
+
+// Error returns the error message.
+func (e *ErrNotFound) Error() string {
+	return fmt.Sprintf("object with identifier '%s' not found", e.ID)
+}

--- a/internal/database/dao/generic_dao.go
+++ b/internal/database/dao/generic_dao.go
@@ -877,7 +877,9 @@ func (d *GenericDAO[O]) delete(ctx context.Context, tx database.Tx, id string) (
 		&data,
 	)
 	if errors.Is(err, pgx.ErrNoRows) {
-		err = nil
+		err = &ErrNotFound{
+			ID: id,
+		}
 		return
 	}
 	if err != nil {

--- a/internal/servers/clusters_server_test.go
+++ b/internal/servers/clusters_server_test.go
@@ -839,6 +839,17 @@ var _ = Describe("Clusters server", func() {
 			Expect(object.GetMetadata().GetDeletionTimestamp()).ToNot(BeNil())
 		})
 
+		It("Returns not found error when deleting object that doesn't exist", func() {
+			response, err := server.Delete(ctx, ffv1.ClustersDeleteRequest_builder{
+				Id: "does_not_exist",
+			}.Build())
+			Expect(err).To(HaveOccurred())
+			Expect(response).To(BeNil())
+			status, ok := grpcstatus.FromError(err)
+			Expect(ok).To(BeTrue())
+			Expect(status.Code()).To(Equal(grpccodes.NotFound))
+		})
+
 		It("Preserves private data during update", func() {
 			// Use the DAO directly to create an object with private data:
 			dao, err := dao.NewGenericDAO[*privatev1.Cluster]().

--- a/internal/servers/generic_server.go
+++ b/internal/servers/generic_server.go
@@ -489,6 +489,10 @@ func (s *GenericServer[O]) Delete(ctx context.Context, request any, response any
 	}
 	err := s.dao.Delete(ctx, id)
 	if err != nil {
+		var notFoundErr *dao.ErrNotFound
+		if errors.As(err, &notFoundErr) {
+			return grpcstatus.Errorf(grpccodes.NotFound, "object with identifier '%s' not found", id)
+		}
 		s.logger.ErrorContext(
 			ctx,
 			"Failed to delete object",


### PR DESCRIPTION
This change introduces a new `ErrNotFound` error type in the DAO layer that is returned when attempting to delete an object that doesn't exist. Previously, the `Delete` method would silently succeed even when no object was found, which made it difficult for callers to distinguish between successful deletion and attempts to delete non-existent objects.

The generic server has been updated to translate the `ErrNotFound` error into a gRPC `NotFound` status code, ensuring that API clients receive the appropriate HTTP 404 response. Tests have been added at both the DAO and server layers to verify that the error is correctly returned and propagated when deleting objects that don't exist or are not visible due to tenant filtering.

Related: https://github.com/innabox/fulfillment-service/issues/138