### PR TITLE
Label VirtualMachine with tenant ID

### DIFF
--- a/internal/controllers/vm/vm_reconciler_function.go
+++ b/internal/controllers/vm/vm_reconciler_function.go
@@ -175,6 +175,7 @@ func (t *task) update(ctx context.Context) error {
 		object.SetGenerateName(objectPrefix)
 		object.SetLabels(map[string]string{
 			labels.VirtualMachineUuid: t.vm.GetId(),
+			labels.TenantId:           utils.ListAsDNSName(t.vm.GetMetadata().Tenants),
 		})
 		err = unstructured.SetNestedField(object.Object, spec, "spec")
 		if err != nil {

--- a/internal/kubernetes/gvks/kubernetes_gkvs.go
+++ b/internal/kubernetes/gvks/kubernetes_gkvs.go
@@ -15,8 +15,10 @@ package gvks
 
 import "k8s.io/apimachinery/pkg/runtime/schema"
 
+var CloudkitGroup = "cloudkit.openshift.io"
+
 var ClusterOrder = schema.GroupVersionKind{
-	Group:   "cloudkit.openshift.io",
+	Group:   CloudkitGroup,
 	Version: "v1alpha1",
 	Kind:    "ClusterOrder",
 }
@@ -32,7 +34,7 @@ var HostedCluster = schema.GroupVersionKind{
 var HostedClusterList = listGVK(HostedCluster)
 
 var VirtualMachine = schema.GroupVersionKind{
-	Group:   "cloudkit.openshift.io",
+	Group:   CloudkitGroup,
 	Version: "v1alpha1",
 	Kind:    "VirtualMachine",
 }
@@ -40,7 +42,7 @@ var VirtualMachine = schema.GroupVersionKind{
 var VirtualMachineList = listGVK(VirtualMachine)
 
 var Host = schema.GroupVersionKind{
-	Group:   "cloudkit.openshift.io",
+	Group:   CloudkitGroup,
 	Version: "v1alpha1",
 	Kind:    "Host",
 }
@@ -48,7 +50,7 @@ var Host = schema.GroupVersionKind{
 var HostList = listGVK(Host)
 
 var HostPool = schema.GroupVersionKind{
-	Group:   "cloudkit.openshift.io",
+	Group:   CloudkitGroup,
 	Version: "v1alpha1",
 	Kind:    "HostPool",
 }

--- a/internal/kubernetes/labels/kubernetes_labels.go
+++ b/internal/kubernetes/labels/kubernetes_labels.go
@@ -19,6 +19,8 @@ import (
 	"github.com/innabox/fulfillment-service/internal/kubernetes/gvks"
 )
 
+var TenantId = fmt.Sprintf("%s/%s", gvks.CloudkitGroup, "tenant-id")
+
 // ClusterOrderUuid is the label where the fulfillment API will write the identifier of the order.
 var ClusterOrderUuid = fmt.Sprintf("%s/%s", gvks.ClusterOrder.Group, "clusterorder-uuid")
 

--- a/internal/utils/normalize.go
+++ b/internal/utils/normalize.go
@@ -1,0 +1,106 @@
+/*
+Copyright (c) 2025 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package utils
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"slices"
+	"strings"
+	"unicode"
+)
+
+const (
+	// maxLabelValueLength is the maximum length for a Kubernetes label value
+	maxLabelValueLength = 63
+	// HashSuffixLength is the length reserved for the hash suffix to differentiate strings
+	HashSuffixLength = 8
+	// maxNormalizedLength is the maximum length for the normalized part before appending the hash
+	maxNormalizedLength = maxLabelValueLength - HashSuffixLength
+)
+
+// AsDNSName normalizes a string as a DNS name that is compatible with Kubernetes naming constraints.
+// The result conforms to Kubernetes label value requirements:
+// - Must be 63 characters or less
+// - Must be empty or consist of alphanumeric characters, '-', '_' or '.'
+// - Must start and end with an alphanumeric character (if not empty)
+//
+// Invalid characters are replaced with '-', and the result is truncated to leave space for a hash suffix.
+// A hash suffix is always appended to differentiate strings, even if they have the same normalized prefix.
+func AsDNSName(input string) string {
+	if input == "" {
+		return ""
+	}
+
+	var result strings.Builder
+	result.Grow(len(input))
+
+	// First pass: replace invalid characters and build the string
+	for _, r := range input {
+		if unicode.IsLetter(r) {
+			result.WriteRune(unicode.ToLower(r))
+		} else if unicode.IsDigit(r) || r == '-' || r == '_' || r == '.' {
+			result.WriteRune(r)
+		} else {
+			// Replace invalid characters with '-'
+			result.WriteRune('-')
+		}
+	}
+
+	normalized := result.String()
+
+	// Remove leading non-alphanumeric characters
+	normalized = strings.TrimLeftFunc(normalized, func(r rune) bool {
+		return !unicode.IsLetter(r) && !unicode.IsDigit(r)
+	})
+
+	// Always calculate hash of original input for differentiation
+	hash := sha256.Sum256([]byte(input))
+	hashSuffix := fmt.Sprintf("%x", hash)[:HashSuffixLength]
+
+	// If after trimming we have an empty string, use default value
+	if normalized == "" {
+		normalized = "x"
+	}
+
+	// Truncate to leave space for hash suffix (always append hash)
+	if len(normalized) > maxNormalizedLength {
+		normalized = normalized[:maxNormalizedLength]
+	}
+
+	// Always append hash suffix
+	normalized = normalized + hashSuffix
+
+	return normalized
+}
+
+// ListAsDNSName normalizes a list of strings as a DNS name that is compatible with Kubernetes naming constraints.
+// The input list is sorted (without mutation), joined together, and then normalized using AsDNSName.
+// Returns a single normalized DNS name string.
+func ListAsDNSName(inputs []string) string {
+	if len(inputs) == 0 {
+		return ""
+	}
+
+	// Create a copy and sort it without mutating the input
+	sorted := make([]string, len(inputs))
+	copy(sorted, inputs)
+	slices.Sort(sorted)
+
+	// Join the sorted strings with a dot
+	joined := strings.Join(sorted, ".")
+
+	// Normalize the joined string
+	return AsDNSName(joined)
+}

--- a/internal/utils/normalize_test.go
+++ b/internal/utils/normalize_test.go
@@ -1,0 +1,348 @@
+/*
+Copyright (c) 2025 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package utils
+
+import (
+	"strings"
+
+	. "github.com/onsi/ginkgo/v2/dsl/core"
+	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/util/validation"
+)
+
+var _ = Describe("AsDNSName", func() {
+	Context("with valid input", func() {
+		It("should append hash suffix to lowercase alphanumeric strings", func() {
+			result := AsDNSName("abc123")
+			Expect(result).To(HavePrefix("abc123"))
+			Expect(len(result)).To(BeNumerically("<=", 63))
+			// Hash is always appended, so result will be longer than input if input is short
+			if len("abc123")+HashSuffixLength <= 63 {
+				Expect(len(result)).To(Equal(len("abc123") + HashSuffixLength))
+			}
+
+			result2 := AsDNSName("my-label-value")
+			Expect(result2).To(HavePrefix("my-label-value"))
+			Expect(len(result2)).To(BeNumerically("<=", 63))
+		})
+
+		It("should convert uppercase to lowercase and append hash", func() {
+			result := AsDNSName("ABC123")
+			Expect(result).To(HavePrefix("abc123"))
+			Expect(len(result)).To(BeNumerically("<=", 63))
+
+			result2 := AsDNSName("My-Label-Value")
+			Expect(result2).To(HavePrefix("my-label-value"))
+			Expect(len(result2)).To(BeNumerically("<=", 63))
+		})
+
+		It("should handle mixed valid characters and append hash", func() {
+			result := AsDNSName("abc-123_def.456")
+			Expect(result).To(HavePrefix("abc-123_def.456"))
+			Expect(len(result)).To(BeNumerically("<=", 63))
+		})
+	})
+
+	Context("with invalid characters", func() {
+		It("should replace invalid characters with hyphens and append hash", func() {
+			result := AsDNSName("abc@123")
+			Expect(result).To(HavePrefix("abc-123"))
+			Expect(len(result)).To(BeNumerically("<=", 63))
+
+			result2 := AsDNSName("abc#123")
+			Expect(result2).To(HavePrefix("abc-123"))
+			Expect(len(result2)).To(BeNumerically("<=", 63))
+		})
+
+		It("should handle multiple consecutive invalid characters and append hash", func() {
+			result := AsDNSName("abc@@@123")
+			Expect(result).To(HavePrefix("abc---123"))
+			Expect(len(result)).To(BeNumerically("<=", 63))
+		})
+	})
+
+	Context("with leading and trailing invalid characters", func() {
+		It("should trim leading non-alphanumeric characters and append hash", func() {
+			result := AsDNSName("-abc123")
+			Expect(result).To(HavePrefix("abc123"))
+			Expect(len(result)).To(BeNumerically("<=", 63))
+
+			result2 := AsDNSName("_abc123")
+			Expect(result2).To(HavePrefix("abc123"))
+		})
+
+		It("should trim trailing non-alphanumeric characters and append hash", func() {
+			result := AsDNSName("abc123-")
+			Expect(result).To(HavePrefix("abc123"))
+			Expect(len(result)).To(BeNumerically("<=", 63))
+
+			result2 := AsDNSName("abc123_")
+			Expect(result2).To(HavePrefix("abc123"))
+		})
+
+		It("should trim both leading and trailing non-alphanumeric characters and append hash", func() {
+			result := AsDNSName("-abc123-")
+			Expect(result).To(HavePrefix("abc123"))
+			Expect(len(result)).To(BeNumerically("<=", 63))
+
+			result2 := AsDNSName("@abc123@")
+			Expect(result2).To(HavePrefix("abc123"))
+		})
+	})
+
+	Context("with length constraints", func() {
+		It("should always append hash suffix", func() {
+			shortString := strings.Repeat("a", 10)
+			result := AsDNSName(shortString)
+			Expect(result).To(HavePrefix(shortString))
+			Expect(len(result)).To(Equal(len(shortString) + HashSuffixLength))
+		})
+
+		It("should truncate long strings and append hash", func() {
+			longString := strings.Repeat("a", 100)
+			result := AsDNSName(longString)
+			Expect(len(result)).To(Equal(63))
+			Expect(result).To(HavePrefix(strings.Repeat("a", 55)))
+			hashSuffix := result[55:]
+			Expect(hashSuffix).To(MatchRegexp("^[a-z0-9]{8}$"))
+		})
+
+		It("should differentiate long strings with same prefix using hash", func() {
+			string1 := strings.Repeat("a", 100) + "different-suffix-1"
+			string2 := strings.Repeat("a", 100) + "different-suffix-2"
+
+			result1 := AsDNSName(string1)
+			result2 := AsDNSName(string2)
+
+			Expect(result1).To(HavePrefix(strings.Repeat("a", 55)))
+			Expect(result2).To(HavePrefix(strings.Repeat("a", 55)))
+			Expect(result1[55:]).ToNot(Equal(result2[55:]))
+			Expect(len(result1)).To(Equal(63))
+			Expect(len(result2)).To(Equal(63))
+		})
+
+		It("should generate different DNS names for strings with same first 63 characters", func() {
+			// Two strings that have the same first 63 characters but differ after
+			prefix := strings.Repeat("a", 63)
+			string1 := prefix + "suffix1"
+			string2 := prefix + "suffix2"
+
+			result1 := AsDNSName(string1)
+			result2 := AsDNSName(string2)
+
+			// Both should be truncated to 55 chars + 8 char hash = 63 total
+			Expect(len(result1)).To(Equal(63))
+			Expect(len(result2)).To(Equal(63))
+			// Both should have the same normalized prefix (55 'a's)
+			Expect(result1).To(HavePrefix(strings.Repeat("a", 55)))
+			Expect(result2).To(HavePrefix(strings.Repeat("a", 55)))
+			// But different hash suffixes because the original inputs differ
+			Expect(result1[55:]).ToNot(Equal(result2[55:]), "Strings with same first 63 chars but different overall should have different hash suffixes")
+		})
+	})
+
+	Context("with edge cases", func() {
+		It("should return empty string for empty input", func() {
+			Expect(AsDNSName("")).To(Equal(""))
+		})
+
+		It("should handle strings that become empty after trimming", func() {
+			result := AsDNSName("@@@")
+			Expect(result).To(HavePrefix("x"))
+			Expect(len(result)).To(Equal(1 + HashSuffixLength))
+		})
+
+		It("should handle single character inputs", func() {
+			result := AsDNSName("a")
+			Expect(result).To(HavePrefix("a"))
+			Expect(len(result)).To(Equal(1 + HashSuffixLength))
+
+			result2 := AsDNSName("1")
+			Expect(result2).To(HavePrefix("1"))
+			Expect(len(result2)).To(Equal(1 + HashSuffixLength))
+
+			result3 := AsDNSName("-")
+			Expect(result3).To(HavePrefix("x"))
+			Expect(len(result3)).To(Equal(1 + HashSuffixLength))
+		})
+	})
+
+	Context("with real-world examples", func() {
+		It("should normalize UUIDs and append hash", func() {
+			uuid := "550e8400-e29b-41d4-a716-446655440000"
+			result := AsDNSName(uuid)
+			Expect(result).To(HavePrefix("550e8400-e29b-41d4-a716-446655440000"))
+			// UUID is 36 chars, so result should be 36 + 8 = 44 chars
+			Expect(len(result)).To(Equal(36 + HashSuffixLength))
+		})
+
+		It("should normalize tenant IDs with special characters and append hash", func() {
+			tenantID := "tenant@example.com"
+			result := AsDNSName(tenantID)
+			// '@' is replaced with '-', but '.' is valid and preserved
+			Expect(result).To(HavePrefix("tenant-example.com"))
+			Expect(len(result)).To(BeNumerically("<=", 63))
+		})
+
+		It("should normalize paths and append hash", func() {
+			path := "/path/to/resource"
+			result := AsDNSName(path)
+			Expect(result).To(HavePrefix("path-to-resource"))
+			Expect(len(result)).To(BeNumerically("<=", 63))
+		})
+
+		It("should normalize strings with spaces and append hash", func() {
+			spaced := "my resource name"
+			result := AsDNSName(spaced)
+			Expect(result).To(HavePrefix("my-resource-name"))
+			Expect(len(result)).To(BeNumerically("<=", 63))
+		})
+	})
+
+	Context("with Unicode characters", func() {
+		It("should handle Unicode letters and append hash", func() {
+			// Unicode letters should be converted to lowercase
+			result := AsDNSName("Café")
+			Expect(result).To(HavePrefix("café"))
+			Expect(len(result)).To(Equal(len("café") + HashSuffixLength))
+		})
+
+		It("should replace non-ASCII invalid characters and append hash", func() {
+			result := AsDNSName("test©value")
+			Expect(result).To(HavePrefix("test-value"))
+			Expect(len(result)).To(BeNumerically("<=", 63))
+		})
+	})
+
+	Context("validation against Kubernetes standards", func() {
+		It("should produce values that pass Kubernetes validation", func() {
+			testCases := []string{
+				"abc123",
+				"ABC123",
+				"my-label-value",
+				"my_label_value",
+				"my.label.value",
+				"abc@123",
+				"tenant@example.com",
+				"/path/to/resource",
+				"my resource name",
+				strings.Repeat("a", 100),
+				"---",
+				"@@@",
+			}
+
+			for _, input := range testCases {
+				result := AsDNSName(input)
+				// Verify the result passes Kubernetes validation
+				errs := validation.IsValidLabelValue(result)
+				Expect(errs).To(BeEmpty(), "AsDNSName(%q) = %q should be valid, but got errors: %v", input, result, errs)
+			}
+		})
+	})
+})
+
+var _ = Describe("ListAsDNSName", func() {
+	Context("with empty list", func() {
+		It("should return empty string", func() {
+			result := ListAsDNSName([]string{})
+			Expect(result).To(Equal(""))
+		})
+
+		It("should return empty string for nil input", func() {
+			result := ListAsDNSName(nil)
+			Expect(result).To(Equal(""))
+		})
+	})
+
+	Context("with single element", func() {
+		It("should normalize the single element", func() {
+			result := ListAsDNSName([]string{"Test@String"})
+			Expect(result).To(HavePrefix("test-string"))
+		})
+	})
+
+	Context("with multiple elements", func() {
+		It("should sort, join, and normalize", func() {
+			input := []string{"zebra", "alpha", "beta"}
+			result := ListAsDNSName(input)
+
+			// Verify input is not mutated
+			Expect(input).To(Equal([]string{"zebra", "alpha", "beta"}))
+
+			// Result should be the normalized joined string: "alphabetazebra" (sorted)
+			// The exact result depends on the hash, but it should contain the normalized parts
+			Expect(len(result)).To(BeNumerically("<=", 63))
+			// Verify it's a valid DNS name
+			errs := validation.IsValidLabelValue(result)
+			Expect(errs).To(BeEmpty())
+		})
+
+		It("should handle strings with special characters", func() {
+			input := []string{"test@example.com", "user#123", "path/to/resource"}
+			result := ListAsDNSName(input)
+
+			// After sorting and joining: "path/to/resourcetest@example.comuser#123"
+			// Then normalized
+			Expect(len(result)).To(BeNumerically("<=", 63))
+			errs := validation.IsValidLabelValue(result)
+			Expect(errs).To(BeEmpty())
+		})
+
+		It("should produce consistent results for same input", func() {
+			input := []string{"test", "alpha", "test", "beta"}
+			result1 := ListAsDNSName(input)
+			result2 := ListAsDNSName(input)
+
+			Expect(result1).To(Equal(result2))
+			Expect(len(result1)).To(BeNumerically("<=", 63))
+		})
+
+		It("should handle empty strings in list", func() {
+			input := []string{"test", "", "alpha"}
+			result := ListAsDNSName(input)
+
+			// After sorting: "", "alpha", "test"
+			// Joined: "alphatest" (empty string doesn't contribute)
+			Expect(len(result)).To(BeNumerically("<=", 63))
+			errs := validation.IsValidLabelValue(result)
+			Expect(errs).To(BeEmpty())
+		})
+
+		It("should produce same result regardless of input order", func() {
+			input1 := []string{"alpha", "beta"}
+			input2 := []string{"beta", "alpha"}
+
+			result1 := ListAsDNSName(input1)
+			result2 := ListAsDNSName(input2)
+
+			Expect(result1).To(Equal(result2))
+		})
+
+		It("should handle strings that exceed 63 characters when joined", func() {
+			// Create strings that when joined with dots exceed 63 characters
+			input := []string{
+				strings.Repeat("a", 30),
+				strings.Repeat("b", 30),
+				strings.Repeat("c", 30),
+			}
+			// Joined: "aaa...bbb...ccc..." = 90+ chars, then normalized
+			result := ListAsDNSName(input)
+
+			// Result should be truncated to 63 characters (55 + 8 char hash)
+			Expect(len(result)).To(Equal(63))
+			errs := validation.IsValidLabelValue(result)
+			Expect(errs).To(BeEmpty())
+		})
+	})
+})

--- a/internal/utils/template_parameters_test.go
+++ b/internal/utils/template_parameters_test.go
@@ -14,8 +14,6 @@ language governing permissions and limitations under the License.
 package utils
 
 import (
-	"testing"
-
 	. "github.com/onsi/ginkgo/v2/dsl/core"
 	. "github.com/onsi/gomega"
 	"google.golang.org/grpc/codes"
@@ -25,11 +23,6 @@ import (
 
 	privatev1 "github.com/innabox/fulfillment-service/internal/api/private/v1"
 )
-
-func TestTemplateParameters(t *testing.T) {
-	RegisterFailHandler(Fail)
-	RunSpecs(t, "Template Parameters")
-}
 
 var _ = Describe("ValidateTemplateParameters", func() {
 	var (

--- a/internal/utils/utils_suite_test.go
+++ b/internal/utils/utils_suite_test.go
@@ -1,0 +1,26 @@
+/*
+Copyright (c) 2025 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package utils
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2/dsl/core"
+	. "github.com/onsi/gomega"
+)
+
+func TestUtils(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Utils")
+}


### PR DESCRIPTION
Since virtual machines belonging to a tenant will be created in the same
UDN network, we need to pass tenant's information to VirtualMachine CR.

This change labels the VirtualMachine CR with the tenant ID. The ID is
generated from the aggregation of the tenants available in fulfillment
metadata, along with a hash to comply with Kubernetes naming and avoid
collisions.

I could have just hashed the tenant name, but I think it would help with
maintenance and debugging to have tenant's name in the ID.
