### PR TITLE
Support namespace other than _innabox_

### DIFF
--- a/manifests/base/grpc-server/authconfig.yaml
+++ b/manifests/base/grpc-server/authconfig.yaml
@@ -72,8 +72,8 @@ spec:
 
           # Define admin subjects:
           admin_subjects := {
-            "system:serviceaccount:innabox:admin",
-            "system:serviceaccount:innabox:controller",
+            "system:serviceaccount:{{ .Release.Namespace }}:admin",
+            "system:serviceaccount:{{ .Release.Namespace }}:controller",
           }
 
           # Get the gRPC method:


### PR DESCRIPTION
Currently the Rego authorization rules assume that the namespace name is `innabox`. If it is different then the authorization for the `admin`, `client` and `controller` service accounts will not work because the `innabox` name is hard-coded. To avoid that this patch changes the template that generates those rules so that it uses the Helm release namespace name instead.