### PR TITLE
Enable password authentication for the `fulfillment-cli` client

### DIFF
--- a/charts/keycloak/files/realm.json
+++ b/charts/keycloak/files/realm.json
@@ -629,7 +629,7 @@
     "consentRequired" : false,
     "standardFlowEnabled" : true,
     "implicitFlowEnabled" : false,
-    "directAccessGrantsEnabled" : false,
+    "directAccessGrantsEnabled" : true,
     "serviceAccountsEnabled" : false,
     "publicClient" : true,
     "frontchannelLogout" : true,


### PR DESCRIPTION
This patch changes the Keycloak configuration to enable password authentication foor the `fulfillment-cli` client. This will be used only for the integration tests, where it is necessary to obtain user tokens without going trough a browser.