### PR TITLE
Only update finalizers and status from reconcilers

### DIFF
--- a/internal/controllers/cluster/cluster_reconciler_function.go
+++ b/internal/controllers/cluster/cluster_reconciler_function.go
@@ -23,6 +23,7 @@ import (
 
 	"google.golang.org/grpc"
 	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/fieldmaskpb"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	clnt "sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -128,6 +129,12 @@ func (r *function) run(ctx context.Context, cluster *privatev1.Cluster) error {
 	if !proto.Equal(cluster, oldCluster) {
 		_, err = r.clustersClient.Update(ctx, privatev1.ClustersUpdateRequest_builder{
 			Object: cluster,
+			UpdateMask: &fieldmaskpb.FieldMask{
+				Paths: []string{
+					"metadata.finalizers",
+					"status",
+				},
+			},
 		}.Build())
 	}
 	return err

--- a/internal/controllers/host/host_reconciler_function.go
+++ b/internal/controllers/host/host_reconciler_function.go
@@ -22,6 +22,7 @@ import (
 
 	"google.golang.org/grpc"
 	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/fieldmaskpb"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	clnt "sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -127,6 +128,12 @@ func (r *function) run(ctx context.Context, host *privatev1.Host) error {
 	if !proto.Equal(host, oldHost) {
 		_, err = r.hostsClient.Update(ctx, privatev1.HostsUpdateRequest_builder{
 			Object: host,
+			UpdateMask: &fieldmaskpb.FieldMask{
+				Paths: []string{
+					"metadata.finalizers",
+					"status",
+				},
+			},
 		}.Build())
 	}
 	return err

--- a/internal/controllers/vm/vm_reconciler_function.go
+++ b/internal/controllers/vm/vm_reconciler_function.go
@@ -23,6 +23,7 @@ import (
 
 	"google.golang.org/grpc"
 	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/fieldmaskpb"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	clnt "sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -130,6 +131,12 @@ func (r *function) run(ctx context.Context, vm *privatev1.VirtualMachine) error 
 	if !proto.Equal(vm, oldVM) {
 		_, err = r.vmsClient.Update(ctx, privatev1.VirtualMachinesUpdateRequest_builder{
 			Object: vm,
+			UpdateMask: &fieldmaskpb.FieldMask{
+				Paths: []string{
+					"metadata.finalizers",
+					"status",
+				},
+			},
 		}.Build())
 	}
 


### PR DESCRIPTION
Currently reconcilers send full updates of objects, which sometimes results in overwriting changes made by users to the spec of the object. To reduce the chances of that happening, this patch changes all reconcilers so that they will use an update mask to ensure that they only update the `metadata.finalizers` and the `status` of the objects.

This issue was discovered by Elad Tabak, and he is working on a more general solution in https://github.com/innabox/fulfillment-service/pull/214. Meanwhile, I am copying part of his work to make the integration tests less flaky.