### PR TITLE
Update build image action to use updated tag

### DIFF
--- a/.github/workflows/check-pull-request.yaml
+++ b/.github/workflows/check-pull-request.yaml
@@ -67,7 +67,7 @@ jobs:
     steps:
     - uses: actions/checkout@v5
     - run: |
-        image="ghcr.io/innabox/fulfillment-service:latest"
+        image="ghcr.io/innabox/fulfillment-service:main"
         podman build --tag "${image}" .
         podman save --output image.tar "${image}"
     - uses: actions/upload-artifact@v5


### PR DESCRIPTION
We recently moved from running with tag latest to main. This updates the action which builds the image for running integration tests to use the correct tag name.