### PR TITLE
Add `User-Agent` header

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -17,7 +17,9 @@ RUN go mod download
 
 # Copy the rest of the source and build the binary:
 COPY . /source
-RUN go build
+RUN \
+  version=$(git describe --tags --always) && \
+  go build -ldflags="-X github.com/innabox/fulfillment-service/internal/version.id=${version}"
 
 FROM registry.access.redhat.com/ubi10/ubi:10.1-1763341459 AS runtime
 

--- a/go.mod
+++ b/go.mod
@@ -4,10 +4,11 @@ go 1.24.5
 
 require (
 	github.com/dustin/go-humanize v1.0.1
+	github.com/envoyproxy/go-control-plane/envoy v1.36.0
 	github.com/go-logr/logr v1.4.3
 	github.com/google/uuid v1.6.0
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.27.2
-	github.com/innabox/fulfillment-common v0.0.24
+	github.com/innabox/fulfillment-common v0.0.27
 	github.com/jackc/pgerrcode v0.0.0-20220416144525-469b46aa5efa
 	github.com/json-iterator/go v1.1.12
 	github.com/kelseyhightower/envconfig v1.4.0
@@ -15,6 +16,7 @@ require (
 	go.uber.org/mock v0.6.0
 	golang.org/x/exp v0.0.0-20241108190413-2d47ceb2692f
 	google.golang.org/genproto/googleapis/api v0.0.0-20250908214217-97024824d090
+	google.golang.org/genproto/googleapis/rpc v0.0.0-20250826171959-ef028d996bc1
 	google.golang.org/grpc v1.75.1
 	google.golang.org/protobuf v1.36.10
 	gopkg.in/yaml.v3 v3.0.1
@@ -36,7 +38,6 @@ require (
 	github.com/cncf/xds/go v0.0.0-20250501225837-2ac532fd4443 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/emicklei/go-restful/v3 v3.12.2 // indirect
-	github.com/envoyproxy/go-control-plane/envoy v1.36.0 // indirect
 	github.com/envoyproxy/protoc-gen-validate v1.2.1 // indirect
 	github.com/evanphx/json-patch/v5 v5.9.11 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
@@ -93,7 +94,6 @@ require (
 	golang.org/x/term v0.34.0 // indirect
 	golang.org/x/time v0.11.0 // indirect
 	golang.org/x/tools v0.36.0 // indirect
-	google.golang.org/genproto/googleapis/rpc v0.0.0-20250826171959-ef028d996bc1 // indirect
 	gopkg.in/evanphx/json-patch.v4 v4.12.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20250710124328-f3f2b991d03b // indirect

--- a/go.sum
+++ b/go.sum
@@ -121,8 +121,8 @@ github.com/hashicorp/go-multierror v1.1.1 h1:H5DkEtf6CXdFp0N0Em5UCwQpXMWke8IA0+l
 github.com/hashicorp/go-multierror v1.1.1/go.mod h1:iw975J/qwKPdAO1clOe2L8331t/9/fmwbPZ6JB6eMoM=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
-github.com/innabox/fulfillment-common v0.0.24 h1:p5nmxnADNRY+qerw3WZBZ96tJEemyzx/h4lQhPLaExo=
-github.com/innabox/fulfillment-common v0.0.24/go.mod h1:B860RSo86YZucRU2uNzx5k/0LV85VbWWZKZUmYH7PNY=
+github.com/innabox/fulfillment-common v0.0.27 h1:L9czCqKpF1HQ90+/WqUoyPLNgcdDwSyPH6IUUlN3W8U=
+github.com/innabox/fulfillment-common v0.0.27/go.mod h1:B860RSo86YZucRU2uNzx5k/0LV85VbWWZKZUmYH7PNY=
 github.com/itchyny/gojq v0.12.17 h1:8av8eGduDb5+rvEdaOO+zQUjA04MS0m3Ps8HiD+fceg=
 github.com/itchyny/gojq v0.12.17/go.mod h1:WBrEMkgAfAGO1LUcGOckBl5O726KPp+OlkKug0I/FEY=
 github.com/itchyny/timefmt-go v0.1.6 h1:ia3s54iciXDdzWzwaVKXZPbiXzxxnv1SPGFfM/myJ5Q=
@@ -258,9 +258,8 @@ go.opentelemetry.io/otel/sdk/metric v1.37.0 h1:90lI228XrB9jCMuSdA0673aubgRobVZFh
 go.opentelemetry.io/otel/sdk/metric v1.37.0/go.mod h1:cNen4ZWfiD37l5NhS+Keb5RXVWZWpRE+9WyVCpbo5ps=
 go.opentelemetry.io/otel/trace v1.37.0 h1:HLdcFNbRQBE2imdSEgm/kwqmQj1Or1l/7bW6mxVK7z4=
 go.opentelemetry.io/otel/trace v1.37.0/go.mod h1:TlgrlQ+PtQO5XFerSPUYG0JSgGyryXewPGyayAWSBS0=
-go.opentelemetry.io/proto/otlp v1.5.0 h1:xJvq7gMzB31/d406fB8U5CBdyQGw4P399D1aQWU/3i4=
-go.opentelemetry.io/proto/otlp v1.5.0/go.mod h1:keN8WnHxOy8PG0rQZjJJ5A2ebUoafqWp0eVQ4yIXvJ4=
 go.opentelemetry.io/proto/otlp v1.7.1 h1:gTOMpGDb0WTBOP8JaO72iL3auEZhVmAQg4ipjOVAtj4=
+go.opentelemetry.io/proto/otlp v1.7.1/go.mod h1:b2rVh6rfI/s2pHWNlB7ILJcRALpcNDzKhACevjI+ZnE=
 go.uber.org/atomic v1.9.0 h1:ECmE8Bn/WFTYwEW/bpKD3M8VtR/zQVbavAoalC1PYyE=
 go.uber.org/atomic v1.9.0/go.mod h1:fEN4uk6kAWBTFdckzkM89CLk9XfWZrxpCo0nPH17wJc=
 go.uber.org/automaxprocs v1.6.0 h1:O3y2/QNTOdbF+e/dpXNNW7Rx2hZ4sTIPyybbxyNqTUs=
@@ -331,12 +330,8 @@ google.golang.org/genproto/googleapis/api v0.0.0-20250908214217-97024824d090 h1:
 google.golang.org/genproto/googleapis/api v0.0.0-20250908214217-97024824d090/go.mod h1:U8EXRNSd8sUYyDfs/It7KVWodQr+Hf9xtxyxWudSwEw=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20250826171959-ef028d996bc1 h1:pmJpJEvT846VzausCQ5d7KreSROcDqmO388w5YbnltA=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20250826171959-ef028d996bc1/go.mod h1:GmFNa4BdJZ2a8G+wCe9Bg3wwThLrJun751XstdJt5Og=
-google.golang.org/grpc v1.75.0 h1:+TW+dqTd2Biwe6KKfhE5JpiYIBWq865PhKGSXiivqt4=
-google.golang.org/grpc v1.75.0/go.mod h1:JtPAzKiq4v1xcAB2hydNlWI2RnF85XXcV0mhKXr2ecQ=
 google.golang.org/grpc v1.75.1 h1:/ODCNEuf9VghjgO3rqLcfg8fiOP0nSluljWFlDxELLI=
 google.golang.org/grpc v1.75.1/go.mod h1:JtPAzKiq4v1xcAB2hydNlWI2RnF85XXcV0mhKXr2ecQ=
-google.golang.org/protobuf v1.36.9 h1:w2gp2mA27hUeUzj9Ex9FBjsBm40zfaDtEWow293U7Iw=
-google.golang.org/protobuf v1.36.9/go.mod h1:fuxRtAxBytpl4zzqUh6/eyUujkJdNiuEkXntxiD/uRU=
 google.golang.org/protobuf v1.36.10 h1:AYd7cD/uASjIL6Q9LiTjz8JLcrh/88q5UObnmY3aOOE=
 google.golang.org/protobuf v1.36.10/go.mod h1:HTf+CrKn2C3g5S8VImy6tdcUvCska2kB7j23XfzDpco=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/internal/cmd/dev/dev_watch_cmd.go
+++ b/internal/cmd/dev/dev_watch_cmd.go
@@ -30,6 +30,7 @@ import (
 
 	"github.com/innabox/fulfillment-service/internal"
 	eventsv1 "github.com/innabox/fulfillment-service/internal/api/events/v1"
+	"github.com/innabox/fulfillment-service/internal/version"
 )
 
 // NewWatchCommand creates and returns the `listen` command.
@@ -105,12 +106,16 @@ func (c *watchCommandRunner) run(cmd *cobra.Command, argv []string) error {
 		return fmt.Errorf("failed to create token source: %w", err)
 	}
 
+	// Calculate the user agent:
+	userAgent := fmt.Sprintf("%s/%s", watchUserAgent, version.Get())
+
 	// Create the grpcClient:
 	grpcClient, err := network.NewGrpcClient().
 		SetLogger(c.logger).
 		SetFlags(c.flags, network.GrpcClientName).
 		SetCaPool(caPool).
 		SetTokenSource(tokenSource).
+		SetUserAgent(userAgent).
 		Build()
 	if err != nil {
 		return err
@@ -157,3 +162,6 @@ func (c *watchCommandRunner) run(cmd *cobra.Command, argv []string) error {
 	c.logger.InfoContext(ctx, "Signal received, shutting down")
 	return nil
 }
+
+// watchUserAgent is the user agent string for the watch command.
+const watchUserAgent = "fulfillment-watch"

--- a/internal/cmd/probe_grpc_server_cmd.go
+++ b/internal/cmd/probe_grpc_server_cmd.go
@@ -26,6 +26,7 @@ import (
 	healthv1 "google.golang.org/grpc/health/grpc_health_v1"
 
 	"github.com/innabox/fulfillment-service/internal"
+	"github.com/innabox/fulfillment-service/internal/version"
 )
 
 func NewProbeGrpcServerCommand() *cobra.Command {
@@ -84,11 +85,15 @@ func (c *probeGrpcServerCommandRunner) run(cmd *cobra.Command, argv []string) er
 		return fmt.Errorf("failed to load trusted CA certificates: %w", err)
 	}
 
+	// Calculate the user agent:
+	userAgent := fmt.Sprintf("%s/%s", grpcProbeUserAgent, version.Get())
+
 	// Create the gRPC client connection:
 	conn, err := network.NewGrpcClient().
 		SetLogger(c.logger).
 		SetFlags(c.flags, network.GrpcClientName).
 		SetCaPool(caPool).
+		SetUserAgent(userAgent).
 		Build()
 	if err != nil {
 		return fmt.Errorf("failed to create gRPC client: %w", err)
@@ -133,3 +138,6 @@ func (c *probeGrpcServerCommandRunner) checkHealth(ctx context.Context, conn *gr
 	)
 	return nil
 }
+
+// grpcProbeUserAgent is the user agent string for the gRPC probe.
+const grpcProbeUserAgent = "fulfillment-grpc-probe"

--- a/internal/cmd/start_controller_cmd.go
+++ b/internal/cmd/start_controller_cmd.go
@@ -42,6 +42,7 @@ import (
 	"github.com/innabox/fulfillment-service/internal/controllers/hostpool"
 	"github.com/innabox/fulfillment-service/internal/controllers/vm"
 	internalhealth "github.com/innabox/fulfillment-service/internal/health"
+	"github.com/innabox/fulfillment-service/internal/version"
 )
 
 // NewStartControllerCommand creates and returns the `start controllers` command.
@@ -119,12 +120,16 @@ func (r *startControllerRunner) run(cmd *cobra.Command, argv []string) error {
 		return fmt.Errorf("failed to create token source: %w", err)
 	}
 
+	// Calculate the user agent:
+	userAgent := fmt.Sprintf("%s/%s", grpcServerUserAgent, version.Get())
+
 	// Create the gRPC client:
 	r.client, err = network.NewGrpcClient().
 		SetLogger(r.logger).
 		SetFlags(r.flags, network.GrpcClientName).
 		SetCaPool(caPool).
 		SetTokenSource(tokenSource).
+		SetUserAgent(userAgent).
 		Build()
 	if err != nil {
 		return fmt.Errorf("failed to create gRPC client: %w", err)
@@ -384,3 +389,6 @@ func (r *startControllerRunner) waitForServer(ctx context.Context) error {
 		}
 	}
 }
+
+// controllerUserAgent is the user agent string for the controller.
+const controllerUserAgent = "fulfillment-controller"

--- a/internal/cmd/start_grpc_server_cmd.go
+++ b/internal/cmd/start_grpc_server_cmd.go
@@ -41,6 +41,7 @@ import (
 	"github.com/innabox/fulfillment-service/internal/database"
 	"github.com/innabox/fulfillment-service/internal/recovery"
 	"github.com/innabox/fulfillment-service/internal/servers"
+	"github.com/innabox/fulfillment-service/internal/version"
 )
 
 // NewStartGrpcServerCommand creates and returns the `start grpc-server` command.
@@ -178,6 +179,9 @@ func (c *startGrpcServerCommandRunner) run(cmd *cobra.Command, argv []string) er
 		return err
 	}
 
+	// Calculate the user agent:
+	userAgent := fmt.Sprintf("%s/%s", grpcServerUserAgent, version.Get())
+
 	// Prepare the auth interceptor:
 	c.logger.InfoContext(
 		ctx,
@@ -208,6 +212,7 @@ func (c *startGrpcServerCommandRunner) run(cmd *cobra.Command, argv []string) er
 			SetAddress(c.args.externalAuthAddress).
 			SetCaPool(caPool).
 			AddPublicMethodRegex(publicMethodRegex).
+			SetUserAgent(userAgent).
 			Build()
 		if err != nil {
 			return fmt.Errorf("failed to create external auth interceptor: %w", err)
@@ -616,3 +621,6 @@ func (c *startGrpcServerCommandRunner) run(cmd *cobra.Command, argv []string) er
 // publicMethodRegex is regular expression for the methods that are considered public, including the metadata, and
 // reflection and health methods. These will skip authentication and authorization.
 const publicMethodRegex = `^/(metadata|grpc\.(reflection|health))\..*$`
+
+// grpcServerUserAgent is the user agent string for the gRPC server.
+const grpcServerUserAgent = "fulfillment-grpc-server"

--- a/internal/cmd/start_rest_gateway_cmd.go
+++ b/internal/cmd/start_rest_gateway_cmd.go
@@ -31,6 +31,7 @@ import (
 	"github.com/innabox/fulfillment-service/internal"
 	api "github.com/innabox/fulfillment-service/internal/api/fulfillment/v1"
 	privateapi "github.com/innabox/fulfillment-service/internal/api/private/v1"
+	"github.com/innabox/fulfillment-service/internal/version"
 )
 
 // NewStartRestGatewayCommand creates and returns the `start rest-gateway` command.
@@ -97,12 +98,16 @@ func (c *startRestGatewayCommandRunner) run(cmd *cobra.Command, argv []string) e
 		return fmt.Errorf("failed to load trusted CA certificates: %w", err)
 	}
 
+	// Calculate the user agent:
+	userAgent := fmt.Sprintf("%s/%s", restGatewayUserAgent, version.Get())
+
 	// Create the gRPC client:
 	c.logger.InfoContext(ctx, "Creating gRPC client")
 	c.grpcClient, err = network.NewGrpcClient().
 		SetLogger(c.logger).
 		SetFlags(c.flags, network.GrpcClientName).
 		SetCaPool(caPool).
+		SetUserAgent(userAgent).
 		Build()
 	if err != nil {
 		return err
@@ -242,3 +247,6 @@ func (c *startRestGatewayCommandRunner) handleHealth(
 	}
 	w.WriteHeader(http.StatusOK)
 }
+
+// restGatewayUserAgent is the user agent string for the REST gateway.
+const restGatewayUserAgent = "fulfillment-rest-gateway"

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,0 +1,50 @@
+/*
+Copyright (c) 2025 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package version
+
+import (
+	"runtime/debug"
+	"strings"
+)
+
+// Unknown is the constant value used when version information is not available.
+const Unknown = "unknown"
+
+// This will be injected into the binary during the build.
+var id = Unknown
+
+func init() {
+	if id != Unknown {
+		return
+	}
+	info, ok := debug.ReadBuildInfo()
+	if ok {
+		for _, setting := range info.Settings {
+			switch setting.Key {
+			case "vcs.revision":
+				id = setting.Value
+			}
+		}
+	}
+}
+
+// Get returns the version identifier.
+func Get() string {
+	return strings.TrimPrefix(id, "v")
+}
+
+// Set sets the version identifier. This is intended for unit tests and there is no reason to call it in other contexts.
+func Set(value string) {
+	id = value
+}

--- a/internal/version/version_suite_test.go
+++ b/internal/version/version_suite_test.go
@@ -1,0 +1,39 @@
+/*
+Copyright (c) 2025 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package version
+
+import (
+	"log/slog"
+	"testing"
+
+	"github.com/innabox/fulfillment-common/logging"
+	. "github.com/onsi/ginkgo/v2/dsl/core"
+	. "github.com/onsi/gomega"
+)
+
+func TestVersion(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Version")
+}
+
+var logger *slog.Logger
+
+var _ = BeforeSuite(func() {
+	var err error
+	logger, err = logging.NewLogger().
+		SetLevel(slog.LevelDebug.String()).
+		SetWriter(GinkgoWriter).
+		Build()
+	Expect(err).ToNot(HaveOccurred())
+})

--- a/internal/version/version_test.go
+++ b/internal/version/version_test.go
@@ -1,0 +1,63 @@
+/*
+Copyright (c) 2025 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package version
+
+import (
+	. "github.com/onsi/ginkgo/v2/dsl/core"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Get", func() {
+	When("Version has 'v' prefix", func() {
+		BeforeEach(func() {
+			value := Get()
+			Set("v1.2.3")
+			DeferCleanup(func() {
+				Set(value)
+			})
+		})
+
+		It("Removes the prefix", func() {
+			Expect(Get()).To(Equal("1.2.3"))
+		})
+	})
+
+	When("Version has no 'v' prefix", func() {
+		BeforeEach(func() {
+			value := Get()
+			Set("v1.2.3")
+			DeferCleanup(func() {
+				Set(value)
+			})
+		})
+
+		It("Returns value without changes", func() {
+			Expect(Get()).To(Equal("1.2.3"))
+		})
+	})
+
+	When("Version is unknown", func() {
+		BeforeEach(func() {
+			value := Get()
+			Set(Unknown)
+			DeferCleanup(func() {
+				Set(value)
+			})
+		})
+
+		It("Returns git hash", func() {
+			Expect(Get()).To(Equal(Unknown))
+		})
+	})
+})


### PR DESCRIPTION
This patch adds a `User-Agent` header to outgoing gRPC requests from the REST gateway and the controller. The Format of the header will be the following:

- `fulfillment-gprc-gateway` - For the REST gateway
- `fulfillment-grpc-server` - For the gRPC server
- `fulfillment-controller` - For the controller

Note that the gRPC server needs it because it sends gRPC requests to the external auth service.