### PR TITLE
Add `setup` label to integration tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,6 +246,16 @@ When `IT_KEEP_KIND=true`, the cluster will remain running after the tests finish
 - Debug test failures manually.
 - Examine logs and cluster state.
 
+The `setup` label can be combined with this to get a fresh integration environment where you can then
+run your manual tests:
+
+```bash
+$ IT_KEEP_KIND=true ginkgo run --label-filter setup it
+```
+
+That will create the Kind cluster, install the dependencies and deploy the application, but will not
+run any actual test.
+
 To clean up a preserved cluster manually:
 
 ```bash

--- a/it/it_suite_test.go
+++ b/it/it_suite_test.go
@@ -32,6 +32,7 @@ import (
 	. "github.com/innabox/fulfillment-common/testing"
 	"github.com/kelseyhightower/envconfig"
 	. "github.com/onsi/ginkgo/v2/dsl/core"
+	. "github.com/onsi/ginkgo/v2/dsl/decorators"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/ghttp"
 	"google.golang.org/grpc"
@@ -366,6 +367,17 @@ var _ = BeforeSuite(func() {
 		}.Build(),
 	}.Build())
 	Expect(err).ToNot(HaveOccurred())
+})
+
+var _ = Describe("Integration", func() {
+	It("Only", Label("setup"), func() {
+		// This is a dummy test to have a mechanism to run the setup of the integration tests without running
+		// any actual tests, with a command like this:
+		//
+		// ginkgo run --label-filter setup it
+		//
+		// This will create the kind cluster, install the dependencies, and deploy the application.
+	})
 })
 
 // Names of the command line tools:


### PR DESCRIPTION
This patch adds to the integration tests a `setup` label that can be used to run only the setup:

```bash
$ IT_KEEP_KIND=true ginkgo run --label-filter setup it
```

That will create the Kind cluster, install the dependencies and deploy the application. The integration environment can then be used to run manual tests, for example.