### PR TITLE
Make Keycloak hostname configurable

### DIFF
--- a/charts/keycloak/README.md
+++ b/charts/keycloak/README.md
@@ -46,12 +46,25 @@ you will need to:
 
     ```bash
     $ helm install keycloak charts/keycloak \
-      --namespace keycloak \
-      --create-namespace \
-      --set issuerRef.kind=Issuer \
-      --set issuerRef.name=my-issuer \
-      --wait
+    --namespace keycloak \
+    --create-namespace \
+    --set issuerRef.kind=Issuer \
+    --set issuerRef.name=my-issuer \
+    --wait
     ```
+
+By default the hostname is `keycloak.keycloak.svc.cluster.local`, which is fine
+for use from within the cluster. If you want to use the chart in some other
+development or testing scenario where a different hostname is needed or
+convenient, you can use the `hostname` variable:
+
+```bash
+$ helm install keycloak charts/keycloak \
+--namespace keycloak \
+--create-namespace \
+--set hostname=keycloak.example.com \
+--wait
+```
 
 ## Accessing the console
 
@@ -68,7 +81,7 @@ using the DNS name add the following to your `/etc/hosts` file:
 The go to `https://keycloak.keycloak.svc.cluster.local:8001` from your
 local machine.
 
-# Exporting the realm
+## Exporting the realm
 
 To export the realm configuration to a JSON file, you need to find the Keycloak
 pod and execute the `export` command inside it. The exported data can be written

--- a/charts/keycloak/templates/service/deployment.yaml
+++ b/charts/keycloak/templates/service/deployment.yaml
@@ -82,7 +82,7 @@ spec:
         - name: KC_HTTPS_CERTIFICATE_KEY_FILE
           value: "/secrets/tls/tls.key"
         - name: KC_HOSTNAME
-          value: "keycloak.{{ .Release.Namespace }}.svc.cluster.local"
+          value: {{ if .Values.hostname }}"{{ .Values.hostname }}"{{ else }}"keycloak.{{ .Release.Namespace }}.svc.cluster.local"{{ end }}
         - name: KC_HOSTNAME_PORT
           value: "8001"
         - name: KC_DB

--- a/charts/keycloak/values.yaml
+++ b/charts/keycloak/values.yaml
@@ -14,6 +14,10 @@
 # This indicates if the chart is being deployed to an OpenShift or Kind cluster. Valid values are `openshift` and `kind`
 variant: kind
 
+# This defines the hostname that Keycloak uses to refer to itself. If not set, the default value will be
+# 'keycloak.<namespace>.svc.cluster.local' which is usually valid only inside the cluster.
+# hostname: keycloak.example.com
+
 # This defines the cert-manager issuer that will be used for the certificates used by Keycloak. The default is to use
 # the cluster issuer that is automatically created for the Kind cluster used for integration tests.
 issuerRef:


### PR DESCRIPTION
This patch changes the chart used to install the Keycloak instance used in the integration tests so that the hostname is configurable:

```shell
$ helm install keycloak charts/keycloak \
--namespace keycloak \
--create-namespace \
--set hostname=keycloak.example.com \
--wait
```

This will simplify its use in other development or testing scenarios.