### PR TITLE
Fix missing auth header message

### DIFF
--- a/internal/auth/grpc_external_authn_func.go
+++ b/internal/auth/grpc_external_authn_func.go
@@ -128,7 +128,11 @@ func (f *grpcExternalAuthnFunc) call(ctx context.Context, method string) (result
 			"Expected exactly one value for the subject header",
 			slog.Any("values", values),
 		)
-		err = errors.New("too many values for authentication header")
+		if count == 0 {
+			err = errors.New("missing authentication header")
+		} else {
+			err = errors.New("too many values for authentication header")
+		}
 		return
 	}
 	value := values[0]

--- a/internal/auth/grpc_external_authn_func_test.go
+++ b/internal/auth/grpc_external_authn_func_test.go
@@ -154,6 +154,18 @@ var _ = Describe("gRPC external authentication function", func() {
 		Expect(err).To(MatchError("missing authentication header"))
 	})
 
+	It("Fails if header is missing", func() {
+		// Create the function:
+		function, err := NewGrpcExternalAuthnFunc().
+			SetLogger(logger).
+			Build()
+		Expect(err).ToNot(HaveOccurred())
+
+		// Verify the results:
+		ctx, err = function(ctx, "/my_package/MyMethod")
+		Expect(err).To(MatchError("missing authentication header"))
+	})
+
 	It("Fails header has multiple values", func() {
 		// Create the function:
 		function, err := NewGrpcExternalAuthnFunc().


### PR DESCRIPTION
Currently the error message when the `Authorization` header isn't injected in the request by _Authorino_ is this:

```
too many values for authentication header
```

That is what should be returned when there are multiple authorization headers. It should be:

```
missing authentication header
```

This patch fixes that.