### PR TITLE
Kick controller sync loop before watch

### DIFF
--- a/internal/work/work_loop.go
+++ b/internal/work/work_loop.go
@@ -1,0 +1,215 @@
+/*
+Copyright (c) 2025 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package work
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"time"
+)
+
+// LoopBuilder contains the data and logic needed to create a work loop. Don't create instances of this directly, use
+// the NewLoop function instead.
+type LoopBuilder struct {
+	// logger is the logger that will be used to write messages to the log.
+	logger *slog.Logger
+
+	// workFunc is the function that will be executed in the loop.
+	workFunc func(context.Context) error
+
+	// interval is the interval between executions of the function.
+	interval time.Duration
+
+	// name is the name of the loop.
+	name string
+}
+
+// Loop executes a work function in a loop.
+//
+// It is intended for situations where a funcion needs to be executed repeated, and restarted when it finishes.
+//
+// To prevent the function from running too often, specially when the function fails, the loop will sleep after running
+// the function for the configured interval, minus the time that the function took to run. For example, if the interval
+// is 10s and the function ran for 8s, then after running the function, it will sleep for 2s. If the function ran for
+// longer than the interval, it will not sleep.
+//
+// If the work function returns an error, the loop will log the error and continue.
+//
+// The loop will exit when the context is cancelled.
+//
+// The loop can be woken up by calling the kicking it, with the Kick method, which will interrupt the sleep and start
+// the work function immediately.
+type Loop struct {
+	// logger is the logger that will be used to write messages to the log.
+	logger *slog.Logger
+
+	// workFunc is the function that will be executed in the loop.
+	workFunc func(context.Context) error
+
+	// interval is the interval between executions of the function.
+	interval time.Duration
+
+	// last is the time of the last execution of the function.
+	last time.Time
+
+	// kick is a channel that will be used to interrupt the sleep and start the function immediately.
+	kick chan struct{}
+}
+
+// NewLoop creates a builder that can then be used to configure and create a loop.
+func NewLoop() *LoopBuilder {
+	return &LoopBuilder{}
+}
+
+// SetLogger sets the logger. This is mandatory.
+func (b *LoopBuilder) SetLogger(value *slog.Logger) *LoopBuilder {
+	b.logger = value
+	return b
+}
+
+// SetWorkFunc sets the function that will be executed in the loop. This is mandatory.
+func (b *LoopBuilder) SetWorkFunc(value func(context.Context) error) *LoopBuilder {
+	b.workFunc = value
+	return b
+}
+
+// SetInterval sets the interval between executions of the work function. This is mandatory.
+//
+// The work function will be executed repeatedly. After each execution, the loop will sleep for the given interval minus
+// the time that the work function was running. For example, if the interval is 10s and the work function ran for 8s,
+// then after running the work function, it will sleep for 2s. If the work function ran for longer than the interval,
+// it will not sleep.
+//
+// If the work function returns an error, the loop will log the error and continue.
+func (b *LoopBuilder) SetInterval(value time.Duration) *LoopBuilder {
+	b.interval = value
+	return b
+}
+
+// SetName sets the name of the loop. This is mandatory.
+func (b *LoopBuilder) SetName(value string) *LoopBuilder {
+	b.name = value
+	return b
+}
+
+// Build uses the data stored in the builder to create a new loop.
+func (b *LoopBuilder) Build() (result *Loop, err error) {
+	// Check parameters:
+	if b.logger == nil {
+		err = errors.New("logger is mandatory")
+		return
+	}
+	if b.workFunc == nil {
+		err = errors.New("function is mandatory")
+		return
+	}
+	if b.interval <= 0 {
+		err = fmt.Errorf("interval should be positive, but it is %s", b.interval)
+		return
+	}
+	if b.name == "" {
+		err = errors.New("name is mandatory")
+		return
+	}
+
+	// Create a logger with the name of the loop:
+	logger := b.logger.With(
+		slog.String("loop", b.name),
+	)
+
+	// Create and populate the object:
+	result = &Loop{
+		logger:   logger,
+		workFunc: b.workFunc,
+		interval: b.interval,
+		kick:     make(chan struct{}, 1),
+	}
+	return
+}
+
+// Run runs the loop until the context is cancelled.
+//
+// The function work will be executed repeatedly. After each execution, the loop will sleep for the configured interval
+// minus the time that the work function was running. For example, if the interval is 10s and the work function ran for
+// 8s, then after running the work function, it will sleep for 2s. If the work function ran for longer than the
+// interval, it will not sleep.
+//
+// The loop will exit when the context is cancelled.
+func (l *Loop) Run(ctx context.Context) error {
+	for {
+		// Capture the start time of the iteration:
+		l.last = time.Now()
+
+		// Execute the function:
+		err := l.workFunc(ctx)
+		if err != nil {
+			l.logger.ErrorContext(
+				ctx,
+				"Work function failed",
+				slog.Any("error", err),
+			)
+		}
+
+		// Check if the context has been cancelled:
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+
+		// Sleep:
+		err = l.sleep(ctx)
+		if err != nil {
+			return err
+		}
+	}
+}
+
+// Kick interrupts the sleep and starts the work function immediately. If the work function is already running it does
+// nothing. Note that it never blocks: it will return inmediately regardless of whether the work function is already
+// running or not.
+func (l *Loop) Kick() {
+	select {
+	case l.kick <- struct{}{}:
+	default:
+	}
+}
+
+func (l *Loop) sleep(ctx context.Context) error {
+	elapsed := time.Since(l.last)
+	duration := l.interval - elapsed
+	logger := l.logger.With(
+		slog.Time("last", l.last),
+		slog.Duration("interval", l.interval),
+		slog.Duration("elapsed", elapsed),
+	)
+	if duration <= 0 {
+		logger.DebugContext(ctx, "No need to sleep")
+		return nil
+	}
+	l.logger.DebugContext(
+		ctx,
+		"Sleeping",
+		slog.Duration("duration", duration),
+	)
+	select {
+	case <-ctx.Done():
+		return context.Canceled
+	case <-l.kick:
+		l.logger.DebugContext(ctx, "Woken up by kick")
+		return nil
+	case <-time.After(duration):
+		return nil
+	}
+}

--- a/internal/work/work_loop_test.go
+++ b/internal/work/work_loop_test.go
@@ -1,0 +1,272 @@
+/*
+Copyright (c) 2025 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package work
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2/dsl/core"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Loop", func() {
+	var (
+		ctx    context.Context
+		cancel context.CancelFunc
+	)
+
+	BeforeEach(func() {
+		ctx, cancel = context.WithCancel(context.Background())
+		DeferCleanup(cancel)
+	})
+
+	It("Fails if name is missing", func() {
+		loop, err := NewLoop().
+			SetLogger(logger).
+			SetInterval(1 * time.Hour).
+			SetWorkFunc(func(ctx context.Context) error {
+				return nil
+			}).
+			Build()
+		Expect(err).To(HaveOccurred())
+		Expect(loop).To(BeNil())
+		Expect(err.Error()).To(ContainSubstring("name is mandatory"))
+	})
+
+	It("Runs the function repeatedly", func() {
+		// Create a channel to signal that the function has run:
+		ran := make(chan struct{})
+
+		// Create the loop:
+		loop, err := NewLoop().
+			SetLogger(logger).
+			SetName("test").
+			SetInterval(10 * time.Millisecond).
+			SetWorkFunc(func(ctx context.Context) error {
+				ran <- struct{}{}
+				return nil
+			}).
+			Build()
+		Expect(err).ToNot(HaveOccurred())
+
+		// Start the loop in the background:
+		go func() {
+			defer GinkgoRecover()
+			err = loop.Run(ctx)
+			Expect(err).To(MatchError(context.Canceled))
+		}()
+
+		// Verify that the function runs multiple times:
+		Eventually(ran).Should(Receive())
+		Eventually(ran).Should(Receive())
+		Eventually(ran).Should(Receive())
+	})
+
+	It("Stops when the context is cancelled", func() {
+		// Create the loop:
+		loop, err := NewLoop().
+			SetLogger(logger).
+			SetName("test").
+			SetInterval(1 * time.Hour).
+			SetWorkFunc(func(ctx context.Context) error {
+				return nil
+			}).
+			Build()
+		Expect(err).ToNot(HaveOccurred())
+
+		// Start the loop in the background:
+		done := make(chan struct{})
+		go func() {
+			defer GinkgoRecover()
+			err = loop.Run(ctx)
+			Expect(err).To(MatchError(context.Canceled))
+			close(done)
+		}()
+
+		// Cancel the context and verify that the loop stops:
+		cancel()
+		Eventually(done).Should(BeClosed())
+	})
+
+	It("Logs errors returned by the function", func() {
+		// Create a channel to signal that the function has run:
+		ran := make(chan struct{})
+
+		// Create the loop:
+		loop, err := NewLoop().
+			SetLogger(logger).
+			SetName("test").
+			SetInterval(10 * time.Millisecond).
+			SetWorkFunc(func(ctx context.Context) error {
+				defer func() {
+					ran <- struct{}{}
+				}()
+				return errors.New("test error")
+			}).
+			Build()
+		Expect(err).ToNot(HaveOccurred())
+
+		// Start the loop in the background:
+		go func() {
+			defer GinkgoRecover()
+			err = loop.Run(ctx)
+			Expect(err).To(MatchError(context.Canceled))
+		}()
+
+		// Verify that the function runs (even if it errors):
+		Eventually(ran).Should(Receive())
+		Eventually(ran).Should(Receive())
+	})
+
+	It("Respects the sleep interval", func() {
+		// Create a channel to record the time of each run:
+		times := make(chan time.Time, 10)
+
+		// Create the loop:
+		loop, err := NewLoop().
+			SetLogger(logger).
+			SetName("test").
+			SetInterval(100 * time.Millisecond).
+			SetWorkFunc(func(ctx context.Context) error {
+				times <- time.Now()
+				return nil
+			}).
+			Build()
+		Expect(err).ToNot(HaveOccurred())
+
+		// Start the loop in the background:
+		go func() {
+			defer GinkgoRecover()
+			err = loop.Run(ctx)
+			Expect(err).To(MatchError(context.Canceled))
+		}()
+
+		// Get two execution times:
+		var t1, t2 time.Time
+		Eventually(times).Should(Receive(&t1))
+		Eventually(times).Should(Receive(&t2))
+
+		// Verify that the interval between runs is approximately correct:
+		Expect(t2.Sub(t1)).To(BeNumerically(">=", 100*time.Millisecond))
+	})
+
+	It("Subtracts execution time from sleep interval", func() {
+		// Create a channel to record the time of each run:
+		times := make(chan time.Time, 10)
+
+		// Create the loop:
+		loop, err := NewLoop().
+			SetLogger(logger).
+			SetName("test").
+			SetInterval(100 * time.Millisecond).
+			SetWorkFunc(func(ctx context.Context) error {
+				times <- time.Now()
+				time.Sleep(50 * time.Millisecond)
+				return nil
+			}).
+			Build()
+		Expect(err).ToNot(HaveOccurred())
+
+		// Start the loop in the background:
+		go func() {
+			defer GinkgoRecover()
+			err = loop.Run(ctx)
+			Expect(err).To(MatchError(context.Canceled))
+		}()
+
+		// Get two execution times:
+		var t1, t2 time.Time
+		Eventually(times).Should(Receive(&t1))
+		Eventually(times).Should(Receive(&t2))
+
+		// Verify that the interval between start times is still approximately the interval,
+		// meaning it slept interval - execution time.
+		// t2 - t1 should be close to 100ms.
+		// If it didn't subtract, it would be 100ms + 50ms = 150ms.
+		diff := t2.Sub(t1)
+		Expect(diff).To(BeNumerically(">=", 100*time.Millisecond))
+		Expect(diff).To(BeNumerically("<", 150*time.Millisecond))
+	})
+
+	It("Does not sleep if execution takes longer than interval", func() {
+		// Create a channel to record the time of each run:
+		times := make(chan time.Time, 10)
+
+		// Create the loop:
+		loop, err := NewLoop().
+			SetLogger(logger).
+			SetName("test").
+			SetInterval(50 * time.Millisecond).
+			SetWorkFunc(func(ctx context.Context) error {
+				times <- time.Now()
+				time.Sleep(100 * time.Millisecond)
+				return nil
+			}).
+			Build()
+		Expect(err).ToNot(HaveOccurred())
+
+		// Start the loop in the background:
+		go func() {
+			defer GinkgoRecover()
+			err = loop.Run(ctx)
+			Expect(err).To(MatchError(context.Canceled))
+		}()
+
+		// Get two execution times:
+		var t1, t2 time.Time
+		Eventually(times).Should(Receive(&t1))
+		Eventually(times).Should(Receive(&t2))
+
+		// Verify that the interval between start times is roughly the execution time (no extra sleep).
+		diff := t2.Sub(t1)
+		Expect(diff).To(BeNumerically(">=", 100*time.Millisecond))
+		// Allow some small overhead, but it shouldn't be 150ms.
+		Expect(diff).To(BeNumerically("<", 120*time.Millisecond))
+	})
+
+	It("Wakes up immediately when kicked", func() {
+		// Create a channel to signal that the function has run:
+		ran := make(chan struct{})
+
+		// Create the loop with a long interval:
+		loop, err := NewLoop().
+			SetLogger(logger).
+			SetName("test").
+			SetInterval(1 * time.Hour).
+			SetWorkFunc(func(ctx context.Context) error {
+				ran <- struct{}{}
+				return nil
+			}).
+			Build()
+		Expect(err).ToNot(HaveOccurred())
+
+		// Start the loop in the background:
+		go func() {
+			defer GinkgoRecover()
+			err = loop.Run(ctx)
+			Expect(err).To(MatchError(context.Canceled))
+		}()
+
+		// Wait for the first run:
+		Eventually(ran).Should(Receive())
+
+		// Kick the loop:
+		loop.Kick()
+
+		// Verify that it runs again immediately:
+		Eventually(ran).Should(Receive())
+	})
+})

--- a/internal/work/work_suite_test.go
+++ b/internal/work/work_suite_test.go
@@ -1,0 +1,30 @@
+package work
+
+import (
+	"log/slog"
+	"testing"
+
+	"github.com/innabox/fulfillment-common/logging"
+	. "github.com/onsi/ginkgo/v2/dsl/core"
+	. "github.com/onsi/gomega"
+)
+
+func TestWork(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Work")
+}
+
+// Logger used for tests:
+var logger *slog.Logger
+
+var _ = BeforeSuite(func() {
+	var err error
+
+	// Create a logger that writes to the Ginkgo writer, so that the log messages will be attached to the output of
+	// the right test:
+	logger, err = logging.NewLogger().
+		SetLevel(slog.LevelDebug.String()).
+		SetOut(GinkgoWriter).
+		Build()
+	Expect(err).ToNot(HaveOccurred())
+})


### PR DESCRIPTION
The code that controls the sync and watch loops of the reconcilers is fragile. This patch moves the control of those loops to a separate component that will hopefully be easier to understand and fix when needed.

In addition this new `work.Loop` component has a `Kick` method that can be used to wake up the loop when it is sleeping. This is used to wake up the sync loop automatically before each execution of the watch loop, which happens when the watch fails, for example. This should make the loops more reliable, specially in the integration tests.