### PR TITLE
Add support for explicitly setting the assigned tenant

### DIFF
--- a/internal/auth/default_tenancy_logic.go
+++ b/internal/auth/default_tenancy_logic.go
@@ -78,14 +78,26 @@ func (b *DefaultTenancyLogicBuilder) Build() (result *DefaultTenancyLogic, err e
 	return
 }
 
-// DetermineAssignedTenants extracts the subject from the auth context and returns the identifiers of the tenants.
-func (p *DefaultTenancyLogic) DetermineAssignedTenants(ctx context.Context) (result collections.Set[string], err error) {
+// DetermineAssignableTenants extracts the subject from the auth context and returns the identifiers of the tenants
+// that can be assigned to objects.
+func (p *DefaultTenancyLogic) DetermineAssignableTenants(ctx context.Context) (result collections.Set[string], err error) {
 	subject := SubjectFromContext(ctx)
 	delegate, err := p.selectDelegate(subject)
 	if err != nil {
 		return
 	}
-	return delegate.DetermineAssignedTenants(ctx)
+	return delegate.DetermineAssignableTenants(ctx)
+}
+
+// DetermineDefaultTenants extracts the subject from the auth context and returns the identifiers of the tenants
+// that will be assigned by default to objects.
+func (p *DefaultTenancyLogic) DetermineDefaultTenants(ctx context.Context) (result collections.Set[string], err error) {
+	subject := SubjectFromContext(ctx)
+	delegate, err := p.selectDelegate(subject)
+	if err != nil {
+		return
+	}
+	return delegate.DetermineDefaultTenants(ctx)
 }
 
 // DetermineVisibleTenants extracts the subject from the auth context and returns the identifiers of the tenants

--- a/internal/auth/empty_tenancy_logic.go
+++ b/internal/auth/empty_tenancy_logic.go
@@ -51,8 +51,14 @@ func (b *EmptyTenancyLogicBuilder) Build() (result *EmptyTenancyLogic, err error
 	return
 }
 
-// DetermineAssignedTenants returns an empty set of tenants.
-func (p *EmptyTenancyLogic) DetermineAssignedTenants(_ context.Context) (result collections.Set[string], err error) {
+// DetermineAssignableTenants returns an universal set of tenants.
+func (p *EmptyTenancyLogic) DetermineAssignableTenants(_ context.Context) (result collections.Set[string], err error) {
+	result = collections.NewUniversal[string]()
+	return
+}
+
+// DetermineDefaultTenants returns an empty set of tenants.
+func (p *EmptyTenancyLogic) DetermineDefaultTenants(_ context.Context) (result collections.Set[string], err error) {
 	result = collections.NewEmptySet[string]()
 	return
 }

--- a/internal/auth/empty_tenancy_logic_test.go
+++ b/internal/auth/empty_tenancy_logic_test.go
@@ -40,15 +40,27 @@ var _ = Describe("Empty tenancy logic", func() {
 		Expect(logic).ToNot(BeNil())
 	})
 
-	It("Should return an empty list of tenants", func() {
-		result, err := logic.DetermineAssignedTenants(ctx)
-		Expect(err).ToNot(HaveOccurred())
-		Expect(result.Empty()).To(BeTrue())
+	Describe("Determine assignable tenants", func() {
+		It("Should return the universal set of tenants", func() {
+			result, err := logic.DetermineAssignableTenants(ctx)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result.Universal()).To(BeTrue())
+		})
 	})
 
-	It("Should return an empty list of visible tenants", func() {
-		result, err := logic.DetermineVisibleTenants(ctx)
-		Expect(err).ToNot(HaveOccurred())
-		Expect(result.Universal()).To(BeTrue())
+	Describe("Determine default tenants", func() {
+		It("Should return an empty set of tenants", func() {
+			result, err := logic.DetermineDefaultTenants(ctx)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result.Empty()).To(BeTrue())
+		})
+	})
+
+	Describe("Determine visible tenants", func() {
+		It("Should return an universal set of tenants", func() {
+			result, err := logic.DetermineVisibleTenants(ctx)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result.Universal()).To(BeTrue())
+		})
 	})
 })

--- a/internal/auth/guest_tenancy_logic.go
+++ b/internal/auth/guest_tenancy_logic.go
@@ -52,15 +52,24 @@ func (b *GuestTenancyLogicBuilder) Build() (result *GuestTenancyLogic, err error
 	return
 }
 
-// DetermineAssignedTenants returns a set containing only the guest tenant, regardless of the user's identity.
-func (p *GuestTenancyLogic) DetermineAssignedTenants(_ context.Context) (result collections.Set[string], err error) {
-	result = collections.NewSet("guest")
+// DetermineAssignableTenants returns a set containing only the guest tenant, regardless of the user's identity.
+func (p *GuestTenancyLogic) DetermineAssignableTenants(_ context.Context) (result collections.Set[string], err error) {
+	result = GuestTenants
+	return
+}
+
+// DetermineDefaultTenants returns a set containing only the guest tenant, regardless of the user's identity.
+func (p *GuestTenancyLogic) DetermineDefaultTenants(_ context.Context) (result collections.Set[string], err error) {
+	result = GuestTenants
 	return
 }
 
 // DetermineVisibleTenants returns a set containing both the guest and shared tenants, allowing guest users to see
 // objects from both tenants.
 func (p *GuestTenancyLogic) DetermineVisibleTenants(_ context.Context) (result collections.Set[string], err error) {
-	result = collections.NewSet("guest", "shared")
+	result = GuestTenants.Union(SharedTenants)
 	return
 }
+
+// GuestTenants is the set of tenants that are assigned to guest users.
+var GuestTenants = collections.NewSet("guest")

--- a/internal/auth/guest_tenancy_logic_test.go
+++ b/internal/auth/guest_tenancy_logic_test.go
@@ -40,17 +40,27 @@ var _ = Describe("Guest tenancy logic", func() {
 		Expect(logic).ToNot(BeNil())
 	})
 
-	It("Should return the guest tenant", func() {
-		result, err := logic.DetermineAssignedTenants(ctx)
-		Expect(err).ToNot(HaveOccurred())
-		Expect(result.Contains("guest")).To(BeTrue())
-		Expect(result.Contains("shared")).To(BeFalse())
+	Describe("Determine assignable tenants", func() {
+		It("Should return the guest tenant", func() {
+			result, err := logic.DetermineAssignableTenants(ctx)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result.Equal(GuestTenants)).To(BeTrue())
+		})
 	})
 
-	It("Should return guest and shared as visible tenants", func() {
-		result, err := logic.DetermineVisibleTenants(ctx)
-		Expect(err).ToNot(HaveOccurred())
-		Expect(result.Contains("guest")).To(BeTrue())
-		Expect(result.Contains("shared")).To(BeTrue())
+	Describe("Determine default tenants", func() {
+		It("Should return the guest tenant", func() {
+			result, err := logic.DetermineDefaultTenants(ctx)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result.Equal(GuestTenants)).To(BeTrue())
+		})
+	})
+
+	Describe("Determine visible tenants", func() {
+		It("Should return the guest and shared tenants", func() {
+			result, err := logic.DetermineVisibleTenants(ctx)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result.Equal(GuestTenants.Union(SharedTenants))).To(BeTrue())
+		})
 	})
 })

--- a/internal/auth/service_account_tenancy_logic.go
+++ b/internal/auth/service_account_tenancy_logic.go
@@ -61,8 +61,10 @@ func (b *ServiceAccountTenancyLogicBuilder) Build() (result *ServiceAccountTenan
 	return
 }
 
-// DetermineAssignedTenants extracts the subject from the auth context and returns the identifiers of the tenants.
-func (p *ServiceAccountTenancyLogic) DetermineAssignedTenants(ctx context.Context) (result collections.Set[string], err error) {
+// DetermineAssignableTenants extracts the subject from the auth context and returns the identifiers of the tenants
+// that can be assigned to objects.
+func (p *ServiceAccountTenancyLogic) DetermineAssignableTenants(ctx context.Context) (result collections.Set[string],
+	err error) {
 	// Objects created by a service account are assigned to a tenant that is the namespace of the service account.
 	namespace, err := p.extractNamespace(ctx)
 	if err != nil {
@@ -72,11 +74,20 @@ func (p *ServiceAccountTenancyLogic) DetermineAssignedTenants(ctx context.Contex
 	return
 }
 
+// DetermineDefaultTenants extracts the subject from the auth context and returns the identifiers of the tenants
+// that will be assigned by default to objects.
+func (p *ServiceAccountTenancyLogic) DetermineDefaultTenants(ctx context.Context) (result collections.Set[string],
+	err error) {
+	result, err = p.DetermineAssignableTenants(ctx)
+	return
+}
+
 // DetermineVisibleTenants extracts the subject from the auth context and returns the identifiers of the tenants
 // that the current user has permission to see.
-func (p *ServiceAccountTenancyLogic) DetermineVisibleTenants(ctx context.Context) (result collections.Set[string], err error) {
-	// A service account can see the resources correponding to the tenant with the same name as the namespace of the
-	// service account, as well as the shared tenant.
+func (p *ServiceAccountTenancyLogic) DetermineVisibleTenants(ctx context.Context) (result collections.Set[string],
+	err error) {
+	// A service account can see the resources correponding to the tenant with the same name as the namespace of
+	// the service account, as well as the shared tenant.
 	namespace, err := p.extractNamespace(ctx)
 	if err != nil {
 		return

--- a/internal/auth/system_tenancy_logic.go
+++ b/internal/auth/system_tenancy_logic.go
@@ -53,8 +53,15 @@ func (b *SystemTenancyLogicBuilder) Build() (result *SystemTenancyLogic, err err
 	return
 }
 
-// DetermineAssignedTenants returns the shared tenant for objects created through the private API.
-func (p *SystemTenancyLogic) DetermineAssignedTenants(_ context.Context) (result collections.Set[string], err error) {
+// DetermineAssignableTenants returns a universal set of tenants, which allows the private API to assign objects to any
+// tenant.
+func (p *SystemTenancyLogic) DetermineAssignableTenants(_ context.Context) (result collections.Set[string], err error) {
+	result = AllTenants
+	return
+}
+
+// DetermineDefaultTenants returns the shared tenant for objects created through the private API.
+func (p *SystemTenancyLogic) DetermineDefaultTenants(_ context.Context) (result collections.Set[string], err error) {
 	result = SharedTenants
 	return
 }

--- a/internal/auth/system_tenancy_logic_test.go
+++ b/internal/auth/system_tenancy_logic_test.go
@@ -16,7 +16,6 @@ package auth
 import (
 	"context"
 
-	"github.com/innabox/fulfillment-service/internal/collections"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
@@ -41,15 +40,27 @@ var _ = Describe("System tenancy logic", func() {
 		Expect(logic).ToNot(BeNil())
 	})
 
-	It("Returns the shared tenant for assigned tenants", func() {
-		result, err := logic.DetermineAssignedTenants(ctx)
-		Expect(err).ToNot(HaveOccurred())
-		Expect(result.Equal(collections.NewSet("shared"))).To(BeTrue())
+	Describe("Determine assignable tenants", func() {
+		It("Returns the universal set of tenants", func() {
+			result, err := logic.DetermineAssignableTenants(ctx)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result.Universal()).To(BeTrue())
+		})
 	})
 
-	It("Returns an empty list of visible tenants to disable filtering", func() {
-		result, err := logic.DetermineVisibleTenants(ctx)
-		Expect(err).ToNot(HaveOccurred())
-		Expect(result.Universal()).To(BeTrue())
+	Describe("Determine default tenants", func() {
+		It("Returns the shared tenant", func() {
+			result, err := logic.DetermineDefaultTenants(ctx)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result.Equal(SharedTenants)).To(BeTrue())
+		})
+	})
+
+	Describe("Determine visible tenants", func() {
+		It("Returns the universal set of tenants", func() {
+			result, err := logic.DetermineVisibleTenants(ctx)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result.Universal()).To(BeTrue())
+		})
 	})
 })

--- a/internal/auth/tenancy_logic.go
+++ b/internal/auth/tenancy_logic.go
@@ -23,16 +23,22 @@ import (
 //
 //go:generate mockgen -destination=tenancy_logic_mock.go -package=auth . TenancyLogic
 type TenancyLogic interface {
-	// DetermineAssignedTenants calculates and returns the list of tenant names that should be assigned to an object
-	// being created. The context will contain authentication and authorization information that can be used to
-	// determine the appropriate tenants.
-	DetermineAssignedTenants(ctx context.Context) (collections.Set[string], error)
+	// DetermineAssignableTenants calculates and returns the list of tenant names that can be assigned to an object
+	// that is being created or updated. This should be a superset of the default tenants.
+	DetermineAssignableTenants(ctx context.Context) (collections.Set[string], error)
+
+	// DetermineDefaultTenants calculates and returns the list of tenant names that are assigned by default when an
+	// object is created without an explicit tenant request. This should be a subset of the assignable tenants.
+	DetermineDefaultTenants(ctx context.Context) (collections.Set[string], error)
 
 	// DetermineVisibleTenants calculates and returns the list of tenant names that the current user has permission
 	// to see. Database queries will be filtered to only return objects where the tenants column has a non-empty
 	// intersection with the values returned by this method.
 	DetermineVisibleTenants(ctx context.Context) (collections.Set[string], error)
 }
+
+// SystemTenants is the set of tenants that are assigned to objects that are only visible to the system.
+var SystemTenants = collections.NewSet("system")
 
 // SharedTenants is the set of tenants that are always visible to all users.
 var SharedTenants = collections.NewSet("shared")

--- a/internal/auth/tenancy_logic_mock.go
+++ b/internal/auth/tenancy_logic_mock.go
@@ -41,19 +41,34 @@ func (m *MockTenancyLogic) EXPECT() *MockTenancyLogicMockRecorder {
 	return m.recorder
 }
 
-// DetermineAssignedTenants mocks base method.
-func (m *MockTenancyLogic) DetermineAssignedTenants(ctx context.Context) (collections.Set[string], error) {
+// DetermineAssignableTenants mocks base method.
+func (m *MockTenancyLogic) DetermineAssignableTenants(ctx context.Context) (collections.Set[string], error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DetermineAssignedTenants", ctx)
+	ret := m.ctrl.Call(m, "DetermineAssignableTenants", ctx)
 	ret0, _ := ret[0].(collections.Set[string])
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// DetermineAssignedTenants indicates an expected call of DetermineAssignedTenants.
-func (mr *MockTenancyLogicMockRecorder) DetermineAssignedTenants(ctx any) *gomock.Call {
+// DetermineAssignableTenants indicates an expected call of DetermineAssignableTenants.
+func (mr *MockTenancyLogicMockRecorder) DetermineAssignableTenants(ctx any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DetermineAssignedTenants", reflect.TypeOf((*MockTenancyLogic)(nil).DetermineAssignedTenants), ctx)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DetermineAssignableTenants", reflect.TypeOf((*MockTenancyLogic)(nil).DetermineAssignableTenants), ctx)
+}
+
+// DetermineDefaultTenants mocks base method.
+func (m *MockTenancyLogic) DetermineDefaultTenants(ctx context.Context) (collections.Set[string], error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DetermineDefaultTenants", ctx)
+	ret0, _ := ret[0].(collections.Set[string])
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DetermineDefaultTenants indicates an expected call of DetermineDefaultTenants.
+func (mr *MockTenancyLogicMockRecorder) DetermineDefaultTenants(ctx any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DetermineDefaultTenants", reflect.TypeOf((*MockTenancyLogic)(nil).DetermineDefaultTenants), ctx)
 }
 
 // DetermineVisibleTenants mocks base method.

--- a/internal/database/dao/generic_dao_tenancy_test.go
+++ b/internal/database/dao/generic_dao_tenancy_test.go
@@ -1,0 +1,654 @@
+/*
+Copyright (c) 2025 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package dao
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"go.uber.org/mock/gomock"
+
+	testsv1 "github.com/innabox/fulfillment-service/internal/api/tests/v1"
+	"github.com/innabox/fulfillment-service/internal/auth"
+	"github.com/innabox/fulfillment-service/internal/collections"
+	"github.com/innabox/fulfillment-service/internal/database"
+)
+
+var _ = Describe("Tenancy logic", func() {
+	var (
+		ctrl *gomock.Controller
+		ctx  context.Context
+		tx   database.Tx
+	)
+
+	BeforeEach(func() {
+		var err error
+
+		// Create the mock controller:
+		ctrl = gomock.NewController(GinkgoT())
+		DeferCleanup(ctrl.Finish)
+
+		// Create a context:
+		ctx = context.Background()
+
+		// Prepare the database pool:
+		db := server.MakeDatabase()
+		DeferCleanup(db.Close)
+		pool, err := pgxpool.New(ctx, db.MakeURL())
+		Expect(err).ToNot(HaveOccurred())
+		DeferCleanup(pool.Close)
+
+		// Create the transaction manager:
+		tm, err := database.NewTxManager().
+			SetLogger(logger).
+			SetPool(pool).
+			Build()
+		Expect(err).ToNot(HaveOccurred())
+
+		// Start a transaction and add it to the context:
+		tx, err = tm.Begin(ctx)
+		Expect(err).ToNot(HaveOccurred())
+		DeferCleanup(func() {
+			err := tm.End(ctx, tx)
+			Expect(err).ToNot(HaveOccurred())
+		})
+		ctx = database.TxIntoContext(ctx, tx)
+
+		// Create the objects table:
+		err = CreateTables(ctx, "objects")
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	It("When an object is created, it only shows the visible tenants", func() {
+		// Create a tenancy logic that assigns a visible tenant and an invisible one:
+		tenancy := auth.NewMockTenancyLogic(ctrl)
+		tenancy.EXPECT().DetermineAssignableTenants(gomock.Any()).
+			Return(
+				collections.NewSet(
+					"tenant-a",
+					"tenant-b",
+				),
+				nil,
+			).
+			AnyTimes()
+		tenancy.EXPECT().DetermineDefaultTenants(gomock.Any()).
+			Return(
+				collections.NewSet(
+					"tenant-a",
+					"tenant-b",
+				),
+				nil,
+			).
+			AnyTimes()
+		tenancy.EXPECT().DetermineVisibleTenants(gomock.Any()).
+			Return(
+				collections.NewSet(
+					"tenant-a",
+				),
+				nil,
+			).
+			AnyTimes()
+
+		// Create the DAO:
+		dao, err := NewGenericDAO[*testsv1.Object]().
+			SetLogger(logger).
+			SetTable("objects").
+			SetTenancyLogic(tenancy).
+			Build()
+		Expect(err).ToNot(HaveOccurred())
+
+		// Create an object and verify that it only shows the visible tenant:
+		object, err := dao.Create(ctx, testsv1.Object_builder{}.Build())
+		Expect(err).ToNot(HaveOccurred())
+		Expect(object.GetMetadata().GetTenants()).To(ConsistOf("tenant-a"))
+
+		// Verify that both tenants have been saved in the database:
+		var tenants []string
+		row := tx.QueryRow(ctx, "select tenants from objects where id = $1", object.GetId())
+		err = row.Scan(&tenants)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(tenants).To(ConsistOf("tenant-a", "tenant-b"))
+	})
+
+	It("When an object is retrieved by identifier, it only shows the visible tenants", func() {
+		// Create a tenancy logic that assigns a visible tenant and an invisible one:
+		tenancy := auth.NewMockTenancyLogic(ctrl)
+		tenancy.EXPECT().DetermineAssignableTenants(gomock.Any()).
+			Return(
+				collections.NewSet(
+					"tenant-a",
+					"tenant-b",
+				),
+				nil,
+			).
+			AnyTimes()
+		tenancy.EXPECT().DetermineDefaultTenants(gomock.Any()).
+			Return(
+				collections.NewSet(
+					"tenant-a",
+					"tenant-b",
+				),
+				nil,
+			).
+			AnyTimes()
+		tenancy.EXPECT().DetermineVisibleTenants(gomock.Any()).
+			Return(
+				collections.NewSet(
+					"tenant-a",
+				),
+				nil,
+			).
+			AnyTimes()
+
+		// Create the DAO:
+		dao, err := NewGenericDAO[*testsv1.Object]().
+			SetLogger(logger).
+			SetTable("objects").
+			SetTenancyLogic(tenancy).
+			Build()
+		Expect(err).ToNot(HaveOccurred())
+
+		// Create an object:
+		object, err := dao.Create(ctx, testsv1.Object_builder{}.Build())
+		Expect(err).ToNot(HaveOccurred())
+
+		// Retrieve the object and verify that it only shows the visible tenant:
+		object, err = dao.Get(ctx, object.GetId())
+		Expect(err).ToNot(HaveOccurred())
+		Expect(object.GetMetadata().GetTenants()).To(ConsistOf("tenant-a"))
+	})
+
+	It("When an object is retrieved by list, it only shows the visible tenants", func() {
+		// Create a tenancy logic that assigns a visible tenant and an invisible one:
+		tenancy := auth.NewMockTenancyLogic(ctrl)
+		tenancy.EXPECT().DetermineAssignableTenants(gomock.Any()).
+			Return(
+				collections.NewSet(
+					"tenant-a",
+					"tenant-b",
+				),
+				nil,
+			).
+			AnyTimes()
+		tenancy.EXPECT().DetermineDefaultTenants(gomock.Any()).
+			Return(
+				collections.NewSet(
+					"tenant-a",
+					"tenant-b",
+				),
+				nil,
+			).
+			AnyTimes()
+		tenancy.EXPECT().DetermineVisibleTenants(gomock.Any()).
+			Return(
+				collections.NewSet(
+					"tenant-a",
+				),
+				nil,
+			).
+			AnyTimes()
+
+		// Create the DAO:
+		dao, err := NewGenericDAO[*testsv1.Object]().
+			SetLogger(logger).
+			SetTable("objects").
+			SetTenancyLogic(tenancy).
+			Build()
+		Expect(err).ToNot(HaveOccurred())
+
+		// Create an object:
+		object, err := dao.Create(ctx, testsv1.Object_builder{}.Build())
+		Expect(err).ToNot(HaveOccurred())
+
+		// Retrieve the object and verify that it only shows the visible tenant:
+		response, err := dao.List(ctx, ListRequest{
+			Filter: fmt.Sprintf("this.id == %s", strconv.Quote(object.GetId())),
+			Limit:  1,
+		})
+		Expect(err).ToNot(HaveOccurred())
+		Expect(response.Items).To(HaveLen(1))
+		Expect(response.Items[0].GetMetadata().GetTenants()).To(ConsistOf("tenant-a"))
+	})
+
+	It("When an object is updated, it only shows the visible tenants", func() {
+		// Create a tenancy logic that assigns a visible tenant and an invisible one:
+		tenancy := auth.NewMockTenancyLogic(ctrl)
+		tenancy.EXPECT().DetermineAssignableTenants(gomock.Any()).
+			Return(
+				collections.NewSet(
+					"tenant-a",
+					"tenant-b",
+				),
+				nil,
+			).
+			AnyTimes()
+		tenancy.EXPECT().DetermineDefaultTenants(gomock.Any()).
+			Return(
+				collections.NewSet(
+					"tenant-a",
+					"tenant-b",
+				),
+				nil,
+			).
+			AnyTimes()
+		tenancy.EXPECT().DetermineVisibleTenants(gomock.Any()).
+			Return(
+				collections.NewSet(
+					"tenant-a",
+				),
+				nil,
+			).
+			AnyTimes()
+
+		// Create the DAO:
+		dao, err := NewGenericDAO[*testsv1.Object]().
+			SetLogger(logger).
+			SetTable("objects").
+			SetTenancyLogic(tenancy).
+			Build()
+		Expect(err).ToNot(HaveOccurred())
+
+		// Create an object:
+		object, err := dao.Create(ctx, testsv1.Object_builder{}.Build())
+		Expect(err).ToNot(HaveOccurred())
+
+		// Update the object and verify that it only shows the visible tenant:
+		object.SetMyString("my-string")
+		object, err = dao.Update(ctx, object)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(object.GetMetadata().GetTenants()).To(ContainElement("tenant-a"))
+	})
+
+	It("Allows user to override the assigned tenants", func() {
+		// Create a tenancy logic that returns two assigned and visible tenants:
+		tenancy := auth.NewMockTenancyLogic(ctrl)
+		tenancy.EXPECT().DetermineAssignableTenants(gomock.Any()).
+			Return(
+				collections.NewSet(
+					"tenant-a",
+					"tenant-b",
+				),
+				nil,
+			).
+			AnyTimes()
+		tenancy.EXPECT().DetermineDefaultTenants(gomock.Any()).
+			Return(
+				collections.NewSet(
+					"tenant-a",
+					"tenant-b",
+				),
+				nil,
+			).
+			AnyTimes()
+		tenancy.EXPECT().DetermineVisibleTenants(gomock.Any()).
+			Return(
+				collections.NewSet(
+					"tenant-a",
+					"tenant-b",
+				),
+				nil,
+			).
+			AnyTimes()
+
+		// Create the DAO:
+		dao, err := NewGenericDAO[*testsv1.Object]().
+			SetLogger(logger).
+			SetTable("objects").
+			SetTenancyLogic(tenancy).
+			Build()
+		Expect(err).ToNot(HaveOccurred())
+
+		// Create an object overridng the assigned tenants:
+		object, err := dao.Create(ctx, testsv1.Object_builder{
+			Metadata: testsv1.Metadata_builder{
+				Tenants: []string{
+					"tenant-a",
+				},
+			}.Build(),
+		}.Build())
+		Expect(err).ToNot(HaveOccurred())
+		Expect(object.GetMetadata().GetTenants()).To(ConsistOf("tenant-a"))
+
+		// Verify that only the overridden tenant is saved in the database:
+		var tenants []string
+		row := tx.QueryRow(ctx, "select tenants from objects where id = $1", object.GetId())
+		err = row.Scan(&tenants)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(tenants).To(ConsistOf("tenant-a"))
+	})
+
+	It("Can't create an object explicitly setting an invisible tenant", func() {
+		// Create a tenancy logic that assigns a visible tenant and an invisible one:
+		tenancy := auth.NewMockTenancyLogic(ctrl)
+		tenancy.EXPECT().DetermineAssignableTenants(gomock.Any()).
+			Return(
+				collections.NewSet(
+					"tenant-a",
+					"tenant-b",
+				),
+				nil,
+			).
+			AnyTimes()
+		tenancy.EXPECT().DetermineDefaultTenants(gomock.Any()).
+			Return(
+				collections.NewSet(
+					"tenant-a",
+					"tenant-b",
+				),
+				nil,
+			).
+			AnyTimes()
+		tenancy.EXPECT().DetermineVisibleTenants(gomock.Any()).
+			Return(
+				collections.NewSet(
+					"tenant-a",
+				),
+				nil,
+			).
+			AnyTimes()
+
+		// Create the DAO:
+		dao, err := NewGenericDAO[*testsv1.Object]().
+			SetLogger(logger).
+			SetTable("objects").
+			SetTenancyLogic(tenancy).
+			Build()
+		Expect(err).ToNot(HaveOccurred())
+
+		// Try to create an object with an invisible tenant and verify that it fails:
+		_, err = dao.Create(ctx, testsv1.Object_builder{
+			Metadata: testsv1.Metadata_builder{
+				Tenants: []string{
+					"tenant-b",
+				},
+			}.Build(),
+		}.Build())
+		Expect(err).To(HaveOccurred())
+		Expect(err).To(MatchError("tenant 'tenant-b' doesn't exist"))
+	})
+
+	It("Can't create an object explicitly setting two invisible tenants", func() {
+		// Create a tenancy logic that assigns one visibile tenant and two invisible ones:
+		tenancy := auth.NewMockTenancyLogic(ctrl)
+		tenancy.EXPECT().DetermineAssignableTenants(gomock.Any()).
+			Return(
+				collections.NewSet(
+					"tenant-a",
+					"tenant-b",
+					"tenant-c",
+				),
+				nil,
+			).
+			AnyTimes()
+		tenancy.EXPECT().DetermineDefaultTenants(gomock.Any()).
+			Return(
+				collections.NewSet(
+					"tenant-a",
+					"tenant-b",
+					"tenant-c",
+				),
+				nil,
+			).
+			AnyTimes()
+		tenancy.EXPECT().DetermineVisibleTenants(gomock.Any()).
+			Return(
+				collections.NewSet(
+					"tenant-a",
+				),
+				nil,
+			).
+			AnyTimes()
+
+		// Create the DAO:
+		dao, err := NewGenericDAO[*testsv1.Object]().
+			SetLogger(logger).
+			SetTable("objects").
+			SetTenancyLogic(tenancy).
+			Build()
+		Expect(err).ToNot(HaveOccurred())
+
+		// Try to create an object with an invisible tenant and verify that it fails:
+		_, err = dao.Create(ctx, testsv1.Object_builder{
+			Metadata: testsv1.Metadata_builder{
+				Tenants: []string{
+					"tenant-b",
+					"tenant-c",
+				},
+			}.Build(),
+		}.Build())
+		Expect(err).To(HaveOccurred())
+		Expect(err).To(MatchError("tenants 'tenant-b' and 'tenant-c' don't exist"))
+	})
+
+	It("Can't create an object explicitly setting one tenant that can't be assigned", func() {
+		// Create a tenancy logic that has two visibile tenants, but only assigns the first one:
+		tenancy := auth.NewMockTenancyLogic(ctrl)
+		tenancy.EXPECT().DetermineAssignableTenants(gomock.Any()).
+			Return(
+				collections.NewSet(
+					"tenant-a",
+				),
+				nil,
+			).
+			AnyTimes()
+		tenancy.EXPECT().DetermineDefaultTenants(gomock.Any()).
+			Return(
+				collections.NewSet(
+					"tenant-a",
+				),
+				nil,
+			).
+			AnyTimes()
+		tenancy.EXPECT().DetermineVisibleTenants(gomock.Any()).
+			Return(
+				collections.NewSet(
+					"tenant-a",
+					"tenant-b",
+				),
+				nil,
+			).
+			AnyTimes()
+
+		// Create the DAO:
+		dao, err := NewGenericDAO[*testsv1.Object]().
+			SetLogger(logger).
+			SetTable("objects").
+			SetTenancyLogic(tenancy).
+			Build()
+		Expect(err).ToNot(HaveOccurred())
+
+		// Try to create an object using the unnassignable tenant and verify that it fails:
+		_, err = dao.Create(ctx, testsv1.Object_builder{
+			Metadata: testsv1.Metadata_builder{
+				Tenants: []string{
+					"tenant-b",
+				},
+			}.Build(),
+		}.Build())
+		Expect(err).To(HaveOccurred())
+		Expect(err).To(MatchError("tenant 'tenant-b' can't be assigned"))
+	})
+
+	It("Can't create an object explicitly setting two tenants that can't be assigned", func() {
+		// Create a tenancy logic that has three visible tenants, but only assigns the first one:
+		tenancy := auth.NewMockTenancyLogic(ctrl)
+		tenancy.EXPECT().DetermineAssignableTenants(gomock.Any()).
+			Return(
+				collections.NewSet(
+					"tenant-a",
+				),
+				nil,
+			).
+			AnyTimes()
+		tenancy.EXPECT().DetermineDefaultTenants(gomock.Any()).
+			Return(
+				collections.NewSet(
+					"tenant-a",
+				),
+				nil,
+			).
+			AnyTimes()
+		tenancy.EXPECT().DetermineVisibleTenants(gomock.Any()).
+			Return(
+				collections.NewSet(
+					"tenant-a",
+					"tenant-b",
+					"tenant-c",
+				),
+				nil,
+			).
+			AnyTimes()
+
+		// Create the DAO:
+		dao, err := NewGenericDAO[*testsv1.Object]().
+			SetLogger(logger).
+			SetTable("objects").
+			SetTenancyLogic(tenancy).
+			Build()
+		Expect(err).ToNot(HaveOccurred())
+
+		// Try to create an object using the unnassignable tenant and verify that it fails:
+		_, err = dao.Create(ctx, testsv1.Object_builder{
+			Metadata: testsv1.Metadata_builder{
+				Tenants: []string{
+					"tenant-b",
+					"tenant-c",
+				},
+			}.Build(),
+		}.Build())
+		Expect(err).To(HaveOccurred())
+		Expect(err).To(MatchError("tenants 'tenant-b' and 'tenant-c' can't be assigned"))
+	})
+
+	It("Can't update an object to add an invisible tenant", func() {
+		// Create a tenancy logic that a visible tenant and an invisible one:
+		tenancy := auth.NewMockTenancyLogic(ctrl)
+		tenancy.EXPECT().DetermineAssignableTenants(gomock.Any()).
+			Return(
+				collections.NewSet(
+					"tenant-a",
+					"tenant-b",
+				),
+				nil,
+			).
+			AnyTimes()
+		tenancy.EXPECT().DetermineDefaultTenants(gomock.Any()).
+			Return(
+				collections.NewSet(
+					"tenant-a",
+					"tenant-b",
+				),
+				nil,
+			).
+			AnyTimes()
+		tenancy.EXPECT().DetermineVisibleTenants(gomock.Any()).
+			Return(
+				collections.NewSet(
+					"tenant-a",
+				),
+				nil,
+			).
+			AnyTimes()
+
+		// Create the DAO:
+		dao, err := NewGenericDAO[*testsv1.Object]().
+			SetLogger(logger).
+			SetTable("objects").
+			SetTenancyLogic(tenancy).
+			Build()
+		Expect(err).ToNot(HaveOccurred())
+
+		// Create the object with the default assigned tenants::
+		object, err := dao.Create(ctx, testsv1.Object_builder{}.Build())
+		Expect(err).ToNot(HaveOccurred())
+
+		// Verify that that both tenants have been saved in the database:
+		var tenants []string
+		row := tx.QueryRow(ctx, "select tenants from objects where id = $1", object.GetId())
+		err = row.Scan(&tenants)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(tenants).To(ConsistOf("tenant-a", "tenant-b"))
+
+		// Try to update the object to add the invisible tenant and verify that it fails:
+		object.GetMetadata().SetTenants([]string{
+			"tenant-a",
+			"tenant-b",
+		})
+		_, err = dao.Update(ctx, object)
+		Expect(err).To(HaveOccurred())
+		Expect(err).To(MatchError("tenant 'tenant-b' doesn't exist"))
+	})
+
+	It("Can't update an object to add an unassignable tenant", func() {
+		// Create a tenancy logic that has two visible tenants, but only assigns the first one:
+		tenancy := auth.NewMockTenancyLogic(ctrl)
+		tenancy.EXPECT().DetermineAssignableTenants(gomock.Any()).
+			Return(
+				collections.NewSet(
+					"tenant-a",
+				),
+				nil,
+			).
+			AnyTimes()
+		tenancy.EXPECT().DetermineDefaultTenants(gomock.Any()).
+			Return(
+				collections.NewSet(
+					"tenant-a",
+				),
+				nil,
+			).
+			AnyTimes()
+		tenancy.EXPECT().DetermineVisibleTenants(gomock.Any()).
+			Return(
+				collections.NewSet(
+					"tenant-a",
+					"tenant-b",
+				),
+				nil,
+			).
+			AnyTimes()
+
+		// Create the DAO:
+		dao, err := NewGenericDAO[*testsv1.Object]().
+			SetLogger(logger).
+			SetTable("objects").
+			SetTenancyLogic(tenancy).
+			Build()
+		Expect(err).ToNot(HaveOccurred())
+
+		// Create the object with the default assigned tenants:
+		object, err := dao.Create(ctx, testsv1.Object_builder{}.Build())
+		Expect(err).ToNot(HaveOccurred())
+
+		// Verify that only the assigned tenant has been saved in the database:
+		var tenants []string
+		row := tx.QueryRow(ctx, "select tenants from objects where id = $1", object.GetId())
+		err = row.Scan(&tenants)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(tenants).To(ConsistOf("tenant-a"))
+
+		// Try to update the object to add the unassignable tenant and verify that it fails:
+		object.GetMetadata().SetTenants([]string{
+			"tenant-a",
+			"tenant-b",
+		})
+		_, err = dao.Update(ctx, object)
+		Expect(err).To(HaveOccurred())
+		Expect(err).To(MatchError("tenant 'tenant-b' can't be assigned"))
+	})
+})

--- a/internal/database/dao/generic_dao_test.go
+++ b/internal/database/dao/generic_dao_test.go
@@ -210,7 +210,13 @@ var _ = Describe("Generic DAO", func() {
 
 			// Create the tenancy logic:
 			tenancyLogic := auth.NewMockTenancyLogic(ctrl)
-			tenancyLogic.EXPECT().DetermineAssignedTenants(gomock.Any()).
+			tenancyLogic.EXPECT().DetermineAssignableTenants(gomock.Any()).
+				Return(
+					collections.NewSet("my_tenant"),
+					nil,
+				).
+				AnyTimes()
+			tenancyLogic.EXPECT().DetermineDefaultTenants(gomock.Any()).
 				Return(
 					collections.NewSet("my_tenant"),
 					nil,
@@ -1432,7 +1438,10 @@ var _ = Describe("Generic DAO", func() {
 			It("Filters results based on tenant visibility", func() {
 				// Create a new DAO with restricted tenant visibility:
 				restrictedTenancyLogic := auth.NewMockTenancyLogic(ctrl)
-				restrictedTenancyLogic.EXPECT().DetermineAssignedTenants(gomock.Any()).
+				restrictedTenancyLogic.EXPECT().DetermineAssignableTenants(gomock.Any()).
+					Return(collections.NewSet("tenant_a"), nil).
+					AnyTimes()
+				restrictedTenancyLogic.EXPECT().DetermineDefaultTenants(gomock.Any()).
 					Return(collections.NewSet("tenant_a"), nil).
 					AnyTimes()
 				restrictedTenancyLogic.EXPECT().DetermineVisibleTenants(gomock.Any()).

--- a/internal/database/dao/tenancy_logic_test.go
+++ b/internal/database/dao/tenancy_logic_test.go
@@ -77,7 +77,17 @@ var _ = Describe("Tenancy logic", func() {
 	It("Filters field based on user visibility", func() {
 		// Create a tenancy logic that assigns multiple tenants to objects but only makes some visible
 		tenancy := auth.NewMockTenancyLogic(ctrl)
-		tenancy.EXPECT().DetermineAssignedTenants(gomock.Any()).
+		tenancy.EXPECT().DetermineAssignableTenants(gomock.Any()).
+			Return(
+				collections.NewSet(
+					"tenant_a",
+					"tenant_b",
+					"tenant_c",
+				),
+				nil,
+			).
+			AnyTimes()
+		tenancy.EXPECT().DetermineDefaultTenants(gomock.Any()).
 			Return(
 				collections.NewSet(
 					"tenant_a",
@@ -139,13 +149,29 @@ var _ = Describe("Tenancy logic", func() {
 	})
 
 	It("Shows all tenants when user has no tenant restrictions", func() {
-		// Create a tenancy logic that returns an empty list, which means no tenant filtering will be applied:
+		// Create a tenancy logic without restrictions:
 		tenancy := auth.NewMockTenancyLogic(ctrl)
-		tenancy.EXPECT().DetermineVisibleTenants(gomock.Any()).
-			Return(collections.NewUniversal[string](), nil).
+		tenancy.EXPECT().DetermineAssignableTenants(gomock.Any()).
+			Return(
+				collections.NewUniversal[string](),
+				nil,
+			).
 			AnyTimes()
-		tenancy.EXPECT().DetermineAssignedTenants(gomock.Any()).
-			Return(collections.NewSet("tenant_a", "tenant_b", "tenant_c"), nil).
+		tenancy.EXPECT().DetermineVisibleTenants(gomock.Any()).
+			Return(
+				collections.NewUniversal[string](),
+				nil,
+			).
+			AnyTimes()
+		tenancy.EXPECT().DetermineDefaultTenants(gomock.Any()).
+			Return(
+				collections.NewSet(
+					"tenant_a",
+					"tenant_b",
+					"tenant_c",
+				),
+				nil,
+			).
 			AnyTimes()
 
 		// Create the DAO:
@@ -165,11 +191,23 @@ var _ = Describe("Tenancy logic", func() {
 	It("Shows no tenants when user has no visible tenants that intersect with object tenants", func() {
 		// Create a tenancy logic that assigns tenant X but only makes tenant Y visible:
 		tenancy := auth.NewMockTenancyLogic(ctrl)
-		tenancy.EXPECT().DetermineAssignedTenants(gomock.Any()).
-			Return(collections.NewSet("tenant_y"), nil).
+		tenancy.EXPECT().DetermineAssignableTenants(gomock.Any()).
+			Return(
+				collections.NewSet("tenant_y"),
+				nil,
+			).
+			AnyTimes()
+		tenancy.EXPECT().DetermineDefaultTenants(gomock.Any()).
+			Return(
+				collections.NewSet("tenant_y"),
+				nil,
+			).
 			AnyTimes()
 		tenancy.EXPECT().DetermineVisibleTenants(gomock.Any()).
-			Return(collections.NewSet("tenant_x"), nil).
+			Return(
+				collections.NewSet("tenant_x"),
+				nil,
+			).
 			AnyTimes()
 
 		// Create the DAO:
@@ -184,5 +222,722 @@ var _ = Describe("Tenancy logic", func() {
 		object, err := dao.Create(ctx, testsv1.Object_builder{}.Build())
 		Expect(err).ToNot(HaveOccurred())
 		Expect(object.GetMetadata().GetTenants()).To(BeEmpty())
+	})
+
+	It("Assigns user default tenants when creating object without explicit tenants", func() {
+		tenancy := auth.NewMockTenancyLogic(ctrl)
+		tenancy.EXPECT().DetermineAssignableTenants(gomock.Any()).
+			Return(
+				collections.NewSet(
+					"tenant-a",
+					"tenant-b",
+				),
+				nil,
+			).
+			AnyTimes()
+		tenancy.EXPECT().DetermineDefaultTenants(gomock.Any()).
+			Return(
+				collections.NewSet(
+					"tenant-a",
+					"tenant-b",
+				),
+				nil,
+			).
+			AnyTimes()
+		tenancy.EXPECT().DetermineVisibleTenants(gomock.Any()).
+			Return(
+				collections.NewSet(
+					"tenant-a",
+					"tenant-b",
+				),
+				nil,
+			).
+			AnyTimes()
+
+		// Create the DAO:
+		dao, err := NewGenericDAO[*testsv1.Object]().
+			SetLogger(logger).
+			SetTable("objects").
+			SetTenancyLogic(tenancy).
+			Build()
+		Expect(err).ToNot(HaveOccurred())
+
+		// Create an object without specifying tenants in the metadata:
+		object, err := dao.Create(ctx, testsv1.Object_builder{}.Build())
+		Expect(err).ToNot(HaveOccurred())
+
+		// Verify the returned object has the user's default tenants:
+		Expect(object.GetMetadata().GetTenants()).To(ConsistOf("tenant-a", "tenant-b"))
+
+		// Verify the actual database contains the default tenants:
+		var tenants []string
+		row := tx.QueryRow(ctx, "select tenants from objects where id = $1", object.GetId())
+		err = row.Scan(&tenants)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(tenants).To(ConsistOf("tenant-a", "tenant-b"))
+	})
+
+	It("Assigns only the requested tenants when user explicitly specifies a subset", func() {
+		tenancy := auth.NewMockTenancyLogic(ctrl)
+		tenancy.EXPECT().DetermineAssignableTenants(gomock.Any()).
+			Return(
+				collections.NewSet(
+					"tenant-a",
+					"tenant-b",
+				),
+				nil,
+			).
+			AnyTimes()
+		tenancy.EXPECT().DetermineDefaultTenants(gomock.Any()).
+			Return(
+				collections.NewSet(
+					"tenant-a",
+					"tenant-b",
+				),
+				nil,
+			).
+			AnyTimes()
+		tenancy.EXPECT().DetermineVisibleTenants(gomock.Any()).
+			Return(
+				collections.NewSet(
+					"tenant-a",
+					"tenant-b",
+				),
+				nil,
+			).
+			AnyTimes()
+
+		// Create the DAO:
+		dao, err := NewGenericDAO[*testsv1.Object]().
+			SetLogger(logger).
+			SetTable("objects").
+			SetTenancyLogic(tenancy).
+			Build()
+		Expect(err).ToNot(HaveOccurred())
+
+		// Create an object explicitly requesting only a subset of the available tenants:
+		object, err := dao.Create(ctx, testsv1.Object_builder{
+			Metadata: testsv1.Metadata_builder{
+				Tenants: []string{"tenant-a"},
+			}.Build(),
+		}.Build())
+		Expect(err).ToNot(HaveOccurred())
+
+		// Verify the returned object has only the requested tenant:
+		Expect(object.GetMetadata().GetTenants()).To(ConsistOf("tenant-a"))
+
+		// Verify the actual database contains only the requested tenant:
+		var tenants []string
+		row := tx.QueryRow(ctx, "select tenants from objects where id = $1", object.GetId())
+		err = row.Scan(&tenants)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(tenants).To(ConsistOf("tenant-a"))
+	})
+
+	It("Preserves invisible tenants when creating object with explicit tenants", func() {
+		// Configure tenancy logic so that with an invisible tenant:
+		tenancy := auth.NewMockTenancyLogic(ctrl)
+		tenancy.EXPECT().DetermineAssignableTenants(gomock.Any()).
+			Return(
+				collections.NewSet(
+					"tenant-a",
+					"tenant-b",
+					"invisible",
+				),
+				nil,
+			).
+			AnyTimes()
+		tenancy.EXPECT().DetermineDefaultTenants(gomock.Any()).
+			Return(
+				collections.NewSet(
+					"tenant-a",
+					"tenant-b",
+					"invisible",
+				),
+				nil,
+			).
+			AnyTimes()
+		tenancy.EXPECT().DetermineVisibleTenants(gomock.Any()).
+			Return(
+				collections.NewSet(
+					"tenant-a",
+					"tenant-b",
+				),
+				nil,
+			).
+			AnyTimes()
+
+		// Create the DAO:
+		dao, err := NewGenericDAO[*testsv1.Object]().
+			SetLogger(logger).
+			SetTable("objects").
+			SetTenancyLogic(tenancy).
+			Build()
+		Expect(err).ToNot(HaveOccurred())
+
+		// Create an object explicitly requesting only 'tenant-a':
+		object, err := dao.Create(ctx, testsv1.Object_builder{
+			Metadata: testsv1.Metadata_builder{
+				Tenants: []string{"tenant-a"},
+			}.Build(),
+		}.Build())
+		Expect(err).ToNot(HaveOccurred())
+
+		// Verify the returned object shows only the visible tenant:
+		Expect(object.GetMetadata().GetTenants()).To(ConsistOf("tenant-a"))
+
+		// Verify the database contains both the requested tenant and the invisible tenant:
+		var tenants []string
+		row := tx.QueryRow(ctx, "select tenants from objects where id = $1", object.GetId())
+		err = row.Scan(&tenants)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(tenants).To(ConsistOf("tenant-a", "invisible"))
+	})
+
+	It("Rejects request when user explicitly tries to add an invisible tenant", func() {
+		// Configure tenancy logic with an invisible tenant:
+		tenancy := auth.NewMockTenancyLogic(ctrl)
+		tenancy.EXPECT().DetermineAssignableTenants(gomock.Any()).
+			Return(
+				collections.NewSet(
+					"tenant-a",
+					"tenant-b",
+					"invisible",
+				),
+				nil,
+			).
+			AnyTimes()
+		tenancy.EXPECT().DetermineDefaultTenants(gomock.Any()).
+			Return(
+				collections.NewSet(
+					"tenant-a",
+					"tenant-b",
+					"invisible",
+				),
+				nil,
+			).
+			AnyTimes()
+		tenancy.EXPECT().DetermineVisibleTenants(gomock.Any()).
+			Return(
+				collections.NewSet(
+					"tenant-a",
+					"tenant-b",
+				),
+				nil,
+			).
+			AnyTimes()
+
+		// Create the DAO:
+		dao, err := NewGenericDAO[*testsv1.Object]().
+			SetLogger(logger).
+			SetTable("objects").
+			SetTenancyLogic(tenancy).
+			Build()
+		Expect(err).ToNot(HaveOccurred())
+
+		// Try to create an object explicitly requesting the invisible tenant:
+		_, err = dao.Create(ctx, testsv1.Object_builder{
+			Metadata: testsv1.Metadata_builder{
+				Tenants: []string{"tenant-a", "invisible"},
+			}.Build(),
+		}.Build())
+
+		// Verify the request is rejected with an error indicating the tenant doesn't exist:
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(Equal("tenant 'invisible' doesn't exist"))
+	})
+
+	It("Rejects request when user tries to add a tenant that isn't assignable", func() {
+		// Configure tenancy logic where the user can only assign specific tenants:
+		tenancy := auth.NewMockTenancyLogic(ctrl)
+		tenancy.EXPECT().DetermineAssignableTenants(gomock.Any()).
+			Return(
+				collections.NewSet(
+					"tenant-a",
+					"tenant-b",
+				),
+				nil,
+			).
+			AnyTimes()
+		tenancy.EXPECT().DetermineDefaultTenants(gomock.Any()).
+			Return(
+				collections.NewSet(
+					"tenant-a",
+					"tenant-b",
+				),
+				nil,
+			).
+			AnyTimes()
+		tenancy.EXPECT().DetermineVisibleTenants(gomock.Any()).
+			Return(
+				collections.NewSet(
+					"tenant-a",
+					"tenant-b",
+					"tenant-c",
+				),
+				nil,
+			).
+			AnyTimes()
+
+		// Create the DAO:
+		dao, err := NewGenericDAO[*testsv1.Object]().
+			SetLogger(logger).
+			SetTable("objects").
+			SetTenancyLogic(tenancy).
+			Build()
+		Expect(err).ToNot(HaveOccurred())
+
+		// Try to create an object requesting a tenant that is visible but not assignable:
+		_, err = dao.Create(ctx, testsv1.Object_builder{
+			Metadata: testsv1.Metadata_builder{
+				Tenants: []string{"tenant-a", "tenant-c"},
+			}.Build(),
+		}.Build())
+
+		// Verify the request is rejected with an error indicating the tenant can't be assigned:
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(Equal("tenant 'tenant-c' can't be assigned"))
+	})
+
+	It("Preserves existing tenants when updating without specifying tenants", func() {
+		tenancy := auth.NewMockTenancyLogic(ctrl)
+		tenancy.EXPECT().DetermineAssignableTenants(gomock.Any()).
+			Return(
+				collections.NewSet(
+					"tenant-a",
+					"tenant-b",
+				),
+				nil,
+			).
+			AnyTimes()
+		tenancy.EXPECT().DetermineDefaultTenants(gomock.Any()).
+			Return(
+				collections.NewSet(
+					"tenant-a",
+					"tenant-b",
+				),
+				nil,
+			).
+			AnyTimes()
+		tenancy.EXPECT().DetermineVisibleTenants(gomock.Any()).
+			Return(
+				collections.NewSet(
+					"tenant-a",
+					"tenant-b",
+				),
+				nil,
+			).
+			AnyTimes()
+
+		// Create the DAO:
+		dao, err := NewGenericDAO[*testsv1.Object]().
+			SetLogger(logger).
+			SetTable("objects").
+			SetTenancyLogic(tenancy).
+			Build()
+		Expect(err).ToNot(HaveOccurred())
+
+		// Create an object with default tenants:
+		object, err := dao.Create(ctx, testsv1.Object_builder{}.Build())
+		Expect(err).ToNot(HaveOccurred())
+		Expect(object.GetMetadata().GetTenants()).To(ConsistOf("tenant-a", "tenant-b"))
+
+		// Update the object without specifying tenants:
+		object.SetMyString("updated")
+		object.GetMetadata().SetTenants(nil)
+		updated, err := dao.Update(ctx, object)
+		Expect(err).ToNot(HaveOccurred())
+
+		// Verify the tenants are preserved:
+		Expect(updated.GetMetadata().GetTenants()).To(ConsistOf("tenant-a", "tenant-b"))
+
+		// Verify the database still has the original tenants:
+		var tenants []string
+		row := tx.QueryRow(ctx, "select tenants from objects where id = $1", object.GetId())
+		err = row.Scan(&tenants)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(tenants).To(ConsistOf("tenant-a", "tenant-b"))
+	})
+
+	It("Keeps tenants unchanged when updating with same tenants", func() {
+		tenancy := auth.NewMockTenancyLogic(ctrl)
+		tenancy.EXPECT().DetermineAssignableTenants(gomock.Any()).
+			Return(
+				collections.NewSet(
+					"tenant-a",
+					"tenant-b",
+				),
+				nil,
+			).
+			AnyTimes()
+		tenancy.EXPECT().DetermineDefaultTenants(gomock.Any()).
+			Return(
+				collections.NewSet(
+					"tenant-a",
+					"tenant-b",
+				),
+				nil,
+			).
+			AnyTimes()
+		tenancy.EXPECT().DetermineVisibleTenants(gomock.Any()).
+			Return(
+				collections.NewSet(
+					"tenant-a",
+					"tenant-b",
+				),
+				nil,
+			).
+			AnyTimes()
+
+		// Create the DAO:
+		dao, err := NewGenericDAO[*testsv1.Object]().
+			SetLogger(logger).
+			SetTable("objects").
+			SetTenancyLogic(tenancy).
+			Build()
+		Expect(err).ToNot(HaveOccurred())
+
+		// Create an object with default tenants:
+		object, err := dao.Create(ctx, testsv1.Object_builder{}.Build())
+		Expect(err).ToNot(HaveOccurred())
+		Expect(object.GetMetadata().GetTenants()).To(ConsistOf("tenant-a", "tenant-b"))
+
+		// Update the object explicitly specifying the same tenants:
+		object.SetMyString("updated")
+		object.GetMetadata().SetTenants([]string{"tenant-a", "tenant-b"})
+		updated, err := dao.Update(ctx, object)
+		Expect(err).ToNot(HaveOccurred())
+
+		// Verify the tenants remain the same:
+		Expect(updated.GetMetadata().GetTenants()).To(ConsistOf("tenant-a", "tenant-b"))
+
+		// Verify the database has the same tenants:
+		var tenants []string
+		row := tx.QueryRow(ctx, "select tenants from objects where id = $1", object.GetId())
+		err = row.Scan(&tenants)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(tenants).To(ConsistOf("tenant-a", "tenant-b"))
+	})
+
+	It("Removes visible and assignable tenant when user explicitly removes it", func() {
+		tenancy := auth.NewMockTenancyLogic(ctrl)
+		tenancy.EXPECT().DetermineAssignableTenants(gomock.Any()).
+			Return(
+				collections.NewSet(
+					"tenant-a",
+					"tenant-b",
+				),
+				nil,
+			).
+			AnyTimes()
+		tenancy.EXPECT().DetermineDefaultTenants(gomock.Any()).
+			Return(
+				collections.NewSet(
+					"tenant-a",
+					"tenant-b",
+				),
+				nil,
+			).
+			AnyTimes()
+		tenancy.EXPECT().DetermineVisibleTenants(gomock.Any()).
+			Return(
+				collections.NewSet(
+					"tenant-a",
+					"tenant-b",
+				),
+				nil,
+			).
+			AnyTimes()
+
+		// Create the DAO:
+		dao, err := NewGenericDAO[*testsv1.Object]().
+			SetLogger(logger).
+			SetTable("objects").
+			SetTenancyLogic(tenancy).
+			Build()
+		Expect(err).ToNot(HaveOccurred())
+
+		// Create an object with default tenants:
+		object, err := dao.Create(ctx, testsv1.Object_builder{}.Build())
+		Expect(err).ToNot(HaveOccurred())
+		Expect(object.GetMetadata().GetTenants()).To(ConsistOf("tenant-a", "tenant-b"))
+
+		// Update the object removing one tenant:
+		object.GetMetadata().SetTenants([]string{"tenant-a"})
+		updated, err := dao.Update(ctx, object)
+		Expect(err).ToNot(HaveOccurred())
+
+		// Verify the tenant was removed:
+		Expect(updated.GetMetadata().GetTenants()).To(ConsistOf("tenant-a"))
+
+		// Verify the database has only the remaining tenant:
+		var tenants []string
+		row := tx.QueryRow(ctx, "select tenants from objects where id = $1", object.GetId())
+		err = row.Scan(&tenants)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(tenants).To(ConsistOf("tenant-a"))
+	})
+
+	It("Preserves invisible tenants when updating object", func() {
+		// Configure tenancy logic with an invisible tenant:
+		tenancy := auth.NewMockTenancyLogic(ctrl)
+		tenancy.EXPECT().DetermineAssignableTenants(gomock.Any()).
+			Return(
+				collections.NewSet(
+					"tenant-a",
+					"tenant-b",
+					"invisible",
+				),
+				nil,
+			).
+			AnyTimes()
+		tenancy.EXPECT().DetermineDefaultTenants(gomock.Any()).
+			Return(
+				collections.NewSet(
+					"tenant-a",
+					"invisible",
+				),
+				nil,
+			).
+			AnyTimes()
+		tenancy.EXPECT().DetermineVisibleTenants(gomock.Any()).
+			Return(
+				collections.NewSet(
+					"tenant-a",
+					"tenant-b",
+				),
+				nil,
+			).
+			AnyTimes()
+
+		// Create the DAO:
+		dao, err := NewGenericDAO[*testsv1.Object]().
+			SetLogger(logger).
+			SetTable("objects").
+			SetTenancyLogic(tenancy).
+			Build()
+		Expect(err).ToNot(HaveOccurred())
+
+		// Create an object (will get default tenants including invisible one):
+		object, err := dao.Create(ctx, testsv1.Object_builder{}.Build())
+		Expect(err).ToNot(HaveOccurred())
+		Expect(object.GetMetadata().GetTenants()).To(ConsistOf("tenant-a"))
+
+		// Verify the database has the invisible tenant:
+		var tenants []string
+		row := tx.QueryRow(ctx, "select tenants from objects where id = $1", object.GetId())
+		err = row.Scan(&tenants)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(tenants).To(ConsistOf("tenant-a", "invisible"))
+
+		// Update the object changing the visible tenant:
+		object.GetMetadata().SetTenants([]string{"tenant-b"})
+		updated, err := dao.Update(ctx, object)
+		Expect(err).ToNot(HaveOccurred())
+
+		// Verify only the visible tenant is shown:
+		Expect(updated.GetMetadata().GetTenants()).To(ConsistOf("tenant-b"))
+
+		// Verify the database still has the invisible tenant:
+		row = tx.QueryRow(ctx, "select tenants from objects where id = $1", object.GetId())
+		err = row.Scan(&tenants)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(tenants).To(ConsistOf("tenant-b", "invisible"))
+	})
+
+	It("Rejects update when user tries to add an invisible tenant", func() {
+		// Configure tenancy logic with an invisible tenant:
+		tenancy := auth.NewMockTenancyLogic(ctrl)
+		tenancy.EXPECT().DetermineAssignableTenants(gomock.Any()).
+			Return(
+				collections.NewSet(
+					"tenant-a",
+					"tenant-b",
+					"invisible",
+				),
+				nil,
+			).
+			AnyTimes()
+		tenancy.EXPECT().DetermineDefaultTenants(gomock.Any()).
+			Return(
+				collections.NewSet(
+					"tenant-a",
+				),
+				nil,
+			).
+			AnyTimes()
+		tenancy.EXPECT().DetermineVisibleTenants(gomock.Any()).
+			Return(
+				collections.NewSet(
+					"tenant-a",
+					"tenant-b",
+				),
+				nil,
+			).
+			AnyTimes()
+
+		// Create the DAO:
+		dao, err := NewGenericDAO[*testsv1.Object]().
+			SetLogger(logger).
+			SetTable("objects").
+			SetTenancyLogic(tenancy).
+			Build()
+		Expect(err).ToNot(HaveOccurred())
+
+		// Create an object with visible tenants only:
+		object, err := dao.Create(ctx, testsv1.Object_builder{}.Build())
+		Expect(err).ToNot(HaveOccurred())
+
+		// Try to update the object adding the invisible tenant:
+		object.GetMetadata().SetTenants([]string{"tenant-a", "invisible"})
+		_, err = dao.Update(ctx, object)
+
+		// Verify the request is rejected:
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(Equal("tenant 'invisible' doesn't exist"))
+	})
+
+	It("Rejects update when user tries to add a tenant that isn't assignable", func() {
+		// Configure tenancy logic where tenant-c is visible but not assignable:
+		tenancy := auth.NewMockTenancyLogic(ctrl)
+		tenancy.EXPECT().DetermineAssignableTenants(gomock.Any()).
+			Return(
+				collections.NewSet(
+					"tenant-a",
+					"tenant-b",
+				),
+				nil,
+			).
+			AnyTimes()
+		tenancy.EXPECT().DetermineDefaultTenants(gomock.Any()).
+			Return(
+				collections.NewSet(
+					"tenant-a",
+				),
+				nil,
+			).
+			AnyTimes()
+		tenancy.EXPECT().DetermineVisibleTenants(gomock.Any()).
+			Return(
+				collections.NewSet(
+					"tenant-a",
+					"tenant-b",
+					"tenant-c",
+				),
+				nil,
+			).
+			AnyTimes()
+
+		// Create the DAO:
+		dao, err := NewGenericDAO[*testsv1.Object]().
+			SetLogger(logger).
+			SetTable("objects").
+			SetTenancyLogic(tenancy).
+			Build()
+		Expect(err).ToNot(HaveOccurred())
+
+		// Create an object:
+		object, err := dao.Create(ctx, testsv1.Object_builder{}.Build())
+		Expect(err).ToNot(HaveOccurred())
+
+		// Try to update the object adding a non-assignable tenant:
+		object.GetMetadata().SetTenants([]string{"tenant-a", "tenant-c"})
+		_, err = dao.Update(ctx, object)
+
+		// Verify the request is rejected:
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(Equal("tenant 'tenant-c' can't be assigned"))
+	})
+
+	It("Allows user with universal assignability and visibility to create objects", func() {
+		// Configure tenancy logic with universal assignability and visibility:
+		tenancy := auth.NewMockTenancyLogic(ctrl)
+		tenancy.EXPECT().DetermineAssignableTenants(gomock.Any()).
+			Return(
+				collections.NewUniversal[string](),
+				nil,
+			).
+			AnyTimes()
+		tenancy.EXPECT().DetermineDefaultTenants(gomock.Any()).
+			Return(
+				collections.NewSet("system"),
+				nil,
+			).
+			AnyTimes()
+		tenancy.EXPECT().DetermineVisibleTenants(gomock.Any()).
+			Return(
+				collections.NewUniversal[string](),
+				nil,
+			).
+			AnyTimes()
+
+		// Create the DAO:
+		dao, err := NewGenericDAO[*testsv1.Object]().
+			SetLogger(logger).
+			SetTable("objects").
+			SetTenancyLogic(tenancy).
+			Build()
+		Expect(err).ToNot(HaveOccurred())
+
+		// Create an object without specifying tenants (should get default):
+		object, err := dao.Create(ctx, testsv1.Object_builder{}.Build())
+		Expect(err).ToNot(HaveOccurred())
+		Expect(object.GetMetadata().GetTenants()).To(ConsistOf("system"))
+
+		// Verify the database contains the default tenants:
+		var tenants []string
+		row := tx.QueryRow(ctx, "select tenants from objects where id = $1", object.GetId())
+		err = row.Scan(&tenants)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(tenants).To(ConsistOf("system"))
+	})
+
+	It("Allows user with universal assignability and visibility to update objects", func() {
+		// Configure tenancy logic with universal assignability and visibility:
+		tenancy := auth.NewMockTenancyLogic(ctrl)
+		tenancy.EXPECT().DetermineAssignableTenants(gomock.Any()).
+			Return(
+				collections.NewUniversal[string](),
+				nil,
+			).
+			AnyTimes()
+		tenancy.EXPECT().DetermineDefaultTenants(gomock.Any()).
+			Return(
+				collections.NewSet("system"),
+				nil,
+			).
+			AnyTimes()
+		tenancy.EXPECT().DetermineVisibleTenants(gomock.Any()).
+			Return(
+				collections.NewUniversal[string](),
+				nil,
+			).
+			AnyTimes()
+
+		// Create the DAO:
+		dao, err := NewGenericDAO[*testsv1.Object]().
+			SetLogger(logger).
+			SetTable("objects").
+			SetTenancyLogic(tenancy).
+			Build()
+		Expect(err).ToNot(HaveOccurred())
+
+		// Create an object with default tenants:
+		object, err := dao.Create(ctx, testsv1.Object_builder{}.Build())
+		Expect(err).ToNot(HaveOccurred())
+		Expect(object.GetMetadata().GetTenants()).To(ConsistOf("system"))
+
+		// Update the object changing the tenants to arbitrary values:
+		object.GetMetadata().SetTenants([]string{"tenant-a", "tenant-b"})
+		updated, err := dao.Update(ctx, object)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(updated.GetMetadata().GetTenants()).To(ConsistOf("tenant-a", "tenant-b"))
+
+		// Verify the database contains the new tenants:
+		var tenants []string
+		row := tx.QueryRow(ctx, "select tenants from objects where id = $1", object.GetId())
+		err = row.Scan(&tenants)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(tenants).To(ConsistOf("tenant-a", "tenant-b"))
 	})
 })

--- a/internal/servers/servers_tenancy_test.go
+++ b/internal/servers/servers_tenancy_test.go
@@ -81,7 +81,13 @@ var _ = Describe("Tenancy logic", func() {
 	It("Returns tenants in metadata when object is created", func() {
 		// Create a mock tenancy logic that returns specific tenants:
 		tenancy := auth.NewMockTenancyLogic(ctrl)
-		tenancy.EXPECT().DetermineAssignedTenants(gomock.Any()).
+		tenancy.EXPECT().DetermineAssignableTenants(gomock.Any()).
+			Return(
+				collections.NewSet("my-tenant", "your-tenant"),
+				nil,
+			).
+			AnyTimes()
+		tenancy.EXPECT().DetermineDefaultTenants(gomock.Any()).
 			Return(
 				collections.NewSet("my-tenant", "your-tenant"),
 				nil,


### PR DESCRIPTION
Currently when a user creates an object the system automatically assigns to the object the tenants determined by the tenancy logic, which usually are all the tenants of the user. But in some situations users will want to explicitly select one of the tenants that they belong to. This patch adds suport for that: the user will be able to set the value for the `metadata.tenants` field, and that will be respected by the server as log as the specified tenants are visibile to the user and don't contradict the decision of the tenancy logic.