### PR TITLE
Add `hostname` configuration to service chart

### DIFF
--- a/charts/service/README.md
+++ b/charts/service/README.md
@@ -27,6 +27,7 @@ The following table lists the configurable parameters of the chart and their def
 | `certs.issuerRef.kind` | Kind of _cert-manager_ issuer | `ClusterIssuer` |
 | `certs.issuerRef.name` | Name of _cert-manager_ issuer | None |
 | `certs.caBundle.configMap` | Name of configmap containing trusted CA certificates in PEM format | None |
+| `hostname` | Hostname used to access the service from outside the cluster | None |
 | `auth.issuerUrl` | OAuth issuer URL for authentication | `https://keycloak.keycloak.svc.cluster.local:8001/realms/innabox` |
 | `log.level` | Log level for all components (debug, info, warn, error) | `info` |
 | `log.headers` | Enable logging of HTTP/gRPC headers | `false` |
@@ -49,6 +50,8 @@ certs:
     name: my-issuer
   caBundle:
     configMap: my-ca-bundle
+
+hostname: fulfillment-service.example.com
 
 auth:
   issuerUrl: https://keycloak.example.com/realms/innabox

--- a/charts/service/templates/service/certificate.yaml
+++ b/charts/service/templates/service/certificate.yaml
@@ -25,4 +25,7 @@ spec:
   - fulfillment-api
   - fulfillment-api.{{ .Release.Namespace }}
   - fulfillment-api.{{ .Release.Namespace }}.svc.cluster.local
+  {{- if .Values.hostname }}
+  - {{ .Values.hostname }}
+  {{- end }}
   secretName: fulfillment-service-tls

--- a/charts/service/values.yaml
+++ b/charts/service/values.yaml
@@ -28,6 +28,10 @@ certs:
   caBundle:
     configMap:
 
+# Hostname used to access the service from outside the cluster. If set, this will be added to the service certificate
+# as a DNS name.
+hostname:
+
 # Authentication and authorization configuration:
 auth:
 


### PR DESCRIPTION
This change adds an optional `hostname` parameter to the service chart that allows specifying an external hostname for accessing the service. When configured, the hostname is automatically included as a DNS name in the TLS certificate, enabling secure external access to the fulfillment service.