### PR TITLE
Fix empty tenancy check, and report errors better

### DIFF
--- a/internal/database/dao/dao_errors.go
+++ b/internal/database/dao/dao_errors.go
@@ -38,3 +38,15 @@ type ErrAlreadyExists struct {
 func (e *ErrAlreadyExists) Error() string {
 	return fmt.Sprintf("object with identifier '%s' already exists", e.ID)
 }
+
+// ErrDenied is an error type that indicates a requested operation is not allowed. The reason string is a human friendly
+// description that will never contain technical details, so it can be safely returned to the user as part of the error
+// response, for example as the message of a gRPC status error.
+type ErrDenied struct {
+	Reason string
+}
+
+// Error returns the error message.
+func (e *ErrDenied) Error() string {
+	return e.Reason
+}

--- a/internal/database/dao/dao_errors_test.go
+++ b/internal/database/dao/dao_errors_test.go
@@ -1,0 +1,62 @@
+/*
+Copyright (c) 2025 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package dao
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Errors", func() {
+	Describe("ErrNotFound", func() {
+		It("Implements the error interface", func() {
+			var err error = &ErrNotFound{ID: "123"}
+			Expect(err).ToNot(BeNil())
+		})
+
+		It("Returns expected error message", func() {
+			err := &ErrNotFound{ID: "my-id"}
+			Expect(err.Error()).To(Equal("object with identifier 'my-id' not found"))
+		})
+	})
+
+	Describe("ErrAlreadyExists", func() {
+		It("Implements the error interface", func() {
+			var err error = &ErrAlreadyExists{ID: "123"}
+			Expect(err).ToNot(BeNil())
+		})
+
+		It("Returns expected error message", func() {
+			err := &ErrAlreadyExists{ID: "my-id"}
+			Expect(err.Error()).To(Equal("object with identifier 'my-id' already exists"))
+		})
+	})
+
+	Describe("ErrDenied", func() {
+		It("Implements the error interface", func() {
+			var err error = &ErrDenied{Reason: "not allowed"}
+			Expect(err).ToNot(BeNil())
+		})
+
+		It("Returns the Reason field as the error message", func() {
+			err := &ErrDenied{Reason: "operation not permitted"}
+			Expect(err.Error()).To(Equal("operation not permitted"))
+		})
+
+		It("Returns empty string when Reason is empty", func() {
+			err := &ErrDenied{}
+			Expect(err.Error()).To(BeEmpty())
+		})
+	})
+})

--- a/internal/servers/generic_server.go
+++ b/internal/servers/generic_server.go
@@ -319,6 +319,10 @@ func (s *GenericServer[O]) List(ctx context.Context, request any, response any) 
 		SetLimit(requestMsg.GetLimit()).
 		Do(ctx)
 	if err != nil {
+		var deniedErr *dao.ErrDenied
+		if errors.As(err, &deniedErr) {
+			return grpcstatus.Errorf(grpccodes.PermissionDenied, "%s", deniedErr.Reason)
+		}
 		s.logger.ErrorContext(
 			ctx,
 			"Failed to list",
@@ -353,6 +357,10 @@ func (s *GenericServer[O]) Get(ctx context.Context, request any, response any) e
 		var notFoundErr *dao.ErrNotFound
 		if errors.As(err, &notFoundErr) {
 			return grpcstatus.Errorf(grpccodes.NotFound, "object with identifier '%s' not found", id)
+		}
+		var deniedErr *dao.ErrDenied
+		if errors.As(err, &deniedErr) {
+			return grpcstatus.Errorf(grpccodes.PermissionDenied, "%s", deniedErr.Reason)
 		}
 		s.logger.ErrorContext(
 			ctx,
@@ -400,6 +408,10 @@ func (s *GenericServer[O]) Create(ctx context.Context, request any, response any
 				alreadyExistsErr.ID,
 			)
 		}
+		var deniedErr *dao.ErrDenied
+		if errors.As(err, &deniedErr) {
+			return grpcstatus.Errorf(grpccodes.PermissionDenied, "%s", deniedErr.Reason)
+		}
 		s.logger.ErrorContext(
 			ctx,
 			"Failed to create",
@@ -444,6 +456,10 @@ func (s *GenericServer[O]) Update(ctx context.Context, request any, response any
 				"object with identifier '%s' not found",
 				id,
 			)
+		}
+		var deniedErr *dao.ErrDenied
+		if errors.As(err, &deniedErr) {
+			return grpcstatus.Errorf(grpccodes.PermissionDenied, "%s", deniedErr.Reason)
 		}
 		s.logger.ErrorContext(
 			ctx,
@@ -499,6 +515,10 @@ func (s *GenericServer[O]) Update(ctx context.Context, request any, response any
 		SetObject(object).
 		Do(ctx)
 	if err != nil {
+		var deniedErr *dao.ErrDenied
+		if errors.As(err, &deniedErr) {
+			return grpcstatus.Errorf(grpccodes.PermissionDenied, "%s", deniedErr.Reason)
+		}
 		s.logger.ErrorContext(
 			ctx,
 			"Failed to update object",
@@ -569,6 +589,10 @@ func (s *GenericServer[O]) Delete(ctx context.Context, request any, response any
 				id,
 			)
 		}
+		var deniedErr *dao.ErrDenied
+		if errors.As(err, &deniedErr) {
+			return grpcstatus.Errorf(grpccodes.PermissionDenied, "%s", deniedErr.Reason)
+		}
 		s.logger.ErrorContext(
 			ctx,
 			"Failed to delete object",
@@ -606,6 +630,10 @@ func (s *GenericServer[O]) Signal(ctx context.Context, request any, response any
 				"object with identifier '%s' not found",
 				id,
 			)
+		}
+		var deniedErr *dao.ErrDenied
+		if errors.As(err, &deniedErr) {
+			return grpcstatus.Errorf(grpccodes.PermissionDenied, "%s", deniedErr.Reason)
 		}
 		s.logger.ErrorContext(
 			ctx,

--- a/internal/servers/private_clusters_server.go
+++ b/internal/servers/private_clusters_server.go
@@ -231,6 +231,10 @@ func (s *PrivateClustersServer) lookupTemplate(ctx context.Context,
 		SetLimit(1).
 		Do(ctx)
 	if err != nil {
+		var deniedErr *dao.ErrDenied
+		if errors.As(err, &deniedErr) {
+			err = grpcstatus.Errorf(grpccodes.PermissionDenied, "%s", deniedErr.Reason)
+		}
 		return
 	}
 	switch response.GetSize() {
@@ -262,6 +266,10 @@ func (s *PrivateClustersServer) lookupHostClass(ctx context.Context,
 		SetLimit(1).
 		Do(ctx)
 	if err != nil {
+		var deniedErr *dao.ErrDenied
+		if errors.As(err, &deniedErr) {
+			err = grpcstatus.Errorf(grpccodes.PermissionDenied, "%s", deniedErr.Reason)
+		}
 		return
 	}
 	switch response.GetSize() {


### PR DESCRIPTION
This patch fixes the empty tenancy check that I broke in a recent commit. In addition it adds a new `ErrDenied` error to the DAO which should improve the error messages returned to users.