### PR TITLE
Add JWT tenancy logic with delegation pattern

### DIFF
--- a/charts/keycloak/README.md
+++ b/charts/keycloak/README.md
@@ -67,3 +67,34 @@ using the DNS name add the following to your `/etc/hosts` file:
 
 The go to `https://keycloak.keycloak.svc.cluster.local:8001` from your
 local machine.
+
+# Exporting the realm
+
+To export the realm configuration to a JSON file, you need to find the Keycloak
+pod and execute the `export` command inside it. The exported data can be written
+to a local JSON file using the following steps:
+
+1. First, find the name of the Keycloak pod:
+
+    ```bash
+    $ pod=$(kubectl get pods -n keycloak -l app=keycloak-service -o json | jq -r '.items[].metadata.name')
+    ```
+
+2. Run the `export` command inside the pod to write the ream to a temporary file:
+
+    ```bash
+    $ kubectl exec -n keycloak "${pod}" -- /opt/keycloak/bin/kc.sh export --realm innabox --file /tmp/realm.json
+    ```
+
+3. Copy the temporary file to a local file:
+
+    ```bash
+    $ kubectl exec -n keycloak "${pod}" -- cat /tmp/realm.json > realm.json
+    ```
+
+4. Optionally, if you want to replace the realm used by the chart, overwrite the
+   `realm.json` file:
+
+   ```bash
+   $ cp realm.json charts/keycloak/files/ream.json
+   ```

--- a/charts/keycloak/files/realm.json
+++ b/charts/keycloak/files/realm.json
@@ -118,7 +118,7 @@
         "composite" : true,
         "composites" : {
           "client" : {
-            "realm-management" : [ "query-groups", "view-identity-providers", "manage-clients", "query-clients", "view-users", "impersonation", "manage-realm", "manage-identity-providers", "view-realm", "view-clients", "manage-events", "query-users", "manage-users", "create-client", "view-events", "view-authorization", "manage-authorization", "query-realms" ]
+            "realm-management" : [ "query-groups", "view-identity-providers", "manage-clients", "query-clients", "view-users", "impersonation", "manage-identity-providers", "manage-realm", "view-clients", "view-realm", "manage-events", "query-users", "manage-users", "create-client", "view-events", "manage-authorization", "view-authorization", "query-realms" ]
           }
         },
         "clientRole" : true,
@@ -340,7 +340,6 @@
   "groups" : [ {
     "id" : "4a0a8896-3d83-4327-b472-61d6880e4643",
     "name" : "admins",
-    "description" : "Administrators",
     "path" : "/admins",
     "subGroups" : [ ],
     "attributes" : { },
@@ -349,7 +348,6 @@
   }, {
     "id" : "eb89cecb-39cc-4e20-adb3-8661d9ffd592",
     "name" : "my_group",
-    "description" : "My group",
     "path" : "/my_group",
     "subGroups" : [ ],
     "attributes" : { },
@@ -358,7 +356,6 @@
   }, {
     "id" : "54cc5f3e-7a2d-47ab-942e-16010f087b98",
     "name" : "your_group",
-    "description" : "Your group",
     "path" : "/your_group",
     "subGroups" : [ ],
     "attributes" : { },
@@ -429,7 +426,9 @@
   }, {
     "id" : "f81e5429-26ff-418e-bf67-c054e449e7b7",
     "username" : "my_user",
-    "firstName" : "My user",
+    "firstName" : "My",
+    "lastName" : "User",
+    "email" : "my_user@example.com",
     "emailVerified" : true,
     "enabled" : true,
     "createdTimestamp" : 1757683688569,
@@ -450,7 +449,9 @@
   }, {
     "id" : "bd0e8d6c-0095-4937-81a2-7f7c47caae59",
     "username" : "your_user",
-    "firstName" : "Your user",
+    "firstName" : "Your",
+    "lastName" : "User",
+    "email" : "your_user@example.com",
     "emailVerified" : true,
     "enabled" : true,
     "createdTimestamp" : 1757683762187,
@@ -572,7 +573,8 @@
     "protocol" : "openid-connect",
     "attributes" : {
       "realm_client" : "false",
-      "client.use.lightweight.access.token.enabled" : "true"
+      "client.use.lightweight.access.token.enabled" : "true",
+      "post.logout.redirect.uris" : "+"
     },
     "authenticationFlowBindingOverrides" : { },
     "fullScopeAllowed" : true,
@@ -600,7 +602,8 @@
     "frontchannelLogout" : false,
     "protocol" : "openid-connect",
     "attributes" : {
-      "realm_client" : "true"
+      "realm_client" : "true",
+      "post.logout.redirect.uris" : "+"
     },
     "authenticationFlowBindingOverrides" : { },
     "fullScopeAllowed" : false,
@@ -636,6 +639,7 @@
       "oidc.ciba.grant.enabled" : "false",
       "backchannel.logout.session.required" : "true",
       "standard.token.exchange.enabled" : "false",
+      "post.logout.redirect.uris" : "+",
       "oauth2.device.authorization.grant.enabled" : "true",
       "pkce.code.challenge.method" : "S256",
       "backchannel.logout.revoke.offline.tokens" : "false"
@@ -643,8 +647,8 @@
     "authenticationFlowBindingOverrides" : { },
     "fullScopeAllowed" : true,
     "nodeReRegistrationTimeout" : -1,
-    "defaultClientScopes" : [ "web-origins", "acr", "profile", "roles", "basic", "email" ],
-    "optionalClientScopes" : [ "address", "phone", "organization", "offline_access", "microprofile-jwt" ]
+    "defaultClientScopes" : [ "groups", "basic", "username" ],
+    "optionalClientScopes" : [ ]
   }, {
     "id" : "90e7d0e5-cac0-4de7-94cd-bcfe2cb1ae3c",
     "clientId" : "fulfillment-controller",
@@ -676,6 +680,7 @@
       "client.secret.creation.time" : "1757684016",
       "backchannel.logout.session.required" : "true",
       "standard.token.exchange.enabled" : "false",
+      "post.logout.redirect.uris" : "+",
       "oauth2.device.authorization.grant.enabled" : "false",
       "backchannel.logout.revoke.offline.tokens" : "false"
     },
@@ -705,7 +710,8 @@
     "frontchannelLogout" : false,
     "protocol" : "openid-connect",
     "attributes" : {
-      "realm_client" : "true"
+      "realm_client" : "true",
+      "post.logout.redirect.uris" : "+"
     },
     "authenticationFlowBindingOverrides" : { },
     "fullScopeAllowed" : false,
@@ -779,8 +785,9 @@
       "consentRequired" : false,
       "config" : {
         "user.session.note" : "clientAddress",
-        "id.token.claim" : "true",
         "introspection.token.claim" : "true",
+        "userinfo.token.claim" : "true",
+        "id.token.claim" : "true",
         "access.token.claim" : "true",
         "claim.name" : "clientAddress",
         "jsonType.label" : "String"
@@ -793,8 +800,9 @@
       "consentRequired" : false,
       "config" : {
         "user.session.note" : "client_id",
-        "id.token.claim" : "true",
         "introspection.token.claim" : "true",
+        "userinfo.token.claim" : "true",
+        "id.token.claim" : "true",
         "access.token.claim" : "true",
         "claim.name" : "client_id",
         "jsonType.label" : "String"
@@ -807,8 +815,9 @@
       "consentRequired" : false,
       "config" : {
         "user.session.note" : "clientHost",
-        "id.token.claim" : "true",
         "introspection.token.claim" : "true",
+        "userinfo.token.claim" : "true",
+        "id.token.claim" : "true",
         "access.token.claim" : "true",
         "claim.name" : "clientHost",
         "jsonType.label" : "String"
@@ -856,6 +865,36 @@
       }
     } ]
   }, {
+    "id" : "f2837054-fef4-4bb7-aa8f-9d1e102388ea",
+    "name" : "username",
+    "description" : "User name",
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "include.in.token.scope" : "false",
+      "display.on.consent.screen" : "true",
+      "gui.order" : "",
+      "consent.screen.text" : "User name"
+    },
+    "protocolMappers" : [ {
+      "id" : "08e9ffe6-ad5f-4e60-a1bf-c76f47aa2a21",
+      "name" : "username",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "aggregate.attrs" : "false",
+        "introspection.token.claim" : "true",
+        "multivalued" : "false",
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "username",
+        "id.token.claim" : "true",
+        "lightweight.claim" : "false",
+        "access.token.claim" : "true",
+        "claim.name" : "username",
+        "jsonType.label" : "String"
+      }
+    } ]
+  }, {
     "id" : "26c93a2a-6291-4ba0-bbfe-3821617c6713",
     "name" : "role_list",
     "description" : "SAML role list",
@@ -893,12 +932,13 @@
       "protocolMapper" : "oidc-organization-membership-mapper",
       "consentRequired" : false,
       "config" : {
-        "id.token.claim" : "true",
         "introspection.token.claim" : "true",
+        "multivalued" : "true",
+        "userinfo.token.claim" : "true",
+        "id.token.claim" : "true",
         "access.token.claim" : "true",
         "claim.name" : "organization",
-        "jsonType.label" : "String",
-        "multivalued" : "true"
+        "jsonType.label" : "String"
       }
     } ]
   }, {
@@ -950,6 +990,7 @@
       "config" : {
         "introspection.token.claim" : "true",
         "multivalued" : "true",
+        "userinfo.token.claim" : "true",
         "user.attribute" : "foo",
         "id.token.claim" : "true",
         "access.token.claim" : "true",
@@ -984,7 +1025,8 @@
       "config" : {
         "id.token.claim" : "true",
         "introspection.token.claim" : "true",
-        "access.token.claim" : "true"
+        "access.token.claim" : "true",
+        "userinfo.token.claim" : "true"
       }
     } ]
   }, {
@@ -1074,8 +1116,9 @@
       "consentRequired" : false,
       "config" : {
         "user.session.note" : "AUTH_TIME",
-        "id.token.claim" : "true",
         "introspection.token.claim" : "true",
+        "userinfo.token.claim" : "true",
+        "id.token.claim" : "true",
         "access.token.claim" : "true",
         "claim.name" : "auth_time",
         "jsonType.label" : "long"
@@ -1191,12 +1234,15 @@
       "protocolMapper" : "oidc-usermodel-attribute-mapper",
       "consentRequired" : false,
       "config" : {
+        "aggregate.attrs" : "false",
         "introspection.token.claim" : "true",
+        "multivalued" : "false",
         "userinfo.token.claim" : "true",
         "user.attribute" : "username",
         "id.token.claim" : "true",
+        "lightweight.claim" : "false",
         "access.token.claim" : "true",
-        "claim.name" : "preferred_username",
+        "claim.name" : "username",
         "jsonType.label" : "String"
       }
     }, {
@@ -1351,6 +1397,34 @@
       }
     } ]
   }, {
+    "id" : "94b64289-42ae-4880-9e6a-e1eac6423a0d",
+    "name" : "groups",
+    "description" : "List of groups of the user",
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "include.in.token.scope" : "false",
+      "display.on.consent.screen" : "true",
+      "gui.order" : "",
+      "consent.screen.text" : "List of groups"
+    },
+    "protocolMappers" : [ {
+      "id" : "9f1d5d83-5e0d-4718-9dde-1befbbf1a545",
+      "name" : "groups",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-group-membership-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "full.path" : "false",
+        "introspection.token.claim" : "true",
+        "multivalued" : "true",
+        "userinfo.token.claim" : "true",
+        "id.token.claim" : "true",
+        "lightweight.claim" : "false",
+        "access.token.claim" : "true",
+        "claim.name" : "groups"
+      }
+    } ]
+  }, {
     "id" : "c20c7864-23e4-4866-8a2c-889d0a55c568",
     "name" : "address",
     "description" : "OpenID Connect built-in scope: address",
@@ -1380,7 +1454,7 @@
       }
     } ]
   } ],
-  "defaultDefaultClientScopes" : [ "role_list", "saml_organization", "profile", "email", "roles", "web-origins", "acr", "basic" ],
+  "defaultDefaultClientScopes" : [ "role_list", "saml_organization", "profile", "email", "roles", "web-origins", "acr", "basic", "groups", "username" ],
   "defaultOptionalClientScopes" : [ "offline_access", "address", "phone", "microprofile-jwt", "organization" ],
   "browserSecurityHeaders" : {
     "contentSecurityPolicyReportOnly" : "",
@@ -1407,7 +1481,7 @@
       "subType" : "authenticated",
       "subComponents" : { },
       "config" : {
-        "allowed-protocol-mapper-types" : [ "oidc-address-mapper", "saml-user-attribute-mapper", "oidc-usermodel-attribute-mapper", "saml-user-property-mapper", "oidc-full-name-mapper", "oidc-usermodel-property-mapper", "saml-role-list-mapper", "oidc-sha256-pairwise-sub-mapper" ]
+        "allowed-protocol-mapper-types" : [ "saml-user-property-mapper", "oidc-usermodel-property-mapper", "oidc-full-name-mapper", "oidc-usermodel-attribute-mapper", "oidc-sha256-pairwise-sub-mapper", "saml-role-list-mapper", "oidc-address-mapper", "saml-user-attribute-mapper" ]
       }
     }, {
       "id" : "3f236ec1-309c-48fb-96cd-08c03ae45271",
@@ -1416,7 +1490,7 @@
       "subType" : "anonymous",
       "subComponents" : { },
       "config" : {
-        "allowed-protocol-mapper-types" : [ "oidc-usermodel-attribute-mapper", "oidc-full-name-mapper", "oidc-sha256-pairwise-sub-mapper", "oidc-address-mapper", "saml-user-attribute-mapper", "oidc-usermodel-property-mapper", "saml-role-list-mapper", "saml-user-property-mapper" ]
+        "allowed-protocol-mapper-types" : [ "saml-user-property-mapper", "oidc-address-mapper", "oidc-usermodel-property-mapper", "oidc-usermodel-attribute-mapper", "saml-user-attribute-mapper", "saml-role-list-mapper", "oidc-full-name-mapper", "oidc-sha256-pairwise-sub-mapper" ]
       }
     }, {
       "id" : "5f50bd47-344d-48f8-b2b3-ee4128dde1cc",
@@ -2189,12 +2263,16 @@
     "cibaExpiresIn" : "120",
     "cibaAuthRequestedUserHint" : "login_hint",
     "oauth2DeviceCodeLifespan" : "600",
+    "clientOfflineSessionMaxLifespan" : "0",
     "oauth2DevicePollingInterval" : "5",
+    "clientSessionIdleTimeout" : "0",
     "parRequestUriLifespan" : "60",
+    "clientSessionMaxLifespan" : "0",
+    "clientOfflineSessionIdleTimeout" : "0",
     "cibaInterval" : "5",
     "realmReusableOtpCode" : "false"
   },
-  "keycloakVersion" : "26.3.3",
+  "keycloakVersion" : "26.3.5",
   "userManagedAccessAllowed" : false,
   "organizationsEnabled" : false,
   "verifiableCredentialsEnabled" : false,

--- a/internal/auth/auth_guest.go
+++ b/internal/auth/auth_guest.go
@@ -15,7 +15,8 @@ package auth
 
 // Guest is the subject used when no authentication has been performed.
 var Guest = &Subject{
-	User: guestName,
+	User:   guestName,
+	Source: SubjectSourceNone,
 }
 
 const guestName = "guest"

--- a/internal/auth/auth_subject.go
+++ b/internal/auth/auth_subject.go
@@ -13,8 +13,25 @@ language governing permissions and limitations under the License.
 
 package auth
 
+// SubjectSource represents the kind of sources from which subjects are extracted.
+type SubjectSource string
+
+const (
+	// SubjectSourceJwt indicates the subject was extracted from a JWT token.
+	SubjectSourceJwt SubjectSource = "jwt"
+
+	// SubjectSourceServiceAccount indicates the subject was extracted from a Kubernetes service account.
+	SubjectSourceServiceAccount SubjectSource = "serviceaccount"
+
+	// SubjectSourceNone indicates the subject represents an unauthenticated guest.
+	SubjectSourceNone SubjectSource = "none"
+)
+
 // Subject represents an entity, such as person or a service account.
 type Subject struct {
+	// Source is the source from which the subject was extracted, service account, JSON web token, etc.
+	Source SubjectSource `json:"source"`
+
 	// User is the name of the user.
 	User string `json:"user"`
 

--- a/internal/auth/default_attribution_logic_test.go
+++ b/internal/auth/default_attribution_logic_test.go
@@ -52,7 +52,8 @@ var _ = Describe("Default attribution logic", func() {
 				Build()
 			Expect(err).ToNot(HaveOccurred())
 			subject := &Subject{
-				User: "my_creator",
+				User:   "my_creator",
+				Source: SubjectSourceJwt,
 			}
 			ctx = ContextWithSubject(ctx, subject)
 			creators, err := logic.DetermineAssignedCreators(ctx)

--- a/internal/auth/default_tenancy_logic_test.go
+++ b/internal/auth/default_tenancy_logic_test.go
@@ -40,23 +40,125 @@ var _ = Describe("Default tenancy logic", func() {
 		Expect(logic).ToNot(BeNil())
 	})
 
-	It("Returns the assiged tenants", func() {
-		subject := &Subject{
-			User: "my_user",
-		}
-		ctx = ContextWithSubject(ctx, subject)
-		result, err := logic.DetermineAssignedTenants(ctx)
-		Expect(err).ToNot(HaveOccurred())
-		Expect(result).To(ConsistOf("shared"))
+	Describe("Builder", func() {
+		It("Fails if logger is not set", func() {
+			logic, err := NewDefaultTenancyLogic().
+				Build()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("logger is mandatory"))
+			Expect(logic).To(BeNil())
+		})
 	})
 
-	It("Returns the visible tenants for the user", func() {
-		subject := &Subject{
-			User: "my_user",
-		}
-		ctx = ContextWithSubject(ctx, subject)
-		result, err := logic.DetermineVisibleTenants(ctx)
-		Expect(err).ToNot(HaveOccurred())
-		Expect(result).To(ConsistOf("shared"))
+	Describe("Regular users authenticated with JWT", func() {
+		It("Returns the groups as assigned tenants", func() {
+			subject := &Subject{
+				User:   "my_user",
+				Groups: []string{"group1", "group2"},
+				Source: SubjectSourceJwt,
+			}
+			ctx = ContextWithSubject(ctx, subject)
+			result, err := logic.DetermineAssignedTenants(ctx)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result).To(ConsistOf("group1", "group2"))
+		})
+
+		It("Returns only shared as visible tenants when user has no groups", func() {
+			subject := &Subject{
+				Source: SubjectSourceJwt,
+				User:   "my_user",
+			}
+			ctx = ContextWithSubject(ctx, subject)
+			result, err := logic.DetermineVisibleTenants(ctx)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result).To(ConsistOf("shared"))
+		})
+
+		It("Returns the groups and shared as visible tenants", func() {
+			subject := &Subject{
+				User:   "my_user",
+				Groups: []string{"group1", "group2"},
+				Source: SubjectSourceJwt,
+			}
+			ctx = ContextWithSubject(ctx, subject)
+			result, err := logic.DetermineVisibleTenants(ctx)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result).To(ConsistOf("group1", "group2", "shared"))
+		})
+	})
+
+	Describe("Service accounts", func() {
+		It("Returns the namespace as the assigned tenant for a service account", func() {
+			subject := &Subject{
+				User:   "system:serviceaccount:my-ns:my-sa",
+				Source: SubjectSourceServiceAccount,
+			}
+			ctx = ContextWithSubject(ctx, subject)
+			result, err := logic.DetermineAssignedTenants(ctx)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result).To(ConsistOf("my-ns"))
+		})
+
+		It("Returns the namespace and shared as visible tenants for a service account", func() {
+			subject := &Subject{
+				User:   "system:serviceaccount:my-ns:my-sa",
+				Source: SubjectSourceServiceAccount,
+			}
+			ctx = ContextWithSubject(ctx, subject)
+			result, err := logic.DetermineVisibleTenants(ctx)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result).To(ConsistOf("my-ns", "shared"))
+		})
+
+		It("Handles service accounts with different namespaces", func() {
+			subject := &Subject{
+				User:   "system:serviceaccount:another-ns:another-sa",
+				Source: SubjectSourceServiceAccount,
+			}
+			ctx = ContextWithSubject(ctx, subject)
+			result, err := logic.DetermineAssignedTenants(ctx)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result).To(ConsistOf("another-ns"))
+		})
+	})
+
+	Describe("Invalid subject source", func() {
+		It("Returns error for unknown source when determining assigned tenants", func() {
+			subject := &Subject{
+				User:   "my_user",
+				Source: SubjectSource("invalid"),
+			}
+			ctx = ContextWithSubject(ctx, subject)
+			result, err := logic.DetermineAssignedTenants(ctx)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("unknown subject source"))
+			Expect(err.Error()).To(ContainSubstring("invalid"))
+			Expect(result).To(BeNil())
+		})
+
+		It("Returns error for unknown source when determining visible tenants", func() {
+			subject := &Subject{
+				User:   "my_user",
+				Source: SubjectSource("invalid"),
+			}
+			ctx = ContextWithSubject(ctx, subject)
+			result, err := logic.DetermineVisibleTenants(ctx)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("unknown subject source"))
+			Expect(err.Error()).To(ContainSubstring("invalid"))
+			Expect(result).To(BeNil())
+		})
+
+		It("Returns error for empty source when determining assigned tenants", func() {
+			subject := &Subject{
+				User:   "my_user",
+				Source: SubjectSource(""),
+			}
+			ctx = ContextWithSubject(ctx, subject)
+			result, err := logic.DetermineAssignedTenants(ctx)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("unknown subject source"))
+			Expect(result).To(BeNil())
+		})
 	})
 })

--- a/internal/auth/grpc_external_authn_func_test.go
+++ b/internal/auth/grpc_external_authn_func_test.go
@@ -61,6 +61,7 @@ var _ = Describe("gRPC external authentication function", func() {
 				"my_first_group",
 				"my_second_group",
 			},
+			Source: SubjectSourceJwt,
 		}
 		value, err := json.Marshal(subject)
 		Expect(err).ToNot(HaveOccurred())
@@ -77,6 +78,7 @@ var _ = Describe("gRPC external authentication function", func() {
 			Expect(subject).ToNot(BeNil())
 			Expect(subject.User).To(Equal("my_user"))
 			Expect(subject.Groups).To(ConsistOf("my_first_group", "my_second_group"))
+			Expect(subject.Source).To(Equal(SubjectSourceJwt))
 		}).ToNot(Panic())
 	})
 

--- a/internal/auth/jwt_tenancy_logic.go
+++ b/internal/auth/jwt_tenancy_logic.go
@@ -1,0 +1,88 @@
+/*
+Copyright (c) 2025 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package auth
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+)
+
+// JwtTenancyLogicBuilder contains the data and logic needed to create JWT tenancy logic.
+type JwtTenancyLogicBuilder struct {
+	logger *slog.Logger
+}
+
+// JwtTenancyLogic implements the TenancyLogic interface for regular users authenticated with JSON web tokens. It
+// extracts the tenants from the user and groups that were extracted from the claims of the token.
+type JwtTenancyLogic struct {
+	logger *slog.Logger
+}
+
+// NewJwtTenancyLogic creates a new builder for JSON web token tenancy logic.
+func NewJwtTenancyLogic() *JwtTenancyLogicBuilder {
+	return &JwtTenancyLogicBuilder{}
+}
+
+// SetLogger sets the logger that will be used by the tenancy logic. This is mandatory.
+func (b *JwtTenancyLogicBuilder) SetLogger(value *slog.Logger) *JwtTenancyLogicBuilder {
+	b.logger = value
+	return b
+}
+
+// Build uses the information stored in the builder to create a new instance of the tenancy logic.
+func (b *JwtTenancyLogicBuilder) Build() (result *JwtTenancyLogic, err error) {
+	// Check that the logger has been set:
+	if b.logger == nil {
+		err = fmt.Errorf("logger is mandatory")
+		return
+	}
+
+	// Create the tenancy logic:
+	result = &JwtTenancyLogic{
+		logger: b.logger,
+	}
+	return
+}
+
+// DetermineAssignedTenants extracts the subject from the auth context and returns the identifiers of the tenants.
+// For JWT-authenticated users, objects are assigned to the groups of the user.
+func (p *JwtTenancyLogic) DetermineAssignedTenants(ctx context.Context) (result []string, err error) {
+	subject := SubjectFromContext(ctx)
+	result = subject.Groups
+	p.logger.DebugContext(
+		ctx,
+		"Determined assigned tenants for JWT user",
+		slog.String("user", subject.User),
+		slog.Any("tenants", result),
+	)
+	return
+}
+
+// DetermineVisibleTenants extracts the subject from the context and returns a tenant for each group that the user
+// belongs to, as well as the shared tenant.
+func (p *JwtTenancyLogic) DetermineVisibleTenants(ctx context.Context) (result []string, err error) {
+	subject := SubjectFromContext(ctx)
+	result = make([]string, 0, len(subject.Groups)+1)
+	result = append(result, subject.Groups...)
+	result = append(result, "shared")
+	p.logger.DebugContext(
+		ctx,
+		"Determined visible tenants for JWT user",
+		slog.String("user", subject.User),
+		slog.Any("groups", subject.Groups),
+		slog.Any("tenants", result),
+	)
+	return
+}

--- a/internal/auth/jwt_tenancy_logic_test.go
+++ b/internal/auth/jwt_tenancy_logic_test.go
@@ -1,0 +1,127 @@
+/*
+Copyright (c) 2025 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package auth
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("JWT tenancy logic", func() {
+	var (
+		ctx   context.Context
+		logic *JwtTenancyLogic
+	)
+
+	BeforeEach(func() {
+		var err error
+
+		// Create the context:
+		ctx = context.Background()
+
+		// Create the tenancy logic:
+		logic, err = NewJwtTenancyLogic().
+			SetLogger(logger).
+			Build()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(logic).ToNot(BeNil())
+	})
+
+	Describe("Builder", func() {
+		It("Fails if logger is not set", func() {
+			logic, err := NewJwtTenancyLogic().
+				Build()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("logger is mandatory"))
+			Expect(logic).To(BeNil())
+		})
+	})
+
+	Describe("Determine assigned tenants", func() {
+		It("Returns the groups as assigned tenants", func() {
+			subject := &Subject{
+				Source: SubjectSourceJwt,
+				User:   "my_user",
+				Groups: []string{"group1", "group2"},
+			}
+			ctx = ContextWithSubject(ctx, subject)
+			result, err := logic.DetermineAssignedTenants(ctx)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result).To(ConsistOf("group1", "group2"))
+		})
+
+		It("Returns empty list when user has no groups", func() {
+			subject := &Subject{
+				Source: SubjectSourceJwt,
+				User:   "my_user",
+				Groups: []string{},
+			}
+			ctx = ContextWithSubject(ctx, subject)
+			result, err := logic.DetermineAssignedTenants(ctx)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result).To(BeEmpty())
+		})
+	})
+
+	Describe("Determine visible tenants", func() {
+		It("Returns only shared when user has no groups", func() {
+			subject := &Subject{
+				Source: SubjectSourceJwt,
+				User:   "my_user",
+			}
+			ctx = ContextWithSubject(ctx, subject)
+			result, err := logic.DetermineVisibleTenants(ctx)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result).To(ConsistOf("shared"))
+		})
+
+		It("Returns the groups and shared", func() {
+			subject := &Subject{
+				Source: SubjectSourceJwt,
+				User:   "my_user",
+				Groups: []string{"group1", "group2"},
+			}
+			ctx = ContextWithSubject(ctx, subject)
+			result, err := logic.DetermineVisibleTenants(ctx)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result).To(ConsistOf("group1", "group2", "shared"))
+		})
+
+		It("Returns multiple groups and shared", func() {
+			subject := &Subject{
+				Source: SubjectSourceJwt,
+				User:   "admin@example.com",
+				Groups: []string{"admins", "developers", "team-a"},
+			}
+			ctx = ContextWithSubject(ctx, subject)
+			result, err := logic.DetermineVisibleTenants(ctx)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result).To(ConsistOf("admins", "developers", "team-a", "shared"))
+		})
+
+		It("Returns only shared when groups is empty array", func() {
+			subject := &Subject{
+				Source: SubjectSourceJwt,
+				User:   "user_with_empty_groups",
+				Groups: []string{},
+			}
+			ctx = ContextWithSubject(ctx, subject)
+			result, err := logic.DetermineVisibleTenants(ctx)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result).To(ConsistOf("shared"))
+		})
+	})
+})

--- a/internal/auth/service_account_tenancy_logic_test.go
+++ b/internal/auth/service_account_tenancy_logic_test.go
@@ -53,7 +53,8 @@ var _ = Describe("Service account tenancy logic", func() {
 	Describe("Determine assigned tenants", func() {
 		It("Returns the namespace for a valid service account", func() {
 			subject := &Subject{
-				User: "system:serviceaccount:my-ns:my-sa",
+				User:   "system:serviceaccount:my-ns:my-sa",
+				Source: SubjectSourceServiceAccount,
 			}
 			ctx = ContextWithSubject(ctx, subject)
 			result, err := logic.DetermineAssignedTenants(ctx)
@@ -63,7 +64,8 @@ var _ = Describe("Service account tenancy logic", func() {
 
 		It("Fails if the subject is not a service account", func() {
 			subject := &Subject{
-				User: "my_user",
+				User:   "my_user",
+				Source: SubjectSourceServiceAccount,
 			}
 			ctx = ContextWithSubject(ctx, subject)
 			result, err := logic.DetermineAssignedTenants(ctx)
@@ -75,7 +77,8 @@ var _ = Describe("Service account tenancy logic", func() {
 
 		It("Fails if the subject has the wrong prefix", func() {
 			subject := &Subject{
-				User: "system:junk:my-ns:my-sa",
+				User:   "system:junk:my-ns:my-sa",
+				Source: SubjectSourceServiceAccount,
 			}
 			ctx = ContextWithSubject(ctx, subject)
 			result, err := logic.DetermineAssignedTenants(ctx)
@@ -86,7 +89,8 @@ var _ = Describe("Service account tenancy logic", func() {
 
 		It("Fails if the subject has the wrong number of parts", func() {
 			subject := &Subject{
-				User: "system:serviceaccount:my-ns:my-sa:junk",
+				User:   "system:serviceaccount:my-ns:my-sa:junk",
+				Source: SubjectSourceServiceAccount,
 			}
 			ctx = ContextWithSubject(ctx, subject)
 			result, err := logic.DetermineAssignedTenants(ctx)
@@ -99,7 +103,8 @@ var _ = Describe("Service account tenancy logic", func() {
 	Describe("Determine visible tenants", func() {
 		It("Returns the namespace and shared for a valid service account", func() {
 			subject := &Subject{
-				User: "system:serviceaccount:my-ns:my-sa",
+				User:   "system:serviceaccount:my-ns:my-sa",
+				Source: SubjectSourceServiceAccount,
 			}
 			ctx = ContextWithSubject(ctx, subject)
 			result, err := logic.DetermineVisibleTenants(ctx)
@@ -109,7 +114,8 @@ var _ = Describe("Service account tenancy logic", func() {
 
 		It("Fails if the subject is not a service account", func() {
 			subject := &Subject{
-				User: "regular_user",
+				User:   "regular_user",
+				Source: SubjectSourceServiceAccount,
 			}
 			ctx = ContextWithSubject(ctx, subject)
 			result, err := logic.DetermineVisibleTenants(ctx)
@@ -120,7 +126,8 @@ var _ = Describe("Service account tenancy logic", func() {
 
 		It("Fails if the subject has the wrong number of parts", func() {
 			subject := &Subject{
-				User: "system:serviceaccount:my-ns:my-sa:junk",
+				User:   "system:serviceaccount:my-ns:my-sa:junk",
+				Source: SubjectSourceServiceAccount,
 			}
 			ctx = ContextWithSubject(ctx, subject)
 			result, err := logic.DetermineVisibleTenants(ctx)

--- a/manifests/base/service/authconfig.yaml
+++ b/manifests/base/service/authconfig.yaml
@@ -70,8 +70,8 @@ spec:
         rego: |
           import future.keywords.in
 
-          # Define service accounts:
-          admin_accounts := {
+          # Define admin subjects:
+          admin_subjects := {
             "system:serviceaccount:innabox:admin",
             "system:serviceaccount:innabox:controller",
           }
@@ -79,24 +79,22 @@ spec:
           # Get the gRPC method:
           grpc_method := input.context.request.http.path
 
-          # Get the account name:
-          account_name := input.auth.identity.user.username
-
-          # Function to check if an account is a service account:
-          is_service_account {
-            startswith(account_name, "system:serviceaccount:")
+          # Get the subject name:
+          subject_name = input.auth.identity.user.username {
+            input.auth.identity.authnMethod == "serviceaccount"
+          }
+          subject_name = input.auth.identity.user.preferred_username {
+            input.auth.identity.authnMethod == "jwt"
           }
 
           # Function to check if an account is an admin account:
           is_admin {
-            is_service_account
-            account_name in admin_accounts
+            subject_name in admin_subjects
           }
 
           # Function to check if an account is a client account:
           is_client {
-            is_service_account
-            not account_name in admin_accounts
+            not is_admin
           }
 
           # Allow metadata, reflection and health to everyone:
@@ -112,6 +110,7 @@ spec:
 
           # Allow specific methods to clients:
           allow {
+            is_client
             grpc_method in {
               "/events.v1/Watch",
               "/fulfillment.v1.ClusterTemplates/Get",
@@ -145,7 +144,6 @@ spec:
               "/fulfillment.v1.VirtualMachines/List",
               "/fulfillment.v1.VirtualMachines/Update",
             }
-            is_client
           }
 
           # Allow everything to admins:
@@ -158,7 +156,12 @@ spec:
         "x-subject":
           json:
             properties:
+              source:
+                expression: |
+                  auth.identity.authnMethod
               user:
-                selector: auth.identity.user.username
+                expression: |
+                  auth.identity.authnMethod == "serviceaccount"? auth.identity.user.username: auth.identity.username
               groups:
-                selector: auth.identity.user.groups
+                expression: |
+                  auth.identity.authnMethod == "serviceaccount"? auth.identity.user.groups: auth.identity.groups

--- a/manifests/base/service/deployment.yaml
+++ b/manifests/base/service/deployment.yaml
@@ -64,7 +64,7 @@ spec:
         - --grpc-listener-address=/run/sockets/server.socket
         - --grpc-authn-trusted-token-issuers=https://keycloak.keycloak.svc.cluster.local:8001/realms/innabox
         - --grpc-authn-type=external
-        - --tenancy-logic=serviceaccount
+        - --tenancy-logic=default
 
       - name: gateway
         image: fulfillment-service


### PR DESCRIPTION
The default tenancy logic now uses a delegation pattern to support both service accounts and users autenticate with JSON web tokens. It checks the source field in the subject to determine which delegate to use, maintaining backwards compatibility with the existing service account logic while adding support for JSON web tokens.

The JSON web token tenancy logic is intentionally simple, extracting tenants from the groups claim in the token. Assigned tenants are the user's groups, and visible tenants include those groups plus the shared tenant. This assumes the presence of username and groups claims in the token, which can be made more sophisticated in later patches if needed.

To support this new tenancy logic this patch also modifies the Keycloak realm used in the integration tests so that the JSON web tokens that it issues (for the `fulfillment-cli` client) will contain a claim named `username` containing the user name and a claim named `groups` containing the names of the groups that the user belongs to.