### PR TITLE
Add `authnMethod` to Authorino JSON

### DIFF
--- a/manifests/base/service/authconfig.yaml
+++ b/manifests/base/service/authconfig.yaml
@@ -55,9 +55,15 @@ spec:
         # abbreviation.
         - https://kubernetes.default.svc
         - https://kubernetes.default.svc.cluster.local
+      overrides:
+        authnMethod:
+          value: serviceaccount
     "keycloak-jwt":
       jwt:
         issuerUrl: https://keycloak.keycloak.svc.cluster.local:8001/realms/innabox
+      overrides:
+        authnMethod:
+          value: jwt
   authorization:
     "fulfillment-api":
       opa:


### PR DESCRIPTION
This patch configures Authorino so that it will add to the JSON document that it generates a field named `authnMethod` that will contain the values `serviceaccount` or `jwt` to indicate what authentication method was used. This will be used in future patches to make authorization decisions.