### PR TITLE
Make notification cleanup asynchronous

### DIFF
--- a/internal/cmd/start_grpc_server_cmd.go
+++ b/internal/cmd/start_grpc_server_cmd.go
@@ -297,9 +297,14 @@ func (c *startGrpcServerCommandRunner) run(cmd *cobra.Command, argv []string) er
 	notifier, err := database.NewNotifier().
 		SetLogger(c.logger).
 		SetChannel("events").
+		SetPool(dbPool).
 		Build()
 	if err != nil {
 		return fmt.Errorf("failed to create notifier: %w", err)
+	}
+	err = notifier.Start(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to start notifier: %w", err)
 	}
 
 	// Create the public attribution logic:

--- a/internal/database/database_listener_test.go
+++ b/internal/database/database_listener_test.go
@@ -181,6 +181,7 @@ var _ = Describe("Listener", func() {
 			notifier, err = NewNotifier().
 				SetLogger(logger).
 				SetChannel(channel).
+				SetPool(pool).
 				Build()
 			Expect(err).ToNot(HaveOccurred())
 


### PR DESCRIPTION
Previously the notifier deleted old notifications synchronously during the `Notify` call. This could delay event delivery and even the operation that caused the event.

This change moves the cleanup to a separate goroutine that runs periodically. The notifier now requires a database connection pool and has a new `Start` method that launches the cleanup goroutine. The goroutine stops when the context passed to `Start` is cancelled.

Changes:
- Add `pool` and `cleanupInterval` fields to the notifier
- Add `SetPool` and `SetCleanupInterval` builder methods
- Add `Start` method that launches the cleanup goroutine
- Remove synchronous cleanup from the `Notify` method
- Update `start_grpc_server_cmd.go` to pass the pool and call `Start`
- Update tests to cover the new async cleanup behavior