### PR TITLE
Use hostname for Keycloak certificate DNS names when specified

### DIFF
--- a/charts/keycloak/templates/service/server-cert.yaml
+++ b/charts/keycloak/templates/service/server-cert.yaml
@@ -21,8 +21,12 @@ spec:
     kind: {{ .Values.issuerRef.kind }}
     name: {{ .Values.issuerRef.name }}
   dnsNames:
+  {{- if .Values.hostname }}
+  - {{ .Values.hostname }}
+  {{- else }}
   - localhost
   - keycloak
   - keycloak.{{ .Release.Namespace }}
   - keycloak.{{ .Release.Namespace }}.svc.cluster.local
+  {{- end }}
   secretName: keycloak-tls-cert


### PR DESCRIPTION
When the `hostname` value is specified in the Keycloak chart, the certificate DNS names will now be set to just that hostname instead of the default list (localhost, keycloak, etc.). This allows for more specific certificate configuration when deploying with a custom hostname.