### PR TITLE
Use Keycloak user for integration tests

### DIFF
--- a/.github/workflows/check-pull-request.yaml
+++ b/.github/workflows/check-pull-request.yaml
@@ -68,6 +68,8 @@ jobs:
     - uses: actions/checkout@v6
     - uses: ./.github/actions/setup-go
     - run: |
+        echo '127.0.0.1 fulfillment-api.innabox.svc.cluster.local' | sudo tee -a /etc/hosts
+        echo '127.0.0.1 keycloak.keycloak.svc.cluster.local' | sudo tee -a /etc/hosts
         IT_DEPLOY_MODE=helm ginkgo run -v it
     - if: always()
       uses: actions/upload-artifact@v6
@@ -83,6 +85,8 @@ jobs:
     - uses: actions/checkout@v6
     - uses: ./.github/actions/setup-go
     - run: |
+        echo '127.0.0.1 fulfillment-api.innabox.svc.cluster.local' | sudo tee -a /etc/hosts
+        echo '127.0.0.1 keycloak.keycloak.svc.cluster.local' | sudo tee -a /etc/hosts
         IT_DEPLOY_MODE=kustomize ginkgo run -v it
     - if: always()
       uses: actions/upload-artifact@v6

--- a/README.md
+++ b/README.md
@@ -219,6 +219,22 @@ The project includes integration tests that run against a real Kubernetes cluste
 [kind](https://kind.sigs.k8s.io). These tests verify the end-to-end functionality of the fulfillment
 service by deploying it to a temporary cluster and exercising the APIs.
 
+The integration tests use TLS with SNI (_Server Name Indication_) routing through the Envoy Gateway.
+This means that the services are accessed using their Kubernetes internal host names, but routed
+through `127.0.0.1:8000` which is exposed by the Kind cluster.
+
+For the tests to work correctly, the following host names must resolve to `127.0.0.1`:
+
+- `keycloak.keycloak.svc.cluster.local` - The Keycloak identity provider used for authentication.
+- `fulfillment-api.innabox.svc.cluster.local` - The fulfillment service API.
+
+Add the following entries to your `/etc/hosts` file:
+
+```
+127.0.0.1 keycloak.keycloak.svc.cluster.local
+127.0.0.1 fulfillment-api.innabox.svc.cluster.local
+```
+
 To run the integration tests:
 
 ```bash
@@ -272,15 +288,4 @@ To clean up a preserved cluster manually:
 
 ```bash
 $ kind delete cluster --name fulfillment-service-it
-```
-
-The automated tests do not require any special host name configuration. However, if you want to
-manually access the services running in the kind cluster, the host names
-`fulfillment-api.innabox.svc.cluster.local` and `keycloak.keycloak.svc.cluster.local` must be
-resolvable and point to `127.0.0.1`. One way to achieve this is by adding the following entries to
-your `/etc/hosts` file:
-
-```
-127.0.0.1 fulfillment-api.innabox.svc.cluster.local
-127.0.0.1 keycloak.keycloak.svc.cluster.local
 ```

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/go-logr/logr v1.4.3
 	github.com/google/uuid v1.6.0
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.27.2
-	github.com/innabox/fulfillment-common v0.0.32
+	github.com/innabox/fulfillment-common v0.0.34
 	github.com/jackc/pgerrcode v0.0.0-20220416144525-469b46aa5efa
 	github.com/jackc/puddle/v2 v2.2.2
 	github.com/json-iterator/go v1.1.12
@@ -16,6 +16,7 @@ require (
 	github.com/open-policy-agent/opa v1.4.0
 	github.com/prometheus/client_golang v1.22.0
 	go.uber.org/mock v0.6.0
+	go.yaml.in/yaml/v2 v2.4.2
 	golang.org/x/exp v0.0.0-20241108190413-2d47ceb2692f
 	google.golang.org/genproto/googleapis/api v0.0.0-20250908214217-97024824d090
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20250826171959-ef028d996bc1
@@ -54,6 +55,7 @@ require (
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/google/gnostic-models v0.7.0 // indirect
 	github.com/google/go-cmp v0.7.0 // indirect
+	github.com/google/go-querystring v1.1.0 // indirect
 	github.com/google/pprof v0.0.0-20250403155104-27863c87afa6 // indirect
 	github.com/gorilla/mux v1.8.1 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
@@ -73,6 +75,7 @@ require (
 	github.com/prometheus/procfs v0.15.1 // indirect
 	github.com/rcrowley/go-metrics v0.0.0-20200313005456-10cdbea86bc0 // indirect
 	github.com/sirupsen/logrus v1.9.3 // indirect
+	github.com/skratchdot/open-golang v0.0.0-20200116055534-eef842397966 // indirect
 	github.com/stoewer/go-strcase v1.3.0 // indirect
 	github.com/tchap/go-patricia/v2 v2.3.2 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
@@ -86,7 +89,6 @@ require (
 	go.opentelemetry.io/otel/trace v1.37.0 // indirect
 	go.uber.org/atomic v1.9.0 // indirect
 	go.uber.org/automaxprocs v1.6.0 // indirect
-	go.yaml.in/yaml/v2 v2.4.2 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/crypto v0.41.0 // indirect
 	golang.org/x/oauth2 v0.30.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -101,8 +101,11 @@ github.com/google/flatbuffers v25.2.10+incompatible h1:F3vclr7C3HpB1k9mxCGRMXq6F
 github.com/google/flatbuffers v25.2.10+incompatible/go.mod h1:1AeVuKshWv4vARoZatz6mlQ0JxURH0Kv5+zNeJKJCa8=
 github.com/google/gnostic-models v0.7.0 h1:qwTtogB15McXDaNqTZdzPJRHvaVJlAl+HVQnLmJEJxo=
 github.com/google/gnostic-models v0.7.0/go.mod h1:whL5G0m6dmc5cPxKc5bdKdEN3UjI7OUGxBlw57miDrQ=
+github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
+github.com/google/go-querystring v1.1.0 h1:AnCroh3fv4ZBgVIf1Iwtovgjaw/GiKJo8M8yD/fhyJ8=
+github.com/google/go-querystring v1.1.0/go.mod h1:Kcdr2DB4koayq7X8pmAG4sNG59So17icRSOU623lUBU=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/pprof v0.0.0-20250403155104-27863c87afa6 h1:BHT72Gu3keYf3ZEu2J0b1vyeLSOYI8bm5wbJM/8yDe8=
 github.com/google/pprof v0.0.0-20250403155104-27863c87afa6/go.mod h1:boTsfXsheKC2y+lKOCMpSfarhxDeIzfZG1jqGcPl3cA=
@@ -121,8 +124,8 @@ github.com/hashicorp/go-multierror v1.1.1 h1:H5DkEtf6CXdFp0N0Em5UCwQpXMWke8IA0+l
 github.com/hashicorp/go-multierror v1.1.1/go.mod h1:iw975J/qwKPdAO1clOe2L8331t/9/fmwbPZ6JB6eMoM=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
-github.com/innabox/fulfillment-common v0.0.32 h1:PjWB4n/Q1ss4cTnwOSycSEYAkq9UkswH7x21g6rIBHU=
-github.com/innabox/fulfillment-common v0.0.32/go.mod h1:ANsYRiH+DCJeq7mJXvdQ0u9LgxYF01YyLum90yqR/VI=
+github.com/innabox/fulfillment-common v0.0.34 h1:04pRj/Dg9ZjXkem2gCxN7ITi+oUyBR4wvCrZeWcLPMw=
+github.com/innabox/fulfillment-common v0.0.34/go.mod h1:ANsYRiH+DCJeq7mJXvdQ0u9LgxYF01YyLum90yqR/VI=
 github.com/itchyny/gojq v0.12.17 h1:8av8eGduDb5+rvEdaOO+zQUjA04MS0m3Ps8HiD+fceg=
 github.com/itchyny/gojq v0.12.17/go.mod h1:WBrEMkgAfAGO1LUcGOckBl5O726KPp+OlkKug0I/FEY=
 github.com/itchyny/timefmt-go v0.1.6 h1:ia3s54iciXDdzWzwaVKXZPbiXzxxnv1SPGFfM/myJ5Q=
@@ -209,6 +212,8 @@ github.com/rogpeppe/go-internal v1.13.1/go.mod h1:uMEvuHeurkdAXX61udpOXGD/AzZDWN
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ=
 github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
+github.com/skratchdot/open-golang v0.0.0-20200116055534-eef842397966 h1:JIAuq3EEf9cgbU6AtGPK4CTG3Zf6CKMNqf0MHTggAUA=
+github.com/skratchdot/open-golang v0.0.0-20200116055534-eef842397966/go.mod h1:sUM3LWHvSMaG192sy56D9F7CNvL7jUJVXoqM1QKLnog=
 github.com/spf13/cobra v1.9.1 h1:CXSaggrXdbHK9CF+8ywj8Amf7PBRmPCOJugH954Nnlo=
 github.com/spf13/cobra v1.9.1/go.mod h1:nDyEzZ8ogv936Cinf6g1RU9MRY64Ir93oCnqb9wxYW0=
 github.com/spf13/pflag v1.0.6/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=

--- a/it/it_public_clusters_test.go
+++ b/it/it_public_clusters_test.go
@@ -767,6 +767,6 @@ var _ = Describe("Public clusters", func() {
 		Expect(object).ToNot(BeNil())
 		metadata := object.GetMetadata()
 		Expect(metadata).ToNot(BeNil())
-		Expect(metadata.GetCreators()).To(ConsistOf("system:serviceaccount:innabox:client"))
+		Expect(metadata.GetCreators()).To(ConsistOf("my-user"))
 	})
 })

--- a/it/it_rest_gateway_test.go
+++ b/it/it_rest_gateway_test.go
@@ -102,7 +102,7 @@ var _ = Describe("REST gateway", func() {
 		})
 
 		// Retrieve the template via REST API:
-		url := fmt.Sprintf("https://localhost:8000/api/fulfillment/v1/cluster_templates/%s", templateID)
+		url := fmt.Sprintf("https://%s/api/fulfillment/v1/cluster_templates/%s", serviceAddr, templateID)
 		request, err := http.NewRequestWithContext(ctx, "GET", url, nil)
 		Expect(err).ToNot(HaveOccurred())
 		response, err := tool.UserClient().Do(request)
@@ -181,7 +181,7 @@ var _ = Describe("REST gateway", func() {
 		})
 
 		// Retrieve the template via private REST API:
-		url := fmt.Sprintf("https://localhost:8000/api/private/v1/cluster_templates/%s", templateID)
+		url := fmt.Sprintf("https://%s/api/private/v1/cluster_templates/%s", serviceAddr, templateID)
 		request, err := http.NewRequestWithContext(ctx, "GET", url, nil)
 		Expect(err).ToNot(HaveOccurred())
 		response, err := tool.AdminClient().Do(request)


### PR DESCRIPTION
This patch change the integration tests so that they use a Keycloak user instead of a Kubernetes service account.

Note that for the `admin` service account is still when administrative access is required.