### PR TITLE
Accept identifiers and names for templates and host classes

### DIFF
--- a/internal/servers/private_clusters_server_test.go
+++ b/internal/servers/private_clusters_server_test.go
@@ -120,6 +120,28 @@ var _ = Describe("Private clusters server", func() {
 				tenants text[] not null default '{}',
 				data jsonb not null
 			);
+
+			create table host_classes (
+				id text not null primary key,
+				name text not null default '',
+				creation_timestamp timestamp with time zone not null default now(),
+				deletion_timestamp timestamp with time zone not null default 'epoch',
+				finalizers text[] not null default '{}',
+				creators text[] not null default '{}',
+				tenants text[] not null default '{}',
+				data jsonb not null
+			);
+
+			create table archived_host_classes (
+				id text not null,
+				name text not null default '',
+				creation_timestamp timestamp with time zone not null,
+				deletion_timestamp timestamp with time zone not null,
+				archival_timestamp timestamp with time zone not null default now(),
+				creators text[] not null default '{}',
+				tenants text[] not null default '{}',
+				data jsonb not null
+			);
 			`,
 		)
 		Expect(err).ToNot(HaveOccurred())

--- a/internal/servers/private_hosts_server.go
+++ b/internal/servers/private_hosts_server.go
@@ -109,6 +109,7 @@ func (s *PrivateHostsServer) Get(ctx context.Context,
 
 func (s *PrivateHostsServer) Create(ctx context.Context,
 	request *privatev1.HostsCreateRequest) (response *privatev1.HostsCreateResponse, err error) {
+	s.setDefaults(request.GetObject())
 	err = s.generic.Create(ctx, request, &response)
 	return
 }
@@ -123,4 +124,10 @@ func (s *PrivateHostsServer) Delete(ctx context.Context,
 	request *privatev1.HostsDeleteRequest) (response *privatev1.HostsDeleteResponse, err error) {
 	err = s.generic.Delete(ctx, request, &response)
 	return
+}
+
+func (s *PrivateHostsServer) setDefaults(host *privatev1.Host) {
+	if !host.HasStatus() {
+		host.SetStatus(&privatev1.HostStatus{})
+	}
 }


### PR DESCRIPTION
This change allows the server to accept both identifiers and names when specifying cluster templates and host classes in cluster creation requests. The server looks up the corresponding object by matching either the identifier or the name field, and then stores the identifier internally. This provides a more flexible API that allows clients to use either identifiers or human-readable names when creating clusters.