### PR TITLE
Faster image build for integration tests

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -13,7 +13,10 @@
                         "type": "go",
                         "request": "launch",
                         "mode": "test",
-                        "program": "${fileDirname}"
+                        "program": "${fileDirname}",
+                        "args": [
+                                "-ginkgo.v"
+                        ]
                 },
                 {
                         "name": "attach",

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/go-logr/logr v1.4.3
 	github.com/google/uuid v1.6.0
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.27.2
-	github.com/innabox/fulfillment-common v0.0.18
+	github.com/innabox/fulfillment-common v0.0.21
 	github.com/jackc/pgerrcode v0.0.0-20220416144525-469b46aa5efa
 	github.com/json-iterator/go v1.1.12
 	github.com/kelseyhightower/envconfig v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -115,8 +115,8 @@ github.com/hashicorp/go-multierror v1.1.1 h1:H5DkEtf6CXdFp0N0Em5UCwQpXMWke8IA0+l
 github.com/hashicorp/go-multierror v1.1.1/go.mod h1:iw975J/qwKPdAO1clOe2L8331t/9/fmwbPZ6JB6eMoM=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
-github.com/innabox/fulfillment-common v0.0.18 h1:9/TJ/zAz0Rcmp4KaqJl4YGCtfP1FdL6EXU1xllzZdiE=
-github.com/innabox/fulfillment-common v0.0.18/go.mod h1:B860RSo86YZucRU2uNzx5k/0LV85VbWWZKZUmYH7PNY=
+github.com/innabox/fulfillment-common v0.0.21 h1:M+DZ8gSQRqAFA9b/fPWeIT/nnQbCwDXyUU8uc6EI9L4=
+github.com/innabox/fulfillment-common v0.0.21/go.mod h1:B860RSo86YZucRU2uNzx5k/0LV85VbWWZKZUmYH7PNY=
 github.com/itchyny/gojq v0.12.17 h1:8av8eGduDb5+rvEdaOO+zQUjA04MS0m3Ps8HiD+fceg=
 github.com/itchyny/gojq v0.12.17/go.mod h1:WBrEMkgAfAGO1LUcGOckBl5O726KPp+OlkKug0I/FEY=
 github.com/itchyny/timefmt-go v0.1.6 h1:ia3s54iciXDdzWzwaVKXZPbiXzxxnv1SPGFfM/myJ5Q=

--- a/it/Containerfile
+++ b/it/Containerfile
@@ -1,0 +1,8 @@
+# Thi is used to build the container image for the integration tests, where it is faster, specially
+# for the development environment, to build the binar in advance, and then copy the result to the
+# container image. That way the dependencies don't need to be downloaded again.
+
+FROM registry.access.redhat.com/ubi10/ubi:10.0-1758699521
+
+# Note that this assumes that the binary has already been built with 'go build'.
+COPY fulfillment-service /usr/local/bin


### PR DESCRIPTION
This patch changes the setup of the integration tests so that the binary of the service is built in advance, and then added directly to the image. This speeds up the build in the development environment.