### PR TITLE
Fix location of username for JWT authentication

### DIFF
--- a/charts/service/templates/service/authconfig.yaml
+++ b/charts/service/templates/service/authconfig.yaml
@@ -84,7 +84,7 @@ spec:
           subject_name = input.auth.identity.user.username {
             input.auth.identity.authnMethod == "serviceaccount"
           }
-          subject_name = input.auth.identity.user.preferred_username {
+          subject_name = input.auth.identity.username {
             input.auth.identity.authnMethod == "jwt"
           }
 


### PR DESCRIPTION
This patch fixes the part of the Authorino configuration where we specify the path of the `username` claim. With the current Keycloak configuration it is `username` not `user.preferred_username`.