### PR TITLE
Add `logs` directory for integration test debugging                 

### DIFF
--- a/.github/workflows/check-pull-request.yaml
+++ b/.github/workflows/check-pull-request.yaml
@@ -69,3 +69,9 @@ jobs:
     - uses: ./.github/actions/setup-go
     - run: |
         ginkgo run -v it
+    - if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: logs
+        path: logs
+        retention-days: 7

--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,5 @@
 *.test
 /dev.yaml
 /fulfillment-service
+/logs
 __debug_bin*

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,8 @@ require (
 	github.com/go-logr/logr v1.4.3
 	github.com/google/uuid v1.6.0
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.27.2
-	github.com/innabox/fulfillment-common v0.0.14
+	github.com/innabox/fulfillment-common v0.0.18
+	github.com/jackc/pgerrcode v0.0.0-20220416144525-469b46aa5efa
 	github.com/json-iterator/go v1.1.12
 	github.com/kelseyhightower/envconfig v1.4.0
 	github.com/open-policy-agent/opa v1.4.0
@@ -53,7 +54,6 @@ require (
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/itchyny/timefmt-go v0.1.6 // indirect
-	github.com/jackc/pgerrcode v0.0.0-20220416144525-469b46aa5efa // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect
 	github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 // indirect
 	github.com/jackc/puddle/v2 v2.2.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -115,8 +115,8 @@ github.com/hashicorp/go-multierror v1.1.1 h1:H5DkEtf6CXdFp0N0Em5UCwQpXMWke8IA0+l
 github.com/hashicorp/go-multierror v1.1.1/go.mod h1:iw975J/qwKPdAO1clOe2L8331t/9/fmwbPZ6JB6eMoM=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
-github.com/innabox/fulfillment-common v0.0.14 h1:GucEuSon7RCKhBv5e6W24Ah4XLQcRQQKd53Docl+vsU=
-github.com/innabox/fulfillment-common v0.0.14/go.mod h1:B860RSo86YZucRU2uNzx5k/0LV85VbWWZKZUmYH7PNY=
+github.com/innabox/fulfillment-common v0.0.18 h1:9/TJ/zAz0Rcmp4KaqJl4YGCtfP1FdL6EXU1xllzZdiE=
+github.com/innabox/fulfillment-common v0.0.18/go.mod h1:B860RSo86YZucRU2uNzx5k/0LV85VbWWZKZUmYH7PNY=
 github.com/itchyny/gojq v0.12.17 h1:8av8eGduDb5+rvEdaOO+zQUjA04MS0m3Ps8HiD+fceg=
 github.com/itchyny/gojq v0.12.17/go.mod h1:WBrEMkgAfAGO1LUcGOckBl5O726KPp+OlkKug0I/FEY=
 github.com/itchyny/timefmt-go v0.1.6 h1:ia3s54iciXDdzWzwaVKXZPbiXzxxnv1SPGFfM/myJ5Q=

--- a/it/it_suite_test.go
+++ b/it/it_suite_test.go
@@ -154,6 +154,11 @@ var _ = BeforeSuite(func() {
 			Expect(err).ToNot(HaveOccurred())
 		})
 	}
+	DeferCleanup(func() {
+		logsDir := filepath.Join(projectDir, "logs")
+		err := cluster.Dump(ctx, logsDir)
+		Expect(err).ToNot(HaveOccurred())
+	})
 
 	// Build the container image:
 	imageTag := time.Now().Format("20060102150405")


### PR DESCRIPTION
Add functionality to dump all pods and logs from the kind cluster before it is deleted, so that they can be inspected for debugging purposes.

The changes include:
- Add `DeferCleanup` hook in `it_suite_test.go` to dump cluster state before cleanup. The dump runs unconditionally, even when `IT_KEEP_KIND` ia `true`, so that debugging information is always available.

- Clear the logs directory before each dump to avoid mixing previous output with current output.

- Add GitHub Actions workflow step to archive the logs directory as an artifact, making it available for download after test runs. The artifact is retained for 7 days.

- Add `/logs` to `.gitignore` to prevent committing dump files.

In order to use the `Dump` method it is also necessary to update to version 0.0.18 of the `fulfillment-common` library.