### PR TITLE
Additional allows for CORS

### DIFF
--- a/charts/service/files/service/envoy.yaml
+++ b/charts/service/files/service/envoy.yaml
@@ -52,8 +52,9 @@ static_resources:
                   allow_origin_string_match:
                   - safe_regex:
                       regex: ".*"
-                  allow_methods: "POST"
-                  allow_headers: "Authorization, Content-Type, X-User-Agent, X-Grpc-Web"
+                  allow_methods: "GET,POST,PUT,PATCH,DELETE,OPTIONS"
+                  allow_headers: "Authorization,Content-Type,X-User-Agent,X-Grpc-Web, Accept"
+                  expose_headers: "Grpc-Status,Grpc-Message"
                   allow_credentials: true
                   max_age: "86400"
               routes:

--- a/manifests/base/service/files/envoy.yaml
+++ b/manifests/base/service/files/envoy.yaml
@@ -52,8 +52,9 @@ static_resources:
                   allow_origin_string_match:
                   - safe_regex:
                       regex: ".*"
-                  allow_methods: "POST"
-                  allow_headers: "Authorization, Content-Type, X-User-Agent, X-Grpc-Web"
+                  allow_methods: "GET,POST,PUT,PATCH,DELETE,OPTIONS"
+                  allow_headers: "Authorization,Content-Type,X-User-Agent,X-Grpc-Web, Accept"
+                  expose_headers: "Grpc-Status,Grpc-Message"
                   allow_credentials: true
                   max_age: "86400"
               routes:


### PR DESCRIPTION
Add additional allowed CORS methods and headers. These are needed for clients that use the REST API from a browser.