### PR TITLE
Add bundle to CA chart

### DIFF
--- a/charts/ca/README.md
+++ b/charts/ca/README.md
@@ -3,7 +3,12 @@
 This Helm chart creates a self-signed CA certificate and a `ClusterIssuer` named `default-ca` that can be used by other
 components in the _Innabox_ project.
 
+The CA certificate is copied to a config map named `ca-bundle` into all the namespaces of the cluster, in the
+`bundle.pem` key.
+
 ## Installation
+
+Before installing this chart you will need to install the _cert-manager_ and _trust-manager_ operators.
 
 To install the chart with the default configuration:
 
@@ -24,10 +29,10 @@ $ helm install default-ca charts/ca \
 
 The following table lists the configurable parameters of the CA chart and their default values:
 
-| Parameter | Description | Default |
-|-----------|-------------|---------|
+| Parameter    | Description                               | Default      |
+|--------------|-------------------------------------------|--------------|
 | `issuerName` | The name of the `ClusterIssuer` to create | `default-ca` |
-| `commonName` | The common name for the CA certificate | `Innabox CA` |
+| `commonName` | The common name for the CA certificate    | `Innabox CA` |
 
 The namespace can also be changed using the `--namespace` flag, but it must match the namespace
 where _cert-manager_ stores the secrets for cluster issuers, which is usually `cert-manager`.

--- a/charts/ca/templates/bundle.yaml
+++ b/charts/ca/templates/bundle.yaml
@@ -1,0 +1,40 @@
+{{/*
+Copyright (c) 2025 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+the License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+*/}}
+
+# This is a trust-manager bundle that will copy the CA certificate to a 'ca-bundle' config map in all the namespaces.
+# The certificate will be in the 'bundle.pem' key.
+
+apiVersion: trust.cert-manager.io/v1alpha
+kind: Bundle
+metadata:
+  namespace: {{ .Release.Namespace }}
+  name: {{ .Values.issuerName }}
+spec:
+  sources:
+  - secret:
+      name: {{ .Values.issuerName }}
+      key: tls.crt
+  target:
+    configMap:
+      key: bundle.pem
+      namespaceSelector:
+        matchExpressions:
+        - key: kubernetes.io/metadata.name
+          operator: NotIn
+          values:
+          - cert-manager
+          - kube-node-lease
+          - kube-public
+          - kube-system
+          - kube-system
+          - local-path-storage


### PR DESCRIPTION
This patch adds to the CA chart a _trust-manager_ bundle that copies the CA certificate to a config map in all namespaces.