### PR TITLE
Change Keycloak HTTPS port from 8001 to 8000

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -54,7 +54,7 @@
                                 "--log-level=debug",
                                 "--log-headers=true",
                                 "--log-bodies=true",
-                                "--grpc-authn-trusted-token-issuers=https://keycloak.keycloak.svc.cluster.local:8001/realms/innabox",
+                                "--grpc-authn-trusted-token-issuers=https://keycloak.keycloak.svc.cluster.local:8000/realms/innabox",
                                 "--grpc-listener-address=localhost:8000",
                                 "--db-url=postgres://service:service123@localhost:5432/service",
                                 "--tenancy-logic=serviceaccount"
@@ -72,7 +72,7 @@
                                 "--log-level=debug",
                                 "--log-headers=true",
                                 "--log-bodies=true",
-                                "--http-listener-address=localhost:8001",
+                                "--http-listener-address=localhost:8000",
                                 "--grpc-server-address=localhost:8000",
                                 "--grpc-server-plaintext",
                                 "--grpc-keep-alive=5m"

--- a/charts/keycloak/templates/route.yaml
+++ b/charts/keycloak/templates/route.yaml
@@ -45,5 +45,5 @@ spec:
   rules:
   - backendRefs:
     - name: keycloak
-      port: 8001
+      port: 8000
 {{ end }}

--- a/charts/keycloak/templates/service/deployment.yaml
+++ b/charts/keycloak/templates/service/deployment.yaml
@@ -76,7 +76,7 @@ spec:
         - name: KC_HTTPS_ENABLED
           value: "true"
         - name: KC_HTTPS_PORT
-          value: "8001"
+          value: "8000"
         - name: KC_HTTPS_CERTIFICATE_FILE
           value: "/secrets/tls/tls.crt"
         - name: KC_HTTPS_CERTIFICATE_KEY_FILE
@@ -84,7 +84,7 @@ spec:
         - name: KC_HOSTNAME
           value: "{{ include "keycloak.hostname" . }}"
         - name: KC_HOSTNAME_PORT
-          value: "8001"
+          value: "8000"
         - name: KC_DB
           value: "postgres"
         - name: KC_DB_URL
@@ -102,18 +102,18 @@ spec:
         - --import-realm
         ports:
         - name: https
-          containerPort: 8001
+          containerPort: 8000
         readinessProbe:
           httpGet:
             path: /realms/master
-            port: 8001
+            port: 8000
             scheme: HTTPS
           initialDelaySeconds: 30
           periodSeconds: 10
         livenessProbe:
           httpGet:
             path: /realms/master
-            port: 8001
+            port: 8000
             scheme: HTTPS
           initialDelaySeconds: 60
           periodSeconds: 30

--- a/charts/keycloak/templates/service/service.yaml
+++ b/charts/keycloak/templates/service/service.yaml
@@ -23,5 +23,5 @@ spec:
     app: keycloak-service
   ports:
   - name: https
-    port: 8001
-    targetPort: 8001
+    port: 8000
+    targetPort: 8000

--- a/charts/service/README.md
+++ b/charts/service/README.md
@@ -28,7 +28,7 @@ The following table lists the configurable parameters of the chart and their def
 | `certs.issuerRef.name` | Name of _cert-manager_ issuer | None |
 | `certs.caBundle.configMap` | Name of configmap containing trusted CA certificates in PEM format | None |
 | `hostname` | Hostname used to access the service from outside the cluster | None |
-| `auth.issuerUrl` | OAuth issuer URL for authentication | `https://keycloak.keycloak.svc.cluster.local:8001/realms/innabox` |
+| `auth.issuerUrl` | OAuth issuer URL for authentication | `https://keycloak.keycloak.svc.cluster.local:8000/realms/innabox` |
 | `log.level` | Log level for all components (debug, info, warn, error) | `info` |
 | `log.headers` | Enable logging of HTTP/gRPC headers | `false` |
 | `log.bodies` | Enable logging of HTTP/gRPC request and response bodies | `false` |

--- a/docs/AUTH.md
+++ b/docs/AUTH.md
@@ -141,32 +141,24 @@ The realm includes the **fulfillment-cli** (Public) client:
 
 To access the Keycloak Admin Console:
 
-1. **Port-forward to the Keycloak service**:
+1. **Access the console**:
 
-   ```bash
-   kubectl port-forward -n keycloak svc/keycloak 8443:8001
-   ```
-
-Alternatively, for development purposes, you can add the host name used internally in the cluster (keycloak.keycloak.svc.cluster.local) pointing to 127.0.0.1 to /etc/hosts:
+   Add the host name used internally in the cluster pointing to `127.0.0.1` to `/etc/hosts`:
 
    ```
    127.0.0.1 keycloak.keycloak.svc.cluster.local
    ```
 
-2. **Access the console**:
+   Open your browser and navigate to https://keycloak.keycloak.svc.cluster.local:8000, then
+   accept the self-signed certificate warning.
 
-   Open your browser and navigate to:
-   ```
-   https://localhost:8443 (or https://keycloak.keycloak.svc.cluster.local:8443 if configured)
-   ```
+2. **Login**:
 
-   Accept the self-signed certificate warning.
-
-3. **Login**:
    - Username: `admin`
    - Password: `admin`
 
-4. **Select the realm**:
+3. **Select the realm**:
+
    - Click on the realm dropdown (top left)
    - Select `innabox`
 
@@ -212,7 +204,7 @@ https://<keycloak-hostname>:<port>/realms/<realm-name>
 
 For example:
 ```
-https://keycloak.keycloak.svc.cluster.local:8001/realms/innabox
+https://keycloak.keycloak.svc.cluster.local:8000/realms/innabox
 ```
 
 ### 2. Update the Fulfillment Service Deployment
@@ -228,7 +220,7 @@ helm install fulfillment-service oci://ghcr.io/innabox/charts/fulfillment-servic
   --set hostname=fulfillment-api.innabox.cluster.local \
   --set certs.issuerRef.name=default-ca \
   --set certs.caBundle.configMap=ca-bundle \
-  --set auth.issuerUrl=https://keycloak.keycloak.svc.cluster.local:8001/realms/innabox \
+  --set auth.issuerUrl=https://keycloak.keycloak.svc.cluster.local:8000/realms/innabox \
   --wait
 ```
 
@@ -236,7 +228,7 @@ Or in a values file:
 
 ```yaml
 auth:
-  issuerUrl: https://keycloak.keycloak.svc.cluster.local:8001/realms/innabox
+  issuerUrl: https://keycloak.keycloak.svc.cluster.local:8000/realms/innabox
 ```
 
 ### 3. Update the AuthConfig Resource
@@ -261,7 +253,7 @@ Example AuthConfig snippet:
 authentication:
   "keycloak-jwt":
     jwt:
-      issuerUrl: https://keycloak.keycloak.svc.cluster.local:8001/realms/innabox
+      issuerUrl: https://keycloak.keycloak.svc.cluster.local:8000/realms/innabox
     overrides:
       authnMethod:
         value: jwt
@@ -274,7 +266,7 @@ The fulfillment service server component also needs to be configured with the tr
 The Helm chart automatically sets this from the `auth.issuerUrl` value. In the deployment, you'll see:
 
 ```yaml
-- --grpc-authn-trusted-token-issuers=https://keycloak.keycloak.svc.cluster.local:8001/realms/innabox
+- --grpc-authn-trusted-token-issuers=https://keycloak.keycloak.svc.cluster.local:8000/realms/innabox
 ```
 
 ### 5. Trusted vs Advertised Token Issuers
@@ -818,9 +810,6 @@ kubectl get authconfig fulfillment-service -n innabox -o yaml | grep issuerUrl
 1. **Get a token from Keycloak** (using the fulfillment-cli client):
 
    ```bash
-   # Port-forward to Keycloak
-   kubectl port-forward -n keycloak svc/keycloak 8443:8001
-
    # Get token (replace USERNAME and PASSWORD with actual credentials)
    TOKEN=$(curl -k -X POST \
      https://localhost:8443/realms/innabox/protocol/openid-connect/token \

--- a/it/it_tool.go
+++ b/it/it_tool.go
@@ -553,7 +553,7 @@ func (t *Tool) deployServiceWithHelm(ctx context.Context, imageRef string) error
 			"--set", "certs.issuerRef.kind=ClusterIssuer",
 			"--set", "certs.issuerRef.name=default-ca",
 			"--set", "certs.caBundle.configMap=ca-bundle",
-			"--set", "auth.issuerUrl=https://keycloak.keycloak.svc.cluster.local:8001/realms/innabox",
+			"--set", "auth.issuerUrl=https://keycloak.keycloak.svc.cluster.local:8000/realms/innabox",
 			"--wait",
 		).
 		Build()

--- a/manifests/base/grpc-server/authconfig.yaml
+++ b/manifests/base/grpc-server/authconfig.yaml
@@ -60,7 +60,7 @@ spec:
           value: serviceaccount
     "keycloak-jwt":
       jwt:
-        issuerUrl: https://keycloak.keycloak.svc.cluster.local:8001/realms/innabox
+        issuerUrl: https://keycloak.keycloak.svc.cluster.local:8000/realms/innabox
       overrides:
         authnMethod:
           value: jwt

--- a/manifests/base/grpc-server/deployment.yaml
+++ b/manifests/base/grpc-server/deployment.yaml
@@ -62,7 +62,7 @@ spec:
         - --grpc-listener-address=0.0.0.0:8000
         - --grpc-listener-tls-crt=/etc/fulfillment-grpc-server/tls/tls.crt
         - --grpc-listener-tls-key=/etc/fulfillment-grpc-server/tls/tls.key
-        - --grpc-authn-trusted-token-issuers=https://keycloak.keycloak.svc.cluster.local:8001/realms/innabox
+        - --grpc-authn-trusted-token-issuers=https://keycloak.keycloak.svc.cluster.local:8000/realms/innabox
         - --grpc-authn-type=external
         - --grpc-authn-external-address=authorino-authorino-authorization:50051
         - --tenancy-logic=default


### PR DESCRIPTION
Update the Keycloak HTTPS port to use the standard 8000 port across all configuration files, Helm charts, manifests, and documentation. This includes the Keycloak deployment, service, route, as well as all references in the fulfillment service configuration and authentication setup.

The AUTH.md documentation was also simplified, removing redundant port-forwarding instructions and streamlining the access steps.