### PR TITLE
Add group-based admin authorization

### DIFF
--- a/charts/service/templates/grpc-server/authconfig.yaml
+++ b/charts/service/templates/grpc-server/authconfig.yaml
@@ -71,10 +71,15 @@ spec:
         rego: |
           import future.keywords.in
 
-          # Define admin subjects:
-          admin_subjects := {
+          # Define admin service accounts:
+          admin_service_accounts := {
             "system:serviceaccount:{{ .Release.Namespace }}:admin",
             "system:serviceaccount:{{ .Release.Namespace }}:controller",
+          }
+
+          # Define admin groups:
+          admin_groups := {
+            "admins",
           }
 
           # Get the gRPC method:
@@ -88,9 +93,21 @@ spec:
             input.auth.identity.authnMethod == "jwt"
           }
 
+          # Get the subject groups:
+          subject_groups = input.auth.identity.user.groups {
+            input.auth.identity.authnMethod == "serviceaccount"
+          }
+          subject_groups = input.auth.identity.groups {
+            input.auth.identity.authnMethod == "jwt"
+          }
+
           # Function to check if an account is an admin account:
           is_admin {
-            subject_name in admin_subjects
+            subject_name in admin_service_accounts
+          }
+          is_admin {
+            some group in subject_groups
+            group in admin_groups
           }
 
           # Function to check if an account is a client account:
@@ -125,6 +142,13 @@ spec:
               "/fulfillment.v1.Clusters/GetPasswordViaHttp",
               "/fulfillment.v1.Clusters/List",
               "/fulfillment.v1.Clusters/Update",
+              "/fulfillment.v1.ComputeInstanceTemplates/Get",
+              "/fulfillment.v1.ComputeInstanceTemplates/List",
+              "/fulfillment.v1.ComputeInstances/Create",
+              "/fulfillment.v1.ComputeInstances/Delete",
+              "/fulfillment.v1.ComputeInstances/Get",
+              "/fulfillment.v1.ComputeInstances/List",
+              "/fulfillment.v1.ComputeInstances/Update",
               "/fulfillment.v1.HostClasses/Get",
               "/fulfillment.v1.HostClasses/List",
               "/fulfillment.v1.HostPools/Create",
@@ -137,13 +161,6 @@ spec:
               "/fulfillment.v1.Hosts/Get",
               "/fulfillment.v1.Hosts/List",
               "/fulfillment.v1.Hosts/Update",
-              "/fulfillment.v1.ComputeInstanceTemplates/Get",
-              "/fulfillment.v1.ComputeInstanceTemplates/List",
-              "/fulfillment.v1.ComputeInstances/Create",
-              "/fulfillment.v1.ComputeInstances/Delete",
-              "/fulfillment.v1.ComputeInstances/Get",
-              "/fulfillment.v1.ComputeInstances/List",
-              "/fulfillment.v1.ComputeInstances/Update",
             }
           }
 

--- a/it/it_access_test.go
+++ b/it/it_access_test.go
@@ -1,0 +1,242 @@
+/*
+Copyright (c) 2025 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package it
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2/dsl/core"
+	. "github.com/onsi/gomega"
+	grpccodes "google.golang.org/grpc/codes"
+	grpcstatus "google.golang.org/grpc/status"
+
+	ffv1 "github.com/innabox/fulfillment-service/internal/api/fulfillment/v1"
+	privatev1 "github.com/innabox/fulfillment-service/internal/api/private/v1"
+)
+
+var _ = Describe("Access control", func() {
+	var ctx context.Context
+
+	BeforeEach(func() {
+		ctx = context.Background()
+	})
+
+	Describe("Public API", func() {
+		It("Allows regular users to list cluster templates", func() {
+			client := ffv1.NewClusterTemplatesClient(tool.UserConn())
+			_, err := client.List(ctx, ffv1.ClusterTemplatesListRequest_builder{}.Build())
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("Allows regular users to list clusters", func() {
+			client := ffv1.NewClustersClient(tool.UserConn())
+			_, err := client.List(ctx, ffv1.ClustersListRequest_builder{}.Build())
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("Allows regular users to list host classes", func() {
+			client := ffv1.NewHostClassesClient(tool.UserConn())
+			_, err := client.List(ctx, ffv1.HostClassesListRequest_builder{}.Build())
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("Allows regular users to list hosts", func() {
+			client := ffv1.NewHostsClient(tool.UserConn())
+			_, err := client.List(ctx, ffv1.HostsListRequest_builder{}.Build())
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("Allows regular users to list host pools", func() {
+			client := ffv1.NewHostPoolsClient(tool.UserConn())
+			_, err := client.List(ctx, ffv1.HostPoolsListRequest_builder{}.Build())
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("Allows regular users to list compute instance templates", func() {
+			client := ffv1.NewComputeInstanceTemplatesClient(tool.UserConn())
+			_, err := client.List(ctx, ffv1.ComputeInstanceTemplatesListRequest_builder{}.Build())
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("Allows regular users to list compute instances", func() {
+			client := ffv1.NewComputeInstancesClient(tool.UserConn())
+			_, err := client.List(ctx, ffv1.ComputeInstancesListRequest_builder{}.Build())
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("Allows admin users to list cluster templates", func() {
+			client := ffv1.NewClusterTemplatesClient(tool.AdminConn())
+			_, err := client.List(ctx, ffv1.ClusterTemplatesListRequest_builder{}.Build())
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("Allows admin users to list clusters", func() {
+			client := ffv1.NewClustersClient(tool.AdminConn())
+			_, err := client.List(ctx, ffv1.ClustersListRequest_builder{}.Build())
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("Allows admin users to list host classes", func() {
+			client := ffv1.NewHostClassesClient(tool.AdminConn())
+			_, err := client.List(ctx, ffv1.HostClassesListRequest_builder{}.Build())
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("Allows admin users to list hosts", func() {
+			client := ffv1.NewHostsClient(tool.AdminConn())
+			_, err := client.List(ctx, ffv1.HostsListRequest_builder{}.Build())
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("Allows admin users to list host pools", func() {
+			client := ffv1.NewHostPoolsClient(tool.AdminConn())
+			_, err := client.List(ctx, ffv1.HostPoolsListRequest_builder{}.Build())
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("Allows admin users to list compute instance templates", func() {
+			client := ffv1.NewComputeInstanceTemplatesClient(tool.AdminConn())
+			_, err := client.List(ctx, ffv1.ComputeInstanceTemplatesListRequest_builder{}.Build())
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("Allows admin users to list compute instances", func() {
+			client := ffv1.NewComputeInstancesClient(tool.AdminConn())
+			_, err := client.List(ctx, ffv1.ComputeInstancesListRequest_builder{}.Build())
+			Expect(err).ToNot(HaveOccurred())
+		})
+	})
+
+	Describe("Private API", func() {
+		It("Allows admin users to list host classes", func() {
+			client := privatev1.NewHostClassesClient(tool.AdminConn())
+			_, err := client.List(ctx, privatev1.HostClassesListRequest_builder{}.Build())
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("Allows admin users to list cluster templates", func() {
+			client := privatev1.NewClusterTemplatesClient(tool.AdminConn())
+			_, err := client.List(ctx, privatev1.ClusterTemplatesListRequest_builder{}.Build())
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("Allows admin users to list hubs", func() {
+			client := privatev1.NewHubsClient(tool.AdminConn())
+			_, err := client.List(ctx, privatev1.HubsListRequest_builder{}.Build())
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("Allows admin users to list hosts", func() {
+			client := privatev1.NewHostsClient(tool.AdminConn())
+			_, err := client.List(ctx, privatev1.HostsListRequest_builder{}.Build())
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("Allows admin users to list host pools", func() {
+			client := privatev1.NewHostPoolsClient(tool.AdminConn())
+			_, err := client.List(ctx, privatev1.HostPoolsListRequest_builder{}.Build())
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("Allows admin users to list private clusters", func() {
+			client := privatev1.NewClustersClient(tool.AdminConn())
+			_, err := client.List(ctx, privatev1.ClustersListRequest_builder{}.Build())
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("Allows admin users to list compute instance templates", func() {
+			client := privatev1.NewComputeInstanceTemplatesClient(tool.AdminConn())
+			_, err := client.List(ctx, privatev1.ComputeInstanceTemplatesListRequest_builder{}.Build())
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("Allows admin users to list private compute instances", func() {
+			client := privatev1.NewComputeInstancesClient(tool.AdminConn())
+			_, err := client.List(ctx, privatev1.ComputeInstancesListRequest_builder{}.Build())
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("Denies regular users access to host classes", func() {
+			client := privatev1.NewHostClassesClient(tool.UserConn())
+			_, err := client.List(ctx, privatev1.HostClassesListRequest_builder{}.Build())
+			Expect(err).To(HaveOccurred())
+			status, ok := grpcstatus.FromError(err)
+			Expect(ok).To(BeTrue())
+			Expect(status.Code()).To(Equal(grpccodes.PermissionDenied))
+		})
+
+		It("Denies regular users access to cluster templates", func() {
+			client := privatev1.NewClusterTemplatesClient(tool.UserConn())
+			_, err := client.List(ctx, privatev1.ClusterTemplatesListRequest_builder{}.Build())
+			Expect(err).To(HaveOccurred())
+			status, ok := grpcstatus.FromError(err)
+			Expect(ok).To(BeTrue())
+			Expect(status.Code()).To(Equal(grpccodes.PermissionDenied))
+		})
+
+		It("Denies regular users access to hubs", func() {
+			client := privatev1.NewHubsClient(tool.UserConn())
+			_, err := client.List(ctx, privatev1.HubsListRequest_builder{}.Build())
+			Expect(err).To(HaveOccurred())
+			status, ok := grpcstatus.FromError(err)
+			Expect(ok).To(BeTrue())
+			Expect(status.Code()).To(Equal(grpccodes.PermissionDenied))
+		})
+
+		It("Denies regular users access to hosts", func() {
+			client := privatev1.NewHostsClient(tool.UserConn())
+			_, err := client.List(ctx, privatev1.HostsListRequest_builder{}.Build())
+			Expect(err).To(HaveOccurred())
+			status, ok := grpcstatus.FromError(err)
+			Expect(ok).To(BeTrue())
+			Expect(status.Code()).To(Equal(grpccodes.PermissionDenied))
+		})
+
+		It("Denies regular users access to host pools", func() {
+			client := privatev1.NewHostPoolsClient(tool.UserConn())
+			_, err := client.List(ctx, privatev1.HostPoolsListRequest_builder{}.Build())
+			Expect(err).To(HaveOccurred())
+			status, ok := grpcstatus.FromError(err)
+			Expect(ok).To(BeTrue())
+			Expect(status.Code()).To(Equal(grpccodes.PermissionDenied))
+		})
+
+		It("Denies regular users access to private clusters", func() {
+			client := privatev1.NewClustersClient(tool.UserConn())
+			_, err := client.List(ctx, privatev1.ClustersListRequest_builder{}.Build())
+			Expect(err).To(HaveOccurred())
+			status, ok := grpcstatus.FromError(err)
+			Expect(ok).To(BeTrue())
+			Expect(status.Code()).To(Equal(grpccodes.PermissionDenied))
+		})
+
+		It("Denies regular users access to compute instance templates", func() {
+			client := privatev1.NewComputeInstanceTemplatesClient(tool.UserConn())
+			_, err := client.List(ctx, privatev1.ComputeInstanceTemplatesListRequest_builder{}.Build())
+			Expect(err).To(HaveOccurred())
+			status, ok := grpcstatus.FromError(err)
+			Expect(ok).To(BeTrue())
+			Expect(status.Code()).To(Equal(grpccodes.PermissionDenied))
+		})
+
+		It("Denies regular users access to private compute instances", func() {
+			client := privatev1.NewComputeInstancesClient(tool.UserConn())
+			_, err := client.List(ctx, privatev1.ComputeInstancesListRequest_builder{}.Build())
+			Expect(err).To(HaveOccurred())
+			status, ok := grpcstatus.FromError(err)
+			Expect(ok).To(BeTrue())
+			Expect(status.Code()).To(Equal(grpccodes.PermissionDenied))
+		})
+	})
+})

--- a/it/it_cluster_reconciler_test.go
+++ b/it/it_cluster_reconciler_test.go
@@ -55,7 +55,7 @@ var _ = Describe("Cluster reconciler", func() {
 		ctx = context.Background()
 
 		// Create the clients:
-		clustersClient = ffv1.NewClustersClient(tool.ClientConn())
+		clustersClient = ffv1.NewClustersClient(tool.UserConn())
 		hostClassesClient = privatev1.NewHostClassesClient(tool.AdminConn())
 		templatesClient = privatev1.NewClusterTemplatesClient(tool.AdminConn())
 

--- a/it/it_emergency_access_test.go
+++ b/it/it_emergency_access_test.go
@@ -1,0 +1,89 @@
+/*
+Copyright (c) 2025 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package it
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	. "github.com/onsi/ginkgo/v2/dsl/core"
+	. "github.com/onsi/gomega"
+
+	privatev1 "github.com/innabox/fulfillment-service/internal/api/private/v1"
+	"github.com/innabox/fulfillment-service/internal/uuid"
+)
+
+var _ = Describe("Emergency access", func() {
+	var ctx context.Context
+
+	BeforeEach(func() {
+		ctx = context.Background()
+	})
+
+	It("Can create objects using gRPC and the emergency admin service account", func() {
+		// Create the client:
+		client := privatev1.NewClusterTemplatesClient(tool.EmergencyConn())
+
+		// Create the object:
+		id := fmt.Sprintf("emergency_grpc_%s", uuid.New())
+		_, err := client.Create(ctx, privatev1.ClusterTemplatesCreateRequest_builder{
+			Object: privatev1.ClusterTemplate_builder{
+				Id:          id,
+				Title:       "Emergency gRPC template",
+				Description: "Template created via gRPC using emergency admin service account.",
+			}.Build(),
+		}.Build())
+		Expect(err).ToNot(HaveOccurred())
+
+		// Delete the object:
+		_, err = client.Delete(ctx, privatev1.ClusterTemplatesDeleteRequest_builder{
+			Id: id,
+		}.Build())
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	It("Can create objects using REST the emergency admin service account", func() {
+		// Prepare the request body:
+		id := fmt.Sprintf("emergency_rest_%s", uuid.New())
+		requestBody := map[string]any{
+			"id":          id,
+			"title":       "Emergency REST template",
+			"description": "Template created via REST using emergency admin service account.",
+		}
+		requestData, err := json.Marshal(requestBody)
+		Expect(err).ToNot(HaveOccurred())
+
+		// Create the object:
+		createUrl := fmt.Sprintf("https://%s/api/private/v1/cluster_templates", serviceAddr)
+		createRequest, err := http.NewRequestWithContext(ctx, "POST", createUrl, bytes.NewReader(requestData))
+		Expect(err).ToNot(HaveOccurred())
+		createRequest.Header.Set("Content-Type", "application/json")
+		createResponse, err := tool.EmergencyClient().Do(createRequest)
+		Expect(err).ToNot(HaveOccurred())
+		defer createResponse.Body.Close()
+		Expect(createResponse.StatusCode).To(Equal(http.StatusOK))
+
+		// Delete the object:
+		deleteUrl := fmt.Sprintf("https://%s/api/private/v1/cluster_templates/%s", serviceAddr, id)
+		deleteRequest, err := http.NewRequestWithContext(ctx, "DELETE", deleteUrl, nil)
+		Expect(err).ToNot(HaveOccurred())
+		deleteResponse, err := tool.EmergencyClient().Do(deleteRequest)
+		Expect(err).ToNot(HaveOccurred())
+		defer deleteResponse.Body.Close()
+		Expect(deleteResponse.StatusCode).To(Equal(http.StatusOK))
+	})
+})

--- a/it/it_nodeset_removal_test.go
+++ b/it/it_nodeset_removal_test.go
@@ -40,7 +40,7 @@ var _ = Describe("Node set removal", func() {
 	BeforeEach(func() {
 		ctx = context.Background()
 
-		clustersClient = ffv1.NewClustersClient(tool.ClientConn())
+		clustersClient = ffv1.NewClustersClient(tool.UserConn())
 		hostClassesClient = privatev1.NewHostClassesClient(tool.AdminConn())
 		templatesClient = privatev1.NewClusterTemplatesClient(tool.AdminConn())
 

--- a/it/it_public_cluster_templates_test.go
+++ b/it/it_public_cluster_templates_test.go
@@ -30,7 +30,7 @@ var _ = Describe("Cluster templates", func() {
 
 	BeforeEach(func() {
 		ctx = context.Background()
-		client = ffv1.NewClusterTemplatesClient(tool.ClientConn())
+		client = ffv1.NewClusterTemplatesClient(tool.UserConn())
 	})
 
 	It("Can get the list of templates", func() {

--- a/it/it_public_clusters_test.go
+++ b/it/it_public_clusters_test.go
@@ -50,7 +50,7 @@ var _ = Describe("Public clusters", func() {
 		ctx = context.Background()
 
 		// Create the clients:
-		clustersClient = ffv1.NewClustersClient(tool.ClientConn())
+		clustersClient = ffv1.NewClustersClient(tool.UserConn())
 		hostClassesClient = privatev1.NewHostClassesClient(tool.AdminConn())
 		templatesClient = privatev1.NewClusterTemplatesClient(tool.AdminConn())
 
@@ -767,6 +767,6 @@ var _ = Describe("Public clusters", func() {
 		Expect(object).ToNot(BeNil())
 		metadata := object.GetMetadata()
 		Expect(metadata).ToNot(BeNil())
-		Expect(metadata.GetCreators()).To(ConsistOf("my-user"))
+		Expect(metadata.GetCreators()).To(ConsistOf(userUsername))
 	})
 })

--- a/manifests/base/grpc-server/authconfig.yaml
+++ b/manifests/base/grpc-server/authconfig.yaml
@@ -70,10 +70,15 @@ spec:
         rego: |
           import future.keywords.in
 
-          # Define admin subjects:
-          admin_subjects := {
+          # Define admin service accounts:
+          admin_service_accounts := {
             "system:serviceaccount:innabox:admin",
             "system:serviceaccount:innabox:controller",
+          }
+
+          # Define admin groups:
+          admin_groups := {
+            "admins",
           }
 
           # Get the gRPC method:
@@ -87,9 +92,21 @@ spec:
             input.auth.identity.authnMethod == "jwt"
           }
 
+          # Get the subject groups:
+          subject_groups = input.auth.identity.user.groups {
+            input.auth.identity.authnMethod == "serviceaccount"
+          }
+          subject_groups = input.auth.identity.groups {
+            input.auth.identity.authnMethod == "jwt"
+          }
+
           # Function to check if an account is an admin account:
           is_admin {
-            subject_name in admin_subjects
+            subject_name in admin_service_accounts
+          }
+          is_admin {
+            some group in subject_groups
+            group in admin_groups
           }
 
           # Function to check if an account is a client account:
@@ -124,6 +141,13 @@ spec:
               "/fulfillment.v1.Clusters/GetPasswordViaHttp",
               "/fulfillment.v1.Clusters/List",
               "/fulfillment.v1.Clusters/Update",
+              "/fulfillment.v1.ComputeInstanceTemplates/Get",
+              "/fulfillment.v1.ComputeInstanceTemplates/List",
+              "/fulfillment.v1.ComputeInstances/Create",
+              "/fulfillment.v1.ComputeInstances/Delete",
+              "/fulfillment.v1.ComputeInstances/Get",
+              "/fulfillment.v1.ComputeInstances/List",
+              "/fulfillment.v1.ComputeInstances/Update",
               "/fulfillment.v1.HostClasses/Get",
               "/fulfillment.v1.HostClasses/List",
               "/fulfillment.v1.HostPools/Create",
@@ -136,13 +160,6 @@ spec:
               "/fulfillment.v1.Hosts/Get",
               "/fulfillment.v1.Hosts/List",
               "/fulfillment.v1.Hosts/Update",
-              "/fulfillment.v1.ComputeInstanceTemplates/Get",
-              "/fulfillment.v1.ComputeInstanceTemplates/List",
-              "/fulfillment.v1.ComputeInstances/Create",
-              "/fulfillment.v1.ComputeInstances/Delete",
-              "/fulfillment.v1.ComputeInstances/Get",
-              "/fulfillment.v1.ComputeInstances/List",
-              "/fulfillment.v1.ComputeInstances/Update",
             }
           }
 


### PR DESCRIPTION
This change extends the authorization policy to support admin access based on group membership in addition to the existing service account-based check. Users belonging to the `admins` group are now granted admin privileges.

The authorization policy has been updated to:

- Rename `admin_subjects` to `admin_service_accounts` for clarity.
- Add an `admin_groups` set containing the `admins` group.
- Extract `subject_groups` from JWT tokens or service account identities.
- Extend the `is_admin` check to include group membership verification.

The integration test infrastructure has been refactored to support three types of clients:

- Emergency: Uses the `admin` Kubernetes service account for emergency access.
- Admin: Uses a Keycloak user in the `admins` group for regular admin operations.
- User: Uses a Keycloak user in the `users` group for regular user operations.

This provides a clearer separation between emergency administrative access via service accounts and regular administrative access via JWT users.

New integration tests verify that regular users can access public API endpoints while being denied access to private API endpoints, and that admin users have access to both. Additional tests verify that the emergency admin service account can perform operations via both gRPC and REST.

Unit tests for the gRPC stream server interceptor have also been added.