### PR TITLE
Add bundleName parameter to CA chart

### DIFF
--- a/charts/ca/README.md
+++ b/charts/ca/README.md
@@ -29,10 +29,11 @@ $ helm install default-ca charts/ca \
 
 The following table lists the configurable parameters of the CA chart and their default values:
 
-| Parameter    | Description                               | Default      |
-|--------------|-------------------------------------------|--------------|
-| `issuerName` | The name of the `ClusterIssuer` to create | `default-ca` |
-| `commonName` | The common name for the CA certificate    | `Innabox CA` |
+| Parameter    | Description                               | Default       |
+|--------------|-------------------------------------------|---------------|
+| `issuerName` | The name of the `ClusterIssuer` to create | `default-ca`  |
+| `bundleName` | The name of the bundle to create          | `ca-bundle`   |
+| `commonName` | The common name for the CA certificate    | `Innabox CA`  |
 
 The namespace can also be changed using the `--namespace` flag, but it must match the namespace
 where _cert-manager_ stores the secrets for cluster issuers, which is usually `cert-manager`.

--- a/charts/ca/templates/bundle.yaml
+++ b/charts/ca/templates/bundle.yaml
@@ -18,7 +18,7 @@ apiVersion: trust.cert-manager.io/v1alpha1
 kind: Bundle
 metadata:
   namespace: {{ .Release.Namespace }}
-  name: {{ .Values.issuerName }}
+  name: {{ .Values.bundleName }}
 spec:
   sources:
   - secret:

--- a/charts/ca/values.yaml
+++ b/charts/ca/values.yaml
@@ -14,5 +14,8 @@
 # The name of the issuer to create:
 issuerName: default-ca
 
-# The common name for the CA certificate
+# The name of the bundle to create:
+bundleName: ca-bundle
+
+# The common name for the CA certificate:
 commonName: Innabox CA


### PR DESCRIPTION
This adds a new `bundleName` parameter to control the name of the `Bundle` resource created by the chart, which determines the config map name that _trust-manager_ creates in target namespaces. The default is `ca-bundle`.