### PR TITLE
Add service chart

### DIFF
--- a/.github/workflows/publish-chart.yaml
+++ b/.github/workflows/publish-chart.yaml
@@ -1,0 +1,55 @@
+#
+# Copyright (c) 2025 Red Hat Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License. You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License
+# is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+# or implied. See the License for the specific language governing permissions and limitations under
+# the License.
+#
+
+name: Publish chart
+
+on:
+  push:
+    tags:
+    - 'v*'
+
+jobs:
+
+  publish-chart:
+    name: Publish chart
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+    - uses: actions/checkout@v5
+      with:
+        fetch-depth: 0
+    - id: run
+      run: |
+        # Login to the registry:
+        export registry="ghcr.io"
+        echo "${{ secrets.GITHUB_TOKEN }}" | helm registry login --username "${{ github.actor }}" --password-stdin "${registry}"
+
+        # Get the git version:
+        export git_version="$(git describe --tags)"
+
+        # Update the image reference in the chart:
+        export app_version="${git_version}"
+        export app_image="${registry}/${{ github.repository }}:${app_version}"
+        yq -i '.images.service = strenv(app_image)' charts/service/values.yaml
+
+        # Package the chart:
+        export chart_version="${git_version#v}"
+        helm package charts/service --version "${chart_version}" --app-version "${app_version}"
+
+        # Push the chart to the registry:
+        export chart_name="$(yq -r '.name' charts/service/Chart.yaml)"
+        export chart_file="${chart_name}-${chart_version}.tgz"
+        helm push "${chart_file}" "oci://${registry}/${{ github.repository_owner }}/charts"

--- a/charts/service/Chart.yaml
+++ b/charts/service/Chart.yaml
@@ -1,0 +1,19 @@
+#
+# Copyright (c) 2025 Red Hat Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+# the License. You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+apiVersion: v2
+name: fulfillment-service
+description: Fulfillment service
+type: application
+version: 0.0.0
+appVersion: 0.0.0

--- a/charts/service/README.md
+++ b/charts/service/README.md
@@ -1,0 +1,99 @@
+# Service Helm Chart
+
+This Helm chart deploys the complete fulfillment service.
+
+## Prerequisites
+
+- Kubernetes cluster (_Kind_ or _OpenShift_).
+- _cert-manager_ operator installed.
+- _trust-manager_ operator installed (optional, but highly recommended).
+- _Authorino_ operator installed.
+
+## Installation
+
+To install the chart with the release name `fulfillment-service`:
+
+```bash
+$ helm install fulfillment-service ./charts/service -n innabox --create-namespace
+```
+
+## Configuration
+
+The following table lists the configurable parameters of the chart and their default values:
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `variant` | Deployment variant (`kind` or `openshift`) | `kind` |
+| `certs.issuerRef.kind` | Kind of _cert-manager_ issuer | `ClusterIssuer` |
+| `certs.issuerRef.name` | Name of _cert-manager_ issuer | None |
+| `certs.caBundle.configMap` | Name of configmap containing trusted CA certificates in PEM format | None |
+| `auth.issuerUrl` | OAuth issuer URL for authentication | `https://keycloak.keycloak.svc.cluster.local:8001/realms/innabox` |
+| `log.level` | Log level for all components (debug, info, warn, error) | `info` |
+| `log.headers` | Enable logging of HTTP/gRPC headers | `false` |
+| `log.bodies` | Enable logging of HTTP/gRPC request and response bodies | `false` |
+| `images.service` | Fulfillment service container image | `ghcr.io/innabox/fulfillment-service:main` |
+| `images.postgres` | PostgreSQL container image | `quay.io/sclorg/postgresql-15-c9s:latest` |
+| `images.envoy` | Envoy proxy container image | `docker.io/envoyproxy/envoy:v1.33.0` |
+| `database.storageSize` | Size of database persistent volume | `10Gi` |
+
+### Example custom values
+
+To customize the deployment, create a `values.yaml` file:
+
+```yaml
+variant: openshift
+
+certs:
+  issuerRef:
+    kind: Issuer
+    name: my-issuer
+  caBundle:
+    configMap: my-ca-bundle
+
+auth:
+  issuerUrl: https://keycloak.example.com/realms/innabox
+
+log:
+  level: debug
+  headers: true
+  bodies: true
+
+images:
+  service: ghcr.io/innabox/fulfillment-service:v1.0.0
+
+database:
+  storageSize: 50Gi
+```
+
+Then install with:
+
+```bash
+$ helm install fulfillment-service ./charts/service -n innabox -f values.yaml
+```
+
+## Variants
+
+### Kind variant
+
+When `variant: kind` is set:
+- The API service uses NodePort type with port 30000
+- Suitable for development and testing
+
+### OpenShift variant
+
+When `variant: openshift` is set:
+- The API service uses ClusterIP type
+- An OpenShift Route is created for external access
+- Suitable for production deployments on OpenShift
+
+## Uninstallation
+
+To uninstall the chart:
+
+```bash
+helm uninstall fulfillment-service -n innabox
+```
+
+## Database
+
+The chart includes a complete _PostgreSQL_ database deployment.

--- a/charts/service/files/database/access.conf
+++ b/charts/service/files/database/access.conf
@@ -1,0 +1,19 @@
+#
+# Copyright (c) 2025 Red Hat Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+# the License. You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+# This is needed by the scripts that setup the database.
+local all all peer
+
+# For any other user we only allow access with certificates.
+hostssl all all 0.0.0.0/0 cert
+hostssl all all ::0/0 cert

--- a/charts/service/files/database/server.conf
+++ b/charts/service/files/database/server.conf
@@ -1,0 +1,21 @@
+#
+# Copyright (c) 2025 Red Hat Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+# the License. You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+# Enable TLS:
+ssl = on
+ssl_ca_file = '/secrets/cert/ca.crt'
+ssl_cert_file = '/secrets/cert/tls.crt'
+ssl_key_file = '/secrets/cert/tls.key'
+
+# Use our custom access file:
+hba_file = '/config/access/access.conf'

--- a/charts/service/files/service/envoy.yaml
+++ b/charts/service/files/service/envoy.yaml
@@ -1,0 +1,280 @@
+#
+# Copyright (c) 2025 Red Hat Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+# the License. You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+admin:
+  address:
+    pipe:
+      path: /run/sockets/admin.socket
+
+static_resources:
+
+  listeners:
+
+  # This listener receives traffic from outside, so it needs to be secured with CORS, TLS, authentication and
+  # authorization.
+  - name: ingress
+    address:
+      socket_address:
+        address: 0.0.0.0
+        port_value: 8000
+    filter_chains:
+    - filters:
+      - name: envoy.filters.network.http_connection_manager
+        typed_config:
+          "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+          access_log:
+          - name: envoy.access_loggers.file
+            typed_config:
+              "@type": type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog
+              path: /dev/stdout
+          use_remote_address: true
+          xff_num_trusted_hops: 1
+          stat_prefix: ingress
+          route_config:
+            name: backend
+            virtual_hosts:
+            - name: all
+              domains:
+              - "*"
+              typed_per_filter_config:
+                envoy.filters.http.cors:
+                  "@type": type.googleapis.com/envoy.extensions.filters.http.cors.v3.CorsPolicy
+                  allow_origin_string_match:
+                  - safe_regex:
+                      regex: ".*"
+                  allow_methods: "POST"
+                  allow_headers: "Authorization, Content-Type, X-User-Agent, X-Grpc-Web"
+                  allow_credentials: true
+                  max_age: "86400"
+              routes:
+
+              # This route is for the REST gateway, and for that we need to disable the auth filter because requests
+              # will go to the gateway and then again to Envoy, translated to gRPC, and it is then when the auth filter
+              # will be applied.
+              - name: gateway
+                match:
+                  prefix: /api
+                route:
+                  cluster: gateway
+                  timeout: 300s
+                typed_per_filter_config:
+                  envoy.filters.http.ext_authz:
+                    "@type": type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute
+                    disabled: true
+
+              # This route is for the gRPC streaming requests used to watch events. Those streams can last very long,
+              # so we don't want to set a timeout, as that would cause the connection to be closed and events to be
+              # potentially lost.
+              - name: watch
+                match:
+                  safe_regex:
+                    regex: ^.*/Watch$
+                route:
+                  cluster: server
+                  timeout: 0s
+                  idle_timeout: 0s
+                typed_per_filter_config:
+                  envoy.filters.http.header_mutation:
+                    "@type": type.googleapis.com/envoy.extensions.filters.http.header_mutation.v3.HeaderMutationPerRoute
+                    mutations:
+                      request_mutations:
+                      - remove: authorization
+
+              # For the metadata, reflection and health methods we need to disable authentication, as they need to be
+              # publicly available.
+              - name: public
+                match:
+                  safe_regex:
+                    regex: ^/(metadata|grpc\.(reflection|health))\..*$
+                route:
+                  cluster: server
+                  timeout: 300s
+                typed_per_filter_config:
+                  envoy.filters.http.ext_authz:
+                    "@type": type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute
+                    disabled: true
+                  envoy.filters.http.header_mutation:
+                    "@type": type.googleapis.com/envoy.extensions.filters.http.header_mutation.v3.HeaderMutationPerRoute
+                    mutations:
+                      request_mutations:
+                      - remove: authorization
+
+              # This route is for gRPC unary requests, which should be quite fast, so we can safely set a timeout
+              - name: other
+                match:
+                  prefix: /
+                route:
+                  cluster: server
+                  timeout: 300s
+                typed_per_filter_config:
+                  envoy.filters.http.header_mutation:
+                    "@type": type.googleapis.com/envoy.extensions.filters.http.header_mutation.v3.HeaderMutationPerRoute
+                    mutations:
+                      request_mutations:
+                      - remove: authorization
+
+          http_filters:
+          - name: envoy.filters.http.grpc_web
+            typed_config:
+              "@type": type.googleapis.com/envoy.extensions.filters.http.grpc_web.v3.GrpcWeb
+          - name: envoy.filters.http.cors
+            typed_config:
+              "@type": type.googleapis.com/envoy.extensions.filters.http.cors.v3.Cors
+          - name: envoy.filters.http.ext_authz
+            typed_config:
+              "@type": type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthz
+              grpc_service:
+                envoy_grpc:
+                  cluster_name: authorino
+                timeout: 1s
+              failure_mode_allow: false
+          - name: envoy.filters.http.header_mutation
+            typed_config:
+              "@type": type.googleapis.com/envoy.extensions.filters.http.header_mutation.v3.HeaderMutation
+          - name: envoy.filters.http.router
+            typed_config:
+              "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+
+      transport_socket:
+        name: envoy.transport_sockets.tls
+        typed_config:
+          "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.DownstreamTlsContext
+          common_tls_context:
+            alpn_protocols:
+            - http1.1
+            - h2
+            tls_certificates:
+            - certificate_chain:
+                filename: /etc/envoy/tls/tls.crt
+              private_key:
+                filename: /etc/envoy/tls/tls.key
+
+  # This listener is used only for requests from the REST gateway. Those are internal only, and always gRPC, so we don't
+  # need CORS or TLS, but we do need authentication and authorization.
+  - name: gateway
+    address:
+      pipe:
+        path: /run/sockets/ingress.socket
+    filter_chains:
+    - filters:
+      - name: envoy.filters.network.http_connection_manager
+        typed_config:
+          "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+          access_log:
+          - name: envoy.access_loggers.file
+            typed_config:
+              "@type": type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog
+              path: /dev/stdout
+          use_remote_address: true
+          xff_num_trusted_hops: 1
+          stat_prefix: gateway
+          route_config:
+            name: backend
+            virtual_hosts:
+            - name: all
+              domains:
+              - "*"
+              routes:
+              - name: server
+                match:
+                  prefix: /
+                route:
+                  cluster: server
+                  timeout: 300s
+                typed_per_filter_config:
+                  envoy.filters.http.header_mutation:
+                    "@type": type.googleapis.com/envoy.extensions.filters.http.header_mutation.v3.HeaderMutationPerRoute
+                    mutations:
+                      request_mutations:
+                      - remove: authorization
+                      - remove: grpcgateway-authorization
+          http_filters:
+          - name: envoy.filters.http.ext_authz
+            typed_config:
+              "@type": type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthz
+              grpc_service:
+                envoy_grpc:
+                  cluster_name: authorino
+                timeout: 1s
+              failure_mode_allow: false
+          - name: envoy.filters.http.header_mutation
+            typed_config:
+              "@type": type.googleapis.com/envoy.extensions.filters.http.header_mutation.v3.HeaderMutation
+          - name: envoy.filters.http.router
+            typed_config:
+              "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+
+  clusters:
+
+  - name: authorino
+    connect_timeout: 1s
+    type: STRICT_DNS
+    lb_policy: RANDOM
+    typed_extension_protocol_options:
+      envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+        "@type": type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+        explicit_http_config:
+          http2_protocol_options: {}
+    load_assignment:
+      cluster_name: authorino
+      endpoints:
+      - lb_endpoints:
+        - endpoint:
+            address:
+              socket_address:
+                address: authorino-authorino-authorization
+                port_value: 50051
+    transport_socket:
+      name: envoy.transport_sockets.tls
+      typed_config:
+        "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
+        common_tls_context:
+          validation_context:
+            trusted_ca:
+              filename: /etc/envoy/tls/ca.crt
+
+  - name: server
+    connect_timeout: 1s
+    type: STATIC
+    lb_policy: ROUND_ROBIN
+    typed_extension_protocol_options:
+      envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+        "@type": type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+        explicit_http_config:
+          http2_protocol_options: {}
+    load_assignment:
+      cluster_name: server
+      endpoints:
+      - lb_endpoints:
+        - endpoint:
+            address:
+              pipe:
+                path: /run/sockets/server.socket
+
+  - name: gateway
+    connect_timeout: 1s
+    type: STATIC
+    lb_policy: ROUND_ROBIN
+    typed_extension_protocol_options:
+      envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+        "@type": type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+        explicit_http_config:
+          http2_protocol_options: {}
+    load_assignment:
+      cluster_name: gateway
+      endpoints:
+      - lb_endpoints:
+        - endpoint:
+            address:
+              pipe:
+                path: /run/sockets/gateway.socket

--- a/charts/service/templates/admin/sa.yaml
+++ b/charts/service/templates/admin/sa.yaml
@@ -1,0 +1,18 @@
+{{/*
+Copyright (c) 2025 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+the License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+*/}}
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  namespace: {{ .Release.Namespace }}
+  name: admin

--- a/charts/service/templates/authorino/authorino.yaml
+++ b/charts/service/templates/authorino/authorino.yaml
@@ -1,0 +1,37 @@
+{{/*
+Copyright (c) 2025 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+the License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+*/}}
+
+apiVersion: operator.authorino.kuadrant.io/v1beta1
+kind: Authorino
+metadata:
+  namespace: {{ .Release.Namespace }}
+  name: authorino
+spec:
+  clusterWide: false
+  logLevel: {{ .Values.log.level }}
+  listener:
+    tls:
+      enabled: true
+      certSecretRef:
+        name: authorino-tls
+  oidcServer:
+    tls:
+      enabled: false
+  {{- if .Values.certs.caBundle.configMap }}
+  volumes:
+    items:
+    - name: ca-bundle
+      configMaps:
+      - {{ .Values.certs.caBundle.configMap }}
+      mountPath: /etc/ssl/certs
+  {{- end }}

--- a/charts/service/templates/authorino/certificate.yaml
+++ b/charts/service/templates/authorino/certificate.yaml
@@ -1,0 +1,27 @@
+{{/*
+Copyright (c) 2025 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+the License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+*/}}
+
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  namespace: {{ .Release.Namespace }}
+  name: authorino
+spec:
+  issuerRef:
+    kind: {{ .Values.certs.issuerRef.kind }}
+    name: {{ required "certs.issuerRef.name is required" .Values.certs.issuerRef.name }}
+  dnsNames:
+  - authorino-authorino-authorization
+  - authorino-authorino-authorization.{{ .Release.Namespace }}
+  - authorino-authorino-authorization.{{ .Release.Namespace }}.svc.cluster.local
+  secretName: authorino-tls

--- a/charts/service/templates/client/sa.yaml
+++ b/charts/service/templates/client/sa.yaml
@@ -1,0 +1,18 @@
+{{/*
+Copyright (c) 2025 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+the License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+*/}}
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  namespace: {{ .Release.Namespace }}
+  name: client

--- a/charts/service/templates/controller/deployment.yaml
+++ b/charts/service/templates/controller/deployment.yaml
@@ -1,0 +1,57 @@
+{{/*
+Copyright (c) 2025 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+the License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+*/}}
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  namespace: {{ .Release.Namespace }}
+  name: fulfillment-controller
+spec:
+  selector:
+    matchLabels:
+      app: fulfillment-controller
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: fulfillment-controller
+    spec:
+      serviceAccountName: controller
+      volumes:
+      {{- if .Values.certs.caBundle.configMap }}
+      - name: cas
+        configMap:
+          name: {{ .Values.certs.caBundle.configMap }}
+      {{- end }}
+      containers:
+      - name: controller
+        image: {{ .Values.images.service }}
+        volumeMounts:
+        {{- if .Values.certs.caBundle.configMap }}
+        - name: cas
+          mountPath: /etc/fulfillment-controller/tls/cas
+        {{- end }}
+        command:
+        - /usr/local/bin/fulfillment-service
+        - start
+        - controller
+        - --log-level={{ .Values.log.level }}
+        - --log-headers={{ .Values.log.headers }}
+        - --log-bodies={{ .Values.log.bodies }}
+        {{- if .Values.certs.caBundle.configMap }}
+        - --ca-file=/etc/fulfillment-controller/tls/cas
+        {{- end }}
+        - --token-file=/var/run/secrets/kubernetes.io/serviceaccount/token
+        - --grpc-server-network=tcp
+        - --grpc-server-address=fulfillment-api:8000
+        - --grpc-keep-alive=5m

--- a/charts/service/templates/controller/sa.yaml
+++ b/charts/service/templates/controller/sa.yaml
@@ -1,0 +1,18 @@
+{{/*
+Copyright (c) 2025 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+the License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+*/}}
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  namespace: {{ .Release.Namespace }}
+  name: controller

--- a/charts/service/templates/database/client-cert.yaml
+++ b/charts/service/templates/database/client-cert.yaml
@@ -1,0 +1,26 @@
+{{/*
+Copyright (c) 2025 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+the License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+*/}}
+
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  namespace: {{ .Release.Namespace }}
+  name: fulfillment-database-client
+spec:
+  issuerRef:
+    kind: {{ .Values.certs.issuerRef.kind }}
+    name: {{ required "certs.issuerRef.name is required" .Values.certs.issuerRef.name }}
+  usages:
+  - client auth
+  commonName: client
+  secretName: fulfillment-database-client-cert

--- a/charts/service/templates/database/configmap.yaml
+++ b/charts/service/templates/database/configmap.yaml
@@ -1,0 +1,21 @@
+{{/*
+Copyright (c) 2025 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+the License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+*/}}
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  namespace: {{ .Release.Namespace }}
+  name: fulfillment-database
+data:
+  server.conf: {{ .Files.Get "files/database/server.conf" | quote }}
+  access.conf: {{ .Files.Get "files/database/access.conf" | quote }}

--- a/charts/service/templates/database/pvc.yaml
+++ b/charts/service/templates/database/pvc.yaml
@@ -1,0 +1,24 @@
+{{/*
+Copyright (c) 2025 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+the License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+*/}}
+
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  namespace: {{ .Release.Namespace }}
+  name: fulfillment-database
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: {{ .Values.database.storageSize }}

--- a/charts/service/templates/database/server-cert.yaml
+++ b/charts/service/templates/database/server-cert.yaml
@@ -1,0 +1,27 @@
+{{/*
+Copyright (c) 2025 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+the License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+*/}}
+
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  namespace: {{ .Release.Namespace }}
+  name: fulfillment-database-server
+spec:
+  issuerRef:
+    kind: {{ .Values.certs.issuerRef.kind }}
+    name: {{ required "certs.issuerRef.name is required" .Values.certs.issuerRef.name }}
+  dnsNames:
+  - fulfillment-database
+  - fulfillment-database.{{ .Release.Namespace }}
+  - fulfillment-database.{{ .Release.Namespace }}.svc.cluster.local
+  secretName: fulfillment-database-server-cert

--- a/charts/service/templates/database/service.yaml
+++ b/charts/service/templates/database/service.yaml
@@ -1,0 +1,25 @@
+{{/*
+Copyright (c) 2025 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+the License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+*/}}
+
+apiVersion: v1
+kind: Service
+metadata:
+  namespace: {{ .Release.Namespace }}
+  name: fulfillment-database
+spec:
+  selector:
+    app: fulfillment-database
+  ports:
+  - name: postgres
+    port: 5432
+    targetPort: postgres

--- a/charts/service/templates/database/statefulset.yaml
+++ b/charts/service/templates/database/statefulset.yaml
@@ -1,0 +1,65 @@
+{{/*
+Copyright (c) 2025 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+the License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+*/}}
+
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  namespace: {{ .Release.Namespace }}
+  name: fulfillment-database
+spec:
+  selector:
+    matchLabels:
+      app: fulfillment-database
+  serviceName: fulfillment-database
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: fulfillment-database
+    spec:
+      volumes:
+      - name: server-cert
+        secret:
+          secretName: fulfillment-database-server-cert
+          defaultMode: 0440
+      - name: config
+        configMap:
+          name: fulfillment-database
+      - name: data
+        persistentVolumeClaim:
+          claimName: fulfillment-database
+      containers:
+      - name: server
+        image: {{ .Values.images.postgres }}
+        env:
+        - name: POSTGRESQL_USER
+          value: client
+        - name: POSTGRESQL_PASSWORD
+          value: ''
+        - name: POSTGRESQL_DATABASE
+          value: service
+        volumeMounts:
+        - name: data
+          mountPath: /var/lib/pgsql/data
+        - name: server-cert
+          mountPath: /secrets/cert
+        - name: config
+          mountPath: /opt/app-root/src/postgresql-cfg/server.conf
+          subPath: server.conf
+        - name: config
+          mountPath: /config/access/access.conf
+          subPath: access.conf
+        ports:
+        - name: postgres
+          protocol: TCP
+          containerPort: 5432

--- a/charts/service/templates/route.yaml
+++ b/charts/service/templates/route.yaml
@@ -1,0 +1,28 @@
+{{/*
+Copyright (c) 2025 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+the License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+*/}}
+
+{{ if eq .Values.variant "openshift" }}
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  namespace: {{ .Release.Namespace }}
+  name: fulfillment-api
+spec:
+  to:
+    kind: Service
+    name: fulfillment-api
+  port:
+    targetPort: api
+  tls:
+    termination: passthrough
+{{ end }}

--- a/charts/service/templates/service/authconfig.yaml
+++ b/charts/service/templates/service/authconfig.yaml
@@ -1,0 +1,168 @@
+{{/*
+Copyright (c) 2025 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+the License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+*/}}
+
+apiVersion: authorino.kuadrant.io/v1beta3
+kind: AuthConfig
+metadata:
+  namespace: {{ .Release.Namespace }}
+  name: fulfillment-service
+spec:
+  hosts:
+  - "*"
+  authentication:
+    "fulfillment-api":
+      kubernetesTokenReview:
+        audiences:
+        # TODO: This is the default audience for the Kubernetes API server. We should probably create a custom audience,
+        # for example `fulfillment-api`, but then the users will need to create tokens for that audience. For example:
+        #
+        # $ kubectl create token -n innabox --audience=fulfillment-api client
+        #
+        # It is not clear to me if we can also use that audience for the tokens generated automatically for the service
+        # accounts of other pods, for example for the `controller` pods. It may be possible using a projected service
+        # account token, something like this:
+        #
+        # apiVersion: v1
+        # kind: Pod
+        # metadata:
+        #   name: my
+        # spec:
+        #   containers:
+        #   - volumeMounts:
+        #     - mountPath: /var/run/secrets/tokens
+        #       name: api-token
+        #   volumes:
+        #   - name: api-token
+        #     projected:
+        #       sources:
+        #       - serviceAccountToken:
+        #           path: api-token
+        #           audience: fulfillment-api
+        #
+        # But that needs to be tested.
+        #
+        # Note also that different flavours of Kubernetes use different audicences for the service account tokens. Kind
+        # uses the full DNS name `kubernetes.default.svc.cluster.local`, but OpenShift uses the `kubernetes.default.svc`
+        # abbreviation.
+        - https://kubernetes.default.svc
+        - https://kubernetes.default.svc.cluster.local
+      overrides:
+        authnMethod:
+          value: serviceaccount
+    "keycloak-jwt":
+      jwt:
+        issuerUrl: {{ required "auth.issuerUrl is required" .Values.auth.issuerUrl }}
+      overrides:
+        authnMethod:
+          value: jwt
+  authorization:
+    "fulfillment-api":
+      opa:
+        rego: |
+          import future.keywords.in
+
+          # Define admin subjects:
+          admin_subjects := {
+            "system:serviceaccount:{{ .Release.Namespace }}:admin",
+            "system:serviceaccount:{{ .Release.Namespace }}:controller",
+          }
+
+          # Get the gRPC method:
+          grpc_method := input.context.request.http.path
+
+          # Get the subject name:
+          subject_name = input.auth.identity.user.username {
+            input.auth.identity.authnMethod == "serviceaccount"
+          }
+          subject_name = input.auth.identity.user.preferred_username {
+            input.auth.identity.authnMethod == "jwt"
+          }
+
+          # Function to check if an account is an admin account:
+          is_admin {
+            subject_name in admin_subjects
+          }
+
+          # Function to check if an account is a client account:
+          is_client {
+            not is_admin
+          }
+
+          # Allow metadata, reflection and health to everyone:
+          allow {
+            startswith(grpc_method, "/metadata.")
+          }
+          allow {
+            startswith(grpc_method, "/grpc.reflection.")
+          }
+          allow {
+            startswith(grpc_method, "/grpc.health.")
+          }
+
+          # Allow specific methods to clients:
+          allow {
+            is_client
+            grpc_method in {
+              "/events.v1/Watch",
+              "/fulfillment.v1.ClusterTemplates/Get",
+              "/fulfillment.v1.ClusterTemplates/List",
+              "/fulfillment.v1.Clusters/Create",
+              "/fulfillment.v1.Clusters/Delete",
+              "/fulfillment.v1.Clusters/Get",
+              "/fulfillment.v1.Clusters/GetKubeconfig",
+              "/fulfillment.v1.Clusters/GetKubeconfigViaHttp",
+              "/fulfillment.v1.Clusters/GetPassword",
+              "/fulfillment.v1.Clusters/GetPasswordViaHttp",
+              "/fulfillment.v1.Clusters/List",
+              "/fulfillment.v1.Clusters/Update",
+              "/fulfillment.v1.HostClasses/Get",
+              "/fulfillment.v1.HostClasses/List",
+              "/fulfillment.v1.HostPools/Create",
+              "/fulfillment.v1.HostPools/Delete",
+              "/fulfillment.v1.HostPools/Get",
+              "/fulfillment.v1.HostPools/List",
+              "/fulfillment.v1.HostPools/Update",
+              "/fulfillment.v1.Hosts/Create",
+              "/fulfillment.v1.Hosts/Delete",
+              "/fulfillment.v1.Hosts/Get",
+              "/fulfillment.v1.Hosts/List",
+              "/fulfillment.v1.Hosts/Update",
+              "/fulfillment.v1.VirtualMachineTemplates/Get",
+              "/fulfillment.v1.VirtualMachineTemplates/List",
+              "/fulfillment.v1.VirtualMachines/Create",
+              "/fulfillment.v1.VirtualMachines/Delete",
+              "/fulfillment.v1.VirtualMachines/Get",
+              "/fulfillment.v1.VirtualMachines/List",
+              "/fulfillment.v1.VirtualMachines/Update",
+            }
+          }
+
+          # Allow everything to admins:
+          allow {
+            is_admin
+          }
+  response:
+    success:
+      headers:
+        "x-subject":
+          json:
+            properties:
+              source:
+                expression: |
+                  auth.identity.authnMethod
+              user:
+                expression: |
+                  auth.identity.authnMethod == "serviceaccount"? auth.identity.user.username: auth.identity.username
+              groups:
+                expression: |
+                  auth.identity.authnMethod == "serviceaccount"? auth.identity.user.groups: auth.identity.groups

--- a/charts/service/templates/service/certificate.yaml
+++ b/charts/service/templates/service/certificate.yaml
@@ -1,0 +1,28 @@
+{{/*
+Copyright (c) 2025 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+the License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+*/}}
+
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  namespace: {{ .Release.Namespace }}
+  name: fulfillment-api
+spec:
+  issuerRef:
+    kind: {{ .Values.certs.issuerRef.kind }}
+    name: {{ required "certs.issuerRef.name is required" .Values.certs.issuerRef.name }}
+  dnsNames:
+  - localhost
+  - fulfillment-api
+  - fulfillment-api.{{ .Release.Namespace }}
+  - fulfillment-api.{{ .Release.Namespace }}.svc.cluster.local
+  secretName: fulfillment-service-tls

--- a/charts/service/templates/service/deployment.yaml
+++ b/charts/service/templates/service/deployment.yaml
@@ -1,0 +1,116 @@
+{{/*
+Copyright (c) 2025 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+the License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+*/}}
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  namespace: {{ .Release.Namespace }}
+  name: fulfillment-service
+spec:
+  selector:
+    matchLabels:
+      app: fulfillment-service
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: fulfillment-service
+    spec:
+      volumes:
+      {{- if .Values.certs.caBundle.configMap }}
+      - name: cas
+        configMap:
+          name: {{ .Values.certs.caBundle.configMap }}
+      {{- end }}
+      - name: sockets
+        emptyDir:
+          medium: Memory
+      - name: cert
+        secret:
+          secretName: fulfillment-database-client-cert
+      - name: envoy
+        configMap:
+          name: fulfillment-service-envoy
+      - name: envoy-tls
+        secret:
+          secretName: fulfillment-service-tls
+      containers:
+
+      - name: server
+        image: {{ .Values.images.service }}
+        volumeMounts:
+        - name: sockets
+          mountPath: /run/sockets
+        - name: cert
+          mountPath: /secrets/cert
+        command:
+        - /usr/local/bin/fulfillment-service
+        - start
+        - server
+        - --log-level={{ .Values.log.level }}
+        - --log-headers={{ .Values.log.headers }}
+        - --log-bodies={{ .Values.log.bodies }}
+        - "--db-url=postgres://client@fulfillment-database:5432/service?\
+          sslmode=verify-full&\
+          sslcert=/secrets/cert/tls.crt&\
+          sslkey=/secrets/cert/tls.key&\
+          sslrootcert=/secrets/cert/ca.crt"
+        - --grpc-listener-network=unix
+        - --grpc-listener-address=/run/sockets/server.socket
+        - --grpc-authn-trusted-token-issuers={{ required "auth.issuerUrl is required" .Values.auth.issuerUrl }}
+        - --grpc-authn-type=external
+        - --tenancy-logic=default
+
+      - name: gateway
+        image: {{ .Values.images.service }}
+        volumeMounts:
+        - name: sockets
+          mountPath: /run/sockets
+        {{- if .Values.certs.caBundle.configMap }}
+        - name: cas
+          mountPath: /etc/fulfillment-gateway/tls/cas
+        {{- end }}
+        command:
+        - /usr/local/bin/fulfillment-service
+        - start
+        - gateway
+        - --log-level={{ .Values.log.level }}
+        - --log-headers={{ .Values.log.headers }}
+        - --log-bodies={{ .Values.log.bodies }}
+        {{- if .Values.certs.caBundle.configMap }}
+        - --ca-file=/etc/fulfillment-gateway/tls/cas
+        {{- end }}
+        - --http-listener-network=unix
+        - --http-listener-address=/run/sockets/gateway.socket
+        - --grpc-server-network=unix
+        - --grpc-server-address=/run/sockets/ingress.socket
+        - --grpc-server-plaintext
+        - --grpc-keep-alive=5m
+
+      - name: envoy
+        image: {{ .Values.images.envoy }}
+        volumeMounts:
+        - name: sockets
+          mountPath: /run/sockets
+        - name: envoy
+          mountPath: /etc/envoy
+        - name: envoy-tls
+          mountPath: /etc/envoy/tls
+        command:
+        - envoy
+        - --config-path
+        - /etc/envoy/envoy.yaml
+        ports:
+        - name: api
+          protocol: TCP
+          containerPort: 8000

--- a/charts/service/templates/service/envoy-configmap.yaml
+++ b/charts/service/templates/service/envoy-configmap.yaml
@@ -1,0 +1,20 @@
+{{/*
+Copyright (c) 2025 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+the License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+*/}}
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  namespace: {{ .Release.Namespace }}
+  name: fulfillment-service-envoy
+data:
+  envoy.yaml: {{ .Files.Get "files/service/envoy.yaml" | quote }}

--- a/charts/service/templates/service/service.yaml
+++ b/charts/service/templates/service/service.yaml
@@ -1,0 +1,33 @@
+{{/*
+Copyright (c) 2025 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+the License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+*/}}
+
+apiVersion: v1
+kind: Service
+metadata:
+  namespace: {{ .Release.Namespace }}
+  name: fulfillment-api
+  labels:
+    app: fulfillment-service
+spec:
+  selector:
+    app: fulfillment-service
+{{- if eq .Values.variant "kind" }}
+  type: NodePort
+{{- end }}
+  ports:
+  - name: api
+    port: 8000
+    targetPort: api
+{{- if eq .Values.variant "kind" }}
+    nodePort: 30000
+{{- end }}

--- a/charts/service/values.yaml
+++ b/charts/service/values.yaml
@@ -1,0 +1,65 @@
+#
+# Copyright (c) 2025 Red Hat Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+# the License. You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+# This indicates if the chart is being deployed to an OpenShift or Kind cluster. Valid values are `openshift` and `kind`.
+variant: kind
+
+# Certificate configuration:
+certs:
+
+  # This defines the cert-manager issuer that will be used for the certificates used by the service. The default is to
+  # use a cluster wide issuer, but there is no default value for the name, so it must be set.
+  issuerRef:
+    kind: ClusterIssuer
+    name:
+
+  # This defines the trusted CA certificates bundle. It should be the name of a configmap in the release namespace
+  # that contains trusted CA certificates in PEM format. If not set or empty, no CA bundle will be used.
+  caBundle:
+    configMap:
+
+# Authentication and authorization configuration:
+auth:
+
+  # This defines the URL of the OAuth issuer used for authentication. This parameter is mandatory.
+  issuerUrl:
+
+# Logging configuration:
+log:
+
+  # This defines the log level for all components. Valid values are 'debug', 'info', 'warn', and 'error'.
+  #
+  # Note that setting this to 'debug' will significantly increase the size of logs and may impact service performance.
+  level: info
+
+  # This controls whether HTTP/gRPC headers are logged.
+  #
+  # Note that setting this to 'true' may result in sensitive information being logged, avoid doing this in production
+  # environments.
+  headers: false
+
+  # This controls whether HTTP/gRPC request and response bodies are logged.
+  #
+  # Note that setting this to 'true' may result in sensitive information being logged, avoid doing this in production
+  # environments.
+  bodies: false
+
+# Image configuration:
+images:
+  service: ghcr.io/innabox/fulfillment-service:main
+  postgres: quay.io/sclorg/postgresql-15-c9s:latest
+  envoy: docker.io/envoyproxy/envoy:v1.33.0
+
+# Database configuration:
+database:
+  storageSize: 10Gi

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/go-logr/logr v1.4.3
 	github.com/google/uuid v1.6.0
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.27.2
-	github.com/innabox/fulfillment-common v0.0.13
+	github.com/innabox/fulfillment-common v0.0.14
 	github.com/json-iterator/go v1.1.12
 	github.com/kelseyhightower/envconfig v1.4.0
 	github.com/open-policy-agent/opa v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -115,8 +115,8 @@ github.com/hashicorp/go-multierror v1.1.1 h1:H5DkEtf6CXdFp0N0Em5UCwQpXMWke8IA0+l
 github.com/hashicorp/go-multierror v1.1.1/go.mod h1:iw975J/qwKPdAO1clOe2L8331t/9/fmwbPZ6JB6eMoM=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
-github.com/innabox/fulfillment-common v0.0.13 h1:nBtJitoqh/9L1LHSQRFE8Wrb6nLH2F+G+JcyGsIrdo0=
-github.com/innabox/fulfillment-common v0.0.13/go.mod h1:B860RSo86YZucRU2uNzx5k/0LV85VbWWZKZUmYH7PNY=
+github.com/innabox/fulfillment-common v0.0.14 h1:GucEuSon7RCKhBv5e6W24Ah4XLQcRQQKd53Docl+vsU=
+github.com/innabox/fulfillment-common v0.0.14/go.mod h1:B860RSo86YZucRU2uNzx5k/0LV85VbWWZKZUmYH7PNY=
 github.com/itchyny/gojq v0.12.17 h1:8av8eGduDb5+rvEdaOO+zQUjA04MS0m3Ps8HiD+fceg=
 github.com/itchyny/gojq v0.12.17/go.mod h1:WBrEMkgAfAGO1LUcGOckBl5O726KPp+OlkKug0I/FEY=
 github.com/itchyny/timefmt-go v0.1.6 h1:ia3s54iciXDdzWzwaVKXZPbiXzxxnv1SPGFfM/myJ5Q=

--- a/it/it_cluster_reconciler_test.go
+++ b/it/it_cluster_reconciler_test.go
@@ -119,7 +119,7 @@ var _ = Describe("Cluster reconciler", func() {
 		})
 
 		// Check that the Kubernetes object is eventually created:
-		kubeClient := kind.Client()
+		kubeClient := cluster.Client()
 		clusterOrderList := &unstructured.UnstructuredList{}
 		clusterOrderList.SetGroupVersionKind(gvks.ClusterOrderList)
 		var kubeObject *unstructured.Unstructured
@@ -174,7 +174,7 @@ var _ = Describe("Cluster reconciler", func() {
 		object := createResponse.GetObject()
 
 		// Wait for the corresponding Kubernetes object to be created:
-		kubeClient := kind.Client()
+		kubeClient := cluster.Client()
 		clusterOrderList := &unstructured.UnstructuredList{}
 		clusterOrderList.SetGroupVersionKind(gvks.ClusterOrderList)
 		var clusterOrderObj *unstructured.Unstructured
@@ -244,7 +244,7 @@ var _ = Describe("Cluster reconciler", func() {
 		})
 
 		// Wait for the corresponding Kubernetes object to be created:
-		kubeClient := kind.Client()
+		kubeClient := cluster.Client()
 		clusterOrderList := &unstructured.UnstructuredList{}
 		clusterOrderList.SetGroupVersionKind(gvks.ClusterOrderList)
 		var clusterOrderObj *unstructured.Unstructured

--- a/it/it_public_clusters_test.go
+++ b/it/it_public_clusters_test.go
@@ -268,7 +268,7 @@ var _ = Describe("Public clusters", func() {
 		})
 
 		// Wait till the Kubernetes object has been created:
-		kubeClient := kind.Client()
+		kubeClient := cluster.Client()
 		clusterOrderList := &unstructured.UnstructuredList{}
 		clusterOrderList.SetGroupVersionKind(gvks.ClusterOrderList)
 		var clusterOrderObj *unstructured.Unstructured
@@ -370,7 +370,7 @@ var _ = Describe("Public clusters", func() {
 		})
 
 		// Wait till the Kubernetes object has been created:
-		kubeClient := kind.Client()
+		kubeClient := cluster.Client()
 		clusterOrderList := &unstructured.UnstructuredList{}
 		clusterOrderList.SetGroupVersionKind(gvks.ClusterOrderList)
 		var clusterOrderObj *unstructured.Unstructured
@@ -472,7 +472,7 @@ var _ = Describe("Public clusters", func() {
 		})
 
 		// Wait till the Kubernetes object has been created:
-		kubeClient := kind.Client()
+		kubeClient := cluster.Client()
 		clusterOrderList := &unstructured.UnstructuredList{}
 		clusterOrderList.SetGroupVersionKind(gvks.ClusterOrderList)
 		var clusterOrderObj *unstructured.Unstructured
@@ -574,7 +574,7 @@ var _ = Describe("Public clusters", func() {
 		})
 
 		// Wait till the Kubernetes object has been created:
-		kubeClient := kind.Client()
+		kubeClient := cluster.Client()
 		clusterOrderList := &unstructured.UnstructuredList{}
 		clusterOrderList.SetGroupVersionKind(gvks.ClusterOrderList)
 		var clusterOrderObj *unstructured.Unstructured


### PR DESCRIPTION
This chart deploys the complete fulfillment service stack including the service itself (with server, gateway and Envoy containers), the controller, a PostgreSQL database with TLS authentication, and Authorino for authorization.

The chart is designed to be portable across environments with a 'variant' parameter to switch between Kind and OpenShift deployments. Configuration is organized into logical sections for certificates, authentication, logging, images, and database settings.

Certificate management is handled via cert-manager with a mandatory issuer reference. Authentication uses either Kubernetes service account tokens or JWT tokens from an OAuth issuer. Logging parameters control verbosity and what information is captured, with defaults appropriate for production use.

All components use the same log level and have consistent CA bundle configuration for TLS verification when connecting to external services.