### PR TITLE
Add gRPC probes to Kustomize manifests

### DIFF
--- a/manifests/base/grpc-server/deployment.yaml
+++ b/manifests/base/grpc-server/deployment.yaml
@@ -71,3 +71,25 @@ spec:
         - name: api
           protocol: TCP
           containerPort: 8000
+        livenessProbe:
+          exec:
+            command:
+            - /usr/local/bin/fulfillment-service
+            - probe
+            - grpc-server
+            - --ca-file=/etc/fulfillment-grpc-server/tls/ca.crt
+            - --grpc-server-address=localhost:8000
+            - --grpc-server-timeout=1s
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        readinessProbe:
+          exec:
+            command:
+            - /usr/local/bin/fulfillment-service
+            - probe
+            - grpc-server
+            - --ca-file=/etc/fulfillment-grpc-server/tls/ca.crt
+            - --grpc-server-address=localhost:8000
+            - --grpc-server-timeout=1s
+          initialDelaySeconds: 5
+          periodSeconds: 10


### PR DESCRIPTION
A previous patch added gRPC probes to the Helm chart. This patch adds the same probes to the Kustomize manifests.