### PR TITLE
Document Authorino image replacement

### DIFF
--- a/manifests/README.md
+++ b/manifests/README.md
@@ -101,7 +101,7 @@ image. So you need to download the manifests, replace the image, and then apply 
 
 ```shell
 $ curl -o authorino.yaml https://raw.githubusercontent.com/Kuadrant/authorino-operator/refs/heads/release-v0.22.0/config/deploy/manifests.yaml
-$ sed -i 's|quay.io/kuadrant/authorino-operator:v0.22.0|quay.io/innabox/authorino-operator:latest|g' authorino.yaml
+$ sed -i 's|quay.io/kuadrant/authorino-operator:v0.20.0|quay.io/innabox/authorino-operator:latest|g' authorino.yaml
 $ kubectl apply -f authorino.yaml
 ```
 


### PR DESCRIPTION
This patch changes the installation instructions to explain that the Authorino image needs to be replaced to address an issue related to the configuration of trusted CA certificates.