### PR TITLE
Add service account auth error and isolation tests

### DIFF
--- a/it/it_multitenancy_test.go
+++ b/it/it_multitenancy_test.go
@@ -1,0 +1,368 @@
+package it
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/innabox/fulfillment-common/testing"
+	ffv1 "github.com/innabox/fulfillment-service/internal/api/fulfillment/v1"
+	privatev1 "github.com/innabox/fulfillment-service/internal/api/private/v1"
+	"google.golang.org/grpc"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Multitenancy authentication error handling", Label("multitenancy", "autherrors"), func() {
+	DescribeTable(
+		"returns error when authenticating with invalid token",
+		func(testUrl string) {
+			invalidToken := testing.MakeTokenString("test", 0)
+
+			req, err := http.NewRequest("GET", testUrl, nil)
+			Expect(err).ToNot(HaveOccurred())
+
+			// Set invalid token in request header
+			req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", invalidToken))
+
+			// Make request with invalid token
+			resp, err := http.Get(testUrl)
+			Expect(err).ToNot(HaveOccurred())
+
+			// Check that unauthorized status code is returned
+			Eventually(func(g Gomega) {
+				resp, err = http.Get(testUrl)
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(resp).ToNot(BeNil())
+				Expect(resp.StatusCode).To(BeNumerically(">=", http.StatusUnauthorized))
+				g.Expect(resp.StatusCode).To(Equal(http.StatusUnauthorized))
+			}).WithTimeout(100 * time.Millisecond).WithPolling(10 * time.Millisecond).Should(Succeed())
+
+			defer resp.Body.Close()
+
+			// Check that permission denied error is returned in response body
+			body, err := io.ReadAll(resp.Body)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(body).To(ContainSubstring("permission denied"))
+		},
+		Entry("clusters", fmt.Sprintf("https://%s/api/fulfillment/v1/clusters", serviceAddr)),
+		Entry("cluster templates", fmt.Sprintf("https://%s/api/fulfillment/v1/cluster_templates", serviceAddr)),
+		Entry("host pools", fmt.Sprintf("https://%s/api/fulfillment/v1/host_pools", serviceAddr)),
+		Entry("host classes", fmt.Sprintf("https://%s/api/fulfillment/v1/host_classes", serviceAddr)),
+	)
+
+	DescribeTable(
+		"returns error when user is not authenticated",
+		func(testUrl string) {
+			var testUser string
+			var testTenant string
+
+			// Get a random user and tenant from map of users
+			for user, tenant := range ServiceAccountTenants {
+				testUser = user
+				testTenant = tenant
+				break
+			}
+
+			// Check that requests can be made with valid token
+			tokenSource, err := tool.makeKubernetesTokenSource(context.Background(), testUser, testTenant)
+			Expect(err).ToNot(HaveOccurred())
+
+			req, err := http.NewRequest("GET", testUrl, nil)
+			Expect(err).ToNot(HaveOccurred())
+
+			// Set token in request header
+			token, err := tokenSource.Token(context.Background())
+			Expect(err).ToNot(HaveOccurred())
+			req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", token.Access))
+
+			// Make request with valid token
+			Eventually(func(g Gomega) {
+				resp, err := http.DefaultClient.Do(req)
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(resp.StatusCode).To(Equal(http.StatusOK))
+			}).WithTimeout(100 * time.Millisecond).WithPolling(10 * time.Millisecond).Should(Succeed())
+
+			// Make request with invalid token
+			var resp *http.Response
+
+			// Check that unauthorized status code is returned
+			Eventually(func(g Gomega) {
+				resp, err = http.Get(testUrl)
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(resp).ToNot(BeNil())
+				Expect(resp.StatusCode).To(BeNumerically(">=", http.StatusUnauthorized))
+				g.Expect(resp.StatusCode).To(Equal(http.StatusUnauthorized))
+			}).WithTimeout(100 * time.Millisecond).WithPolling(10 * time.Millisecond).Should(Succeed())
+
+			defer resp.Body.Close()
+
+			// Check that permission denied error is returned in response body
+			body, err := io.ReadAll(resp.Body)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(body).To(ContainSubstring("permission denied"))
+		},
+		Entry("clusters", fmt.Sprintf("https://%s/api/fulfillment/v1/clusters", serviceAddr)),
+		Entry("cluster templates", fmt.Sprintf("https://%s/api/fulfillment/v1/cluster_templates", serviceAddr)),
+		Entry("host pools", fmt.Sprintf("https://%s/api/fulfillment/v1/host_pools", serviceAddr)),
+		Entry("host classes", fmt.Sprintf("https://%s/api/fulfillment/v1/host_classes", serviceAddr)),
+	)
+})
+
+var _ = Describe("Multitenancy basic tenant isolation", Ordered, Label("multitenancy", "isolation"), func() {
+	Describe("serviceaccount tenants", func() {
+		var (
+			tenantUserMapping map[string][]string
+			ctx               context.Context
+		)
+
+		BeforeAll(func() {
+			ctx = context.Background()
+
+			// Create map to track which users belong to which tenants
+			tenantUserMapping = make(map[string][]string)
+
+			Expect(len(ServiceAccountTenants)).To(BeNumerically(">", 1))
+
+			// Populate map to track which users belong to which tenants
+			for user, tenant := range ServiceAccountTenants {
+				tenantUserMapping[tenant] = append(tenantUserMapping[tenant], user)
+			}
+		})
+
+		Describe("cluster resources", func() {
+			var (
+				tenantClusterMapping map[string][]string
+			)
+
+			BeforeAll(func() {
+				// Create map to track which clusters belong to which tenants
+				tenantClusterMapping = make(map[string][]string)
+
+				// Create host class for testing
+				hostClassesClient := privatev1.NewHostClassesClient(tool.AdminConn())
+				hostClassId := "basic-isolation-hostclass"
+				_, err := hostClassesClient.Create(ctx, privatev1.HostClassesCreateRequest_builder{
+					Object: privatev1.HostClass_builder{
+						Id: hostClassId,
+					}.Build(),
+				}.Build())
+				Expect(err).ToNot(HaveOccurred())
+				DeferCleanup(func() {
+					_, err := hostClassesClient.Delete(ctx, privatev1.HostClassesDeleteRequest_builder{
+						Id: hostClassId,
+					}.Build())
+					Expect(err).ToNot(HaveOccurred())
+				})
+
+				// Create cluster template for testing
+				templateId := "basic-isolation-template"
+				templatesClient := privatev1.NewClusterTemplatesClient(tool.adminConn)
+				_, err = templatesClient.Create(ctx, privatev1.ClusterTemplatesCreateRequest_builder{
+					Object: privatev1.ClusterTemplate_builder{
+						Id: templateId,
+						NodeSets: map[string]*privatev1.ClusterTemplateNodeSet{
+							"my-node-set": privatev1.ClusterTemplateNodeSet_builder{
+								HostClass: hostClassId,
+								Size:      3,
+							}.Build(),
+						},
+					}.Build(),
+				}.Build())
+				Expect(err).ToNot(HaveOccurred())
+				DeferCleanup(func() {
+					_, err := templatesClient.Delete(ctx, privatev1.ClusterTemplatesDeleteRequest_builder{
+						Id: templateId,
+					}.Build())
+					Expect(err).ToNot(HaveOccurred())
+				})
+
+				// Create a cluster object for each user
+				for user, tenant := range ServiceAccountTenants {
+					tokenSource, err := tool.makeKubernetesTokenSource(ctx, user, tenant)
+					Expect(err).ToNot(HaveOccurred())
+					conn, err := tool.makeGrpcConn(tokenSource)
+					Expect(err).ToNot(HaveOccurred())
+
+					clustersClient := ffv1.NewClustersClient(conn)
+					createResponse, err := clustersClient.Create(ctx, ffv1.ClustersCreateRequest_builder{
+						Object: ffv1.Cluster_builder{
+							Spec: ffv1.ClusterSpec_builder{
+								Template: templateId,
+							}.Build(),
+						}.Build(),
+					}.Build())
+					Expect(err).ToNot(HaveOccurred())
+					clusterObject := createResponse.GetObject()
+
+					DeferCleanup(func() { deleteCluster(ctx, clusterObject.GetId()) })
+
+					// Populate map to track which clusters belong to which tenants
+					tenantClusterMapping[tenant] = append(tenantClusterMapping[tenant], clusterObject.GetId())
+				}
+			})
+
+			It("shared within the same tenant", func() {
+				// List clusters for each user
+				for user, tenant := range ServiceAccountTenants {
+					tokenSource, err := tool.makeKubernetesTokenSource(ctx, user, tenant)
+					Expect(err).ToNot(HaveOccurred())
+					conn, err := tool.makeGrpcConn(tokenSource)
+					Expect(err).ToNot(HaveOccurred())
+
+					response := listClusters(ctx, conn)
+					Expect(response).ToNot(BeNil())
+					Expect(len(response.Items)).To(Equal(len(tenantUserMapping[tenant])))
+
+					// Check that each cluster appears under expected tenant
+					for _, cluster := range response.GetItems() {
+						Expect(tenantClusterMapping[tenant]).To(ContainElement(cluster.GetId()))
+					}
+				}
+			})
+
+			It("isolated between tenants", func() {
+				// List clusters for each user
+				for user, tenant := range ServiceAccountTenants {
+					tokenSource, err := tool.makeKubernetesTokenSource(ctx, user, tenant)
+					Expect(err).ToNot(HaveOccurred())
+					conn, err := tool.makeGrpcConn(tokenSource)
+					Expect(err).ToNot(HaveOccurred())
+
+					response := listClusters(ctx, conn)
+					Expect(response).ToNot(BeNil())
+					Expect(len(response.Items)).To(Equal(len(tenantUserMapping[tenant])))
+
+					// Check that each cluster is isolated between tenants
+					for _, cluster := range response.GetItems() {
+						for _, otherTenant := range ServiceAccountTenants {
+							if otherTenant != tenant {
+								Expect(tenantClusterMapping[otherTenant]).ToNot(ContainElement(cluster.GetId()))
+							}
+						}
+					}
+				}
+			})
+		})
+
+		Describe("host pool resources", func() {
+			var (
+				tenantHostPoolMapping map[string][]string
+			)
+
+			BeforeAll(func() {
+				// Create map to track which host pools belong to which tenants
+				tenantHostPoolMapping = make(map[string][]string)
+
+				// Create a host pool for each user
+				for user, tenant := range ServiceAccountTenants {
+					tokenSource, err := tool.makeKubernetesTokenSource(ctx, user, tenant)
+					Expect(err).ToNot(HaveOccurred())
+					conn, err := tool.makeGrpcConn(tokenSource)
+					Expect(err).ToNot(HaveOccurred())
+
+					hostPoolsClient := ffv1.NewHostPoolsClient(conn)
+					createResponse, err := hostPoolsClient.Create(ctx, ffv1.HostPoolsCreateRequest_builder{
+						Object: ffv1.HostPool_builder{
+							Spec: ffv1.HostPoolSpec_builder{
+								HostSets: map[string]*ffv1.HostPoolHostSet{
+									"my-host-set": ffv1.HostPoolHostSet_builder{
+										HostClass: "blah",
+										Size:      3,
+									}.Build(),
+								},
+							}.Build(),
+						}.Build(),
+					}.Build())
+					Expect(err).ToNot(HaveOccurred())
+					hostPoolObject := createResponse.GetObject()
+					DeferCleanup(func() { deleteHostPool(ctx, hostPoolObject.GetId()) })
+
+					// Populate map to track which host pools belong to which tenants
+					tenantHostPoolMapping[tenant] = append(tenantHostPoolMapping[tenant], hostPoolObject.GetId())
+				}
+			})
+
+			It("shared within the same tenant", func() {
+				// List host pools for each user
+				for user, tenant := range ServiceAccountTenants {
+					tokenSource, err := tool.makeKubernetesTokenSource(ctx, user, tenant)
+					Expect(err).ToNot(HaveOccurred())
+					conn, err := tool.makeGrpcConn(tokenSource)
+					Expect(err).ToNot(HaveOccurred())
+
+					response := listHostPools(ctx, conn)
+					Expect(response).ToNot(BeNil())
+					Expect(len(response.Items)).To(Equal(len(tenantUserMapping[tenant])))
+
+					// Check that each host pool appears under expected tenant
+					for _, hostPool := range response.GetItems() {
+						Expect(tenantHostPoolMapping[tenant]).To(ContainElement(hostPool.GetId()))
+					}
+				}
+			})
+
+			It("isolated between tenants", func() {
+				// List host pools for each user
+				for user, tenant := range ServiceAccountTenants {
+					tokenSource, err := tool.makeKubernetesTokenSource(ctx, user, tenant)
+					Expect(err).ToNot(HaveOccurred())
+					conn, err := tool.makeGrpcConn(tokenSource)
+					Expect(err).ToNot(HaveOccurred())
+
+					response := listHostPools(ctx, conn)
+					Expect(response).ToNot(BeNil())
+					Expect(len(response.Items)).To(Equal(len(tenantUserMapping[tenant])))
+
+					// Check that each host pool is isolated between tenants
+					for _, hostPool := range response.GetItems() {
+						for _, otherTenant := range ServiceAccountTenants {
+							if otherTenant != tenant {
+								Expect(tenantHostPoolMapping[otherTenant]).ToNot(ContainElement(hostPool.GetId()))
+							}
+						}
+					}
+				}
+			})
+		})
+	})
+})
+
+func getServiceAccountTenants() map[string]string {
+	return ServiceAccountTenants
+}
+
+func listClusters(ctx context.Context, conn *grpc.ClientConn) *ffv1.ClustersListResponse {
+	clustersClient := ffv1.NewClustersClient(conn)
+	response, err := clustersClient.List(ctx, ffv1.ClustersListRequest_builder{}.Build())
+	Expect(err).ToNot(HaveOccurred(), "error listing clusters")
+
+	return response
+}
+
+func listHostPools(ctx context.Context, conn *grpc.ClientConn) *ffv1.HostPoolsListResponse {
+	hostPoolsClient := ffv1.NewHostPoolsClient(conn)
+	response, err := hostPoolsClient.List(ctx, ffv1.HostPoolsListRequest_builder{}.Build())
+	Expect(err).ToNot(HaveOccurred(), "error listing host pools")
+
+	return response
+}
+
+func deleteCluster(ctx context.Context, clusterId string) error {
+	clusterClient := privatev1.NewClustersClient(tool.AdminConn())
+	_, err := clusterClient.Delete(ctx, privatev1.ClustersDeleteRequest_builder{
+		Id: clusterId,
+	}.Build())
+	return err
+}
+
+func deleteHostPool(ctx context.Context, hostPoolId string) error {
+	hostPoolClient := privatev1.NewHostPoolsClient(tool.AdminConn())
+	_, err := hostPoolClient.Delete(ctx, privatev1.HostPoolsDeleteRequest_builder{
+		Id: hostPoolId,
+	}.Build())
+	return err
+}


### PR DESCRIPTION
## Summary

This PR adds comprehensive integration tests for multitenancy authentication error handling and basic tenant isolation. The tests verify that the fulfillment service correctly handles authentication errors and enforces tenant boundaries for service account-based authentication.

## Changes

### New Test Suite: `it_multitenancy_test.go`

#### Authentication Error Handling Tests
- **Invalid token handling**: Verifies that requests with invalid JWT tokens return `401 Unauthorized` with a "permission denied" error message across fulfillment API endpoints (clusters, cluster_templates, host_pools, host_classes)
- **Unauthenticated requests**: Ensures that requests without authentication tokens are properly rejected with appropriate error responses

#### Tenant Isolation Tests
- **Cluster resource isolation**: 
  - Verifies that clusters are shared within the same tenant (users in the same tenant can see each other's clusters)
  - Verifies that clusters are isolated between different tenants (users cannot see clusters from other tenants)
- **Host pool resource isolation**:
  - Verifies that host pools are shared within the same tenant
  - Verifies that host pools are isolated between different tenants

### Infrastructure Updates: `it_tool.go`

- **Added `createUserServiceAccounts` function**: Automatically creates test service accounts and their associated namespaces during test setup
- **Updated `makeKubernetesTokenSource`**: Now accepts a `namespace` parameter to support multi-tenant token creation

### Test Variables: `testvars/testvars.go`

- **`ServiceAccountTenants`**: Defines test service accounts and their tenant assignments:
  - Tenant "a": alice, bob
  - Tenant "b": carol, dave
- **`MultiTenantUsers`**: Defines additional multi-tenant user configurations for future use
