### PR TITLE
Fix translation of `in` with empty list

### DIFF
--- a/internal/database/dao/filter_translator.go
+++ b/internal/database/dao/filter_translator.go
@@ -506,11 +506,17 @@ func (t *FilterTranslator[O]) translateIn(args []ast.Expr) (result filterTransla
 }
 
 func (t *FilterTranslator[O]) translateInList(key ast.Expr, list ast.ListExpr) (result filterTranslatorResult, err error) {
+	values := list.Elements()
+	if len(values) == 0 {
+		result.sql = "false"
+		result.kind = filterTranslatorBooleanKind
+		result.precedence = filterTranslatorMaxPrecedence
+		return
+	}
 	keyTr, err := t.translate(key)
 	if err != nil {
 		return
 	}
-	values := list.Elements()
 	valueTrs := make([]filterTranslatorResult, len(values))
 	for i, value := range values {
 		if value.Kind() != ast.LiteralKind {

--- a/internal/database/dao/filter_translator_test.go
+++ b/internal/database/dao/filter_translator_test.go
@@ -237,5 +237,10 @@ var _ = Describe("Filter translator", func() {
 			`'my_tenant' in this.metadata.tenants`,
 			`tenants @> array['my_tenant']`,
 		),
+		Entry(
+			"Translates 'in' with empty list into false",
+			"this.id in []",
+			"false",
+		),
 	)
 })


### PR DESCRIPTION
Currently we translate a CEL expression like `this.id in []` into SQL like `where id in ()`. But that is a syntax error in PostgreSQL. To avoid that this patch changes the translator so that it will translate it into `false`.