### PR TITLE
Update README.md to reflect changes in start commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ commands:
 
 To run the the gRPC server use a command like this:
 
-    $ ./fulfillment-service  start server \
+    $ ./fulfillment-service  start grpc-server \
     --log-level=debug \
     --log-headers=true \
     --log-bodies=true \
@@ -64,7 +64,7 @@ To run the the gRPC server use a command like this:
 
 To run the the REST gateway use a command like this:
 
-    $ ./fulfillment-service start gateway \
+    $ ./fulfillment-service start rest-gateway \
     --log-level=debug \
     --log-headers=true \
     --log-bodies=true \


### PR DESCRIPTION
A previous patch changed the names of the commands that start the servers from `server` and `gateway` to `grpc-server` and `rest-gateway` but it didn't change the README.md file accordingly.