### PR TITLE
Allow use of empty tenancy logic

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -23,7 +23,24 @@
                         "processId": "${command:pickGoProcess}"
                 },
                 {
-                        "name": "start server",
+                        "name": "start server (empty tenancy)",
+                        "type": "go",
+                        "request": "launch",
+                        "mode": "auto",
+                        "program": "${workspaceFolder}",
+                        "args": [
+                                "start",
+                                "server",
+                                "--log-level=debug",
+                                "--log-headers=true",
+                                "--log-bodies=true",
+                                "--grpc-listener-address=localhost:8000",
+                                "--db-url=postgres://service:service123@localhost:5432/service",
+                                "--tenancy-logic=empty"
+                        ]
+                },
+                {
+                        "name": "start server (default tenancy)",
                         "type": "go",
                         "request": "launch",
                         "mode": "auto",
@@ -36,7 +53,8 @@
                                 "--log-bodies=true",
                                 "--grpc-authn-trusted-token-issuers=https://keycloak.keycloak.svc.cluster.local:8001/realms/innabox",
                                 "--grpc-listener-address=localhost:8000",
-                                "--db-url=postgres://service:service123@localhost:5432/service"
+                                "--db-url=postgres://service:service123@localhost:5432/service",
+                                "--tenancy-logic=default"
                         ]
                 },
                 {

--- a/internal/cmd/start_server_cmd.go
+++ b/internal/cmd/start_server_cmd.go
@@ -74,7 +74,7 @@ func NewStartServerCommand() *cobra.Command {
 		&runner.args.tenancyLogic,
 		"tenancy-logic",
 		"default",
-		"Type of tenancy logic to use. Valid values are 'default' and 'serviceaccount'.",
+		"Type of tenancy logic to use. Valid values are 'empty', 'default' and 'serviceaccount'.",
 	)
 	return command
 }
@@ -271,6 +271,13 @@ func (c *startServerCommandRunner) run(cmd *cobra.Command, argv []string) error 
 	)
 	var publicTenancyLogic auth.TenancyLogic
 	switch strings.ToLower(c.args.tenancyLogic) {
+	case "empty":
+		publicTenancyLogic, err = auth.NewEmptyTenancyLogic().
+			SetLogger(c.logger).
+			Build()
+		if err != nil {
+			return fmt.Errorf("failed to create empty tenancy logic: %w", err)
+		}
 	case "default":
 		publicTenancyLogic, err = auth.NewDefaultTenancyLogic().
 			SetLogger(c.logger).


### PR DESCRIPTION
Currently the service can be configured to use the default tenancy logic or the service account tenancy logic, but the empty tenancy logic which is the one appropriate for development environments. This patch changes it so that it is possible with the `--tenancy-logic=empty` command line flag.