### PR TITLE
Use `main` instead of `latest` as image tag

### DIFF
--- a/manifests/base/kustomization.yaml
+++ b/manifests/base/kustomization.yaml
@@ -38,7 +38,7 @@ images:
   newTag: v1.33.0
 - name: fulfillment-service
   newName: ghcr.io/innabox/fulfillment-service
-  newTag: latest
+  newTag: main
 - name: postgres
   newName: quay.io/sclorg/postgresql-15-c9s
   newTag: latest


### PR DESCRIPTION
Some time ago we changed the job that publishes images. As a result we now use `main` (the name of the branch) instead of `latest`. We need to change the manifests accordingly.