### PR TITLE
Fix authconfig Kustomize manifest

### DIFF
--- a/manifests/base/grpc-server/authconfig.yaml
+++ b/manifests/base/grpc-server/authconfig.yaml
@@ -72,8 +72,8 @@ spec:
 
           # Define admin subjects:
           admin_subjects := {
-            "system:serviceaccount:{{ .Release.Namespace }}:admin",
-            "system:serviceaccount:{{ .Release.Namespace }}:controller",
+            "system:serviceaccount:innabox:admin",
+            "system:serviceaccount:innabox:controller",
           }
 
           # Get the gRPC method:


### PR DESCRIPTION
A previous patch changed the autconfig used in the Helm chart in order to void hardcoding the namespace name. But that same change was accidentally done to the Kustomize manifests, where it doesn't work. This patch fixes that error.