### PR TITLE
Rename kind cluster from 'it' to 'fulfillment-service-it'

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,7 +226,7 @@ $ ginkgo run it
 ```
 
 The integration tests will automatically:
-1. Create a kind cluster named "it".
+1. Create a kind cluster named "fulfillment-service-it".
 2. Build and load the container image.
 3. Deploy the fulfillment service.
 4. Run all test cases.
@@ -259,5 +259,5 @@ run any actual test.
 To clean up a preserved cluster manually:
 
 ```bash
-$ kind delete cluster --name it
+$ kind delete cluster --name fulfillment-service-it
 ```

--- a/it/it_suite_test.go
+++ b/it/it_suite_test.go
@@ -141,7 +141,7 @@ var _ = BeforeSuite(func() {
 	// Start the cluster, and remember to stop it:
 	cluster, err = NewKind().
 		SetLogger(logger).
-		SetName("it").
+		SetName("fulfillment-service-it").
 		AddCrdFile(filepath.Join("crds", "clusterorders.cloudkit.openshift.io.yaml")).
 		AddCrdFile(filepath.Join("crds", "hostedclusters.hypershift.openshift.io.yaml")).
 		Build()


### PR DESCRIPTION
Rename the kind cluster used for integration tests to avoid conflicts with similar clusters used by other projects, in particular the CLI.