### PR TITLE
Add `guest` tenancly logic

### DIFF
--- a/docs/AUTH.md
+++ b/docs/AUTH.md
@@ -396,9 +396,12 @@ The fulfillment service implements a hard-coded tenancy logic that determines:
 
 ### Tenancy Logic Implementation
 
-The tenancy logic is implemented differently based on the authentication method:
+The tenancy logic can be configured using the `--tenancy-logic` command-line flag when starting the fulfillment
+service. The following implementations are available:
 
-#### For JWT-Authenticated Users (Keycloak)
+#### Default (JWT-Authenticated Users)
+
+Use `--tenancy-logic=default` for JWT-authenticated users (Keycloak):
 
 - **Assigned Tenants**: Resources are assigned to the user's groups (from the `groups` claim in the JWT token)
 - **Visible Tenants**: Users can see resources from:
@@ -412,7 +415,9 @@ Example:
 - When `alice` lists clusters:
   - She can see clusters from: `["team-a", "team-b", "shared"]`
 
-#### For Service Account Users
+#### Service Account
+
+Use `--tenancy-logic=serviceaccount` for service account authentication:
 
 - **Assigned Tenants**: Resources are assigned to a tenant matching the service account's namespace
 - **Visible Tenants**: Service accounts can see resources from:
@@ -425,6 +430,34 @@ Example:
   - Assigned to tenant: `["innabox"]`
 - When listing resources:
   - Can see resources from: `["innabox", "shared"]`
+
+#### Guest
+
+Use `--tenancy-logic=guest` for guest user access:
+
+- **Assigned Tenants**: All resources are assigned to the `guest` tenant, regardless of the user's identity
+- **Visible Tenants**: Users can see resources from:
+  - The `guest` tenant
+  - The `shared` tenant
+
+This is intended only for development and testing environments, in combination with the `guest`
+authentication function.
+
+Example:
+- Any user (authenticated or guest)
+- When creating a resource:
+  - Assigned to tenant: `["guest"]`
+- When listing resources:
+  - Can see resources from: `["guest", "shared"]`
+
+#### Empty
+
+Use `--tenancy-logic=empty` to disable tenant assignment and filtering:
+
+- **Assigned Tenants**: No tenants are assigned to resources
+- **Visible Tenants**: All resources are visible (no tenant filtering applied)
+
+This is primarily used for testing or development scenarios where tenancy should be disabled.
 
 ### Configuring Tenancy in Keycloak
 
@@ -444,10 +477,10 @@ To configure multi-tenant access in Keycloak:
 
 ### Future Enhancements
 
-The current tenancy logic is hard-coded. Future enhancements may include:
-- Configurable tenancy logic (allowing different mapping strategies)
+The tenancy logic is now configurable via the `--tenancy-logic` flag. Future enhancements may include:
 - Support for an additional "organization" layer (requiring development)
 - Custom tenant naming conventions
+- Additional tenancy logic implementations for specific use cases
 
 ## Authorization Configuration
 

--- a/internal/auth/guest_tenancy_logic.go
+++ b/internal/auth/guest_tenancy_logic.go
@@ -1,0 +1,66 @@
+/*
+Copyright (c) 2025 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package auth
+
+import (
+	"context"
+	"log/slog"
+
+	"github.com/innabox/fulfillment-service/internal/collections"
+)
+
+// GuestTenancyLogicBuilder contains the data and logic needed to create guest tenancy logic.
+type GuestTenancyLogicBuilder struct {
+	logger *slog.Logger
+}
+
+// GuestTenancyLogic is a tenancy logic implementation that assigns the guest tenant to all objects and makes both
+// the guest and shared tenants visible. This is useful for scenarios where all users should be treated as guests
+// with access to a limited set of shared resources.
+type GuestTenancyLogic struct {
+	logger *slog.Logger
+}
+
+// NewGuestTenancyLogic creates a new builder for guest tenancy logic.
+func NewGuestTenancyLogic() *GuestTenancyLogicBuilder {
+	return &GuestTenancyLogicBuilder{}
+}
+
+// SetLogger sets the logger that will be used by the tenancy logic.
+func (b *GuestTenancyLogicBuilder) SetLogger(value *slog.Logger) *GuestTenancyLogicBuilder {
+	b.logger = value
+	return b
+}
+
+// Build creates the guest tenancy logic.
+func (b *GuestTenancyLogicBuilder) Build() (result *GuestTenancyLogic, err error) {
+	// Create the tenancy logic:
+	result = &GuestTenancyLogic{
+		logger: b.logger,
+	}
+	return
+}
+
+// DetermineAssignedTenants returns a set containing only the guest tenant, regardless of the user's identity.
+func (p *GuestTenancyLogic) DetermineAssignedTenants(_ context.Context) (result collections.Set[string], err error) {
+	result = collections.NewSet("guest")
+	return
+}
+
+// DetermineVisibleTenants returns a set containing both the guest and shared tenants, allowing guest users to see
+// objects from both tenants.
+func (p *GuestTenancyLogic) DetermineVisibleTenants(_ context.Context) (result collections.Set[string], err error) {
+	result = collections.NewSet("guest", "shared")
+	return
+}

--- a/internal/auth/guest_tenancy_logic_test.go
+++ b/internal/auth/guest_tenancy_logic_test.go
@@ -1,0 +1,56 @@
+/*
+Copyright (c) 2025 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package auth
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Guest tenancy logic", func() {
+	var (
+		ctx   context.Context
+		logic *GuestTenancyLogic
+	)
+
+	BeforeEach(func() {
+		var err error
+
+		// Create the context:
+		ctx = context.Background()
+
+		// Create the tenancy logic:
+		logic, err = NewGuestTenancyLogic().
+			SetLogger(logger).
+			Build()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(logic).ToNot(BeNil())
+	})
+
+	It("Should return the guest tenant", func() {
+		result, err := logic.DetermineAssignedTenants(ctx)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(result.Contains("guest")).To(BeTrue())
+		Expect(result.Contains("shared")).To(BeFalse())
+	})
+
+	It("Should return guest and shared as visible tenants", func() {
+		result, err := logic.DetermineVisibleTenants(ctx)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(result.Contains("guest")).To(BeTrue())
+		Expect(result.Contains("shared")).To(BeTrue())
+	})
+})

--- a/internal/cmd/start_server_cmd.go
+++ b/internal/cmd/start_server_cmd.go
@@ -292,9 +292,16 @@ func (c *startServerCommandRunner) run(cmd *cobra.Command, argv []string) error 
 		if err != nil {
 			return fmt.Errorf("failed to create service account tenancy logic: %w", err)
 		}
+	case "guest":
+		publicTenancyLogic, err = auth.NewGuestTenancyLogic().
+			SetLogger(c.logger).
+			Build()
+		if err != nil {
+			return fmt.Errorf("failed to create guest tenancy logic: %w", err)
+		}
 	default:
 		return fmt.Errorf(
-			"unknown tenancy logic '%s', valid values are 'default' and 'serviceaccount'",
+			"unknown tenancy logic '%s', valid values are 'default', 'serviceaccount', and 'guest'",
 			c.args.tenancyLogic,
 		)
 	}


### PR DESCRIPTION
This patch adds a new `guest` tenancy logic that assigns the `guest` tenant to all users, regardless of their credentials. This is only intended for development and testing environments.