### PR TITLE
Ensure clients receive AlreadyExists error for duplicate identifiers

### DIFF
--- a/internal/database/dao/dao_errors.go
+++ b/internal/database/dao/dao_errors.go
@@ -27,3 +27,14 @@ type ErrNotFound struct {
 func (e *ErrNotFound) Error() string {
 	return fmt.Sprintf("object with identifier '%s' not found", e.ID)
 }
+
+// ErrAlreadyExists is an error type that indicates that an object can't be created because it already exists.
+type ErrAlreadyExists struct {
+	// ID is the identifier of the object that already exists.
+	ID string
+}
+
+// Error returns the error message.
+func (e *ErrAlreadyExists) Error() string {
+	return fmt.Sprintf("object with identifier '%s' already exists", e.ID)
+}

--- a/internal/database/dao/generic_dao_test.go
+++ b/internal/database/dao/generic_dao_test.go
@@ -335,6 +335,24 @@ var _ = Describe("Generic DAO", func() {
 			Expect(object.Metadata).To(BeNil())
 		})
 
+		It("Returns 'already exists' when creating object with existing identifier", func() {
+			// Create an object with a specific identifier:
+			id := uuid.New()
+			_, err := generic.Create(ctx, testsv1.Object_builder{
+				Id: id,
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+
+			// Try to create another object with the same identifier:
+			_, err = generic.Create(ctx, testsv1.Object_builder{
+				Id: id,
+			}.Build())
+			Expect(err).To(HaveOccurred())
+			var alreadyExistsErr *ErrAlreadyExists
+			Expect(errors.As(err, &alreadyExistsErr)).To(BeTrue())
+			Expect(alreadyExistsErr.ID).To(Equal(id))
+		})
+
 		It("Gets object", func() {
 			object, err := generic.Create(ctx, &testsv1.Object{})
 			Expect(err).ToNot(HaveOccurred())

--- a/internal/servers/generic_server.go
+++ b/internal/servers/generic_server.go
@@ -379,6 +379,14 @@ func (s *GenericServer[O]) Create(ctx context.Context, request any, response any
 	}
 	object, err := s.dao.Create(ctx, object)
 	if err != nil {
+		var alreadyExistsErr *dao.ErrAlreadyExists
+		if errors.As(err, &alreadyExistsErr) {
+			return grpcstatus.Errorf(
+				grpccodes.AlreadyExists,
+				"object with identifier '%s' already exists",
+				alreadyExistsErr.ID,
+			)
+		}
 		s.logger.ErrorContext(
 			ctx,
 			"Failed to create",


### PR DESCRIPTION
This change ensures that when clients use the gRPC API to create an object with an identifier that already exists, they receive a proper AlreadyExists error instead of a generic database error. The implementation detects PostgreSQL unique violation errors in the DAO layer and converts them to ErrAlreadyExists, which is then mapped to the appropriate gRPC status code in the server layer.