### PR TITLE
Wait for Authorino authorization before creating Hub

### DIFF
--- a/it/it_suite_test.go
+++ b/it/it_suite_test.go
@@ -426,6 +426,19 @@ var _ = BeforeSuite(func() {
 	hubKubeconfigBytes, err = clientcmd.Write(*hubKubeconfigObject)
 	Expect(err).ToNot(HaveOccurred())
 	hubsClient := privatev1.NewHubsClient(adminConn)
+
+	// Wait for Authorino authorization to be ready before creating the hub:
+	Eventually(
+		func(g Gomega) {
+			// Try a simple list operation to verify authorization is working
+			_, err := hubsClient.List(ctx, privatev1.HubsListRequest_builder{}.Build())
+			g.Expect(err).ToNot(HaveOccurred())
+		},
+		30*time.Second,
+		time.Second,
+	).Should(Succeed())
+
+	// Now create the hub:
 	_, err = hubsClient.Create(ctx, privatev1.HubsCreateRequest_builder{
 		Object: privatev1.Hub_builder{
 			Id:         hubId,


### PR DESCRIPTION
Add an Eventually block that waits for authorization to be ready by testing with a simple List operation on the Hubs API. This prevents PermissionDenied errors when running e2e tests if Authorino hasn't finished processing the AuthConfig yet.

The test now:
1. Waits for health check to pass (existing)
2. Waits for authorization to work (new)
3. Creates the Hub (existing)

This ensures the authorization system is fully initialized before making API calls that require authorization.

Fixes: PermissionDenied error during BeforeSuite in e2e tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)