### PR TITLE
Allow create without object

### DIFF
--- a/internal/database/dao/generic_dao_create.go
+++ b/internal/database/dao/generic_dao_create.go
@@ -17,6 +17,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"reflect"
 	"time"
 
 	"github.com/jackc/pgerrcode"
@@ -54,6 +55,11 @@ func (r *CreateRequest[O]) do(ctx context.Context) (response *CreateResponse[O],
 	err = r.initTenants(ctx)
 	if err != nil {
 		return
+	}
+
+	// If the object is nil, create an empty one:
+	if reflect.ValueOf(r.object).IsNil() {
+		r.object = r.newObject()
 	}
 
 	// Generate an identifier if needed:

--- a/internal/database/dao/generic_dao_test.go
+++ b/internal/database/dao/generic_dao_test.go
@@ -263,6 +263,19 @@ var _ = Describe("Generic DAO", func() {
 			Expect(result).ToNot(BeNil())
 		})
 
+		It("Creates empty object if no object is provided", func() {
+			createResponse, err := generic.Create().Do(ctx)
+			Expect(err).ToNot(HaveOccurred())
+			created := createResponse.GetObject()
+			Expect(created).ToNot(BeNil())
+			Expect(created.GetId()).ToNot(BeEmpty())
+			getResponse, err := generic.Get().SetId(created.GetId()).Do(ctx)
+			Expect(err).ToNot(HaveOccurred())
+			result := getResponse.GetObject()
+			Expect(result).ToNot(BeNil())
+			Expect(result.GetId()).To(Equal(created.GetId()))
+		})
+
 		It("Sets metadata when creating", func() {
 			object := &testsv1.Object{}
 			response, err := generic.Create().
@@ -306,9 +319,7 @@ var _ = Describe("Generic DAO", func() {
 		})
 
 		It("Doesn't set deletion timestamp when creating", func() {
-			response, err := generic.Create().
-				SetObject(&testsv1.Object{}).
-				Do(ctx)
+			response, err := generic.Create().Do(ctx)
 			Expect(err).ToNot(HaveOccurred())
 			object := response.GetObject()
 			Expect(object).ToNot(BeNil())
@@ -338,9 +349,7 @@ var _ = Describe("Generic DAO", func() {
 		})
 
 		It("Generates non empty identifiers", func() {
-			response, err := generic.Create().
-				SetObject(&testsv1.Object{}).
-				Do(ctx)
+			response, err := generic.Create().Do(ctx)
 			Expect(err).ToNot(HaveOccurred())
 			object := response.GetObject()
 			Expect(object).ToNot(BeNil())
@@ -392,9 +401,7 @@ var _ = Describe("Generic DAO", func() {
 		})
 
 		It("Gets object", func() {
-			createResponse, err := generic.Create().
-				SetObject(&testsv1.Object{}).
-				Do(ctx)
+			createResponse, err := generic.Create().Do(ctx)
 			Expect(err).ToNot(HaveOccurred())
 			object := createResponse.GetObject()
 			getResponse, err := generic.Get().
@@ -419,9 +426,7 @@ var _ = Describe("Generic DAO", func() {
 			// Insert a couple of rows:
 			const count = 2
 			for range count {
-				_, err := generic.Create().
-					SetObject(&testsv1.Object{}).
-					Do(ctx)
+				_, err := generic.Create().Do(ctx)
 				Expect(err).ToNot(HaveOccurred())
 			}
 
@@ -464,9 +469,7 @@ var _ = Describe("Generic DAO", func() {
 
 		It("Doesn't save the creation identifier in the 'data' column", func() {
 			// Create an object:
-			response, err := generic.Create().
-				SetObject(&testsv1.Object{}).
-				Do(ctx)
+			response, err := generic.Create().Do(ctx)
 			Expect(err).ToNot(HaveOccurred())
 			object := response.GetObject()
 
@@ -480,9 +483,7 @@ var _ = Describe("Generic DAO", func() {
 
 		It("Doesn't save the creation timestamp in the 'data' column", func() {
 			// Create an object:
-			response, err := generic.Create().
-				SetObject(&testsv1.Object{}).
-				Do(ctx)
+			response, err := generic.Create().Do(ctx)
 			Expect(err).ToNot(HaveOccurred())
 			object := response.GetObject()
 
@@ -716,7 +717,6 @@ var _ = Describe("Generic DAO", func() {
 
 			It("Creates object without finalizers", func() {
 				response, err := generic.Create().
-					SetObject(&testsv1.Object{}).
 					Do(ctx)
 				Expect(err).ToNot(HaveOccurred())
 				object := response.GetObject()
@@ -773,7 +773,6 @@ var _ = Describe("Generic DAO", func() {
 
 			It("Adds one finalizer when object is updated", func() {
 				response, err := generic.Create().
-					SetObject(&testsv1.Object{}).
 					Do(ctx)
 				Expect(err).ToNot(HaveOccurred())
 				object := response.GetObject()
@@ -789,9 +788,6 @@ var _ = Describe("Generic DAO", func() {
 
 			It("Adds two finalizers when object is updated", func() {
 				response, err := generic.Create().
-					SetObject(
-						testsv1.Object_builder{}.Build(),
-					).
 					Do(ctx)
 				Expect(err).ToNot(HaveOccurred())
 				object := response.GetObject()
@@ -829,7 +825,6 @@ var _ = Describe("Generic DAO", func() {
 
 			It("Eliminates duplicated finalizers when object is updated", func() {
 				response, err := generic.Create().
-					SetObject(&testsv1.Object{}).
 					Do(ctx)
 				Expect(err).ToNot(HaveOccurred())
 				object := response.GetObject()
@@ -959,9 +954,7 @@ var _ = Describe("Generic DAO", func() {
 
 		Describe("Check if object exists", func() {
 			It("Returns true if the object exists", func() {
-				response, err := generic.Create().
-					SetObject(&testsv1.Object{}).
-					Do(ctx)
+				response, err := generic.Create().Do(ctx)
 				Expect(err).ToNot(HaveOccurred())
 				object := response.GetObject()
 				existsResponse, err := generic.Exists().

--- a/internal/database/dao/tenancy_logic_test.go
+++ b/internal/database/dao/tenancy_logic_test.go
@@ -688,9 +688,7 @@ var _ = Describe("Tenancy logic", func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		// Create an object with default tenants:
-		createResponse, err := dao.Create().
-			SetObject(testsv1.Object_builder{}.Build()).
-			Do(ctx)
+		createResponse, err := dao.Create().Do(ctx)
 		Expect(err).ToNot(HaveOccurred())
 		object := createResponse.GetObject()
 		Expect(object.GetMetadata().GetTenants()).To(ConsistOf("tenant-a", "tenant-b"))
@@ -753,9 +751,7 @@ var _ = Describe("Tenancy logic", func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		// Create an object with default tenants:
-		createResponse, err := dao.Create().
-			SetObject(testsv1.Object_builder{}.Build()).
-			Do(ctx)
+		createResponse, err := dao.Create().Do(ctx)
 		Expect(err).ToNot(HaveOccurred())
 		object := createResponse.GetObject()
 		Expect(err).ToNot(HaveOccurred())
@@ -822,9 +818,7 @@ var _ = Describe("Tenancy logic", func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		// Create an object with default tenants:
-		createResponse, err := dao.Create().
-			SetObject(testsv1.Object_builder{}.Build()).
-			Do(ctx)
+		createResponse, err := dao.Create().Do(ctx)
 		Expect(err).ToNot(HaveOccurred())
 		object := createResponse.GetObject()
 		Expect(err).ToNot(HaveOccurred())
@@ -892,9 +886,7 @@ var _ = Describe("Tenancy logic", func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		// Create an object (will get default tenants including invisible one):
-		createResponse, err := dao.Create().
-			SetObject(testsv1.Object_builder{}.Build()).
-			Do(ctx)
+		createResponse, err := dao.Create().Do(ctx)
 		Expect(err).ToNot(HaveOccurred())
 		object := createResponse.GetObject()
 		Expect(err).ToNot(HaveOccurred())
@@ -967,9 +959,7 @@ var _ = Describe("Tenancy logic", func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		// Create an object with visible tenants only:
-		createResponse, err := dao.Create().
-			SetObject(testsv1.Object_builder{}.Build()).
-			Do(ctx)
+		createResponse, err := dao.Create().Do(ctx)
 		Expect(err).ToNot(HaveOccurred())
 		object := createResponse.GetObject()
 		Expect(err).ToNot(HaveOccurred())
@@ -1027,9 +1017,7 @@ var _ = Describe("Tenancy logic", func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		// Create an object:
-		createResponse, err := dao.Create().
-			SetObject(testsv1.Object_builder{}.Build()).
-			Do(ctx)
+		createResponse, err := dao.Create().Do(ctx)
 		Expect(err).ToNot(HaveOccurred())
 		object := createResponse.GetObject()
 		Expect(err).ToNot(HaveOccurred())
@@ -1078,9 +1066,7 @@ var _ = Describe("Tenancy logic", func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		// Create an object without specifying tenants (should get default):
-		createResponse, err := dao.Create().
-			SetObject(testsv1.Object_builder{}.Build()).
-			Do(ctx)
+		createResponse, err := dao.Create().Do(ctx)
 		Expect(err).ToNot(HaveOccurred())
 		object := createResponse.GetObject()
 		Expect(err).ToNot(HaveOccurred())
@@ -1126,9 +1112,7 @@ var _ = Describe("Tenancy logic", func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		// Create an object with default tenants:
-		createResponse, err := dao.Create().
-			SetObject(testsv1.Object_builder{}.Build()).
-			Do(ctx)
+		createResponse, err := dao.Create().Do(ctx)
 		Expect(err).ToNot(HaveOccurred())
 		object := createResponse.GetObject()
 		Expect(err).ToNot(HaveOccurred())

--- a/internal/servers/private_virtual_machine_templates_server_test.go
+++ b/internal/servers/private_virtual_machine_templates_server_test.go
@@ -401,11 +401,12 @@ var _ = Describe("Private virtual machine templates server", func() {
 			Expect(getResponse).To(BeNil())
 		})
 
-		It("Handles empty object in create request", func() {
-			// Try to create with nil object:
+		It("Creates empty object if no object is provided", func() {
 			response, err := server.Create(ctx, privatev1.VirtualMachineTemplatesCreateRequest_builder{}.Build())
-			Expect(err).To(HaveOccurred())
-			Expect(response).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
+			Expect(response).ToNot(BeNil())
+			Expect(response.GetObject()).ToNot(BeNil())
+			Expect(response.GetObject().GetId()).ToNot(BeEmpty())
 		})
 
 		It("Handles empty object in update request", func() {


### PR DESCRIPTION
This patch changes the database layer so that it accepts creation of objects without actually specifying the details of the object. This will create an empty object, which is handy, specially in unit tests.