### PR TITLE
Fix location of username for JWT authentication in Kustomize manifests

### DIFF
--- a/manifests/base/service/authconfig.yaml
+++ b/manifests/base/service/authconfig.yaml
@@ -83,7 +83,7 @@ spec:
           subject_name = input.auth.identity.user.username {
             input.auth.identity.authnMethod == "serviceaccount"
           }
-          subject_name = input.auth.identity.user.preferred_username {
+          subject_name = input.auth.identity.username {
             input.auth.identity.authnMethod == "jwt"
           }
 


### PR DESCRIPTION
This applies the same fix from commit 1d35349 to the Kustomize manifests. The username claim path for JWT authentication should be `username` not `user.preferred_username`.