### PR TITLE
Pass tenant name to VirtualMachine CR as an annotation

### DIFF
--- a/internal/kubernetes/annotations/kubernetes_annotations.go
+++ b/internal/kubernetes/annotations/kubernetes_annotations.go
@@ -1,0 +1,23 @@
+/*
+Copyright (c) 2025 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package annotations
+
+import (
+	"fmt"
+
+	"github.com/innabox/fulfillment-service/internal/kubernetes/gvks"
+)
+
+// VirtualMachineTenant is the annotation where the fulfillment API will write the tenant of the virtual machine.
+var VirtualMachineTenant = fmt.Sprintf("%s/tenant", gvks.VirtualMachine.Group)


### PR DESCRIPTION
This change adds a tenant annotation to the VirtualMachine CR. It is
required because VMs belonging to the same tenant will be part of the
same network.

At first, virtual machines are expected to belong to a single tenant, set
at creation time.

Issue https://github.com/innabox/issues/issues/240
