### PR TITLE
Add integration tests tool

### DIFF
--- a/it/it_cluster_reconciler_test.go
+++ b/it/it_cluster_reconciler_test.go
@@ -55,9 +55,9 @@ var _ = Describe("Cluster reconciler", func() {
 		ctx = context.Background()
 
 		// Create the clients:
-		clustersClient = ffv1.NewClustersClient(clientConn)
-		hostClassesClient = privatev1.NewHostClassesClient(adminConn)
-		templatesClient = privatev1.NewClusterTemplatesClient(adminConn)
+		clustersClient = ffv1.NewClustersClient(tool.ClientConn())
+		hostClassesClient = privatev1.NewHostClassesClient(tool.AdminConn())
+		templatesClient = privatev1.NewClusterTemplatesClient(tool.AdminConn())
 
 		// Create a host class for testing:
 		hostClassId = fmt.Sprintf("my_host_class_%s", uuid.New())
@@ -131,7 +131,7 @@ var _ = Describe("Cluster reconciler", func() {
 		})
 
 		// Check that the Kubernetes object is eventually created:
-		kubeClient := cluster.Client()
+		kubeClient := tool.KubeClient()
 		clusterOrderList := &unstructured.UnstructuredList{}
 		clusterOrderList.SetGroupVersionKind(gvks.ClusterOrderList)
 		var kubeObject *unstructured.Unstructured
@@ -186,7 +186,7 @@ var _ = Describe("Cluster reconciler", func() {
 		object := createResponse.GetObject()
 
 		// Wait for the corresponding Kubernetes object to be created:
-		kubeClient := cluster.Client()
+		kubeClient := tool.KubeClient()
 		clusterOrderList := &unstructured.UnstructuredList{}
 		clusterOrderList.SetGroupVersionKind(gvks.ClusterOrderList)
 		var clusterOrderObj *unstructured.Unstructured
@@ -256,7 +256,7 @@ var _ = Describe("Cluster reconciler", func() {
 		})
 
 		// Wait for the corresponding Kubernetes object to be created:
-		kubeClient := cluster.Client()
+		kubeClient := tool.KubeClient()
 		clusterOrderList := &unstructured.UnstructuredList{}
 		clusterOrderList.SetGroupVersionKind(gvks.ClusterOrderList)
 		var clusterOrderObj *unstructured.Unstructured

--- a/it/it_nodeset_removal_test.go
+++ b/it/it_nodeset_removal_test.go
@@ -40,9 +40,9 @@ var _ = Describe("Node set removal", func() {
 	BeforeEach(func() {
 		ctx = context.Background()
 
-		clustersClient = ffv1.NewClustersClient(clientConn)
-		hostClassesClient = privatev1.NewHostClassesClient(adminConn)
-		templatesClient = privatev1.NewClusterTemplatesClient(adminConn)
+		clustersClient = ffv1.NewClustersClient(tool.ClientConn())
+		hostClassesClient = privatev1.NewHostClassesClient(tool.AdminConn())
+		templatesClient = privatev1.NewClusterTemplatesClient(tool.AdminConn())
 
 		// Create worker host class:
 		workerHostClassId = fmt.Sprintf("worker_class_%s", uuid.New())

--- a/it/it_private_cluster_templates_test.go
+++ b/it/it_private_cluster_templates_test.go
@@ -34,7 +34,7 @@ var _ = Describe("Private cluster templates", func() {
 
 	BeforeEach(func() {
 		ctx = context.Background()
-		client = privatev1.NewClusterTemplatesClient(adminConn)
+		client = privatev1.NewClusterTemplatesClient(tool.AdminConn())
 	})
 
 	It("Can get the list of templates", func() {

--- a/it/it_private_host_classes_test.go
+++ b/it/it_private_host_classes_test.go
@@ -32,7 +32,7 @@ var _ = Describe("Priate host classes", func() {
 
 	BeforeEach(func() {
 		ctx = context.Background()
-		client = privatev1.NewHostClassesClient(adminConn)
+		client = privatev1.NewHostClassesClient(tool.AdminConn())
 	})
 
 	It("Can get the list of host classes", func() {

--- a/it/it_public_cluster_templates_test.go
+++ b/it/it_public_cluster_templates_test.go
@@ -30,7 +30,7 @@ var _ = Describe("Cluster templates", func() {
 
 	BeforeEach(func() {
 		ctx = context.Background()
-		client = ffv1.NewClusterTemplatesClient(clientConn)
+		client = ffv1.NewClusterTemplatesClient(tool.ClientConn())
 	})
 
 	It("Can get the list of templates", func() {

--- a/it/it_public_clusters_test.go
+++ b/it/it_public_clusters_test.go
@@ -50,9 +50,9 @@ var _ = Describe("Public clusters", func() {
 		ctx = context.Background()
 
 		// Create the clients:
-		clustersClient = ffv1.NewClustersClient(clientConn)
-		hostClassesClient = privatev1.NewHostClassesClient(adminConn)
-		templatesClient = privatev1.NewClusterTemplatesClient(adminConn)
+		clustersClient = ffv1.NewClustersClient(tool.ClientConn())
+		hostClassesClient = privatev1.NewHostClassesClient(tool.AdminConn())
+		templatesClient = privatev1.NewClusterTemplatesClient(tool.AdminConn())
 
 		// Create a host class for testing:
 		hostClassId = fmt.Sprintf("my-host-class-%s", uuid.New())
@@ -320,7 +320,7 @@ var _ = Describe("Public clusters", func() {
 		})
 
 		// Wait till the Kubernetes object has been created:
-		kubeClient := cluster.Client()
+		kubeClient := tool.KubeClient()
 		clusterOrderList := &unstructured.UnstructuredList{}
 		clusterOrderList.SetGroupVersionKind(gvks.ClusterOrderList)
 		var clusterOrderObj *unstructured.Unstructured
@@ -432,7 +432,7 @@ var _ = Describe("Public clusters", func() {
 		})
 
 		// Wait till the Kubernetes object has been created:
-		kubeClient := cluster.Client()
+		kubeClient := tool.KubeClient()
 		clusterOrderList := &unstructured.UnstructuredList{}
 		clusterOrderList.SetGroupVersionKind(gvks.ClusterOrderList)
 		var clusterOrderObj *unstructured.Unstructured
@@ -543,7 +543,7 @@ var _ = Describe("Public clusters", func() {
 		})
 
 		// Wait till the Kubernetes object has been created:
-		kubeClient := cluster.Client()
+		kubeClient := tool.KubeClient()
 		clusterOrderList := &unstructured.UnstructuredList{}
 		clusterOrderList.SetGroupVersionKind(gvks.ClusterOrderList)
 		var clusterOrderObj *unstructured.Unstructured
@@ -652,7 +652,7 @@ var _ = Describe("Public clusters", func() {
 		})
 
 		// Wait till the Kubernetes object has been created:
-		kubeClient := cluster.Client()
+		kubeClient := tool.KubeClient()
 		clusterOrderList := &unstructured.UnstructuredList{}
 		clusterOrderList.SetGroupVersionKind(gvks.ClusterOrderList)
 		var clusterOrderObj *unstructured.Unstructured

--- a/it/it_rest_gateway_test.go
+++ b/it/it_rest_gateway_test.go
@@ -36,8 +36,8 @@ var _ = Describe("REST gateway", func() {
 
 	BeforeEach(func() {
 		ctx = context.Background()
-		templatesClient = privatev1.NewClusterTemplatesClient(adminConn)
-		hostClassesClient = privatev1.NewHostClassesClient(adminConn)
+		templatesClient = privatev1.NewClusterTemplatesClient(tool.AdminConn())
+		hostClassesClient = privatev1.NewHostClassesClient(tool.AdminConn())
 	})
 
 	It("Should use protobuf field names in JSON representation", func() {
@@ -105,7 +105,7 @@ var _ = Describe("REST gateway", func() {
 		url := fmt.Sprintf("https://localhost:8000/api/fulfillment/v1/cluster_templates/%s", templateID)
 		request, err := http.NewRequestWithContext(ctx, "GET", url, nil)
 		Expect(err).ToNot(HaveOccurred())
-		response, err := userClient.Do(request)
+		response, err := tool.UserClient().Do(request)
 		Expect(err).ToNot(HaveOccurred())
 		defer response.Body.Close()
 		Expect(response.StatusCode).To(Equal(http.StatusOK))
@@ -184,7 +184,7 @@ var _ = Describe("REST gateway", func() {
 		url := fmt.Sprintf("https://localhost:8000/api/private/v1/cluster_templates/%s", templateID)
 		request, err := http.NewRequestWithContext(ctx, "GET", url, nil)
 		Expect(err).ToNot(HaveOccurred())
-		response, err := adminClient.Do(request)
+		response, err := tool.AdminClient().Do(request)
 		Expect(err).ToNot(HaveOccurred())
 		defer response.Body.Close()
 		Expect(response.StatusCode).To(Equal(http.StatusOK))

--- a/it/it_suite_test.go
+++ b/it/it_suite_test.go
@@ -15,42 +15,18 @@ package it
 
 import (
 	"context"
-	"crypto/tls"
-	"errors"
-	"fmt"
 	"log/slog"
-	"net/http"
-	"os"
-	"os/exec"
 	"path/filepath"
 	"testing"
-	"time"
 
 	"github.com/go-logr/logr"
-	"github.com/innabox/fulfillment-common/auth"
 	"github.com/innabox/fulfillment-common/logging"
-	"github.com/innabox/fulfillment-common/network"
-	. "github.com/innabox/fulfillment-common/testing"
 	"github.com/kelseyhightower/envconfig"
 	. "github.com/onsi/ginkgo/v2/dsl/core"
 	. "github.com/onsi/ginkgo/v2/dsl/decorators"
 	. "github.com/onsi/gomega"
-	"github.com/onsi/gomega/ghttp"
-	"google.golang.org/grpc"
-	grpccodes "google.golang.org/grpc/codes"
-	healthv1 "google.golang.org/grpc/health/grpc_health_v1"
-	grpcstatus "google.golang.org/grpc/status"
-	authenticationv1 "k8s.io/api/authentication/v1"
-	corev1 "k8s.io/api/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/klog/v2"
-	"k8s.io/utils/ptr"
-	crclient "sigs.k8s.io/controller-runtime/pkg/client"
 	crlog "sigs.k8s.io/controller-runtime/pkg/log"
-
-	privatev1 "github.com/innabox/fulfillment-service/internal/api/private/v1"
 )
 
 // Config contains configuration options for the integration tests.
@@ -65,13 +41,9 @@ type Config struct {
 }
 
 var (
-	logger      *slog.Logger
-	config      *Config
-	cluster     *Kind
-	clientConn  *grpc.ClientConn
-	adminConn   *grpc.ClientConn
-	userClient  *http.Client
-	adminClient *http.Client
+	logger *slog.Logger
+	config *Config
+	tool   *Tool
 )
 
 func TestIntegration(t *testing.T) {
@@ -92,6 +64,11 @@ var _ = BeforeSuite(func() {
 		Build()
 	Expect(err).ToNot(HaveOccurred())
 
+	// Configure the Kubernetes libraries to use our logger:
+	logrLogger := logr.FromSlogHandler(logger.Handler())
+	crlog.SetLogger(logrLogger)
+	klog.SetLogger(logrLogger)
+
 	// Load configuration from environment variables:
 	config = &Config{}
 	err = envconfig.Process("it", config)
@@ -101,358 +78,25 @@ var _ = BeforeSuite(func() {
 		slog.Any("values", config),
 	)
 
-	// Configure the Kubernetes libraries to use our logger:
-	logrLogger := logr.FromSlogHandler(logger.Handler())
-	crlog.SetLogger(logrLogger)
-	klog.SetLogger(logrLogger)
-
-	// Create a temporary directory:
-	tmpDir, err := os.MkdirTemp("", "*.it")
-	Expect(err).ToNot(HaveOccurred())
-	DeferCleanup(func() {
-		err := os.RemoveAll(tmpDir)
-		Expect(err).ToNot(HaveOccurred())
-	})
-
-	// Get the project directory:
-	currentDir, err := os.Getwd()
-	Expect(err).ToNot(HaveOccurred())
-	for {
-		modFile := filepath.Join(currentDir, "go.mod")
-		_, err := os.Stat(modFile)
-		if err == nil {
-			break
-		}
-		if !errors.Is(err, os.ErrNotExist) {
-			Expect(err).ToNot(HaveOccurred())
-		}
-		parentDir := filepath.Dir(currentDir)
-		Expect(parentDir).ToNot(Equal(currentDir))
-		currentDir = parentDir
-	}
-	projectDir := currentDir
-
-	// Check that the required tools are available:
-	_, err = exec.LookPath(kubectlCmd)
-	Expect(err).ToNot(HaveOccurred())
-	_, err = exec.LookPath(podmanCmd)
-	Expect(err).ToNot(HaveOccurred())
-	_, err = exec.LookPath(helmCmd)
-	Expect(err).ToNot(HaveOccurred())
-
-	// Build the binary:
-	buildCmd, err := NewCommand().
+	// Create and setup the tool:
+	tool, err = NewTool().
 		SetLogger(logger).
-		SetDir(projectDir).
-		SetHome(projectDir).
-		SetName("go").
-		SetArgs("build").
-		Build()
-	Expect(err).ToNot(HaveOccurred())
-	err = buildCmd.Execute(ctx)
-	Expect(err).ToNot(HaveOccurred())
-
-	// Build the container image:
-	imageTag := time.Now().Format("20060102150405")
-	imageRef := fmt.Sprintf("%s:%s", imageName, imageTag)
-	buildCmd, err = NewCommand().
-		SetLogger(logger).
-		SetDir(projectDir).
-		SetName("podman").
-		SetArgs(
-			"build",
-			"--tag", imageRef,
-			"--file", filepath.Join("it", "Containerfile"),
-			".",
-		).
-		Build()
-	Expect(err).ToNot(HaveOccurred())
-	err = buildCmd.Execute(ctx)
-	Expect(err).ToNot(HaveOccurred())
-
-	// Save the container image to the tar file:
-	imageTar := filepath.Join(tmpDir, "image.tar")
-	saveCmd, err := NewCommand().
-		SetLogger(logger).
-		SetDir(projectDir).
-		SetName(podmanCmd).
-		SetArgs(
-			"save",
-			"--output", imageTar,
-			imageRef,
-		).
-		Build()
-	Expect(err).ToNot(HaveOccurred())
-	err = saveCmd.Execute(ctx)
-	Expect(err).ToNot(HaveOccurred())
-
-	// Start the cluster, and remember to stop it:
-	cluster, err = NewKind().
-		SetLogger(logger).
-		SetName("fulfillment-service-it").
-		SetHome(projectDir).
+		SetKeepCluster(config.KeepKind).
+		SetKeepService(config.KeepService).
 		AddCrdFile(filepath.Join("crds", "clusterorders.cloudkit.openshift.io.yaml")).
 		AddCrdFile(filepath.Join("crds", "hostedclusters.hypershift.openshift.io.yaml")).
 		Build()
 	Expect(err).ToNot(HaveOccurred())
-	err = cluster.Start(ctx)
+	err = tool.Setup(ctx)
 	Expect(err).ToNot(HaveOccurred())
-	if !config.KeepKind {
-		DeferCleanup(func() {
-			err := cluster.Stop(ctx)
-			Expect(err).ToNot(HaveOccurred())
-		})
-	}
 	DeferCleanup(func() {
-		logsDir := filepath.Join(projectDir, "logs")
-		err := cluster.Dump(ctx, logsDir)
+		err := tool.Cleanup(ctx)
 		Expect(err).ToNot(HaveOccurred())
 	})
-
-	// Load the container image into the cluster:
-	err = cluster.LoadArchive(ctx, imageTar)
-	Expect(err).ToNot(HaveOccurred())
-
-	// Get the kubeconfig:
-	kcFile := filepath.Join(tmpDir, "kubeconfig")
-	err = os.WriteFile(kcFile, cluster.Kubeconfig(), 0400)
-	Expect(err).ToNot(HaveOccurred())
-
-	// Get the client:
-	kubeClient := cluster.Client()
-	kubeClientSet := cluster.ClientSet()
-
-	// Load the certificates of the CA bundle of the cluster:
-	var caFiles []string
-	caBundleKey := crclient.ObjectKey{
-		Namespace: "default",
-		Name:      "ca-bundle",
-	}
-	caBundleMap := &corev1.ConfigMap{}
-	Eventually(
-		func(g Gomega) {
-			err := kubeClient.Get(ctx, caBundleKey, caBundleMap)
-			g.Expect(err).ToNot(HaveOccurred())
-		},
-		time.Minute,
-		time.Second,
-	).Should(Succeed())
-	for caBundleKey, caBundleText := range caBundleMap.Data {
-		caBundleFile := filepath.Join(tmpDir, caBundleKey)
-		err = os.WriteFile(caBundleFile, []byte(caBundleText), 0400)
+	DeferCleanup(func() {
+		err := tool.Dump(ctx)
 		Expect(err).ToNot(HaveOccurred())
-		caFiles = append(caFiles, caBundleFile)
-	}
-
-	// Create the CA pool:
-	caPool, err := network.NewCertPool().
-		SetLogger(logger).
-		AddFiles(caFiles...).
-		Build()
-	Expect(err).ToNot(HaveOccurred())
-
-	// Install Keycloak:
-	logger.DebugContext(ctx, "Installing Keycloak chart")
-	installCmd, err := NewCommand().
-		SetLogger(logger).
-		SetDir(projectDir).
-		SetHome(projectDir).
-		SetName(helmCmd).
-		SetArgs(
-			"upgrade",
-			"--install",
-			"keycloak",
-			"charts/keycloak",
-			"--kubeconfig", kcFile,
-			"--namespace", "keycloak",
-			"--create-namespace",
-			"--set", "variant=kind",
-			"--set", "hostname=keycloak.keycloak.svc.cluster.local",
-			"--set", "certs.issuerRef.name=default-ca",
-			"--wait",
-		).
-		Build()
-	Expect(err).ToNot(HaveOccurred())
-	err = installCmd.Execute(ctx)
-	Expect(err).ToNot(HaveOccurred())
-
-	// Deploy the service, and remember to uninstall it:
-	logger.DebugContext(ctx, "Installing service")
-	installCmd, err = NewCommand().
-		SetLogger(logger).
-		SetDir(projectDir).
-		SetHome(projectDir).
-		SetName(helmCmd).
-		SetArgs(
-			"upgrade",
-			"--install",
-			"fulfillment-service",
-			"charts/service",
-			"--kubeconfig", kcFile,
-			"--namespace", "innabox",
-			"--create-namespace",
-			"--set", "log.level=debug",
-			"--set", "log.headers=true",
-			"--set", "log.bodies=true",
-			"--set", "variant=kind",
-			"--set", fmt.Sprintf("images.service=%s", imageRef),
-			"--set", "certs.issuerRef.kind=ClusterIssuer",
-			"--set", "certs.issuerRef.name=default-ca",
-			"--set", "certs.caBundle.configMap=ca-bundle",
-			"--set", "auth.issuerUrl=https://keycloak.keycloak.svc.cluster.local:8001/realms/innabox",
-			"--wait",
-		).
-		Build()
-	Expect(err).ToNot(HaveOccurred())
-	err = installCmd.Execute(ctx)
-	Expect(err).ToNot(HaveOccurred())
-	if config.KeepKind && !config.KeepService {
-		DeferCleanup(func() {
-			logger.InfoContext(ctx, "Uninstalling service")
-			uninstallCmd, err := NewCommand().
-				SetLogger(logger).
-				SetDir(projectDir).
-				SetHome(projectDir).
-				SetName(helmCmd).
-				SetArgs(
-					"uninstall",
-					"fulfillment-service",
-					"--kubeconfig", kcFile,
-					"--namespace", "innabox",
-				).
-				Build()
-			Expect(err).ToNot(HaveOccurred())
-			err = uninstallCmd.Execute(ctx)
-			Expect(err).ToNot(HaveOccurred())
-		})
-	}
-
-	// Helper function to create a token source from a service account:
-	makeTokenSource := func(sa string) auth.TokenSource {
-		response, err := kubeClientSet.CoreV1().ServiceAccounts("innabox").CreateToken(
-			ctx,
-			sa,
-			&authenticationv1.TokenRequest{
-				Spec: authenticationv1.TokenRequestSpec{
-					ExpirationSeconds: ptr.To(int64(3600)),
-				},
-			},
-			metav1.CreateOptions{},
-		)
-		Expect(err).ToNot(HaveOccurred())
-		token := &auth.Token{
-			Access: response.Status.Token,
-		}
-		source, err := auth.NewStaticTokenSource().
-			SetLogger(logger).
-			SetToken(token).
-			Build()
-		Expect(err).ToNot(HaveOccurred())
-		return source
-	}
-
-	// Create the token sources:
-	clientTokenSource := makeTokenSource("client")
-	adminTokenSource := makeTokenSource("admin")
-
-	// Create the gRPC clients:
-	makeConn := func(tokenSource auth.TokenSource) *grpc.ClientConn {
-		conn, err := network.NewGrpcClient().
-			SetLogger(logger).
-			SetCaPool(caPool).
-			SetAddress("localhost:8000").
-			SetTokenSource(tokenSource).
-			Build()
-		Expect(err).ToNot(HaveOccurred())
-		return conn
-	}
-	clientConn = makeConn(clientTokenSource)
-	adminConn = makeConn(adminTokenSource)
-
-	// Helper function to create an HTTP client from a token source:
-	makeClient := func(tokenSource auth.TokenSource) *http.Client {
-		transport := &http.Transport{
-			TLSClientConfig: &tls.Config{
-				RootCAs: caPool,
-			},
-		}
-		return &http.Client{
-			Transport: ghttp.RoundTripperFunc(
-				func(request *http.Request) (response *http.Response, err error) {
-					token, err := tokenSource.Token(request.Context())
-					Expect(err).ToNot(HaveOccurred())
-					request.Header.Set("Authorization", fmt.Sprintf("Bearer %s", token.Access))
-					response, err = transport.RoundTrip(request)
-					return
-				},
-			),
-		}
-	}
-	userClient = makeClient(clientTokenSource)
-	adminClient = makeClient(adminTokenSource)
-
-	// Wait till the application is healthy:
-	healthClient := healthv1.NewHealthClient(adminConn)
-	healthRequest := &healthv1.HealthCheckRequest{}
-	Eventually(
-		func(g Gomega) {
-			healthResponse, err := healthClient.Check(ctx, healthRequest)
-			g.Expect(err).ToNot(HaveOccurred())
-			g.Expect(healthResponse.Status).To(Equal(healthv1.HealthCheckResponse_SERVING))
-		},
-		time.Minute,
-		5*time.Second,
-	).Should(Succeed())
-
-	// Create the namespace for the hub:
-	hubNamespaceObject := &corev1.Namespace{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: hubNamespace,
-		},
-	}
-	err = kubeClient.Create(ctx, hubNamespaceObject)
-	if !apierrors.IsAlreadyExists(err) {
-		Expect(err).ToNot(HaveOccurred())
-	}
-
-	// Register the kind cluster as a hub. Note that in order to do this we need to replace the 127.0.0.1 IP
-	// with the internal DNS name of the API server, as otherwise the controller will not be able to connect.
-	hubKubeconfigBytes := cluster.Kubeconfig()
-	hubKubeconfigObject, err := clientcmd.Load(hubKubeconfigBytes)
-	Expect(err).ToNot(HaveOccurred())
-	for clusterKey := range hubKubeconfigObject.Clusters {
-		hubKubeconfigObject.Clusters[clusterKey].Server = "https://kubernetes.default.svc"
-	}
-	hubKubeconfigBytes, err = clientcmd.Write(*hubKubeconfigObject)
-	Expect(err).ToNot(HaveOccurred())
-	hubsClient := privatev1.NewHubsClient(adminConn)
-
-	// Wait for Authorino authorization to be ready before creating the hub:
-	Eventually(
-		func(g Gomega) {
-			// Try a simple list operation to verify authorization is working
-			_, err := hubsClient.List(ctx, privatev1.HubsListRequest_builder{}.Build())
-			g.Expect(err).ToNot(HaveOccurred())
-		},
-		30*time.Second,
-		time.Second,
-	).Should(Succeed())
-
-	// Now create the hub:
-	_, err = hubsClient.Create(ctx, privatev1.HubsCreateRequest_builder{
-		Object: privatev1.Hub_builder{
-			Id:         hubId,
-			Kubeconfig: hubKubeconfigBytes,
-			Namespace:  hubNamespace,
-		}.Build(),
-	}.Build())
-	if err != nil {
-		status, ok := grpcstatus.FromError(err)
-		if ok && status.Code() == grpccodes.AlreadyExists {
-			err = nil
-		}
-	}
-	Expect(err).ToNot(HaveOccurred())
+	})
 })
 
 var _ = Describe("Integration", func() {
@@ -465,17 +109,3 @@ var _ = Describe("Integration", func() {
 		// This will create the kind cluster, install the dependencies, and deploy the application.
 	})
 })
-
-// Names of the command line tools:
-const (
-	helmCmd    = "helm"
-	kubectlCmd = "kubectl"
-	podmanCmd  = "podman"
-)
-
-// Name and namespace of the hub:
-const hubId = "local"
-const hubNamespace = "cloudkit-operator-system"
-
-// Image details:
-const imageName = "ghcr.io/innabox/fulfillment-service"


### PR DESCRIPTION
This patch moves the code that prepares the integration tests environment to a new `it.Tool` component. Within this component it is easier to add new methods without poluting the namespace of the `it` package.