### PR TITLE
Add `CreateTables` function and refactor tests to use it

### DIFF
--- a/internal/database/dao/dao_tables_test.go
+++ b/internal/database/dao/dao_tables_test.go
@@ -1,0 +1,300 @@
+/*
+Copyright (c) 2025 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package dao
+
+import (
+	"context"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/innabox/fulfillment-service/internal/database"
+)
+
+var _ = Describe("Create tables", func() {
+	var (
+		ctx context.Context
+		tx  database.Tx
+		tm  database.TxManager
+	)
+
+	BeforeEach(func() {
+		var err error
+
+		// Create a context:
+		ctx = context.Background()
+
+		// Prepare the database pool:
+		db := server.MakeDatabase()
+		DeferCleanup(db.Close)
+		pool, err := pgxpool.New(ctx, db.MakeURL())
+		Expect(err).ToNot(HaveOccurred())
+		DeferCleanup(pool.Close)
+
+		// Create the transaction manager:
+		tm, err = database.NewTxManager().
+			SetLogger(logger).
+			SetPool(pool).
+			Build()
+		Expect(err).ToNot(HaveOccurred())
+
+		// Start a transaction and add it to the context:
+		tx, err = tm.Begin(ctx)
+		Expect(err).ToNot(HaveOccurred())
+		DeferCleanup(func() {
+			err := tm.End(ctx, tx)
+			Expect(err).ToNot(HaveOccurred())
+		})
+		ctx = database.TxIntoContext(ctx, tx)
+	})
+
+	// tableExists checks if a table exists in the database.
+	tableExists := func(tableName string) bool {
+		var exists bool
+		err := tx.QueryRow(
+			ctx,
+			`
+			select exists (
+				select from information_schema.tables
+				where table_schema = 'public'
+				and table_name = $1
+			)
+			`,
+			tableName,
+		).Scan(&exists)
+		Expect(err).ToNot(HaveOccurred())
+		return exists
+	}
+
+	// indexExists checks if an index exists in the database.
+	indexExists := func(indexName string) bool {
+		var exists bool
+		err := tx.QueryRow(
+			ctx,
+			`
+			select exists (
+				select from pg_indexes
+				where schemaname = 'public'
+				and indexname = $1
+			)
+			`,
+			indexName,
+		).Scan(&exists)
+		Expect(err).ToNot(HaveOccurred())
+		return exists
+	}
+
+	// columnExists checks if a column exists in a table.
+	columnExists := func(tableName, columnName string) bool {
+		var exists bool
+		err := tx.QueryRow(
+			ctx,
+			`
+			select exists (
+				select from information_schema.columns
+				where table_schema = 'public'
+				and table_name = $1
+				and column_name = $2
+			)
+			`,
+			tableName, columnName,
+		).Scan(&exists)
+		Expect(err).ToNot(HaveOccurred())
+		return exists
+	}
+
+	Describe("Creating tables", func() {
+		It("Creates main table, archived table, and indexes for a single object", func() {
+			// Create tables:
+			err := CreateTables(ctx, "test_object")
+			Expect(err).ToNot(HaveOccurred())
+
+			// Verify main table exists:
+			Expect(tableExists("test_object")).To(BeTrue())
+
+			// Verify archived table exists:
+			Expect(tableExists("archived_test_object")).To(BeTrue())
+
+			// Verify indexes exist:
+			Expect(indexExists("test_object_by_name")).To(BeTrue())
+			Expect(indexExists("test_object_by_owner")).To(BeTrue())
+			Expect(indexExists("test_object_by_tenant")).To(BeTrue())
+		})
+
+		It("Creates tables for multiple objects", func() {
+			// Create tables:
+			err := CreateTables(ctx, "object1", "object2", "object3")
+			Expect(err).ToNot(HaveOccurred())
+
+			// Verify all main tables exist:
+			Expect(tableExists("object1")).To(BeTrue())
+			Expect(tableExists("object2")).To(BeTrue())
+			Expect(tableExists("object3")).To(BeTrue())
+
+			// Verify all archived tables exist:
+			Expect(tableExists("archived_object1")).To(BeTrue())
+			Expect(tableExists("archived_object2")).To(BeTrue())
+			Expect(tableExists("archived_object3")).To(BeTrue())
+
+			// Verify all indexes exist:
+			Expect(indexExists("object1_by_name")).To(BeTrue())
+			Expect(indexExists("object1_by_owner")).To(BeTrue())
+			Expect(indexExists("object1_by_tenant")).To(BeTrue())
+			Expect(indexExists("object2_by_name")).To(BeTrue())
+			Expect(indexExists("object2_by_owner")).To(BeTrue())
+			Expect(indexExists("object2_by_tenant")).To(BeTrue())
+			Expect(indexExists("object3_by_name")).To(BeTrue())
+			Expect(indexExists("object3_by_owner")).To(BeTrue())
+			Expect(indexExists("object3_by_tenant")).To(BeTrue())
+		})
+
+		It("Can be called multiple times without error", func() {
+			// Create tables first time:
+			err := CreateTables(ctx, "test_object")
+			Expect(err).ToNot(HaveOccurred())
+
+			// Create tables second time (should not fail due to "if not exists"):
+			err = CreateTables(ctx, "test_object")
+			Expect(err).ToNot(HaveOccurred())
+
+			// Verify tables still exist:
+			Expect(tableExists("test_object")).To(BeTrue())
+			Expect(tableExists("archived_test_object")).To(BeTrue())
+		})
+
+		It("Creates main table with correct columns", func() {
+			// Create tables:
+			err := CreateTables(ctx, "test_object")
+			Expect(err).ToNot(HaveOccurred())
+
+			// Verify all required columns exist:
+			Expect(columnExists("test_object", "id")).To(BeTrue())
+			Expect(columnExists("test_object", "name")).To(BeTrue())
+			Expect(columnExists("test_object", "creation_timestamp")).To(BeTrue())
+			Expect(columnExists("test_object", "deletion_timestamp")).To(BeTrue())
+			Expect(columnExists("test_object", "finalizers")).To(BeTrue())
+			Expect(columnExists("test_object", "creators")).To(BeTrue())
+			Expect(columnExists("test_object", "tenants")).To(BeTrue())
+			Expect(columnExists("test_object", "data")).To(BeTrue())
+		})
+
+		It("Creates archived table with correct columns", func() {
+			// Create tables:
+			err := CreateTables(ctx, "test_object")
+			Expect(err).ToNot(HaveOccurred())
+
+			// Verify all required columns exist:
+			Expect(columnExists("archived_test_object", "id")).To(BeTrue())
+			Expect(columnExists("archived_test_object", "name")).To(BeTrue())
+			Expect(columnExists("archived_test_object", "creation_timestamp")).To(BeTrue())
+			Expect(columnExists("archived_test_object", "deletion_timestamp")).To(BeTrue())
+			Expect(columnExists("archived_test_object", "archival_timestamp")).To(BeTrue())
+			Expect(columnExists("archived_test_object", "creators")).To(BeTrue())
+			Expect(columnExists("archived_test_object", "tenants")).To(BeTrue())
+			Expect(columnExists("archived_test_object", "data")).To(BeTrue())
+		})
+
+		It("Handles empty object list", func() {
+			// Create tables with no objects:
+			err := CreateTables(ctx)
+			Expect(err).ToNot(HaveOccurred())
+		})
+	})
+
+	Describe("Error handling", func() {
+		It("Returns error when transaction is missing from context", func() {
+			// Create context without transaction:
+			ctxWithoutTx := context.Background()
+
+			// Try to create tables:
+			err := CreateTables(ctxWithoutTx, "test_object")
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("failed to get transaction from context"))
+		})
+	})
+
+	Describe("Table structure", func() {
+		It("Creates main table with primary key on id column", func() {
+			// Create tables:
+			err := CreateTables(ctx, "test_object")
+			Expect(err).ToNot(HaveOccurred())
+
+			// Verify primary key exists:
+			var constraintName string
+			err = tx.QueryRow(
+				ctx,
+				`
+				select constraint_name
+				from information_schema.table_constraints
+				where table_schema = 'public'
+				and table_name = 'test_object'
+				and constraint_type = 'PRIMARY KEY'
+				`,
+			).Scan(&constraintName)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(constraintName).ToNot(BeEmpty())
+		})
+
+		It("Creates indexes with correct types", func() {
+			// Create tables:
+			err := CreateTables(ctx, "test_object")
+			Expect(err).ToNot(HaveOccurred())
+
+			// Verify index types:
+			var indexDef string
+
+			// Check by_name index (should be btree):
+			err = tx.QueryRow(
+				ctx,
+				`
+				select indexdef
+				from pg_indexes
+				where schemaname = 'public'
+				and indexname = 'test_object_by_name'
+				`,
+			).Scan(&indexDef)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(indexDef).To(ContainSubstring("(name)"))
+
+			// Check by_owner index (should be gin):
+			err = tx.QueryRow(
+				ctx,
+				`
+				select indexdef
+				from pg_indexes
+				where schemaname = 'public'
+				and indexname = 'test_object_by_owner'
+				`,
+			).Scan(&indexDef)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(indexDef).To(ContainSubstring("gin"))
+			Expect(indexDef).To(ContainSubstring("creators"))
+
+			// Check by_tenant index (should be gin):
+			err = tx.QueryRow(
+				ctx,
+				`
+				select indexdef
+				from pg_indexes
+				where schemaname = 'public'
+				and indexname = 'test_object_by_tenant'
+				`,
+			).Scan(&indexDef)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(indexDef).To(ContainSubstring("gin"))
+			Expect(indexDef).To(ContainSubstring("tenants"))
+		})
+	})
+})

--- a/internal/database/dao/generic_dao_test.go
+++ b/internal/database/dao/generic_dao_test.go
@@ -194,33 +194,8 @@ var _ = Describe("Generic DAO", func() {
 		var generic *GenericDAO[*testsv1.Object]
 
 		BeforeEach(func() {
-			// Create the table:
-			_, err := tx.Exec(
-				ctx,
-				`
-				create table objects (
-					id text not null primary key,
-					name text not null default '',
-					creation_timestamp timestamp with time zone not null default now(),
-					deletion_timestamp timestamp with time zone not null default 'epoch',
-					finalizers text[] not null default '{}',
-					creators text[] not null default '{}',
-					tenants text[] not null default '{}',
-					data jsonb not null
-				);
-
-				create table archived_objects (
-					id text not null,
-					name text not null default '',
-					creation_timestamp timestamp with time zone not null,
-					deletion_timestamp timestamp with time zone not null,
-					archival_timestamp timestamp with time zone not null default now(),
-					creators text[] not null default '{}',
-					tenants text[] not null default '{}',
-					data jsonb not null
-				);
-				`,
-			)
+			// Create the tables:
+			err := CreateTables(ctx, "objects")
 			Expect(err).ToNot(HaveOccurred())
 
 			// Create the attribution logic:

--- a/internal/servers/cluster_templates_server_test.go
+++ b/internal/servers/cluster_templates_server_test.go
@@ -25,6 +25,7 @@ import (
 	ffv1 "github.com/innabox/fulfillment-service/internal/api/fulfillment/v1"
 	"github.com/innabox/fulfillment-service/internal/auth"
 	"github.com/innabox/fulfillment-service/internal/database"
+	"github.com/innabox/fulfillment-service/internal/database/dao"
 )
 
 var _ = Describe("Cluster templates server", func() {
@@ -69,33 +70,8 @@ var _ = Describe("Cluster templates server", func() {
 		})
 		ctx = database.TxIntoContext(ctx, tx)
 
-		// Create the templates table:
-		_, err = tx.Exec(
-			ctx,
-			`
-			create table cluster_templates (
-				id text not null primary key,
-				name text not null default '',
-				creation_timestamp timestamp with time zone not null default now(),
-				deletion_timestamp timestamp with time zone not null default 'epoch',
-				finalizers text[] not null default '{}',
-				creators text[] not null default '{}',
-				tenants text[] not null default '{}',
-				data jsonb not null
-			);
-
-			create table archived_cluster_templates (
-				id text not null,
-				name text not null default '',
-				creation_timestamp timestamp with time zone not null,
-				deletion_timestamp timestamp with time zone not null,
-				archival_timestamp timestamp with time zone not null default now(),
-				creators text[] not null default '{}',
-				tenants text[] not null default '{}',
-				data jsonb not null
-			);
-			`,
-		)
+		// Create the tables:
+		err = dao.CreateTables(ctx, "cluster_templates")
 		Expect(err).ToNot(HaveOccurred())
 	})
 

--- a/internal/servers/clusters_server_test.go
+++ b/internal/servers/clusters_server_test.go
@@ -77,76 +77,12 @@ var _ = Describe("Clusters server", func() {
 		})
 		ctx = database.TxIntoContext(ctx, tx)
 
-		// Create the table:
-		_, err = tx.Exec(
+		// Create the tables:
+		err = dao.CreateTables(
 			ctx,
-			`
-			create table clusters (
-				id text not null primary key,
-				name text not null default '',
-				creation_timestamp timestamp with time zone not null default now(),
-				deletion_timestamp timestamp with time zone not null default 'epoch',
-				finalizers text[] not null default array ['default'],
-				creators text[] not null default '{}',
-				tenants text[] not null default '{}',
-				data jsonb not null
-			);
-
-			create table archived_clusters (
-				id text not null,
-				name text not null default '',
-				creation_timestamp timestamp with time zone not null,
-				deletion_timestamp timestamp with time zone not null,
-				archival_timestamp timestamp with time zone not null default now(),
-				creators text[] not null default '{}',
-				tenants text[] not null default '{}',
-				data jsonb not null
-			);
-
-			create table cluster_templates (
-				id text not null primary key,
-				name text not null default '',
-				creation_timestamp timestamp with time zone not null default now(),
-				deletion_timestamp timestamp with time zone not null default 'epoch',
-				finalizers text[] not null default array ['default'],
-				creators text[] not null default '{}',
-				tenants text[] not null default '{}',
-				data jsonb not null
-			);
-
-			create table archived_clusters_templates (
-				id text not null,
-				name text not null default '',
-				creation_timestamp timestamp with time zone not null,
-				deletion_timestamp timestamp with time zone not null,
-				archival_timestamp timestamp with time zone not null default now(),
-				creators text[] not null default '{}',
-				tenants text[] not null default '{}',
-				data jsonb not null
-			);
-
-			create table host_classes (
-				id text not null primary key,
-				name text not null default '',
-				creation_timestamp timestamp with time zone not null default now(),
-				deletion_timestamp timestamp with time zone not null default 'epoch',
-				finalizers text[] not null default array ['default'],
-				creators text[] not null default '{}',
-				tenants text[] not null default '{}',
-				data jsonb not null
-			);
-
-			create table archived_host_classes (
-				id text not null,
-				name text not null default '',
-				creation_timestamp timestamp with time zone not null,
-				deletion_timestamp timestamp with time zone not null,
-				archival_timestamp timestamp with time zone not null default now(),
-				creators text[] not null default '{}',
-				tenants text[] not null default '{}',
-				data jsonb not null
-			);
-			`,
+			"cluster_templates",
+			"clusters",
+			"host_classes",
 		)
 		Expect(err).ToNot(HaveOccurred())
 	})

--- a/internal/servers/host_classes_server_test.go
+++ b/internal/servers/host_classes_server_test.go
@@ -25,6 +25,7 @@ import (
 	ffv1 "github.com/innabox/fulfillment-service/internal/api/fulfillment/v1"
 	"github.com/innabox/fulfillment-service/internal/auth"
 	"github.com/innabox/fulfillment-service/internal/database"
+	"github.com/innabox/fulfillment-service/internal/database/dao"
 )
 
 var _ = Describe("Host classes server", func() {
@@ -69,33 +70,8 @@ var _ = Describe("Host classes server", func() {
 		})
 		ctx = database.TxIntoContext(ctx, tx)
 
-		// Create the table:
-		_, err = tx.Exec(
-			ctx,
-			`
-			create table host_classes (
-				id text not null primary key,
-				name text not null default '',
-				creation_timestamp timestamp with time zone not null default now(),
-				deletion_timestamp timestamp with time zone not null default 'epoch',
-				finalizers text[] not null default array ['default'],
-				creators text[] not null default '{}',
-				tenants text[] not null default '{}',
-				data jsonb not null
-			);
-
-			create table archived_host_classes (
-				id text not null,
-				name text not null default '',
-				creation_timestamp timestamp with time zone not null,
-				deletion_timestamp timestamp with time zone not null,
-				archival_timestamp timestamp with time zone not null default now(),
-				creators text[] not null default '{}',
-				tenants text[] not null default '{}',
-				data jsonb not null
-			);
-			`,
-		)
+		// Create the tables:
+		err = dao.CreateTables(ctx, "host_classes")
 		Expect(err).ToNot(HaveOccurred())
 	})
 

--- a/internal/servers/host_pools_server_test.go
+++ b/internal/servers/host_pools_server_test.go
@@ -25,6 +25,7 @@ import (
 	ffv1 "github.com/innabox/fulfillment-service/internal/api/fulfillment/v1"
 	"github.com/innabox/fulfillment-service/internal/auth"
 	"github.com/innabox/fulfillment-service/internal/database"
+	"github.com/innabox/fulfillment-service/internal/database/dao"
 )
 
 var _ = Describe("Host pools server", func() {
@@ -69,33 +70,8 @@ var _ = Describe("Host pools server", func() {
 		})
 		ctx = database.TxIntoContext(ctx, tx)
 
-		// Create the host pools table:
-		_, err = tx.Exec(
-			ctx,
-			`
-			create table host_pools (
-				id text not null primary key,
-				name text not null default '',
-				creation_timestamp timestamp with time zone not null default now(),
-				deletion_timestamp timestamp with time zone not null default 'epoch',
-				finalizers text[] not null default '{}',
-				creators text[] not null default '{}',
-				tenants text[] not null default '{}',
-				data jsonb not null
-			);
-
-			create table archived_host_pools (
-				id text not null,
-				name text not null default '',
-				creation_timestamp timestamp with time zone not null,
-				deletion_timestamp timestamp with time zone not null,
-				archival_timestamp timestamp with time zone not null default now(),
-				creators text[] not null default '{}',
-				tenants text[] not null default '{}',
-				data jsonb not null
-			);
-			`,
-		)
+		// Create the tables:
+		err = dao.CreateTables(ctx, "host_pools")
 		Expect(err).ToNot(HaveOccurred())
 	})
 

--- a/internal/servers/hosts_server_test.go
+++ b/internal/servers/hosts_server_test.go
@@ -25,6 +25,7 @@ import (
 	ffv1 "github.com/innabox/fulfillment-service/internal/api/fulfillment/v1"
 	"github.com/innabox/fulfillment-service/internal/auth"
 	"github.com/innabox/fulfillment-service/internal/database"
+	"github.com/innabox/fulfillment-service/internal/database/dao"
 )
 
 var _ = Describe("Hosts server", func() {
@@ -69,33 +70,8 @@ var _ = Describe("Hosts server", func() {
 		})
 		ctx = database.TxIntoContext(ctx, tx)
 
-		// Create the hosts table:
-		_, err = tx.Exec(
-			ctx,
-			`
-			create table hosts (
-				id text not null primary key,
-				name text not null default '',
-				creation_timestamp timestamp with time zone not null default now(),
-				deletion_timestamp timestamp with time zone not null default 'epoch',
-				finalizers text[] not null default '{}',
-				creators text[] not null default '{}',
-				tenants text[] not null default '{}',
-				data jsonb not null
-			);
-
-			create table archived_hosts (
-				id text not null,
-				name text not null default '',
-				creation_timestamp timestamp with time zone not null,
-				deletion_timestamp timestamp with time zone not null,
-				archival_timestamp timestamp with time zone not null default now(),
-				creators text[] not null default '{}',
-				tenants text[] not null default '{}',
-				data jsonb not null
-			);
-			`,
-		)
+		// Create the tables:
+		err = dao.CreateTables(ctx, "hosts")
 		Expect(err).ToNot(HaveOccurred())
 	})
 

--- a/internal/servers/private_cluster_templates_server_test.go
+++ b/internal/servers/private_cluster_templates_server_test.go
@@ -26,6 +26,7 @@ import (
 	privatev1 "github.com/innabox/fulfillment-service/internal/api/private/v1"
 	"github.com/innabox/fulfillment-service/internal/auth"
 	"github.com/innabox/fulfillment-service/internal/database"
+	"github.com/innabox/fulfillment-service/internal/database/dao"
 )
 
 var _ = Describe("Private cluster templates server", func() {
@@ -71,32 +72,7 @@ var _ = Describe("Private cluster templates server", func() {
 		ctx = database.TxIntoContext(ctx, tx)
 
 		// Create the tables:
-		_, err = tx.Exec(
-			ctx,
-			`
-			create table cluster_templates (
-				id text not null primary key,
-				name text not null default '',
-				creation_timestamp timestamp with time zone not null default now(),
-				deletion_timestamp timestamp with time zone not null default 'epoch',
-				finalizers text[] not null default '{}',
-				creators text[] not null default '{}',
-				tenants text[] not null default '{}',
-				data jsonb not null
-			);
-
-			create table archived_cluster_templates (
-				id text not null,
-				name text not null default '',
-				creation_timestamp timestamp with time zone not null,
-				deletion_timestamp timestamp with time zone not null,
-				archival_timestamp timestamp with time zone not null default now(),
-				creators text[] not null default '{}',
-				tenants text[] not null default '{}',
-				data jsonb not null
-			);
-			`,
-		)
+		err = dao.CreateTables(ctx, "cluster_templates")
 		Expect(err).ToNot(HaveOccurred())
 	})
 

--- a/internal/servers/private_clusters_server_test.go
+++ b/internal/servers/private_clusters_server_test.go
@@ -74,75 +74,11 @@ var _ = Describe("Private clusters server", func() {
 		ctx = database.TxIntoContext(ctx, tx)
 
 		// Create the tables:
-		_, err = tx.Exec(
+		err = dao.CreateTables(
 			ctx,
-			`
-			create table clusters (
-				id text not null primary key,
-				name text not null default '',
-				creation_timestamp timestamp with time zone not null default now(),
-				deletion_timestamp timestamp with time zone not null default 'epoch',
-				finalizers text[] not null default '{}',
-				creators text[] not null default '{}',
-				tenants text[] not null default '{}',
-				data jsonb not null
-			);
-
-			create table archived_clusters (
-				id text not null,
-				name text not null default '',
-				creation_timestamp timestamp with time zone not null,
-				deletion_timestamp timestamp with time zone not null,
-				archival_timestamp timestamp with time zone not null default now(),
-				creators text[] not null default '{}',
-				tenants text[] not null default '{}',
-				data jsonb not null
-			);
-
-			create table cluster_templates (
-				id text not null primary key,
-				name text not null default '',
-				creation_timestamp timestamp with time zone not null default now(),
-				deletion_timestamp timestamp with time zone not null default 'epoch',
-				finalizers text[] not null default '{}',
-				creators text[] not null default '{}',
-				tenants text[] not null default '{}',
-				data jsonb not null
-			);
-
-			create table archived_cluster_templates (
-				id text not null,
-				name text not null default '',
-				creation_timestamp timestamp with time zone not null,
-				deletion_timestamp timestamp with time zone not null,
-				archival_timestamp timestamp with time zone not null default now(),
-				creators text[] not null default '{}',
-				tenants text[] not null default '{}',
-				data jsonb not null
-			);
-
-			create table host_classes (
-				id text not null primary key,
-				name text not null default '',
-				creation_timestamp timestamp with time zone not null default now(),
-				deletion_timestamp timestamp with time zone not null default 'epoch',
-				finalizers text[] not null default '{}',
-				creators text[] not null default '{}',
-				tenants text[] not null default '{}',
-				data jsonb not null
-			);
-
-			create table archived_host_classes (
-				id text not null,
-				name text not null default '',
-				creation_timestamp timestamp with time zone not null,
-				deletion_timestamp timestamp with time zone not null,
-				archival_timestamp timestamp with time zone not null default now(),
-				creators text[] not null default '{}',
-				tenants text[] not null default '{}',
-				data jsonb not null
-			);
-			`,
+			"cluster_templates",
+			"clusters",
+			"host_classes",
 		)
 		Expect(err).ToNot(HaveOccurred())
 	})

--- a/internal/servers/private_host_classes_server_test.go
+++ b/internal/servers/private_host_classes_server_test.go
@@ -25,6 +25,7 @@ import (
 	privatev1 "github.com/innabox/fulfillment-service/internal/api/private/v1"
 	"github.com/innabox/fulfillment-service/internal/auth"
 	"github.com/innabox/fulfillment-service/internal/database"
+	"github.com/innabox/fulfillment-service/internal/database/dao"
 )
 
 var _ = Describe("Private host classes server", func() {
@@ -69,33 +70,8 @@ var _ = Describe("Private host classes server", func() {
 		})
 		ctx = database.TxIntoContext(ctx, tx)
 
-		// Create the templates table:
-		_, err = tx.Exec(
-			ctx,
-			`
-			create table host_classes (
-				id text not null primary key,
-				name text not null default '',
-				creation_timestamp timestamp with time zone not null default now(),
-				deletion_timestamp timestamp with time zone not null default 'epoch',
-				finalizers text[] not null default '{}',
-				creators text[] not null default '{}',
-				tenants text[] not null default '{}',
-				data jsonb not null
-			);
-
-			create table archived_host_classes (
-				id text not null,
-				name text not null default '',
-				creation_timestamp timestamp with time zone not null,
-				deletion_timestamp timestamp with time zone not null,
-				archival_timestamp timestamp with time zone not null default now(),
-				creators text[] not null default '{}',
-				tenants text[] not null default '{}',
-				data jsonb not null
-			);
-			`,
-		)
+		// Create the tables:
+		err = dao.CreateTables(ctx, "host_classes")
 		Expect(err).ToNot(HaveOccurred())
 	})
 

--- a/internal/servers/private_host_pools_server_test.go
+++ b/internal/servers/private_host_pools_server_test.go
@@ -25,6 +25,7 @@ import (
 	privatev1 "github.com/innabox/fulfillment-service/internal/api/private/v1"
 	"github.com/innabox/fulfillment-service/internal/auth"
 	"github.com/innabox/fulfillment-service/internal/database"
+	"github.com/innabox/fulfillment-service/internal/database/dao"
 )
 
 var _ = Describe("Private host pools server", func() {
@@ -69,33 +70,8 @@ var _ = Describe("Private host pools server", func() {
 		})
 		ctx = database.TxIntoContext(ctx, tx)
 
-		// Create the host pools table:
-		_, err = tx.Exec(
-			ctx,
-			`
-			create table host_pools (
-				id text not null primary key,
-				name text not null default '',
-				creation_timestamp timestamp with time zone not null default now(),
-				deletion_timestamp timestamp with time zone not null default 'epoch',
-				finalizers text[] not null default '{}',
-				creators text[] not null default '{}',
-				tenants text[] not null default '{}',
-				data jsonb not null
-			);
-
-			create table archived_host_pools (
-				id text not null,
-				name text not null default '',
-				creation_timestamp timestamp with time zone not null,
-				deletion_timestamp timestamp with time zone not null,
-				archival_timestamp timestamp with time zone not null default now(),
-				creators text[] not null default '{}',
-				tenants text[] not null default '{}',
-				data jsonb not null
-			);
-			`,
-		)
+		// Create the tables:
+		err = dao.CreateTables(ctx, "host_pools")
 		Expect(err).ToNot(HaveOccurred())
 	})
 

--- a/internal/servers/private_hosts_server_test.go
+++ b/internal/servers/private_hosts_server_test.go
@@ -25,6 +25,7 @@ import (
 	privatev1 "github.com/innabox/fulfillment-service/internal/api/private/v1"
 	"github.com/innabox/fulfillment-service/internal/auth"
 	"github.com/innabox/fulfillment-service/internal/database"
+	"github.com/innabox/fulfillment-service/internal/database/dao"
 )
 
 var _ = Describe("Private hosts server", func() {
@@ -69,33 +70,8 @@ var _ = Describe("Private hosts server", func() {
 		})
 		ctx = database.TxIntoContext(ctx, tx)
 
-		// Create the hosts table:
-		_, err = tx.Exec(
-			ctx,
-			`
-			create table hosts (
-				id text not null primary key,
-				name text not null default '',
-				creation_timestamp timestamp with time zone not null default now(),
-				deletion_timestamp timestamp with time zone not null default 'epoch',
-				finalizers text[] not null default '{}',
-				creators text[] not null default '{}',
-				tenants text[] not null default '{}',
-				data jsonb not null
-			);
-
-			create table archived_hosts (
-				id text not null,
-				name text not null default '',
-				creation_timestamp timestamp with time zone not null,
-				deletion_timestamp timestamp with time zone not null,
-				archival_timestamp timestamp with time zone not null default now(),
-				creators text[] not null default '{}',
-				tenants text[] not null default '{}',
-				data jsonb not null
-			);
-			`,
-		)
+		// Create the tables:
+		err = dao.CreateTables(ctx, "hosts")
 		Expect(err).ToNot(HaveOccurred())
 	})
 

--- a/internal/servers/private_hubs_server_test.go
+++ b/internal/servers/private_hubs_server_test.go
@@ -25,6 +25,7 @@ import (
 	privatev1 "github.com/innabox/fulfillment-service/internal/api/private/v1"
 	"github.com/innabox/fulfillment-service/internal/auth"
 	"github.com/innabox/fulfillment-service/internal/database"
+	"github.com/innabox/fulfillment-service/internal/database/dao"
 )
 
 var _ = Describe("Private hubs server", func() {
@@ -69,33 +70,8 @@ var _ = Describe("Private hubs server", func() {
 		})
 		ctx = database.TxIntoContext(ctx, tx)
 
-		// Create the templates table:
-		_, err = tx.Exec(
-			ctx,
-			`
-			create table hubs (
-				id text not null primary key,
-				name text not null default '',
-				creation_timestamp timestamp with time zone not null default now(),
-				deletion_timestamp timestamp with time zone not null default 'epoch',
-				finalizers text[] not null default '{}',
-				creators text[] not null default '{}',
-				tenants text[] not null default '{}',
-				data jsonb not null
-			);
-
-			create table archived_hubs (
-				id text not null,
-				name text not null default '',
-				creation_timestamp timestamp with time zone not null,
-				deletion_timestamp timestamp with time zone not null,
-				archival_timestamp timestamp with time zone not null default now(),
-				creators text[] not null default '{}',
-				tenants text[] not null default '{}',
-				data jsonb not null
-			);
-			`,
-		)
+		// Create the tables:
+		err = dao.CreateTables(ctx, "hubs")
 		Expect(err).ToNot(HaveOccurred())
 	})
 

--- a/internal/servers/private_virtual_machine_templates_server_test.go
+++ b/internal/servers/private_virtual_machine_templates_server_test.go
@@ -26,6 +26,7 @@ import (
 	privatev1 "github.com/innabox/fulfillment-service/internal/api/private/v1"
 	"github.com/innabox/fulfillment-service/internal/auth"
 	"github.com/innabox/fulfillment-service/internal/database"
+	"github.com/innabox/fulfillment-service/internal/database/dao"
 )
 
 var _ = Describe("Private virtual machine templates server", func() {
@@ -71,32 +72,7 @@ var _ = Describe("Private virtual machine templates server", func() {
 		ctx = database.TxIntoContext(ctx, tx)
 
 		// Create the tables:
-		_, err = tx.Exec(
-			ctx,
-			`
-			create table virtual_machine_templates (
-				id text not null primary key,
-				name text not null default '',
-				creation_timestamp timestamp with time zone not null default now(),
-				deletion_timestamp timestamp with time zone not null default 'epoch',
-				finalizers text[] not null default '{}',
-				creators text[] not null default '{}',
-				tenants text[] not null default '{}',
-				data jsonb not null
-			);
-
-			create table archived_virtual_machine_templates (
-				id text not null,
-				name text not null default '',
-				creation_timestamp timestamp with time zone not null,
-				deletion_timestamp timestamp with time zone not null,
-				archival_timestamp timestamp with time zone not null default now(),
-				creators text[] not null default '{}',
-				tenants text[] not null default '{}',
-				data jsonb not null
-			);
-			`,
-		)
+		err = dao.CreateTables(ctx, "virtual_machine_templates")
 		Expect(err).ToNot(HaveOccurred())
 	})
 

--- a/internal/servers/private_virtual_machines_server_test.go
+++ b/internal/servers/private_virtual_machines_server_test.go
@@ -74,53 +74,10 @@ var _ = Describe("Private virtual machines server", func() {
 		ctx = database.TxIntoContext(ctx, tx)
 
 		// Create the tables:
-		_, err = tx.Exec(
+		err = dao.CreateTables(
 			ctx,
-			`
-			create table virtual_machine_templates (
-				id text not null primary key,
-				name text not null default '',
-				creation_timestamp timestamp with time zone not null default now(),
-				deletion_timestamp timestamp with time zone not null default 'epoch',
-				finalizers text[] not null default '{}',
-				creators text[] not null default '{}',
-				tenants text[] not null default '{}',
-				data jsonb not null
-			);
-
-			create table archived_virtual_machine_templates (
-				id text not null,
-				name text not null default '',
-				creation_timestamp timestamp with time zone not null,
-				deletion_timestamp timestamp with time zone not null,
-				archival_timestamp timestamp with time zone not null default now(),
-				creators text[] not null default '{}',
-				tenants text[] not null default '{}',
-				data jsonb not null
-			);
-
-			create table virtual_machines (
-				id text not null primary key,
-				name text not null default '',
-				creation_timestamp timestamp with time zone not null default now(),
-				deletion_timestamp timestamp with time zone not null default 'epoch',
-				finalizers text[] not null default '{}',
-				creators text[] not null default '{}',
-				tenants text[] not null default '{}',
-				data jsonb not null
-			);
-
-			create table archived_virtual_machines (
-				id text not null,
-				name text not null default '',
-				creation_timestamp timestamp with time zone not null,
-				deletion_timestamp timestamp with time zone not null,
-				archival_timestamp timestamp with time zone not null default now(),
-				creators text[] not null default '{}',
-				tenants text[] not null default '{}',
-				data jsonb not null
-			);
-			`,
+			"virtual_machine_templates",
+			"virtual_machines",
 		)
 		Expect(err).ToNot(HaveOccurred())
 	})

--- a/internal/servers/virtual_machine_templates_server_test.go
+++ b/internal/servers/virtual_machine_templates_server_test.go
@@ -26,6 +26,7 @@ import (
 	ffv1 "github.com/innabox/fulfillment-service/internal/api/fulfillment/v1"
 	"github.com/innabox/fulfillment-service/internal/auth"
 	"github.com/innabox/fulfillment-service/internal/database"
+	"github.com/innabox/fulfillment-service/internal/database/dao"
 )
 
 var _ = Describe("Virtual machine templates server", func() {
@@ -71,32 +72,8 @@ var _ = Describe("Virtual machine templates server", func() {
 		ctx = database.TxIntoContext(ctx, tx)
 
 		// Create the tables:
-		_, err = tx.Exec(
-			ctx,
-			`
-			create table virtual_machine_templates (
-				id text not null primary key,
-				name text not null default '',
-				creation_timestamp timestamp with time zone not null default now(),
-				deletion_timestamp timestamp with time zone not null default 'epoch',
-				finalizers text[] not null default '{}',
-				creators text[] not null default '{}',
-				tenants text[] not null default '{}',
-				data jsonb not null
-			);
-
-			create table archived_virtual_machine_templates (
-				id text not null,
-				name text not null default '',
-				creation_timestamp timestamp with time zone not null,
-				deletion_timestamp timestamp with time zone not null,
-				archival_timestamp timestamp with time zone not null default now(),
-				creators text[] not null default '{}',
-				tenants text[] not null default '{}',
-				data jsonb not null
-			);
-			`,
-		)
+		err = dao.CreateTables(ctx, "virtual_machine_templates")
+		Expect(err).ToNot(HaveOccurred())
 		Expect(err).ToNot(HaveOccurred())
 	})
 

--- a/internal/servers/virtual_machines_server_test.go
+++ b/internal/servers/virtual_machines_server_test.go
@@ -75,53 +75,10 @@ var _ = Describe("Virtual machines server", func() {
 		ctx = database.TxIntoContext(ctx, tx)
 
 		// Create the tables:
-		_, err = tx.Exec(
+		err = dao.CreateTables(
 			ctx,
-			`
-			create table virtual_machine_templates (
-				id text not null primary key,
-				name text not null default '',
-				creation_timestamp timestamp with time zone not null default now(),
-				deletion_timestamp timestamp with time zone not null default 'epoch',
-				finalizers text[] not null default '{}',
-				creators text[] not null default '{}',
-				tenants text[] not null default '{}',
-				data jsonb not null
-			);
-
-			create table archived_virtual_machine_templates (
-				id text not null,
-				name text not null default '',
-				creation_timestamp timestamp with time zone not null,
-				deletion_timestamp timestamp with time zone not null,
-				archival_timestamp timestamp with time zone not null default now(),
-				creators text[] not null default '{}',
-				tenants text[] not null default '{}',
-				data jsonb not null
-			);
-
-			create table virtual_machines (
-				id text not null primary key,
-				name text not null default '',
-				creation_timestamp timestamp with time zone not null default now(),
-				deletion_timestamp timestamp with time zone not null default 'epoch',
-				finalizers text[] not null default '{}',
-				creators text[] not null default '{}',
-				tenants text[] not null default '{}',
-				data jsonb not null
-			);
-
-			create table archived_virtual_machines (
-				id text not null,
-				name text not null default '',
-				creation_timestamp timestamp with time zone not null,
-				deletion_timestamp timestamp with time zone not null,
-				archival_timestamp timestamp with time zone not null default now(),
-				creators text[] not null default '{}',
-				tenants text[] not null default '{}',
-				data jsonb not null
-			);
-			`,
+			"virtual_machine_templates",
+			"virtual_machines",
 		)
 		Expect(err).ToNot(HaveOccurred())
 	})


### PR DESCRIPTION
Add a new `CreateTables` function in the `dao` package that creates tables, indexes, and archived tables for multiple objects. The function retrieves the transaction from the context and uses it to run the SQL statements.

Refactor all unit tests that were creating tables directly using SQL statements to use the new `CreateTables` function instead. This ensures consistency across the codebase and makes table creation more maintainable.