### PR TITLE
Configure Authorino to trust Keycloak

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/go-logr/logr v1.4.3
 	github.com/google/uuid v1.6.0
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.27.2
-	github.com/innabox/fulfillment-common v0.0.5
+	github.com/innabox/fulfillment-common v0.0.7
 	github.com/json-iterator/go v1.1.12
 	github.com/kelseyhightower/envconfig v1.4.0
 	github.com/open-policy-agent/opa v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -117,8 +117,8 @@ github.com/hashicorp/go-multierror v1.1.1 h1:H5DkEtf6CXdFp0N0Em5UCwQpXMWke8IA0+l
 github.com/hashicorp/go-multierror v1.1.1/go.mod h1:iw975J/qwKPdAO1clOe2L8331t/9/fmwbPZ6JB6eMoM=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
-github.com/innabox/fulfillment-common v0.0.5 h1:ennXamqvyS3Vy2aK521AudAjn4rT6nmRv6nxO+0Ptjk=
-github.com/innabox/fulfillment-common v0.0.5/go.mod h1:4R0R7MwH8bW/F3y2AbNT+MTiQJkKYyqHt+JVwVQoAzE=
+github.com/innabox/fulfillment-common v0.0.7 h1:HswSZYEw8+nbt3Hn1+ERWyAGmpWJqL+8bUuy+9qQav4=
+github.com/innabox/fulfillment-common v0.0.7/go.mod h1:4R0R7MwH8bW/F3y2AbNT+MTiQJkKYyqHt+JVwVQoAzE=
 github.com/itchyny/gojq v0.12.17 h1:8av8eGduDb5+rvEdaOO+zQUjA04MS0m3Ps8HiD+fceg=
 github.com/itchyny/gojq v0.12.17/go.mod h1:WBrEMkgAfAGO1LUcGOckBl5O726KPp+OlkKug0I/FEY=
 github.com/itchyny/timefmt-go v0.1.6 h1:ia3s54iciXDdzWzwaVKXZPbiXzxxnv1SPGFfM/myJ5Q=

--- a/manifests/base/authorino/authorino.yaml
+++ b/manifests/base/authorino/authorino.yaml
@@ -26,3 +26,9 @@ spec:
   oidcServer:
     tls:
       enabled: false
+  volumes:
+    items:
+    - name: ca-bundle
+      configMaps:
+      - ca-bundle
+      mountPath: /etc/ssl/certs

--- a/manifests/base/service/authconfig.yaml
+++ b/manifests/base/service/authconfig.yaml
@@ -55,6 +55,9 @@ spec:
         # abbreviation.
         - https://kubernetes.default.svc
         - https://kubernetes.default.svc.cluster.local
+    "keycloak-jwt":
+      jwt:
+        issuerUrl: https://keycloak.keycloak.svc.cluster.local:8001/realms/innabox
   authorization:
     "fulfillment-api":
       opa:


### PR DESCRIPTION
This patch changes the configuration of Authorino so that it trusts the CA certificate of Keycloak. It also adds an alternative authentication configuration that uses the JSON web tokens issued by Keycloak. These tokens are accepted for authentication, but not yet accepted for authorization. That will be done in separate patches.