### PR TITLE
Return `ErrNotFound` for `Get` and `Update` on non-existent objects

### DIFF
--- a/internal/database/dao/generic_dao.go
+++ b/internal/database/dao/generic_dao.go
@@ -552,7 +552,9 @@ func (d *GenericDAO[O]) get(ctx context.Context, tx database.Tx, id string, forU
 		&data,
 	)
 	if errors.Is(err, pgx.ErrNoRows) {
-		err = nil
+		err = &ErrNotFound{
+			ID: id,
+		}
 		return
 	}
 	if err != nil {

--- a/internal/servers/clusters_server_test.go
+++ b/internal/servers/clusters_server_test.go
@@ -713,6 +713,17 @@ var _ = Describe("Clusters server", func() {
 			Expect(proto.Equal(createResponse.GetObject(), getResponse.GetObject())).To(BeTrue())
 		})
 
+		It("Returns not found error when getting object that doesn't exist", func() {
+			response, err := server.Get(ctx, ffv1.ClustersGetRequest_builder{
+				Id: "does-not-exist",
+			}.Build())
+			Expect(err).To(HaveOccurred())
+			Expect(response).To(BeNil())
+			status, ok := grpcstatus.FromError(err)
+			Expect(ok).To(BeTrue())
+			Expect(status.Code()).To(Equal(grpccodes.NotFound))
+		})
+
 		It("Update object", func() {
 			// Create the object:
 			createResponse, err := server.Create(ctx, ffv1.ClustersCreateRequest_builder{
@@ -1059,6 +1070,22 @@ var _ = Describe("Clusters server", func() {
 			}.Build())
 			Expect(err).ToNot(HaveOccurred())
 			Expect(getResponse.GetObject().GetMetadata().GetName()).To(Equal("your-name"))
+		})
+
+		It("Returns not found error when updating object that doesn't exist", func() {
+			response, err := server.Update(ctx, ffv1.ClustersUpdateRequest_builder{
+				Object: ffv1.Cluster_builder{
+					Id: "does-not-exist",
+					Metadata: sharedv1.Metadata_builder{
+						Name: "my-name",
+					}.Build(),
+				}.Build(),
+			}.Build())
+			Expect(err).To(HaveOccurred())
+			Expect(response).To(BeNil())
+			status, ok := grpcstatus.FromError(err)
+			Expect(ok).To(BeTrue())
+			Expect(status.Code()).To(Equal(grpccodes.NotFound))
 		})
 
 		DescribeTable(

--- a/internal/servers/generic_server.go
+++ b/internal/servers/generic_server.go
@@ -340,6 +340,10 @@ func (s *GenericServer[O]) Get(ctx context.Context, request any, response any) e
 		return grpcstatus.Errorf(grpccodes.InvalidArgument, "identifier is mandatory")
 	}
 	object, err := s.dao.Get(ctx, id)
+	var notFoundErr *dao.ErrNotFound
+	if errors.As(err, &notFoundErr) {
+		return grpcstatus.Errorf(grpccodes.NotFound, "object with identifier '%s' not found", id)
+	}
 	if err != nil {
 		s.logger.ErrorContext(
 			ctx,
@@ -420,6 +424,10 @@ func (s *GenericServer[O]) Update(ctx context.Context, request any, response any
 
 	// Fetch the current representation of the object:
 	object, err := s.dao.Get(ctx, id)
+	var notFoundErr *dao.ErrNotFound
+	if errors.As(err, &notFoundErr) {
+		return grpcstatus.Errorf(grpccodes.NotFound, "object with identifier '%s' not found", id)
+	}
 	if err != nil {
 		s.logger.ErrorContext(
 			ctx,


### PR DESCRIPTION
Change the DAO Get method to return `ErrNotFound` instead of `nil` when objects don't exist. Update the server layer to convert DAO `ErrNotFound` to gRPC NotFound error code. Add comprehensive tests at DAO, server, and integration layers.