### PR TITLE
Add finalizer immediately and return early in reconcilers

### DIFF
--- a/internal/controllers/host/host_reconciler_function.go
+++ b/internal/controllers/host/host_reconciler_function.go
@@ -140,8 +140,11 @@ func (r *function) run(ctx context.Context, host *privatev1.Host) error {
 }
 
 func (t *task) update(ctx context.Context) error {
-	// Add the finalizer:
-	t.addFinalizer()
+	// Add the finalizer and return immediately if it was added. This ensures the finalizer is persisted before any
+	// other work is done, reducing the chance of the object being deleted before the finalizer is saved.
+	if t.addFinalizer() {
+		return nil
+	}
 
 	// Set the default values:
 	t.setDefaults()
@@ -332,12 +335,16 @@ func (t *task) getKubeObject(ctx context.Context) (result *unstructured.Unstruct
 	return
 }
 
-func (t *task) addFinalizer() {
+// addFinalizer adds the controller finalizer if it is not already present. Returns true if the finalizer was added,
+// false if it was already present.
+func (t *task) addFinalizer() bool {
 	list := t.host.GetMetadata().GetFinalizers()
 	if !slices.Contains(list, finalizers.Controller) {
 		list = append(list, finalizers.Controller)
 		t.host.GetMetadata().SetFinalizers(list)
+		return true
 	}
+	return false
 }
 
 func (t *task) removeFinalizer() {

--- a/internal/controllers/hostpool/hostpool_reconciler_function.go
+++ b/internal/controllers/hostpool/hostpool_reconciler_function.go
@@ -133,8 +133,11 @@ func (r *function) run(ctx context.Context, hostPool *privatev1.HostPool) error 
 }
 
 func (t *task) update(ctx context.Context) error {
-	// Add the finalizer:
-	t.addFinalizer()
+	// Add the finalizer and return immediately if it was added. This ensures the finalizer is persisted before any
+	// other work is done, reducing the chance of the object being deleted before the finalizer is saved.
+	if t.addFinalizer() {
+		return nil
+	}
 
 	// Set the default values:
 	t.setDefaults()
@@ -362,12 +365,16 @@ func (t *task) getKubeObject(ctx context.Context) (result *unstructured.Unstruct
 	return
 }
 
-func (t *task) addFinalizer() {
+// addFinalizer adds the controller finalizer if it is not already present. Returns true if the finalizer was added,
+// false if it was already present.
+func (t *task) addFinalizer() bool {
 	list := t.hostPool.GetMetadata().GetFinalizers()
 	if !slices.Contains(list, finalizers.Controller) {
 		list = append(list, finalizers.Controller)
 		t.hostPool.GetMetadata().SetFinalizers(list)
+		return true
 	}
+	return false
 }
 
 func (t *task) removeFinalizer() {

--- a/internal/controllers/vm/vm_reconciler_function.go
+++ b/internal/controllers/vm/vm_reconciler_function.go
@@ -144,8 +144,11 @@ func (r *function) run(ctx context.Context, vm *privatev1.VirtualMachine) error 
 }
 
 func (t *task) update(ctx context.Context) error {
-	// Add the finalizer:
-	t.addFinalizer()
+	// Add the finalizer and return immediately if it was added. This ensures the finalizer is persisted before any
+	// other work is done, reducing the chance of the object being deleted before the finalizer is saved.
+	if t.addFinalizer() {
+		return nil
+	}
 
 	// Set the default values:
 	t.setDefaults()
@@ -380,7 +383,9 @@ func (t *task) getKubeObject(ctx context.Context) (result *unstructured.Unstruct
 	return
 }
 
-func (t *task) addFinalizer() {
+// addFinalizer adds the controller finalizer if it is not already present. Returns true if the finalizer was added,
+// false if it was already present.
+func (t *task) addFinalizer() bool {
 	if !t.vm.HasMetadata() {
 		t.vm.SetMetadata(&privatev1.Metadata{})
 	}
@@ -388,7 +393,9 @@ func (t *task) addFinalizer() {
 	if !slices.Contains(list, finalizers.Controller) {
 		list = append(list, finalizers.Controller)
 		t.vm.GetMetadata().SetFinalizers(list)
+		return true
 	}
+	return false
 }
 
 func (t *task) removeFinalizer() {


### PR DESCRIPTION
This change modifies all reconcilers (cluster, vm, host, hostpool) to persist the finalizer before performing any other work. When `addFinalizer` adds a new finalizer it now returns `true`, causing the `update` method to return immediately. The object is then saved with only the finalizer change, and the reconciler will process it again on the next cycle.

This reduces the risk of an object being deleted before the finalizer is persisted, which could happen if the reconciliation takes an unusually long time.