### PR TITLE
Allow virtualmachines to be updated

### DIFF
--- a/internal/controllers/vm/vm_reconciler_function.go
+++ b/internal/controllers/vm/vm_reconciler_function.go
@@ -137,11 +137,6 @@ func (t *task) update(ctx context.Context) error {
 	// Set the default values:
 	t.setDefaults()
 
-	// Do nothing if the VM isn't progressing:
-	if t.vm.GetStatus().GetState() != privatev1.VirtualMachineState_VIRTUAL_MACHINE_STATE_PROGRESSING {
-		return nil
-	}
-
 	// Select the hub:
 	err := t.selectHub(ctx)
 	if err != nil {


### PR DESCRIPTION
This change enables virtualmachines to be updated at any phases of their
lifecycle (the case of deletion will be handled in 
https://github.com/innabox/issues/issues/219).

https://github.com/innabox/issues/issues/309