### PR TITLE
Publish the CA chart

### DIFF
--- a/.github/workflows/publish-charts.yaml
+++ b/.github/workflows/publish-charts.yaml
@@ -81,3 +81,31 @@ jobs:
         export chart_name="$(yq -r '.name' charts/keycloak/Chart.yaml)"
         export chart_file="${chart_name}-${chart_version}.tgz"
         helm push "${chart_file}" "oci://${registry}/${{ github.repository_owner }}/charts"
+
+  publish-ca-chart:
+    name: Publish CA chart
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+    - uses: actions/checkout@v5
+      with:
+        fetch-depth: 0
+    - id: run
+      run: |
+        # Login to the registry:
+        export registry="ghcr.io"
+        echo "${{ secrets.GITHUB_TOKEN }}" | helm registry login --username "${{ github.actor }}" --password-stdin "${registry}"
+
+        # Get the git version:
+        export git_version="$(git describe --tags)"
+
+        # Package the chart:
+        export chart_version="${git_version#v}"
+        helm package charts/ca --version "${chart_version}"
+
+        # Push the chart to the registry:
+        export chart_name="$(yq -r '.name' charts/ca/Chart.yaml)"
+        export chart_file="${chart_name}-${chart_version}.tgz"
+        helm push "${chart_file}" "oci://${registry}/${{ github.repository_owner }}/charts"

--- a/charts/ca/Chart.yaml
+++ b/charts/ca/Chart.yaml
@@ -13,6 +13,6 @@
 
 apiVersion: v2
 name: ca
-description: A Helm chart for creating a default CA ClusterIssuer for use in the Innabox project
+description: A Helm chart for creating a default CA for use in the Innabox project
 type: application
-version: 0.0.1
+version: 0.0.0


### PR DESCRIPTION
This patch changes the GitHub actions so that the CA chart is also published.