### PR TITLE
Add finalizers to controller

### DIFF
--- a/internal/controllers/finalizers/finalizers.go
+++ b/internal/controllers/finalizers/finalizers.go
@@ -1,0 +1,19 @@
+/*
+Copyright (c) 2025 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package finalizers
+
+// Names of well known finalizers.
+const (
+	Controller = "fulfillment-controller"
+)


### PR DESCRIPTION
This patch adds a `fulfillment-controller` finalizer to reconciled objects to prevent their deletion while the controller is working on them.