### PR TITLE
Explicitly use `Always` certificate rotation policy

### DIFF
--- a/charts/ca/templates/certificate.yaml
+++ b/charts/ca/templates/certificate.yaml
@@ -23,3 +23,5 @@ spec:
     kind: Issuer
     name: {{ .Values.issuerName }}
   secretName: {{ .Values.issuerName }}
+  privateKey:
+    rotationPolicy: Always

--- a/charts/keycloak/templates/database/client-cert.yaml
+++ b/charts/keycloak/templates/database/client-cert.yaml
@@ -26,5 +26,6 @@ spec:
   secretName: keycloak-database-client-cert
   privateKey:
     encoding: PKCS8
+    rotationPolicy: Always
   additionalOutputFormats:
   - type: DER

--- a/charts/keycloak/templates/database/server-cert.yaml
+++ b/charts/keycloak/templates/database/server-cert.yaml
@@ -26,3 +26,5 @@ spec:
   - keycloak-database.{{ .Release.Namespace }}
   - keycloak-database.{{ .Release.Namespace }}.svc.cluster.local
   secretName: keycloak-database-server-cert
+  privateKey:
+    rotationPolicy: Always

--- a/charts/keycloak/templates/service/server-cert.yaml
+++ b/charts/keycloak/templates/service/server-cert.yaml
@@ -23,3 +23,5 @@ spec:
   dnsNames:
   - {{ required "hostname is required" .Values.hostname }}
   secretName: keycloak-tls-cert
+  privateKey:
+    rotationPolicy: Always

--- a/charts/service/templates/authorino/certificate.yaml
+++ b/charts/service/templates/authorino/certificate.yaml
@@ -25,3 +25,5 @@ spec:
   - authorino-authorino-authorization.{{ .Release.Namespace }}
   - authorino-authorino-authorization.{{ .Release.Namespace }}.svc.cluster.local
   secretName: authorino-tls
+  privateKey:
+    rotationPolicy: Always

--- a/charts/service/templates/database/client-cert.yaml
+++ b/charts/service/templates/database/client-cert.yaml
@@ -24,3 +24,5 @@ spec:
   - client auth
   commonName: client
   secretName: fulfillment-database-client-cert
+  privateKey:
+    rotationPolicy: Always

--- a/charts/service/templates/database/server-cert.yaml
+++ b/charts/service/templates/database/server-cert.yaml
@@ -25,3 +25,5 @@ spec:
   - fulfillment-database.{{ .Release.Namespace }}
   - fulfillment-database.{{ .Release.Namespace }}.svc.cluster.local
   secretName: fulfillment-database-server-cert
+  privateKey:
+    rotationPolicy: Always

--- a/charts/service/templates/service/certificate.yaml
+++ b/charts/service/templates/service/certificate.yaml
@@ -29,3 +29,5 @@ spec:
   - {{ .Values.hostname }}
   {{- end }}
   secretName: fulfillment-service-tls
+  privateKey:
+    rotationPolicy: Always


### PR DESCRIPTION
This is the default anyhow, but it causes warnings if not explicitly set.