### PR TITLE
Add option to deploy with Kustomize

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,6 +232,17 @@ The integration tests will automatically:
 4. Run all test cases.
 5. Clean up the kind cluster.
 
+### Deployment mode
+
+By default, the integration tests deploy the service using _Helm_. You can also deploy using
+_Kustomize_ by setting the `IT_DEPLOY_MODE` environment variable:
+
+```bash
+$ IT_DEPLOY_MODE=kustomize ginkgo run it
+```
+
+Valid values are `helm` (default) and `kustomize`.
+
 ### Preserving the test cluster
 
 By default, the kind cluster is deleted after the tests complete. If you want to preserve the cluster

--- a/it/it_suite_test.go
+++ b/it/it_suite_test.go
@@ -38,6 +38,10 @@ type Config struct {
 	// KeepService indicates whether to preserve the application chart after tests complete.
 	// By default, the application chart is uninstalled after running the tests.
 	KeepService bool `json:"keep_service" envconfig:"keep_service" default:"false"`
+
+	// DeployMode indicates how to deploy the service. Valid values are 'helm' and 'kustomize'.
+	// By default, the service is deployed using Helm.
+	DeployMode string `json:"deploy_mode" envconfig:"deploy_mode" default:"helm"`
 }
 
 var (
@@ -83,6 +87,7 @@ var _ = BeforeSuite(func() {
 		SetLogger(logger).
 		SetKeepCluster(config.KeepKind).
 		SetKeepService(config.KeepService).
+		SetDeployMode(config.DeployMode).
 		AddCrdFile(filepath.Join("crds", "clusterorders.cloudkit.openshift.io.yaml")).
 		AddCrdFile(filepath.Join("crds", "hostedclusters.hypershift.openshift.io.yaml")).
 		Build()

--- a/manifests/base/bundle.yaml
+++ b/manifests/base/bundle.yaml
@@ -12,7 +12,7 @@
 #
 
 # Note that this is empty on purpose. It will be populated with the trusted CA certificaes, either using trust-manager,
-# like in the integratoin testing environment or with a Kustomize overlay. All the certificates that end up here will
+# like in the integration testing environment or with a Kustomize overlay. All the certificates that end up here will
 # be loaded and trusted by all the components of the service that use TLS.
 
 apiVersion: v1


### PR DESCRIPTION
This patch adds to the integration tests a new `IT_DEPLOY_MODE` environment variable that is used to define how to deploy the service. The value can be `helm` or `kustomize`. When the value is `helm` the service will be deployed using the Helm chart. When the value is Kustomize the service will be deployed using the Kustomize manifests. In both cases the tests will be the same, the only difference is how the service is deployed. The default is `helm`.