### PR TITLE
Add OpenShift route to the Keycloak chart

### DIFF
--- a/charts/keycloak/templates/route.yaml
+++ b/charts/keycloak/templates/route.yaml
@@ -1,0 +1,28 @@
+{{/*
+Copyright (c) 2025 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+the License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+*/}}
+
+{{ if eq .Values.variant "openshift" }}
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  namespace: {{ .Release.Namespace }}
+  name: keycloak
+spec:
+  to:
+    kind: Service
+    name: keycloak
+  port:
+    targetPort: https
+  tls:
+    termination: passthrough
+{{ end }}


### PR DESCRIPTION
This patch adds an _OpenShift_ route to the Keycloak template.