### PR TITLE
MGMT-22988: Introduce IdP APIs and Keycloak Admin APIs

### DIFF
--- a/internal/apiclient/apiclient_suite_test.go
+++ b/internal/apiclient/apiclient_suite_test.go
@@ -1,0 +1,44 @@
+/*
+Copyright (c) 2026 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package apiclient
+
+import (
+	"log/slog"
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/osac-project/fulfillment-service/internal/logging"
+)
+
+func TestAPIClient(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "APIClient package")
+}
+
+var (
+	logger *slog.Logger
+)
+
+var _ = BeforeSuite(func() {
+	var err error
+
+	// Create the logger:
+	logger, err = logging.NewLogger().
+		SetLevel(slog.LevelDebug.String()).
+		SetWriter(GinkgoWriter).
+		Build()
+	Expect(err).ToNot(HaveOccurred())
+})

--- a/internal/apiclient/client.go
+++ b/internal/apiclient/client.go
@@ -1,0 +1,204 @@
+/*
+Copyright (c) 2026 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package apiclient
+
+import (
+	"bytes"
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+
+	"github.com/osac-project/fulfillment-service/internal/auth"
+)
+
+// APIError represents an HTTP API error with status code and response body.
+type APIError struct {
+	StatusCode int
+	Body       string
+}
+
+// Error implements the error interface.
+func (e *APIError) Error() string {
+	return fmt.Sprintf("API error: status=%d body=%s", e.StatusCode, e.Body)
+}
+
+// Client is a reusable HTTP client with authentication and error handling.
+// It's designed for calling external REST APIs that require bearer token authentication.
+type Client struct {
+	baseURL     string
+	httpClient  *http.Client
+	tokenSource auth.TokenSource
+	logger      *slog.Logger
+}
+
+// ClientBuilder builds an authenticated HTTP client.
+type ClientBuilder struct {
+	baseURL     string
+	tokenSource auth.TokenSource
+	caPool      *x509.CertPool
+	httpClient  *http.Client
+	logger      *slog.Logger
+}
+
+// NewClient creates a builder for an HTTP client.
+func NewClient() *ClientBuilder {
+	return &ClientBuilder{}
+}
+
+// SetLogger sets the logger.
+func (b *ClientBuilder) SetLogger(value *slog.Logger) *ClientBuilder {
+	b.logger = value
+	return b
+}
+
+// SetBaseURL sets the base URL for the API.
+func (b *ClientBuilder) SetBaseURL(value string) *ClientBuilder {
+	b.baseURL = value
+	return b
+}
+
+// SetTokenSource sets the authentication token source.
+func (b *ClientBuilder) SetTokenSource(value auth.TokenSource) *ClientBuilder {
+	b.tokenSource = value
+	return b
+}
+
+// SetCaPool sets a custom CA pool for TLS verification.
+func (b *ClientBuilder) SetCaPool(value *x509.CertPool) *ClientBuilder {
+	b.caPool = value
+	return b
+}
+
+// SetHTTPClient sets a custom HTTP client.
+func (b *ClientBuilder) SetHTTPClient(value *http.Client) *ClientBuilder {
+	b.httpClient = value
+	return b
+}
+
+// Build creates the HTTP client.
+func (b *ClientBuilder) Build() (result *Client, err error) {
+	if b.logger == nil {
+		err = errors.New("logger is mandatory")
+		return
+	}
+	if b.baseURL == "" {
+		err = errors.New("base URL is mandatory")
+		return
+	}
+	if b.tokenSource == nil {
+		err = errors.New("token source is mandatory")
+		return
+	}
+
+	httpClient := b.httpClient
+	if httpClient == nil {
+		transport := http.DefaultTransport.(*http.Transport).Clone()
+		if b.caPool != nil {
+			transport.TLSClientConfig = &tls.Config{
+				RootCAs: b.caPool,
+			}
+		}
+		httpClient = &http.Client{
+			Transport: transport,
+		}
+	}
+
+	result = &Client{
+		baseURL:     b.baseURL,
+		httpClient:  httpClient,
+		tokenSource: b.tokenSource,
+		logger:      b.logger,
+	}
+	return
+}
+
+// DoRequest performs an authenticated HTTP request with JSON handling.
+//
+// Parameters:
+//   - method: HTTP method (GET, POST, PUT, DELETE, etc.)
+//   - path: API path (will be appended to baseURL)
+//   - body: Request body (will be JSON-encoded), or nil for no body
+//
+// Returns:
+//   - response: HTTP response when successful (caller must close response.Body)
+//   - error: Error if request fails or response status >= 400
+//
+// IMPORTANT: Returns nil response when an error occurs (including HTTP status >= 400).
+// Always check err before accessing response to avoid nil pointer dereference.
+//
+// On success, the response body is NOT automatically closed - the caller must defer response.Body.Close().
+func (c *Client) DoRequest(ctx context.Context, method, path string, body any) (response *http.Response, err error) {
+	token, err := c.tokenSource.Token(ctx)
+	if err != nil {
+		err = fmt.Errorf("failed to get authentication token: %w", err)
+		return
+	}
+
+	var bodyReader io.Reader
+	if body != nil {
+		bodyBytes, marshalErr := json.Marshal(body)
+		if marshalErr != nil {
+			err = fmt.Errorf("failed to marshal request body: %w", marshalErr)
+			return
+		}
+		bodyReader = bytes.NewReader(bodyBytes)
+	}
+
+	requestURL := c.baseURL + path
+	request, err := http.NewRequestWithContext(ctx, method, requestURL, bodyReader)
+	if err != nil {
+		err = fmt.Errorf("failed to create HTTP request: %w", err)
+		return
+	}
+
+	request.Header.Set("Authorization", fmt.Sprintf("Bearer %s", token.Access))
+	if body != nil {
+		request.Header.Set("Content-Type", "application/json")
+	}
+
+	c.logger.DebugContext(ctx, "HTTP API request",
+		slog.String("method", method),
+		slog.String("path", path),
+	)
+
+	response, err = c.httpClient.Do(request)
+	if err != nil {
+		err = fmt.Errorf("failed to send HTTP request: %w", err)
+		return
+	}
+
+	if response.StatusCode >= 400 {
+		// Limit error response body to 1MB to prevent memory exhaustion
+		// from malicious or misbehaving upstream servers
+		bodyBytes, _ := io.ReadAll(io.LimitReader(response.Body, 1<<20))
+		response.Body.Close()
+
+		err = &APIError{
+			StatusCode: response.StatusCode,
+			Body:       string(bodyBytes),
+		}
+		// Set response to nil so callers can't accidentally access a closed response.
+		// This enforces checking err before using response.
+		response = nil
+		return
+	}
+
+	return
+}

--- a/internal/apiclient/client_test.go
+++ b/internal/apiclient/client_test.go
@@ -1,0 +1,259 @@
+/*
+Copyright (c) 2026 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package apiclient
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/osac-project/fulfillment-service/internal/auth"
+)
+
+var _ = Describe("HTTP Client", func() {
+	var (
+		ctx    context.Context
+		client *Client
+		server *httptest.Server
+	)
+
+	BeforeEach(func() {
+		ctx = context.Background()
+	})
+
+	AfterEach(func() {
+		if server != nil {
+			server.Close()
+		}
+	})
+
+	Describe("DoRequest", func() {
+		It("makes a successful authenticated request", func() {
+			server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				Expect(r.Header.Get("Authorization")).To(Equal("Bearer test-token"))
+				w.WriteHeader(http.StatusOK)
+				json.NewEncoder(w).Encode(map[string]string{"status": "ok"})
+			}))
+
+			client = createTestClient(server.URL)
+
+			resp, err := client.DoRequest(ctx, http.MethodGet, "/test", nil)
+			Expect(err).ToNot(HaveOccurred())
+			defer resp.Body.Close()
+
+			Expect(resp.StatusCode).To(Equal(http.StatusOK))
+		})
+
+		It("returns an APIError for 404 not found", func() {
+			server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusNotFound)
+			}))
+
+			client = createTestClient(server.URL)
+
+			_, err := client.DoRequest(ctx, http.MethodGet, "/test", nil)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("API error"))
+
+			var apiErr *APIError
+			Expect(errors.As(err, &apiErr)).To(BeTrue())
+			Expect(apiErr.StatusCode).To(Equal(http.StatusNotFound))
+		})
+
+		It("returns an APIError for 409 conflict", func() {
+			server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusConflict)
+			}))
+
+			client = createTestClient(server.URL)
+
+			_, err := client.DoRequest(ctx, http.MethodPost, "/test", map[string]string{"test": "data"})
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("API error"))
+
+			var apiErr *APIError
+			Expect(errors.As(err, &apiErr)).To(BeTrue())
+			Expect(apiErr.StatusCode).To(Equal(http.StatusConflict))
+		})
+
+		It("returns an error for 401 unauthorized", func() {
+			server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusUnauthorized)
+			}))
+
+			client = createTestClient(server.URL)
+
+			_, err := client.DoRequest(ctx, http.MethodGet, "/test", nil)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("API error"))
+		})
+
+		It("returns an error for 403 forbidden", func() {
+			server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusForbidden)
+			}))
+
+			client = createTestClient(server.URL)
+
+			_, err := client.DoRequest(ctx, http.MethodGet, "/test", nil)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("API error"))
+		})
+
+		It("returns an APIError for 400 bad request with body", func() {
+			server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusBadRequest)
+				w.Write([]byte("invalid input"))
+			}))
+
+			client = createTestClient(server.URL)
+
+			_, err := client.DoRequest(ctx, http.MethodPost, "/test", map[string]string{"bad": "data"})
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("API error"))
+
+			var apiErr *APIError
+			Expect(errors.As(err, &apiErr)).To(BeTrue())
+			Expect(apiErr.StatusCode).To(Equal(http.StatusBadRequest))
+			Expect(apiErr.Body).To(Equal("invalid input"))
+		})
+
+		It("returns an error for 500 internal server error", func() {
+			server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusInternalServerError)
+			}))
+
+			client = createTestClient(server.URL)
+
+			_, err := client.DoRequest(ctx, http.MethodGet, "/test", nil)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("API error"))
+			Expect(err.Error()).To(ContainSubstring("status=500"))
+		})
+
+		It("includes Content-Type header when body is provided", func() {
+			server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				Expect(r.Header.Get("Content-Type")).To(Equal("application/json"))
+				Expect(r.Header.Get("Authorization")).To(Equal("Bearer test-token"))
+				w.WriteHeader(http.StatusOK)
+			}))
+
+			client = createTestClient(server.URL)
+
+			resp, err := client.DoRequest(ctx, http.MethodPost, "/test", map[string]string{"key": "value"})
+			Expect(err).ToNot(HaveOccurred())
+			defer resp.Body.Close()
+		})
+
+		It("does not include Content-Type header when body is nil", func() {
+			server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				Expect(r.Header.Get("Content-Type")).To(BeEmpty())
+				Expect(r.Header.Get("Authorization")).To(Equal("Bearer test-token"))
+				w.WriteHeader(http.StatusOK)
+			}))
+
+			client = createTestClient(server.URL)
+
+			resp, err := client.DoRequest(ctx, http.MethodGet, "/test", nil)
+			Expect(err).ToNot(HaveOccurred())
+			defer resp.Body.Close()
+		})
+
+		It("limits error response body to 1MB to prevent memory exhaustion", func() {
+			server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusBadRequest)
+				// Write 2MB of data (exceeds 1MB limit)
+				largeBody := make([]byte, 2<<20) // 2 MB
+				for i := range largeBody {
+					largeBody[i] = 'A'
+				}
+				w.Write(largeBody)
+			}))
+
+			client = createTestClient(server.URL)
+
+			_, err := client.DoRequest(ctx, http.MethodGet, "/test", nil)
+			Expect(err).To(HaveOccurred())
+
+			var apiErr *APIError
+			Expect(errors.As(err, &apiErr)).To(BeTrue())
+			Expect(apiErr.StatusCode).To(Equal(http.StatusBadRequest))
+			// Body should be truncated to 1MB (1<<20 bytes)
+			Expect(len(apiErr.Body)).To(Equal(1 << 20))
+		})
+	})
+
+	Describe("Client Builder", func() {
+		It("returns an error when logger is missing", func() {
+			tokenSource, err := auth.NewStaticTokenSource().
+				SetLogger(logger).
+				SetToken(&auth.Token{Access: "test-token"}).
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+
+			_, err = NewClient().
+				SetBaseURL("http://localhost").
+				SetTokenSource(tokenSource).
+				Build()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("logger is mandatory"))
+		})
+
+		It("returns an error when base URL is missing", func() {
+			tokenSource, err := auth.NewStaticTokenSource().
+				SetLogger(logger).
+				SetToken(&auth.Token{Access: "test-token"}).
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+
+			_, err = NewClient().
+				SetLogger(logger).
+				SetTokenSource(tokenSource).
+				Build()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("base URL is mandatory"))
+		})
+
+		It("returns an error when token source is missing", func() {
+			_, err := NewClient().
+				SetLogger(logger).
+				SetBaseURL("http://localhost").
+				Build()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("token source is mandatory"))
+		})
+	})
+})
+
+func createTestClient(serverURL string) *Client {
+	tokenSource, err := auth.NewStaticTokenSource().
+		SetLogger(logger).
+		SetToken(&auth.Token{Access: "test-token"}).
+		Build()
+	Expect(err).ToNot(HaveOccurred())
+
+	client, err := NewClient().
+		SetLogger(logger).
+		SetBaseURL(serverURL).
+		SetTokenSource(tokenSource).
+		Build()
+	Expect(err).ToNot(HaveOccurred())
+
+	return client
+}

--- a/internal/idp/client.go
+++ b/internal/idp/client.go
@@ -1,0 +1,65 @@
+/*
+Copyright (c) 2026 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package idp
+
+import (
+	"context"
+)
+
+// Client is the generic interface for identity provider admin operations.
+// Different IdP providers (Keycloak, Auth0, Okta, etc.) implement this interface.
+type Client interface {
+	// Organization operations
+	CreateOrganization(ctx context.Context, org *Organization) (*Organization, error)
+	GetOrganization(ctx context.Context, name string) (*Organization, error)
+	DeleteOrganization(ctx context.Context, name string) error
+
+	// User operations
+	CreateUser(ctx context.Context, organizationName string, user *User) (*User, error)
+	GetUser(ctx context.Context, organizationName, userID string) (*User, error)
+	ListUsers(ctx context.Context, organizationName string) ([]*User, error)
+	DeleteUser(ctx context.Context, organizationName, userID string) error
+
+	// Role operations
+	// Roles can be at the organization level or client level
+	ListOrganizationRoles(ctx context.Context, organizationName string) ([]*Role, error)
+	ListClientRoles(ctx context.Context, organizationName, clientID string) ([]*Role, error)
+
+	// User role assignments
+	AssignOrganizationRolesToUser(ctx context.Context, organizationName, userID string, roles []*Role) error
+	AssignClientRolesToUser(ctx context.Context, organizationName, userID, clientID string, roles []*Role) error
+	RemoveOrganizationRolesFromUser(ctx context.Context, organizationName, userID string, roles []*Role) error
+	RemoveClientRolesFromUser(ctx context.Context, organizationName, userID, clientID string, roles []*Role) error
+	GetUserOrganizationRoles(ctx context.Context, organizationName, userID string) ([]*Role, error)
+	GetUserClientRoles(ctx context.Context, organizationName, userID, clientID string) ([]*Role, error)
+
+	// Admin permissions
+	// AssignOrganizationAdminPermissions grants full administrative access to an organization for the specified user.
+	// The implementation is provider-specific:
+	// - Keycloak: Assigns realm-management client roles (manage-realm, manage-users, etc.)
+	// - Auth0: Assigns organization Admin role
+	// - Okta: Assigns Organizational Administrator role
+	// - Azure AD: Assigns Global Administrator or Organizational Administrator role
+	AssignOrganizationAdminPermissions(ctx context.Context, organizationName, userID string) error
+
+	// AssignIdpManagerPermissions grants limited IdP management permissions to the specified user.
+	// This is used for the break-glass account which can manage users and identity providers
+	// but cannot modify critical organization settings.
+	// The implementation is provider-specific:
+	// - Keycloak: Assigns limited realm-management client roles (manage-users, view-users, etc.)
+	// - Auth0: Assigns organization Member Manager role
+	// - Okta: Assigns User Administrator role
+	// - Azure AD: Assigns User Administrator role
+	AssignIdpManagerPermissions(ctx context.Context, organizationName, userID string) error
+}

--- a/internal/idp/idp_suite_test.go
+++ b/internal/idp/idp_suite_test.go
@@ -1,0 +1,44 @@
+/*
+Copyright (c) 2026 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package idp
+
+import (
+	"log/slog"
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/osac-project/fulfillment-service/internal/logging"
+)
+
+func TestIdp(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "IdP package")
+}
+
+var (
+	logger *slog.Logger
+)
+
+var _ = BeforeSuite(func() {
+	var err error
+
+	// Create the logger:
+	logger, err = logging.NewLogger().
+		SetLevel(slog.LevelDebug.String()).
+		SetWriter(GinkgoWriter).
+		Build()
+	Expect(err).ToNot(HaveOccurred())
+})

--- a/internal/idp/keycloak/client.go
+++ b/internal/idp/keycloak/client.go
@@ -1,0 +1,641 @@
+/*
+Copyright (c) 2026 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package keycloak
+
+import (
+	"context"
+	"crypto/x509"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"net/url"
+	"slices"
+	"strings"
+	"sync"
+
+	"github.com/google/uuid"
+
+	"github.com/osac-project/fulfillment-service/internal/apiclient"
+	"github.com/osac-project/fulfillment-service/internal/auth"
+	"github.com/osac-project/fulfillment-service/internal/idp"
+)
+
+// Client is a Keycloak-specific implementation of the idp.Client interface.
+type Client struct {
+	logger     *slog.Logger
+	httpClient *apiclient.Client
+
+	// realm-management client UUIDs by organization name
+	realmManagementUUIDs map[string]string
+	mu                   sync.RWMutex
+}
+
+// ClientBuilder builds a Keycloak client.
+type ClientBuilder struct {
+	logger      *slog.Logger
+	baseURL     string
+	tokenSource auth.TokenSource
+	caPool      *x509.CertPool
+	httpClient  *http.Client
+}
+
+// Ensure Client implements idp.Client at compile time
+var _ idp.Client = (*Client)(nil)
+
+// NewClient creates a builder for a Keycloak admin client.
+func NewClient() *ClientBuilder {
+	return &ClientBuilder{}
+}
+
+// SetLogger sets the logger.
+func (b *ClientBuilder) SetLogger(value *slog.Logger) *ClientBuilder {
+	b.logger = value
+	return b
+}
+
+// SetBaseURL sets the base URL of the Keycloak server.
+func (b *ClientBuilder) SetBaseURL(value string) *ClientBuilder {
+	b.baseURL = value
+	return b
+}
+
+// SetTokenSource sets the token source for authentication.
+func (b *ClientBuilder) SetTokenSource(value auth.TokenSource) *ClientBuilder {
+	b.tokenSource = value
+	return b
+}
+
+// SetCaPool sets the CA certificate pool.
+func (b *ClientBuilder) SetCaPool(value *x509.CertPool) *ClientBuilder {
+	b.caPool = value
+	return b
+}
+
+// SetHTTPClient sets a custom HTTP client.
+func (b *ClientBuilder) SetHTTPClient(value *http.Client) *ClientBuilder {
+	b.httpClient = value
+	return b
+}
+
+// Build creates the Keycloak client.
+func (b *ClientBuilder) Build() (result *Client, err error) {
+	if b.logger == nil {
+		err = errors.New("logger is mandatory")
+		return
+	}
+	if b.baseURL == "" {
+		err = errors.New("base URL is mandatory")
+		return
+	}
+	if b.tokenSource == nil {
+		err = errors.New("token source is mandatory")
+		return
+	}
+
+	// Build the underlying HTTP client
+	httpClientBuilder := apiclient.NewClient().
+		SetLogger(b.logger).
+		SetBaseURL(strings.TrimSuffix(b.baseURL, "/")).
+		SetTokenSource(b.tokenSource)
+
+	if b.caPool != nil {
+		httpClientBuilder = httpClientBuilder.SetCaPool(b.caPool)
+	}
+	if b.httpClient != nil {
+		httpClientBuilder = httpClientBuilder.SetHTTPClient(b.httpClient)
+	}
+
+	httpClient, err := httpClientBuilder.Build()
+	if err != nil {
+		return nil, fmt.Errorf("failed to build HTTP client: %w", err)
+	}
+
+	result = &Client{
+		logger:               b.logger,
+		httpClient:           httpClient,
+		realmManagementUUIDs: make(map[string]string),
+	}
+	return
+}
+
+// CreateOrganization creates a new organization (Keycloak realm).
+// Returns the created organization with server-assigned ID and any server defaults.
+func (c *Client) CreateOrganization(ctx context.Context, org *idp.Organization) (*idp.Organization, error) {
+	kcRealm := toKeycloakRealm(org)
+	response, err := c.httpClient.DoRequest(ctx, http.MethodPost, "/admin/realms", kcRealm)
+	if err != nil {
+		var apiErr *apiclient.APIError
+		if errors.As(err, &apiErr) && apiErr.StatusCode == http.StatusConflict {
+			return nil, fmt.Errorf("organization %q already exists: %w", org.Name, err)
+		}
+		return nil, fmt.Errorf("failed to create organization: %w", err)
+	}
+	response.Body.Close()
+
+	// Keycloak's POST /admin/realms returns 201 with no body, so we fetch the created realm
+	// to get the server-assigned ID and verify the realm was actually created
+	return c.GetOrganization(ctx, org.Name)
+}
+
+// GetOrganization retrieves an organization (Keycloak realm) by name.
+func (c *Client) GetOrganization(ctx context.Context, name string) (*idp.Organization, error) {
+	response, err := c.httpClient.DoRequest(ctx, http.MethodGet, fmt.Sprintf("/admin/realms/%s", url.PathEscape(name)), nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get organization: %w", err)
+	}
+	defer response.Body.Close()
+
+	var kcRealm keycloakRealm
+	if err = json.NewDecoder(response.Body).Decode(&kcRealm); err != nil {
+		return nil, fmt.Errorf("failed to decode organization response: %w", err)
+	}
+	return fromKeycloakRealm(&kcRealm), nil
+}
+
+// DeleteOrganization deletes an organization (Keycloak realm) by name.
+func (c *Client) DeleteOrganization(ctx context.Context, organizationName string) error {
+	response, err := c.httpClient.DoRequest(ctx, http.MethodDelete, fmt.Sprintf("/admin/realms/%s", url.PathEscape(organizationName)), nil)
+	if err != nil {
+		return fmt.Errorf("failed to delete organization: %w", err)
+	}
+	defer response.Body.Close()
+
+	// Clear cached realm-management UUID for this organization to prevent stale data
+	// if the organization is recreated later
+	c.mu.Lock()
+	delete(c.realmManagementUUIDs, organizationName)
+	c.mu.Unlock()
+
+	return nil
+}
+
+// CreateUser creates a new user in an organization.
+// Returns the created user with ID populated.
+func (c *Client) CreateUser(ctx context.Context, organizationName string, user *idp.User) (*idp.User, error) {
+	kcUser := toKeycloakUser(user)
+	response, err := c.httpClient.DoRequest(ctx, http.MethodPost, fmt.Sprintf("/admin/realms/%s/users", url.PathEscape(organizationName)), kcUser)
+	if err != nil {
+		var apiErr *apiclient.APIError
+		if errors.As(err, &apiErr) && apiErr.StatusCode == http.StatusConflict {
+			return nil, fmt.Errorf("user %q already exists: %w", user.Username, err)
+		}
+		return nil, fmt.Errorf("failed to create user: %w", err)
+	}
+	defer response.Body.Close()
+
+	// Extract user ID from Location header
+	// Location format: https://keycloak.example.com/admin/realms/{realm}/users/{user-id}
+	location := response.Header.Get("Location")
+	if location == "" {
+		return nil, fmt.Errorf("Location header not present in create user response")
+	}
+
+	// Extract the last segment of the URL path as the user ID
+	parts := strings.Split(strings.TrimSuffix(location, "/"), "/")
+	if len(parts) == 0 {
+		return nil, fmt.Errorf("failed to extract user ID from Location header: %s", location)
+	}
+
+	userID := parts[len(parts)-1]
+	if userID == "" {
+		return nil, fmt.Errorf("extracted user ID is empty from Location header: %s", location)
+	}
+
+	// Return a copy of the user with ID populated
+	createdUser := &idp.User{
+		ID:              userID,
+		Username:        user.Username,
+		Email:           user.Email,
+		EmailVerified:   user.EmailVerified,
+		Enabled:         user.Enabled,
+		FirstName:       user.FirstName,
+		LastName:        user.LastName,
+		Attributes:      user.Attributes,
+		Groups:          user.Groups,
+		Credentials:     user.Credentials,
+		RequiredActions: user.RequiredActions,
+	}
+
+	return createdUser, nil
+}
+
+// GetUser retrieves a user by ID.
+func (c *Client) GetUser(ctx context.Context, organizationName, userID string) (*idp.User, error) {
+	response, err := c.httpClient.DoRequest(ctx, http.MethodGet, fmt.Sprintf("/admin/realms/%s/users/%s", url.PathEscape(organizationName), url.PathEscape(userID)), nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get user: %w", err)
+	}
+	defer response.Body.Close()
+
+	var kcUser keycloakUser
+	if err = json.NewDecoder(response.Body).Decode(&kcUser); err != nil {
+		return nil, fmt.Errorf("failed to decode user response: %w", err)
+	}
+	return fromKeycloakUser(&kcUser), nil
+}
+
+// ListUsers lists all users in an organization.
+func (c *Client) ListUsers(ctx context.Context, organizationName string) ([]*idp.User, error) {
+	var allUsers []*idp.User
+	const maxPerPage = 100
+	first := 0
+
+	// Fetches all pages to ensure no users are missed due to Keycloak's pagination.
+	for {
+		// Check if context is cancelled before making the next API call
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+
+		// Fetch one page of users
+		path := fmt.Sprintf("/admin/realms/%s/users?first=%d&max=%d",
+			url.PathEscape(organizationName), first, maxPerPage)
+
+		response, err := c.httpClient.DoRequest(ctx, http.MethodGet, path, nil)
+		if err != nil {
+			return nil, fmt.Errorf("failed to list users: %w", err)
+		}
+
+		var kcUsers []keycloakUser
+		err = json.NewDecoder(response.Body).Decode(&kcUsers)
+		response.Body.Close()
+
+		if err != nil {
+			return nil, fmt.Errorf("failed to decode users response: %w", err)
+		}
+
+		// Convert and append this page
+		for _, kcUser := range kcUsers {
+			allUsers = append(allUsers, fromKeycloakUser(&kcUser))
+		}
+
+		// If we got fewer than max, we've reached the last page
+		if len(kcUsers) < maxPerPage {
+			break
+		}
+
+		// Move to next page
+		first += maxPerPage
+	}
+
+	return allUsers, nil
+}
+
+// DeleteUser deletes a user by ID.
+func (c *Client) DeleteUser(ctx context.Context, organizationName, userID string) error {
+	response, err := c.httpClient.DoRequest(ctx, http.MethodDelete, fmt.Sprintf("/admin/realms/%s/users/%s", url.PathEscape(organizationName), url.PathEscape(userID)), nil)
+	if err != nil {
+		var apiErr *apiclient.APIError
+		if errors.As(err, &apiErr) && apiErr.StatusCode == http.StatusNotFound {
+			return fmt.Errorf("user %q not found in organization %q: %w", userID, organizationName, err)
+		}
+		return fmt.Errorf("failed to delete user: %w", err)
+	}
+	defer response.Body.Close()
+	return nil
+}
+
+// ListOrganizationRoles lists all organization-level (realm) roles.
+func (c *Client) ListOrganizationRoles(ctx context.Context, organizationName string) ([]*idp.Role, error) {
+	response, err := c.httpClient.DoRequest(ctx, http.MethodGet, fmt.Sprintf("/admin/realms/%s/roles", url.PathEscape(organizationName)), nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list realm roles: %w", err)
+	}
+	defer response.Body.Close()
+
+	var kcRoles []keycloakRole
+	if err = json.NewDecoder(response.Body).Decode(&kcRoles); err != nil {
+		return nil, fmt.Errorf("failed to decode realm roles response: %w", err)
+	}
+
+	roles := make([]*idp.Role, len(kcRoles))
+	for i, kcRole := range kcRoles {
+		roles[i] = fromKeycloakRole(&kcRole)
+	}
+	return roles, nil
+}
+
+// ListClientRoles lists all roles for a specific client.
+//
+// The clientID parameter accepts either format for convenience:
+//   - Human-readable clientId: "realm-management", "account", "my-app"
+//   - Internal UUID: "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+func (c *Client) ListClientRoles(ctx context.Context, organizationName, clientID string) ([]*idp.Role, error) {
+	// Resolve to internal UUID
+	internalID, err := c.GetClientByClientID(ctx, organizationName, clientID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to resolve client ID: %w", err)
+	}
+
+	response, err := c.httpClient.DoRequest(ctx, http.MethodGet, fmt.Sprintf("/admin/realms/%s/clients/%s/roles", url.PathEscape(organizationName), url.PathEscape(internalID)), nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list client roles: %w", err)
+	}
+	defer response.Body.Close()
+
+	var kcRoles []keycloakRole
+	if err = json.NewDecoder(response.Body).Decode(&kcRoles); err != nil {
+		return nil, fmt.Errorf("failed to decode client roles response: %w", err)
+	}
+
+	roles := make([]*idp.Role, len(kcRoles))
+	for i, kcRole := range kcRoles {
+		roles[i] = fromKeycloakRole(&kcRole)
+	}
+	return roles, nil
+}
+
+// AssignOrganizationRolesToUser adds organization-level (realm) roles to a user.
+func (c *Client) AssignOrganizationRolesToUser(ctx context.Context, organizationName, userID string, roles []*idp.Role) error {
+	kcRoles := make([]keycloakRole, len(roles))
+	for i, role := range roles {
+		kcRoles[i] = *toKeycloakRole(role)
+	}
+
+	response, err := c.httpClient.DoRequest(ctx, http.MethodPost, fmt.Sprintf("/admin/realms/%s/users/%s/role-mappings/realm", url.PathEscape(organizationName), url.PathEscape(userID)), kcRoles)
+	if err != nil {
+		return fmt.Errorf("failed to assign realm roles to user: %w", err)
+	}
+	defer response.Body.Close()
+	return nil
+}
+
+// AssignClientRolesToUser adds client-level roles to a user.
+//
+// The clientID parameter accepts either format:
+//   - Human-readable clientId: "realm-management", "account", "my-app"
+//   - Internal UUID: "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+func (c *Client) AssignClientRolesToUser(ctx context.Context, organizationName, userID, clientID string, roles []*idp.Role) error {
+	// Resolve to internal UUID
+	internalID, err := c.GetClientByClientID(ctx, organizationName, clientID)
+	if err != nil {
+		return fmt.Errorf("failed to resolve client ID: %w", err)
+	}
+
+	kcRoles := make([]keycloakRole, len(roles))
+	for i, role := range roles {
+		kcRoles[i] = *toKeycloakRole(role)
+	}
+
+	response, err := c.httpClient.DoRequest(ctx, http.MethodPost, fmt.Sprintf("/admin/realms/%s/users/%s/role-mappings/clients/%s", url.PathEscape(organizationName), url.PathEscape(userID), url.PathEscape(internalID)), kcRoles)
+	if err != nil {
+		return fmt.Errorf("failed to assign client roles to user: %w", err)
+	}
+	defer response.Body.Close()
+	return nil
+}
+
+// RemoveOrganizationRolesFromUser removes organization-level (realm) roles from a user.
+func (c *Client) RemoveOrganizationRolesFromUser(ctx context.Context, organizationName, userID string, roles []*idp.Role) error {
+	kcRoles := make([]keycloakRole, len(roles))
+	for i, role := range roles {
+		kcRoles[i] = *toKeycloakRole(role)
+	}
+
+	response, err := c.httpClient.DoRequest(ctx, http.MethodDelete, fmt.Sprintf("/admin/realms/%s/users/%s/role-mappings/realm", url.PathEscape(organizationName), url.PathEscape(userID)), kcRoles)
+	if err != nil {
+		return fmt.Errorf("failed to remove realm roles from user: %w", err)
+	}
+	defer response.Body.Close()
+	return nil
+}
+
+// RemoveClientRolesFromUser removes client-level roles from a user.
+//
+// The clientID parameter accepts either format:
+//   - Human-readable clientId: "realm-management", "account", "my-app"
+//   - Internal UUID: "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+func (c *Client) RemoveClientRolesFromUser(ctx context.Context, organizationName, userID, clientID string, roles []*idp.Role) error {
+	// Resolve to internal UUID
+	internalID, err := c.GetClientByClientID(ctx, organizationName, clientID)
+	if err != nil {
+		return fmt.Errorf("failed to resolve client ID: %w", err)
+	}
+
+	kcRoles := make([]keycloakRole, len(roles))
+	for i, role := range roles {
+		kcRoles[i] = *toKeycloakRole(role)
+	}
+
+	response, err := c.httpClient.DoRequest(ctx, http.MethodDelete, fmt.Sprintf("/admin/realms/%s/users/%s/role-mappings/clients/%s", url.PathEscape(organizationName), url.PathEscape(userID), url.PathEscape(internalID)), kcRoles)
+	if err != nil {
+		return fmt.Errorf("failed to remove client roles from user: %w", err)
+	}
+	defer response.Body.Close()
+	return nil
+}
+
+// GetUserOrganizationRoles gets the organization-level (realm) roles assigned to a user.
+func (c *Client) GetUserOrganizationRoles(ctx context.Context, organizationName, userID string) ([]*idp.Role, error) {
+	response, err := c.httpClient.DoRequest(ctx, http.MethodGet, fmt.Sprintf("/admin/realms/%s/users/%s/role-mappings/realm", url.PathEscape(organizationName), url.PathEscape(userID)), nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get user realm roles: %w", err)
+	}
+	defer response.Body.Close()
+
+	var kcRoles []keycloakRole
+	if err = json.NewDecoder(response.Body).Decode(&kcRoles); err != nil {
+		return nil, fmt.Errorf("failed to decode user realm roles response: %w", err)
+	}
+
+	roles := make([]*idp.Role, len(kcRoles))
+	for i, kcRole := range kcRoles {
+		roles[i] = fromKeycloakRole(&kcRole)
+	}
+	return roles, nil
+}
+
+// GetUserClientRoles gets the client-level roles assigned to a user.
+//
+// The clientID parameter accepts either format:
+//   - Human-readable clientId: "realm-management", "account", "my-app"
+//   - Internal UUID: "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+func (c *Client) GetUserClientRoles(ctx context.Context, organizationName, userID, clientID string) ([]*idp.Role, error) {
+	// Resolve to internal UUID
+	internalID, err := c.GetClientByClientID(ctx, organizationName, clientID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to resolve client ID: %w", err)
+	}
+
+	response, err := c.httpClient.DoRequest(ctx, http.MethodGet, fmt.Sprintf("/admin/realms/%s/users/%s/role-mappings/clients/%s", url.PathEscape(organizationName), url.PathEscape(userID), url.PathEscape(internalID)), nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get user client roles: %w", err)
+	}
+	defer response.Body.Close()
+
+	var kcRoles []keycloakRole
+	if err = json.NewDecoder(response.Body).Decode(&kcRoles); err != nil {
+		return nil, fmt.Errorf("failed to decode user client roles response: %w", err)
+	}
+
+	roles := make([]*idp.Role, len(kcRoles))
+	for i, kcRole := range kcRoles {
+		roles[i] = fromKeycloakRole(&kcRole)
+	}
+	return roles, nil
+}
+
+// GetClientByClientID resolves a client identifier to its internal UUID.
+//
+// The clientID parameter accepts either format:
+//   - Human-readable clientId: "realm-management", "account", "my-app"
+//   - Internal UUID: "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+//
+// The method first checks if clientID is a valid UUID. If so, it returns it immediately
+// (no API call needed). For the "realm-management" client (the only client we currently use),
+// the internal UUID is looked up once per organization and stored.
+//
+// This is needed because Keycloak's role-mapping API endpoints require the internal UUID,
+// but we use the human-readable clientId "realm-management".
+//
+// Example:
+//
+//	uuid, err := client.GetClientByClientID(ctx, "my-org", "realm-management")
+//	// Returns: "a1b2c3d4-e5f6-7890-..." (internal UUID)
+func (c *Client) GetClientByClientID(ctx context.Context, organizationName, clientID string) (string, error) {
+	// Check if clientID is already a valid UUID (internal ID)
+	// If so, return it immediately without making an API call
+	if _, err := uuid.Parse(clientID); err == nil {
+		return clientID, nil
+	}
+
+	// For realm-management, check if we already have the UUID for this organization
+	if clientID == realmManagementClientID {
+		c.mu.RLock()
+		if storedUUID, found := c.realmManagementUUIDs[organizationName]; found {
+			c.mu.RUnlock()
+			return storedUUID, nil
+		}
+		c.mu.RUnlock()
+	}
+
+	// Look up the client UUID via API
+	response, err := c.httpClient.DoRequest(ctx, http.MethodGet, fmt.Sprintf("/admin/realms/%s/clients?clientId=%s", url.PathEscape(organizationName), url.QueryEscape(clientID)), nil)
+	if err != nil {
+		return "", fmt.Errorf("failed to get client by clientId: %w", err)
+	}
+	defer response.Body.Close()
+
+	var kcClients []keycloakClient
+	if err = json.NewDecoder(response.Body).Decode(&kcClients); err != nil {
+		return "", fmt.Errorf("failed to decode clients response: %w", err)
+	}
+
+	if len(kcClients) == 0 {
+		return "", fmt.Errorf("client %q not found", clientID)
+	}
+
+	internalUUID := kcClients[0].ID
+
+	// Save realm-management UUID for this organization
+	if clientID == realmManagementClientID {
+		c.mu.Lock()
+		c.realmManagementUUIDs[organizationName] = internalUUID
+		c.mu.Unlock()
+	}
+
+	return internalUUID, nil
+}
+
+// AssignOrganizationAdminPermissions grants full administrative access to an organization for the specified user.
+//
+// For Keycloak, this assigns client roles from the built-in "realm-management" client.
+// NOTE: Keycloak's administrative permissions are NOT organization roles - they are client-level roles
+// on the "realm-management" client that exists by default in every realm. This is why we use
+// AssignClientRolesToUser instead of AssignOrganizationRolesToUser.
+func (c *Client) AssignOrganizationAdminPermissions(ctx context.Context, organizationName, userID string) error {
+	c.logger.DebugContext(ctx, "Assigning organization admin permissions",
+		slog.String("organization", organizationName),
+		slog.String("user_id", userID),
+	)
+
+	// Get all roles from the built-in realm-management client.
+	// This is a special Keycloak client (not one we create) that exists by default
+	// and contains all administrative roles for the realm.
+	roles, err := c.ListClientRoles(ctx, organizationName, realmManagementClientID)
+	if err != nil {
+		return fmt.Errorf("failed to list realm-management roles: %w", err)
+	}
+
+	// Filter for the key management roles
+	var rolesToAssign []*idp.Role
+	for _, role := range roles {
+		if slices.Contains(keycloakRealmManagementRoles, role.Name) {
+			rolesToAssign = append(rolesToAssign, role)
+		}
+	}
+
+	if len(rolesToAssign) == 0 {
+		return fmt.Errorf("no realm management roles found to assign for organization %s", organizationName)
+	}
+
+	// Assign the client roles to the user.
+	// These are client-level roles from the "realm-management" client, not organization-level roles.
+	err = c.AssignClientRolesToUser(ctx, organizationName, userID, realmManagementClientID, rolesToAssign)
+	if err != nil {
+		return fmt.Errorf("failed to assign realm management roles: %w", err)
+	}
+
+	c.logger.InfoContext(ctx, "Organization admin permissions assigned",
+		slog.String("organization", organizationName),
+		slog.String("user_id", userID),
+		slog.Int("role_count", len(rolesToAssign)),
+	)
+	return nil
+}
+
+// AssignIdpManagerPermissions grants limited IdP management permissions to the specified user.
+//
+// For Keycloak, this assigns a limited set of client roles from the built-in "realm-management" client.
+// The break-glass account can manage users and identity providers but cannot modify critical
+// realm settings, clients, or authorization policies.
+func (c *Client) AssignIdpManagerPermissions(ctx context.Context, organizationName, userID string) error {
+	c.logger.DebugContext(ctx, "Assigning IdP manager permissions",
+		slog.String("organization", organizationName),
+		slog.String("user_id", userID),
+	)
+
+	// Get all roles from the built-in realm-management client
+	roles, err := c.ListClientRoles(ctx, organizationName, realmManagementClientID)
+	if err != nil {
+		return fmt.Errorf("failed to list realm-management roles: %w", err)
+	}
+
+	// Filter for the limited IdP manager roles
+	var rolesToAssign []*idp.Role
+	for _, role := range roles {
+		if slices.Contains(keycloakIdpManagerRoles, role.Name) {
+			rolesToAssign = append(rolesToAssign, role)
+		}
+	}
+
+	if len(rolesToAssign) == 0 {
+		return fmt.Errorf("no IdP manager roles found to assign for organization %s", organizationName)
+	}
+
+	// Assign the client roles to the user
+	err = c.AssignClientRolesToUser(ctx, organizationName, userID, realmManagementClientID, rolesToAssign)
+	if err != nil {
+		return fmt.Errorf("failed to assign IdP manager roles: %w", err)
+	}
+
+	c.logger.InfoContext(ctx, "IdP manager permissions assigned",
+		slog.String("organization", organizationName),
+		slog.String("user_id", userID),
+		slog.Int("role_count", len(rolesToAssign)),
+	)
+	return nil
+}

--- a/internal/idp/keycloak/client_test.go
+++ b/internal/idp/keycloak/client_test.go
@@ -1,0 +1,1433 @@
+/*
+Copyright (c) 2026 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package keycloak
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/osac-project/fulfillment-service/internal/apiclient"
+	"github.com/osac-project/fulfillment-service/internal/auth"
+	"github.com/osac-project/fulfillment-service/internal/idp"
+)
+
+var _ = Describe("Keycloak Client", func() {
+	var (
+		ctx    context.Context
+		client *Client
+		server *httptest.Server
+	)
+
+	BeforeEach(func() {
+		ctx = context.Background()
+	})
+
+	AfterEach(func() {
+		if server != nil {
+			server.Close()
+		}
+	})
+
+	Describe("CreateOrganization", func() {
+		It("creates an organization in Keycloak", func() {
+			var receivedRealm *keycloakRealm
+			server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.Method == http.MethodPost && r.URL.Path == "/admin/realms" {
+					// Create request
+					receivedRealm = &keycloakRealm{}
+					json.NewDecoder(r.Body).Decode(receivedRealm)
+					w.WriteHeader(http.StatusCreated)
+					return
+				}
+
+				if r.Method == http.MethodGet && r.URL.Path == "/admin/realms/test-org" {
+					// Get request to verify creation
+					enabled := true
+					response := keycloakRealm{
+						ID:          "realm-uuid-123",
+						Realm:       "test-org",
+						DisplayName: "Test Organization",
+						Enabled:     &enabled,
+					}
+					w.Header().Set("Content-Type", "application/json")
+					w.WriteHeader(http.StatusOK)
+					json.NewEncoder(w).Encode(response)
+					return
+				}
+
+				w.WriteHeader(http.StatusNotFound)
+			}))
+
+			client = createTestClient(server.URL)
+
+			org := &idp.Organization{
+				Name:        "test-org",
+				DisplayName: "Test Organization",
+				Enabled:     true,
+			}
+			createdOrg, err := client.CreateOrganization(ctx, org)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(receivedRealm.Realm).To(Equal("test-org"))
+			Expect(createdOrg).ToNot(BeNil())
+			Expect(createdOrg.ID).To(Equal("realm-uuid-123"))
+			Expect(createdOrg.Name).To(Equal("test-org"))
+			Expect(createdOrg.DisplayName).To(Equal("Test Organization"))
+			Expect(createdOrg.Enabled).To(BeTrue())
+		})
+		It("returns an error if the organization already exists", func() {
+			server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusConflict)
+			}))
+
+			client = createTestClient(server.URL)
+
+			org := &idp.Organization{
+				Name:        "test-org",
+				DisplayName: "Test Organization",
+				Enabled:     true,
+			}
+			_, err := client.CreateOrganization(ctx, org)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("already exists"))
+			Expect(err.Error()).To(ContainSubstring("test-org"))
+
+			var apiErr *apiclient.APIError
+			Expect(errors.As(err, &apiErr)).To(BeTrue())
+			Expect(apiErr.StatusCode).To(Equal(http.StatusConflict))
+		})
+
+		It("returns an error on server error", func() {
+			server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusInternalServerError)
+			}))
+
+			client = createTestClient(server.URL)
+
+			org := &idp.Organization{Name: "test-org"}
+			_, err := client.CreateOrganization(ctx, org)
+			Expect(err).To(HaveOccurred())
+		})
+	})
+
+	Describe("GetOrganization", func() {
+		It("retrieves an organization from Keycloak", func() {
+			enabled := true
+			testRealm := &keycloakRealm{
+				ID:          "org-id",
+				Realm:       "test-org",
+				DisplayName: "Test Organization",
+				Enabled:     &enabled,
+			}
+
+			server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				Expect(r.Method).To(Equal(http.MethodGet))
+
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusOK)
+				json.NewEncoder(w).Encode(testRealm)
+			}))
+
+			client = createTestClient(server.URL)
+
+			org, err := client.GetOrganization(ctx, "test-org")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(org.Name).To(Equal("test-org"))
+			Expect(org.DisplayName).To(Equal("Test Organization"))
+		})
+		It("returns an error if the organization is not found", func() {
+			server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusNotFound)
+			}))
+
+			client = createTestClient(server.URL)
+			_, err := client.GetOrganization(ctx, "test-org")
+			Expect(err).To(HaveOccurred())
+		})
+
+		It("returns an error on malformed JSON response", func() {
+			server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusOK)
+				w.Write([]byte("invalid json"))
+			}))
+
+			client = createTestClient(server.URL)
+			_, err := client.GetOrganization(ctx, "test-org")
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("failed to decode organization response"))
+		})
+	})
+
+	Describe("CreateUser", func() {
+		It("creates a user and extracts ID from Location header", func() {
+			var receivedUser *keycloakUser
+			server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				receivedUser = &keycloakUser{}
+				json.NewDecoder(r.Body).Decode(receivedUser)
+				w.Header().Set("Location", "/admin/realms/test-org/users/user-123-abc")
+				w.WriteHeader(http.StatusCreated)
+			}))
+
+			client = createTestClient(server.URL)
+
+			user := &idp.User{
+				Username:      "testuser",
+				Email:         "test@example.com",
+				EmailVerified: true,
+				Enabled:       true,
+				FirstName:     "Test",
+				LastName:      "User",
+			}
+			createdUser, err := client.CreateUser(ctx, "test-org", user)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(receivedUser.Username).To(Equal("testuser"))
+			Expect(createdUser).ToNot(BeNil())
+			Expect(createdUser.ID).To(Equal("user-123-abc"))
+			Expect(createdUser.Username).To(Equal("testuser"))
+			Expect(createdUser.Email).To(Equal("test@example.com"))
+		})
+		It("returns an error if the Location header is not present", func() {
+			server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusCreated)
+			}))
+
+			client = createTestClient(server.URL)
+			_, err := client.CreateUser(ctx, "test-org", &idp.User{
+				Username: "testuser",
+				Email:    "test@example.com",
+				Enabled:  true,
+			})
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("Location header not present in create user response"))
+		})
+
+		It("returns an error if the user already exists", func() {
+			server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusConflict)
+			}))
+
+			client = createTestClient(server.URL)
+			_, err := client.CreateUser(ctx, "test-org", &idp.User{
+				Username: "testuser",
+				Email:    "test@example.com",
+				Enabled:  true,
+			})
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("already exists"))
+
+			var apiErr *apiclient.APIError
+			Expect(errors.As(err, &apiErr)).To(BeTrue())
+			Expect(apiErr.StatusCode).To(Equal(http.StatusConflict))
+		})
+
+		It("returns an error on server error", func() {
+			server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusInternalServerError)
+			}))
+
+			client = createTestClient(server.URL)
+			_, err := client.CreateUser(ctx, "test-org", &idp.User{
+				Username: "testuser",
+				Email:    "test@example.com",
+				Enabled:  true,
+			})
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("failed to create user"))
+		})
+	})
+
+	Describe("ListUsers", func() {
+		It("fetches all users across multiple pages", func() {
+			requestCount := 0
+			server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				Expect(r.Method).To(Equal(http.MethodGet))
+
+				// Parse query parameters
+				query := r.URL.Query()
+				first := query.Get("first")
+				max := query.Get("max")
+
+				requestCount++
+
+				// Simulate pagination: first page returns 100 users, second page returns 50
+				var users []keycloakUser
+				if first == "0" && max == "100" {
+					// First page: return 100 users
+					for i := 0; i < 100; i++ {
+						enabled := true
+						users = append(users, keycloakUser{
+							ID:       fmt.Sprintf("user-%d", i),
+							Username: fmt.Sprintf("user%d", i),
+							Enabled:  &enabled,
+						})
+					}
+				} else if first == "100" && max == "100" {
+					// Second page: return 50 users (less than max, indicates last page)
+					for i := 100; i < 150; i++ {
+						enabled := true
+						users = append(users, keycloakUser{
+							ID:       fmt.Sprintf("user-%d", i),
+							Username: fmt.Sprintf("user%d", i),
+							Enabled:  &enabled,
+						})
+					}
+				}
+
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusOK)
+				json.NewEncoder(w).Encode(users)
+			}))
+
+			client = createTestClient(server.URL)
+
+			users, err := client.ListUsers(ctx, "test-org")
+			Expect(err).ToNot(HaveOccurred())
+
+			// Should have fetched all 150 users across 2 pages
+			Expect(users).To(HaveLen(150))
+
+			// Should have made 2 requests (one per page)
+			Expect(requestCount).To(Equal(2))
+
+			// Verify first and last user
+			Expect(users[0].ID).To(Equal("user-0"))
+			Expect(users[149].ID).To(Equal("user-149"))
+		})
+
+		It("returns an error on server error", func() {
+			server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusInternalServerError)
+			}))
+
+			client = createTestClient(server.URL)
+			_, err := client.ListUsers(ctx, "test-org")
+			Expect(err).To(HaveOccurred())
+		})
+
+		It("returns an error on malformed JSON response", func() {
+			server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusOK)
+				w.Write([]byte("invalid json"))
+			}))
+
+			client = createTestClient(server.URL)
+			_, err := client.ListUsers(ctx, "test-org")
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("failed to decode users"))
+		})
+
+		It("respects context cancellation during pagination", func() {
+			requestCount := 0
+			server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				requestCount++
+
+				// Return a full page so pagination continues
+				var users []keycloakUser
+				for i := 0; i < 100; i++ {
+					enabled := true
+					users = append(users, keycloakUser{
+						ID:       fmt.Sprintf("user-%d", i),
+						Username: fmt.Sprintf("user%d", i),
+						Enabled:  &enabled,
+					})
+				}
+
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusOK)
+				json.NewEncoder(w).Encode(users)
+			}))
+
+			client = createTestClient(server.URL)
+
+			// Create a context that is already cancelled
+			cancelledCtx, cancel := context.WithCancel(context.Background())
+			cancel()
+
+			_, err := client.ListUsers(cancelledCtx, "test-org")
+			Expect(err).To(HaveOccurred())
+			Expect(err).To(Equal(context.Canceled))
+
+			// Should not have made any requests since context was already cancelled
+			Expect(requestCount).To(Equal(0))
+		})
+	})
+	Describe("GetUser", func() {
+		It("gets a user from Keycloak", func() {
+			enabled := true
+			testUser := &keycloakUser{
+				ID:            "user-123-abc",
+				Username:      "testuser",
+				Email:         "test@example.com",
+				EmailVerified: &enabled,
+				Enabled:       &enabled,
+				FirstName:     "Test",
+				LastName:      "User",
+			}
+
+			server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				Expect(r.Method).To(Equal(http.MethodGet))
+				Expect(r.URL.Path).To(Equal("/admin/realms/test-org/users/user-123-abc"))
+
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusOK)
+				json.NewEncoder(w).Encode(testUser)
+			}))
+			client = createTestClient(server.URL)
+			user, err := client.GetUser(ctx, "test-org", "user-123-abc")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(user.ID).To(Equal("user-123-abc"))
+			Expect(user.Username).To(Equal("testuser"))
+			Expect(user.Email).To(Equal("test@example.com"))
+			Expect(user.Enabled).To(BeTrue())
+			Expect(user.FirstName).To(Equal("Test"))
+			Expect(user.LastName).To(Equal("User"))
+			Expect(user.Attributes).To(BeNil())
+			Expect(user.Groups).To(BeNil())
+			Expect(user.Credentials).To(BeNil())
+			Expect(user.RequiredActions).To(BeNil())
+		})
+		It("returns an error if the user is not found", func() {
+			server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusNotFound)
+			}))
+
+			client = createTestClient(server.URL)
+			_, err := client.GetUser(ctx, "test-org", "user-123-abc")
+			Expect(err).To(HaveOccurred())
+		})
+
+		It("returns an error on malformed JSON response", func() {
+			server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusOK)
+				w.Write([]byte("invalid json"))
+			}))
+
+			client = createTestClient(server.URL)
+			_, err := client.GetUser(ctx, "test-org", "user-123-abc")
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("failed to decode user response"))
+		})
+
+		It("returns an error on server error", func() {
+			server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusInternalServerError)
+			}))
+
+			client = createTestClient(server.URL)
+			_, err := client.GetUser(ctx, "test-org", "user-123-abc")
+			Expect(err).To(HaveOccurred())
+		})
+	})
+
+	Describe("DeleteUser", func() {
+		It("deletes a user from Keycloak", func() {
+			server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				Expect(r.Method).To(Equal(http.MethodDelete))
+				Expect(r.URL.Path).To(Equal("/admin/realms/test-org/users/user-123-abc"))
+				w.WriteHeader(http.StatusNoContent)
+			}))
+			client = createTestClient(server.URL)
+			err := client.DeleteUser(ctx, "test-org", "user-123-abc")
+			Expect(err).ToNot(HaveOccurred())
+		})
+		It("returns an error if the user is not found", func() {
+			server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusNotFound)
+			}))
+
+			client = createTestClient(server.URL)
+			err := client.DeleteUser(ctx, "test-org", "user-123-abc")
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("not found"))
+			Expect(err.Error()).To(ContainSubstring("user-123-abc"))
+
+			var apiErr *apiclient.APIError
+			Expect(errors.As(err, &apiErr)).To(BeTrue())
+			Expect(apiErr.StatusCode).To(Equal(http.StatusNotFound))
+		})
+
+		It("returns an error on server error", func() {
+			server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusInternalServerError)
+			}))
+
+			client = createTestClient(server.URL)
+			err := client.DeleteUser(ctx, "test-org", "user-123-abc")
+			Expect(err).To(HaveOccurred())
+		})
+	})
+
+	Describe("DeleteOrganization", func() {
+		It("deletes an organization from Keycloak", func() {
+			server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				Expect(r.Method).To(Equal(http.MethodDelete))
+				Expect(r.URL.Path).To(Equal("/admin/realms/test-org"))
+				w.WriteHeader(http.StatusNoContent)
+			}))
+
+			client = createTestClient(server.URL)
+			err := client.DeleteOrganization(ctx, "test-org")
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("returns an error if the organization is not found", func() {
+			server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusNotFound)
+			}))
+
+			client = createTestClient(server.URL)
+			err := client.DeleteOrganization(ctx, "test-org")
+			Expect(err).To(HaveOccurred())
+		})
+
+		It("returns an error on server error", func() {
+			server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusInternalServerError)
+			}))
+
+			client = createTestClient(server.URL)
+			err := client.DeleteOrganization(ctx, "test-org")
+			Expect(err).To(HaveOccurred())
+		})
+
+		It("clears cached realm-management UUID when organization is deleted", func() {
+			clients := []keycloakClient{
+				{ID: "internal-uuid-123", ClientID: "realm-management"},
+			}
+
+			requestCount := 0
+			server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				requestCount++
+
+				// Handle GetClientByClientID requests
+				if r.Method == http.MethodGet && r.URL.Path == "/admin/realms/test-org/clients" {
+					w.Header().Set("Content-Type", "application/json")
+					w.WriteHeader(http.StatusOK)
+					json.NewEncoder(w).Encode(clients)
+					return
+				}
+
+				// Handle DeleteOrganization request
+				if r.Method == http.MethodDelete && r.URL.Path == "/admin/realms/test-org" {
+					w.WriteHeader(http.StatusNoContent)
+					return
+				}
+
+				w.WriteHeader(http.StatusNotFound)
+			}))
+
+			client = createTestClient(server.URL)
+
+			// First, populate the cache by calling GetClientByClientID
+			internalID, err := client.GetClientByClientID(ctx, "test-org", "realm-management")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(internalID).To(Equal("internal-uuid-123"))
+			Expect(requestCount).To(Equal(1))
+
+			// Verify the cache is populated (second call doesn't make a request)
+			internalID2, err := client.GetClientByClientID(ctx, "test-org", "realm-management")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(internalID2).To(Equal("internal-uuid-123"))
+			Expect(requestCount).To(Equal(1)) // Still 1, used cache
+
+			// Delete the organization
+			err = client.DeleteOrganization(ctx, "test-org")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(requestCount).To(Equal(2)) // Delete request made
+
+			// Verify the cache was cleared (next call makes a new request)
+			internalID3, err := client.GetClientByClientID(ctx, "test-org", "realm-management")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(internalID3).To(Equal("internal-uuid-123"))
+			Expect(requestCount).To(Equal(3)) // New request made, cache was cleared
+		})
+	})
+
+	Describe("ListOrganizationRoles", func() {
+		It("fetches organization-level roles", func() {
+			clientRole := false
+			roles := []keycloakRole{
+				{ID: "role1", Name: "admin", ClientRole: &clientRole},
+				{ID: "role2", Name: "user", ClientRole: &clientRole},
+			}
+
+			server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				Expect(r.Method).To(Equal(http.MethodGet))
+				Expect(r.URL.Path).To(Equal("/admin/realms/test-org/roles"))
+
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusOK)
+				json.NewEncoder(w).Encode(roles)
+			}))
+
+			client = createTestClient(server.URL)
+			result, err := client.ListOrganizationRoles(ctx, "test-org")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result).To(HaveLen(2))
+			Expect(result[0].Name).To(Equal("admin"))
+			Expect(result[1].Name).To(Equal("user"))
+		})
+
+		It("returns an error on server error", func() {
+			server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusInternalServerError)
+			}))
+
+			client = createTestClient(server.URL)
+			_, err := client.ListOrganizationRoles(ctx, "test-org")
+			Expect(err).To(HaveOccurred())
+		})
+
+		It("returns an error on malformed JSON response", func() {
+			server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusOK)
+				w.Write([]byte("invalid json"))
+			}))
+
+			client = createTestClient(server.URL)
+			_, err := client.ListOrganizationRoles(ctx, "test-org")
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("failed to decode realm roles"))
+		})
+	})
+
+	Describe("ListClientRoles", func() {
+		It("fetches client-level roles", func() {
+			clientRole := true
+			roles := []keycloakRole{
+				{ID: "role1", Name: "manage-users", ClientRole: &clientRole},
+				{ID: "role2", Name: "view-users", ClientRole: &clientRole},
+			}
+			clients := []keycloakClient{
+				{ID: "internal-uuid-123", ClientID: "realm-management"},
+			}
+
+			server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				Expect(r.Method).To(Equal(http.MethodGet))
+
+				// First call is to resolve client ID
+				if r.URL.Path == "/admin/realms/test-org/clients" {
+					w.Header().Set("Content-Type", "application/json")
+					w.WriteHeader(http.StatusOK)
+					json.NewEncoder(w).Encode(clients)
+					return
+				}
+
+				// Second call is to fetch roles
+				Expect(r.URL.Path).To(Equal("/admin/realms/test-org/clients/internal-uuid-123/roles"))
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusOK)
+				json.NewEncoder(w).Encode(roles)
+			}))
+
+			client = createTestClient(server.URL)
+			result, err := client.ListClientRoles(ctx, "test-org", "realm-management")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result).To(HaveLen(2))
+			Expect(result[0].Name).To(Equal("manage-users"))
+			Expect(result[1].Name).To(Equal("view-users"))
+		})
+
+		It("returns an error on server error", func() {
+			server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusInternalServerError)
+			}))
+
+			client = createTestClient(server.URL)
+			_, err := client.ListClientRoles(ctx, "test-org", "realm-management")
+			Expect(err).To(HaveOccurred())
+		})
+
+		It("returns an error on malformed JSON response when fetching roles", func() {
+			clients := []keycloakClient{
+				{ID: "internal-uuid-123", ClientID: "realm-management"},
+			}
+
+			server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusOK)
+
+				// First call returns valid clients, second call returns invalid JSON
+				if r.URL.Path == "/admin/realms/test-org/clients" {
+					json.NewEncoder(w).Encode(clients)
+				} else {
+					w.Write([]byte("invalid json"))
+				}
+			}))
+
+			client = createTestClient(server.URL)
+			_, err := client.ListClientRoles(ctx, "test-org", "realm-management")
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("failed to decode client roles"))
+		})
+	})
+
+	Describe("AssignOrganizationRolesToUser", func() {
+		It("assigns organization roles to a user", func() {
+			server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				Expect(r.Method).To(Equal(http.MethodPost))
+				Expect(r.URL.Path).To(Equal("/admin/realms/test-org/users/user-123/role-mappings/realm"))
+				w.WriteHeader(http.StatusNoContent)
+			}))
+
+			client = createTestClient(server.URL)
+			roles := []*idp.Role{
+				{ID: "role1", Name: "admin"},
+			}
+			err := client.AssignOrganizationRolesToUser(ctx, "test-org", "user-123", roles)
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("returns an error on server error", func() {
+			server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusInternalServerError)
+			}))
+
+			client = createTestClient(server.URL)
+			roles := []*idp.Role{{ID: "role1", Name: "admin"}}
+			err := client.AssignOrganizationRolesToUser(ctx, "test-org", "user-123", roles)
+			Expect(err).To(HaveOccurred())
+		})
+	})
+
+	Describe("AssignClientRolesToUser", func() {
+		It("assigns client roles to a user", func() {
+			clients := []keycloakClient{
+				{ID: "internal-uuid-123", ClientID: "realm-management"},
+			}
+
+			server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				// First call is to resolve client ID
+				if r.Method == http.MethodGet && r.URL.Path == "/admin/realms/test-org/clients" {
+					w.Header().Set("Content-Type", "application/json")
+					w.WriteHeader(http.StatusOK)
+					json.NewEncoder(w).Encode(clients)
+					return
+				}
+
+				// Second call is to assign roles
+				Expect(r.Method).To(Equal(http.MethodPost))
+				Expect(r.URL.Path).To(Equal("/admin/realms/test-org/users/user-123/role-mappings/clients/internal-uuid-123"))
+				w.WriteHeader(http.StatusNoContent)
+			}))
+
+			client = createTestClient(server.URL)
+			roles := []*idp.Role{
+				{ID: "role1", Name: "manage-users"},
+			}
+			err := client.AssignClientRolesToUser(ctx, "test-org", "user-123", "realm-management", roles)
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("returns an error on server error", func() {
+			server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusInternalServerError)
+			}))
+
+			client = createTestClient(server.URL)
+			roles := []*idp.Role{{ID: "role1", Name: "manage-users"}}
+			err := client.AssignClientRolesToUser(ctx, "test-org", "user-123", "realm-management", roles)
+			Expect(err).To(HaveOccurred())
+		})
+	})
+
+	Describe("RemoveOrganizationRolesFromUser", func() {
+		It("removes organization roles from a user", func() {
+			server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				Expect(r.Method).To(Equal(http.MethodDelete))
+				Expect(r.URL.Path).To(Equal("/admin/realms/test-org/users/user-123/role-mappings/realm"))
+				w.WriteHeader(http.StatusNoContent)
+			}))
+
+			client = createTestClient(server.URL)
+			roles := []*idp.Role{
+				{ID: "role1", Name: "admin"},
+			}
+			err := client.RemoveOrganizationRolesFromUser(ctx, "test-org", "user-123", roles)
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("returns an error on server error", func() {
+			server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusInternalServerError)
+			}))
+
+			client = createTestClient(server.URL)
+			roles := []*idp.Role{{ID: "role1", Name: "admin"}}
+			err := client.RemoveOrganizationRolesFromUser(ctx, "test-org", "user-123", roles)
+			Expect(err).To(HaveOccurred())
+		})
+	})
+
+	Describe("RemoveClientRolesFromUser", func() {
+		It("removes client roles from a user", func() {
+			clients := []keycloakClient{
+				{ID: "internal-uuid-123", ClientID: "realm-management"},
+			}
+
+			server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				// First call is to resolve client ID
+				if r.Method == http.MethodGet && r.URL.Path == "/admin/realms/test-org/clients" {
+					w.Header().Set("Content-Type", "application/json")
+					w.WriteHeader(http.StatusOK)
+					json.NewEncoder(w).Encode(clients)
+					return
+				}
+
+				// Second call is to remove roles
+				Expect(r.Method).To(Equal(http.MethodDelete))
+				Expect(r.URL.Path).To(Equal("/admin/realms/test-org/users/user-123/role-mappings/clients/internal-uuid-123"))
+				w.WriteHeader(http.StatusNoContent)
+			}))
+
+			client = createTestClient(server.URL)
+			roles := []*idp.Role{
+				{ID: "role1", Name: "manage-users"},
+			}
+			err := client.RemoveClientRolesFromUser(ctx, "test-org", "user-123", "realm-management", roles)
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("returns an error on server error", func() {
+			server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusInternalServerError)
+			}))
+
+			client = createTestClient(server.URL)
+			roles := []*idp.Role{{ID: "role1", Name: "manage-users"}}
+			err := client.RemoveClientRolesFromUser(ctx, "test-org", "user-123", "realm-management", roles)
+			Expect(err).To(HaveOccurred())
+		})
+	})
+
+	Describe("GetUserOrganizationRoles", func() {
+		It("gets organization roles assigned to a user", func() {
+			clientRole := false
+			roles := []keycloakRole{
+				{ID: "role1", Name: "admin", ClientRole: &clientRole},
+			}
+
+			server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				Expect(r.Method).To(Equal(http.MethodGet))
+				Expect(r.URL.Path).To(Equal("/admin/realms/test-org/users/user-123/role-mappings/realm"))
+
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusOK)
+				json.NewEncoder(w).Encode(roles)
+			}))
+
+			client = createTestClient(server.URL)
+			result, err := client.GetUserOrganizationRoles(ctx, "test-org", "user-123")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result).To(HaveLen(1))
+			Expect(result[0].Name).To(Equal("admin"))
+		})
+
+		It("returns an error on server error", func() {
+			server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusInternalServerError)
+			}))
+
+			client = createTestClient(server.URL)
+			_, err := client.GetUserOrganizationRoles(ctx, "test-org", "user-123")
+			Expect(err).To(HaveOccurred())
+		})
+
+		It("returns an error on malformed JSON response", func() {
+			server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusOK)
+				w.Write([]byte("invalid json"))
+			}))
+
+			client = createTestClient(server.URL)
+			_, err := client.GetUserOrganizationRoles(ctx, "test-org", "user-123")
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("failed to decode user realm roles"))
+		})
+	})
+
+	Describe("GetUserClientRoles", func() {
+		It("gets client roles assigned to a user", func() {
+			clientRole := true
+			roles := []keycloakRole{
+				{ID: "role1", Name: "manage-users", ClientRole: &clientRole},
+			}
+			clients := []keycloakClient{
+				{ID: "internal-uuid-123", ClientID: "realm-management"},
+			}
+
+			server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				Expect(r.Method).To(Equal(http.MethodGet))
+
+				// First call is to resolve client ID
+				if r.URL.Path == "/admin/realms/test-org/clients" {
+					w.Header().Set("Content-Type", "application/json")
+					w.WriteHeader(http.StatusOK)
+					json.NewEncoder(w).Encode(clients)
+					return
+				}
+
+				// Second call is to fetch user's client roles
+				Expect(r.URL.Path).To(Equal("/admin/realms/test-org/users/user-123/role-mappings/clients/internal-uuid-123"))
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusOK)
+				json.NewEncoder(w).Encode(roles)
+			}))
+
+			client = createTestClient(server.URL)
+			result, err := client.GetUserClientRoles(ctx, "test-org", "user-123", "realm-management")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result).To(HaveLen(1))
+			Expect(result[0].Name).To(Equal("manage-users"))
+		})
+
+		It("returns an error on server error", func() {
+			server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusInternalServerError)
+			}))
+
+			client = createTestClient(server.URL)
+			_, err := client.GetUserClientRoles(ctx, "test-org", "user-123", "realm-management")
+			Expect(err).To(HaveOccurred())
+		})
+
+		It("returns an error on malformed JSON response when fetching roles", func() {
+			clients := []keycloakClient{
+				{ID: "internal-uuid-123", ClientID: "realm-management"},
+			}
+
+			server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusOK)
+
+				// First call returns valid clients, second call returns invalid JSON
+				if r.URL.Path == "/admin/realms/test-org/clients" {
+					json.NewEncoder(w).Encode(clients)
+				} else {
+					w.Write([]byte("invalid json"))
+				}
+			}))
+
+			client = createTestClient(server.URL)
+			_, err := client.GetUserClientRoles(ctx, "test-org", "user-123", "realm-management")
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("failed to decode user client roles"))
+		})
+	})
+
+	Describe("AssignOrganizationAdminPermissions", func() {
+		It("assigns all realm management roles to a user", func() {
+			clientRole := true
+			// Return a mix of roles - some that match keycloakRealmManagementRoles and some that don't
+			allRoles := []keycloakRole{
+				{ID: "role1", Name: "manage-realm", ClientRole: &clientRole},
+				{ID: "role2", Name: "manage-users", ClientRole: &clientRole},
+				{ID: "role3", Name: "manage-clients", ClientRole: &clientRole},
+				{ID: "role4", Name: "some-other-role", ClientRole: &clientRole}, // Should be filtered out
+				{ID: "role5", Name: "view-realm", ClientRole: &clientRole},
+			}
+			clients := []keycloakClient{
+				{ID: "internal-uuid-123", ClientID: "realm-management"},
+			}
+
+			var assignedRoles []keycloakRole
+			server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+
+				// Handle different request types based on method and path
+				if r.Method == http.MethodGet && r.URL.Path == "/admin/realms/test-org/clients" {
+					// Resolve client ID (cached after first call)
+					w.WriteHeader(http.StatusOK)
+					json.NewEncoder(w).Encode(clients)
+					return
+				}
+
+				if r.Method == http.MethodGet && r.URL.Path == "/admin/realms/test-org/clients/internal-uuid-123/roles" {
+					// List client roles
+					w.WriteHeader(http.StatusOK)
+					json.NewEncoder(w).Encode(allRoles)
+					return
+				}
+
+				if r.Method == http.MethodPost && r.URL.Path == "/admin/realms/test-org/users/user-123/role-mappings/clients/internal-uuid-123" {
+					// Assign client roles
+					json.NewDecoder(r.Body).Decode(&assignedRoles)
+					w.WriteHeader(http.StatusNoContent)
+					return
+				}
+
+				// Unexpected request
+				w.WriteHeader(http.StatusInternalServerError)
+			}))
+
+			client = createTestClient(server.URL)
+			err := client.AssignOrganizationAdminPermissions(ctx, "test-org", "user-123")
+			Expect(err).ToNot(HaveOccurred())
+
+			// Verify that only the keycloakRealmManagementRoles were assigned
+			Expect(assignedRoles).ToNot(BeEmpty())
+			roleNames := make([]string, len(assignedRoles))
+			for i, role := range assignedRoles {
+				roleNames[i] = role.Name
+			}
+			Expect(roleNames).To(ContainElement("manage-realm"))
+			Expect(roleNames).To(ContainElement("manage-users"))
+			Expect(roleNames).To(ContainElement("manage-clients"))
+			Expect(roleNames).To(ContainElement("view-realm"))
+			Expect(roleNames).ToNot(ContainElement("some-other-role"))
+		})
+
+		It("returns an error when ListClientRoles fails", func() {
+			server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusInternalServerError)
+			}))
+
+			client = createTestClient(server.URL)
+			err := client.AssignOrganizationAdminPermissions(ctx, "test-org", "user-123")
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("failed to list realm-management roles"))
+		})
+
+		It("returns an error when no matching roles are found", func() {
+			clientRole := true
+			// Return roles that don't match keycloakRealmManagementRoles
+			allRoles := []keycloakRole{
+				{ID: "role1", Name: "some-random-role", ClientRole: &clientRole},
+				{ID: "role2", Name: "another-role", ClientRole: &clientRole},
+			}
+			clients := []keycloakClient{
+				{ID: "internal-uuid-123", ClientID: "realm-management"},
+			}
+
+			requestCount := 0
+			server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				requestCount++
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusOK)
+
+				if requestCount == 1 {
+					json.NewEncoder(w).Encode(clients)
+				} else {
+					json.NewEncoder(w).Encode(allRoles)
+				}
+			}))
+
+			client = createTestClient(server.URL)
+			err := client.AssignOrganizationAdminPermissions(ctx, "test-org", "user-123")
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("no realm management roles found"))
+		})
+
+		It("returns an error when AssignClientRolesToUser fails", func() {
+			clientRole := true
+			allRoles := []keycloakRole{
+				{ID: "role1", Name: "manage-realm", ClientRole: &clientRole},
+			}
+			clients := []keycloakClient{
+				{ID: "internal-uuid-123", ClientID: "realm-management"},
+			}
+
+			server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+
+				// Resolve client ID succeeds
+				if r.Method == http.MethodGet && r.URL.Path == "/admin/realms/test-org/clients" {
+					w.WriteHeader(http.StatusOK)
+					json.NewEncoder(w).Encode(clients)
+					return
+				}
+
+				// List roles succeeds
+				if r.Method == http.MethodGet && r.URL.Path == "/admin/realms/test-org/clients/internal-uuid-123/roles" {
+					w.WriteHeader(http.StatusOK)
+					json.NewEncoder(w).Encode(allRoles)
+					return
+				}
+
+				// Assign roles fails
+				if r.Method == http.MethodPost {
+					w.WriteHeader(http.StatusInternalServerError)
+					return
+				}
+
+				w.WriteHeader(http.StatusInternalServerError)
+			}))
+
+			client = createTestClient(server.URL)
+			err := client.AssignOrganizationAdminPermissions(ctx, "test-org", "user-123")
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("failed to assign realm management roles"))
+		})
+	})
+
+	Describe("AssignIdpManagerPermissions", func() {
+		It("assigns limited IdP manager roles to a user", func() {
+			clientRole := true
+			// Return a mix of roles - some that match keycloakIdpManagerRoles and some that don't
+			allRoles := []keycloakRole{
+				{ID: "role1", Name: "manage-users", ClientRole: &clientRole},
+				{ID: "role2", Name: "view-users", ClientRole: &clientRole},
+				{ID: "role3", Name: "manage-identity-providers", ClientRole: &clientRole},
+				{ID: "role4", Name: "view-identity-providers", ClientRole: &clientRole},
+				{ID: "role5", Name: "view-realm", ClientRole: &clientRole},
+				{ID: "role6", Name: "manage-realm", ClientRole: &clientRole},   // Should be filtered out
+				{ID: "role7", Name: "manage-clients", ClientRole: &clientRole}, // Should be filtered out
+			}
+			clients := []keycloakClient{
+				{ID: "internal-uuid-123", ClientID: "realm-management"},
+			}
+
+			var assignedRoles []keycloakRole
+			server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+
+				// Handle different request types based on method and path
+				if r.Method == http.MethodGet && r.URL.Path == "/admin/realms/test-org/clients" {
+					// Resolve client ID (cached after first call)
+					w.WriteHeader(http.StatusOK)
+					json.NewEncoder(w).Encode(clients)
+					return
+				}
+
+				if r.Method == http.MethodGet && r.URL.Path == "/admin/realms/test-org/clients/internal-uuid-123/roles" {
+					// List client roles
+					w.WriteHeader(http.StatusOK)
+					json.NewEncoder(w).Encode(allRoles)
+					return
+				}
+
+				if r.Method == http.MethodPost && r.URL.Path == "/admin/realms/test-org/users/user-123/role-mappings/clients/internal-uuid-123" {
+					// Assign client roles
+					json.NewDecoder(r.Body).Decode(&assignedRoles)
+					w.WriteHeader(http.StatusNoContent)
+					return
+				}
+
+				// Unexpected request
+				w.WriteHeader(http.StatusInternalServerError)
+			}))
+
+			client = createTestClient(server.URL)
+			err := client.AssignIdpManagerPermissions(ctx, "test-org", "user-123")
+			Expect(err).ToNot(HaveOccurred())
+
+			// Verify that only the keycloakIdpManagerRoles were assigned
+			Expect(assignedRoles).ToNot(BeEmpty())
+			roleNames := make([]string, len(assignedRoles))
+			for i, role := range assignedRoles {
+				roleNames[i] = role.Name
+			}
+			Expect(roleNames).To(ContainElement("manage-users"))
+			Expect(roleNames).To(ContainElement("view-users"))
+			Expect(roleNames).To(ContainElement("manage-identity-providers"))
+			Expect(roleNames).To(ContainElement("view-identity-providers"))
+			Expect(roleNames).To(ContainElement("view-realm"))
+			Expect(roleNames).ToNot(ContainElement("manage-realm"))
+			Expect(roleNames).ToNot(ContainElement("manage-clients"))
+		})
+
+		It("returns an error when ListClientRoles fails", func() {
+			server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusInternalServerError)
+			}))
+
+			client = createTestClient(server.URL)
+			err := client.AssignIdpManagerPermissions(ctx, "test-org", "user-123")
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("failed to list realm-management roles"))
+		})
+
+		It("returns an error when no matching roles are found", func() {
+			clientRole := true
+			// Return roles that don't match keycloakIdpManagerRoles
+			allRoles := []keycloakRole{
+				{ID: "role1", Name: "some-random-role", ClientRole: &clientRole},
+				{ID: "role2", Name: "another-role", ClientRole: &clientRole},
+			}
+			clients := []keycloakClient{
+				{ID: "internal-uuid-123", ClientID: "realm-management"},
+			}
+
+			requestCount := 0
+			server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				requestCount++
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusOK)
+
+				if requestCount == 1 {
+					json.NewEncoder(w).Encode(clients)
+				} else {
+					json.NewEncoder(w).Encode(allRoles)
+				}
+			}))
+
+			client = createTestClient(server.URL)
+			err := client.AssignIdpManagerPermissions(ctx, "test-org", "user-123")
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("no IdP manager roles found"))
+		})
+
+		It("returns an error when AssignClientRolesToUser fails", func() {
+			clientRole := true
+			allRoles := []keycloakRole{
+				{ID: "role1", Name: "manage-users", ClientRole: &clientRole},
+			}
+			clients := []keycloakClient{
+				{ID: "internal-uuid-123", ClientID: "realm-management"},
+			}
+
+			server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+
+				// Resolve client ID succeeds
+				if r.Method == http.MethodGet && r.URL.Path == "/admin/realms/test-org/clients" {
+					w.WriteHeader(http.StatusOK)
+					json.NewEncoder(w).Encode(clients)
+					return
+				}
+
+				// List roles succeeds
+				if r.Method == http.MethodGet && r.URL.Path == "/admin/realms/test-org/clients/internal-uuid-123/roles" {
+					w.WriteHeader(http.StatusOK)
+					json.NewEncoder(w).Encode(allRoles)
+					return
+				}
+
+				// Assign roles fails
+				if r.Method == http.MethodPost {
+					w.WriteHeader(http.StatusInternalServerError)
+					return
+				}
+
+				w.WriteHeader(http.StatusInternalServerError)
+			}))
+
+			client = createTestClient(server.URL)
+			err := client.AssignIdpManagerPermissions(ctx, "test-org", "user-123")
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("failed to assign IdP manager roles"))
+		})
+	})
+
+	Describe("GetClientByClientID", func() {
+		It("resolves client ID from clientId attribute", func() {
+			clients := []keycloakClient{
+				{ID: "internal-uuid-123", ClientID: "realm-management"},
+			}
+
+			server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				Expect(r.Method).To(Equal(http.MethodGet))
+				Expect(r.URL.Path).To(Equal("/admin/realms/test-org/clients"))
+				Expect(r.URL.Query().Get("clientId")).To(Equal("realm-management"))
+
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusOK)
+				json.NewEncoder(w).Encode(clients)
+			}))
+
+			client = createTestClient(server.URL)
+			internalID, err := client.GetClientByClientID(ctx, "test-org", "realm-management")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(internalID).To(Equal("internal-uuid-123"))
+		})
+
+		It("returns valid UUID immediately without making API call", func() {
+			// Create a server that will fail if called
+			serverCalled := false
+			server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				serverCalled = true
+				w.WriteHeader(http.StatusInternalServerError)
+			}))
+
+			client = createTestClient(server.URL)
+			validUUID := "550e8400-e29b-41d4-a716-446655440000"
+			internalID, err := client.GetClientByClientID(ctx, "test-org", validUUID)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(internalID).To(Equal(validUUID))
+
+			// Verify no HTTP call was made
+			Expect(serverCalled).To(BeFalse())
+		})
+
+		It("returns an error when clientId is not found", func() {
+			server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusOK)
+				json.NewEncoder(w).Encode([]keycloakClient{})
+			}))
+
+			client = createTestClient(server.URL)
+			_, err := client.GetClientByClientID(ctx, "test-org", "not-a-valid-uuid")
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("not found"))
+		})
+
+		It("returns an error on server error", func() {
+			server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusInternalServerError)
+			}))
+
+			client = createTestClient(server.URL)
+			_, err := client.GetClientByClientID(ctx, "test-org", "realm-management")
+			Expect(err).To(HaveOccurred())
+		})
+
+		It("returns an error on malformed JSON response", func() {
+			server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusOK)
+				w.Write([]byte("invalid json"))
+			}))
+
+			client = createTestClient(server.URL)
+			_, err := client.GetClientByClientID(ctx, "test-org", "realm-management")
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("failed to decode clients response"))
+		})
+
+		It("stores realm-management UUID to avoid repeated API calls", func() {
+			clients := []keycloakClient{
+				{ID: "internal-uuid-123", ClientID: "realm-management"},
+			}
+
+			requestCount := 0
+			server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				requestCount++
+				Expect(r.Method).To(Equal(http.MethodGet))
+				Expect(r.URL.Path).To(Equal("/admin/realms/test-org/clients"))
+
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusOK)
+				json.NewEncoder(w).Encode(clients)
+			}))
+
+			client = createTestClient(server.URL)
+
+			// First call - makes HTTP request
+			internalID1, err := client.GetClientByClientID(ctx, "test-org", "realm-management")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(internalID1).To(Equal("internal-uuid-123"))
+			Expect(requestCount).To(Equal(1))
+
+			// Second call - uses stored UUID, no HTTP request
+			internalID2, err := client.GetClientByClientID(ctx, "test-org", "realm-management")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(internalID2).To(Equal("internal-uuid-123"))
+			Expect(requestCount).To(Equal(1)) // Still 1, not incremented
+
+			// Third call - uses stored UUID
+			internalID3, err := client.GetClientByClientID(ctx, "test-org", "realm-management")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(internalID3).To(Equal("internal-uuid-123"))
+			Expect(requestCount).To(Equal(1))
+		})
+
+		It("stores realm-management UUIDs for multiple organizations", func() {
+			requestCount := 0
+			server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				requestCount++
+				Expect(r.Method).To(Equal(http.MethodGet))
+
+				// Return different UUIDs based on organization
+				var clients []keycloakClient
+				if r.URL.Path == "/admin/realms/org-1/clients" {
+					clients = []keycloakClient{{ID: "uuid-for-org-1", ClientID: "realm-management"}}
+				} else if r.URL.Path == "/admin/realms/org-2/clients" {
+					clients = []keycloakClient{{ID: "uuid-for-org-2", ClientID: "realm-management"}}
+				}
+
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusOK)
+				json.NewEncoder(w).Encode(clients)
+			}))
+
+			client = createTestClient(server.URL)
+
+			// First org - makes HTTP request
+			id1, err := client.GetClientByClientID(ctx, "org-1", "realm-management")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(id1).To(Equal("uuid-for-org-1"))
+			Expect(requestCount).To(Equal(1))
+
+			// Second org - makes HTTP request
+			id2, err := client.GetClientByClientID(ctx, "org-2", "realm-management")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(id2).To(Equal("uuid-for-org-2"))
+			Expect(requestCount).To(Equal(2))
+
+			// First org again - uses stored UUID
+			id1Again, err := client.GetClientByClientID(ctx, "org-1", "realm-management")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(id1Again).To(Equal("uuid-for-org-1"))
+			Expect(requestCount).To(Equal(2)) // No new request
+
+			// Second org again - uses stored UUID
+			id2Again, err := client.GetClientByClientID(ctx, "org-2", "realm-management")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(id2Again).To(Equal("uuid-for-org-2"))
+			Expect(requestCount).To(Equal(2)) // No new request
+		})
+
+		It("does not store UUIDs passed directly", func() {
+			serverCalled := false
+			server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				serverCalled = true
+				w.WriteHeader(http.StatusInternalServerError)
+			}))
+
+			client = createTestClient(server.URL)
+			validUUID := "550e8400-e29b-41d4-a716-446655440000"
+
+			// First call with UUID
+			id1, err := client.GetClientByClientID(ctx, "test-org", validUUID)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(id1).To(Equal(validUUID))
+			Expect(serverCalled).To(BeFalse())
+
+			// Second call with same UUID
+			id2, err := client.GetClientByClientID(ctx, "test-org", validUUID)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(id2).To(Equal(validUUID))
+			Expect(serverCalled).To(BeFalse()) // Still no HTTP call
+		})
+	})
+})
+
+func createTestClient(serverURL string) *Client {
+	tokenSource, err := auth.NewStaticTokenSource().
+		SetLogger(logger).
+		SetToken(&auth.Token{Access: "test-token"}).
+		Build()
+	Expect(err).ToNot(HaveOccurred())
+
+	client, err := NewClient().
+		SetLogger(logger).
+		SetBaseURL(serverURL).
+		SetTokenSource(tokenSource).
+		Build()
+	Expect(err).ToNot(HaveOccurred())
+
+	return client
+}

--- a/internal/idp/keycloak/const.go
+++ b/internal/idp/keycloak/const.go
@@ -1,0 +1,52 @@
+/*
+Copyright (c) 2026 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package keycloak
+
+// realmManagementClientID is the clientId of the built-in Keycloak client that contains
+// all administrative roles for managing a realm. This client exists by default in every
+// realm and is the only client we interact with for role assignments.
+const realmManagementClientID = "realm-management"
+
+// keycloakRealmManagementRoles are the standard Keycloak administrative roles.
+//
+// NOTE: These are CLIENT roles (Keycloak client roles), not organization roles.
+// Keycloak implements administrative permissions as client-level roles on the built-in
+// "realm-management" client that exists by default in every realm. There is no
+// organization-level role equivalent for these admin permissions - they must be assigned
+// using AssignClientRolesToUser with clientID "realm-management".
+var keycloakRealmManagementRoles = []string{
+	"manage-realm",
+	"manage-users",
+	"manage-clients",
+	"manage-identity-providers",
+	"manage-authorization",
+	"manage-events",
+	"view-realm",
+	"view-users",
+	"view-clients",
+	"view-identity-providers",
+	"view-authorization",
+	"view-events",
+}
+
+// keycloakIdpManagerRoles are the limited Keycloak roles for the break-glass account.
+// This account can manage users and identity providers but cannot modify realm settings,
+// clients, or other critical configuration.
+var keycloakIdpManagerRoles = []string{
+	"manage-users",
+	"view-users",
+	"manage-identity-providers",
+	"view-identity-providers",
+	"view-realm",
+}

--- a/internal/idp/keycloak/keycloak_suite_test.go
+++ b/internal/idp/keycloak/keycloak_suite_test.go
@@ -1,0 +1,44 @@
+/*
+Copyright (c) 2026 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package keycloak
+
+import (
+	"log/slog"
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/osac-project/fulfillment-service/internal/logging"
+)
+
+func TestKeycloak(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Keycloak package")
+}
+
+var (
+	logger *slog.Logger
+)
+
+var _ = BeforeSuite(func() {
+	var err error
+
+	// Create the logger:
+	logger, err = logging.NewLogger().
+		SetLevel(slog.LevelDebug.String()).
+		SetWriter(GinkgoWriter).
+		Build()
+	Expect(err).ToNot(HaveOccurred())
+})

--- a/internal/idp/keycloak/types.go
+++ b/internal/idp/keycloak/types.go
@@ -1,0 +1,195 @@
+/*
+Copyright (c) 2026 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package keycloak
+
+import (
+	"github.com/osac-project/fulfillment-service/internal/idp"
+)
+
+// Keycloak-specific API types.
+// These map directly to the Keycloak REST API.
+// See: https://www.keycloak.org/docs-api/latest/rest-api/index.html
+
+type keycloakRealm struct {
+	ID          string              `json:"id,omitempty"`
+	Realm       string              `json:"realm,omitempty"`
+	DisplayName string              `json:"displayName,omitempty"`
+	Enabled     *bool               `json:"enabled,omitempty"`
+	Attributes  map[string][]string `json:"attributes,omitempty"`
+}
+
+type keycloakUser struct {
+	ID              string              `json:"id,omitempty"`
+	Username        string              `json:"username,omitempty"`
+	Email           string              `json:"email,omitempty"`
+	EmailVerified   *bool               `json:"emailVerified,omitempty"`
+	Enabled         *bool               `json:"enabled,omitempty"`
+	FirstName       string              `json:"firstName,omitempty"`
+	LastName        string              `json:"lastName,omitempty"`
+	Attributes      map[string][]string `json:"attributes,omitempty"`
+	Groups          []string            `json:"groups,omitempty"`
+	Credentials     []*keycloakCred     `json:"credentials,omitempty"`
+	RequiredActions []string            `json:"requiredActions,omitempty"`
+}
+
+type keycloakCred struct {
+	Type      string `json:"type,omitempty"`
+	Value     string `json:"value,omitempty"`
+	Temporary *bool  `json:"temporary,omitempty"`
+}
+
+type keycloakClient struct {
+	ID       string `json:"id,omitempty"`
+	ClientID string `json:"clientId,omitempty"`
+}
+
+type keycloakRole struct {
+	ID          string              `json:"id,omitempty"`
+	Name        string              `json:"name,omitempty"`
+	Description string              `json:"description,omitempty"`
+	Composite   *bool               `json:"composite,omitempty"`
+	ClientRole  *bool               `json:"clientRole,omitempty"`
+	ContainerID string              `json:"containerId,omitempty"`
+	Attributes  map[string][]string `json:"attributes,omitempty"`
+}
+
+// Conversion functions from generic types to Keycloak types
+
+func toKeycloakRealm(org *idp.Organization) *keycloakRealm {
+	enabled := org.Enabled
+	return &keycloakRealm{
+		ID:          org.ID,
+		Realm:       org.Name,
+		DisplayName: org.DisplayName,
+		Enabled:     &enabled,
+		Attributes:  org.Attributes,
+	}
+}
+
+func fromKeycloakRealm(kcRealm *keycloakRealm) *idp.Organization {
+	enabled := false
+	if kcRealm.Enabled != nil {
+		enabled = *kcRealm.Enabled
+	}
+	return &idp.Organization{
+		ID:          kcRealm.ID,
+		Name:        kcRealm.Realm,
+		DisplayName: kcRealm.DisplayName,
+		Enabled:     enabled,
+		Attributes:  kcRealm.Attributes,
+	}
+}
+
+func toKeycloakUser(user *idp.User) *keycloakUser {
+	emailVerified := user.EmailVerified
+	enabled := user.Enabled
+
+	var creds []*keycloakCred
+	for _, cred := range user.Credentials {
+		temporary := cred.Temporary
+		creds = append(creds, &keycloakCred{
+			Type:      cred.Type,
+			Value:     cred.Value,
+			Temporary: &temporary,
+		})
+	}
+
+	return &keycloakUser{
+		ID:              user.ID,
+		Username:        user.Username,
+		Email:           user.Email,
+		EmailVerified:   &emailVerified,
+		Enabled:         &enabled,
+		FirstName:       user.FirstName,
+		LastName:        user.LastName,
+		Attributes:      user.Attributes,
+		Groups:          user.Groups,
+		Credentials:     creds,
+		RequiredActions: user.RequiredActions,
+	}
+}
+
+func fromKeycloakUser(kcUser *keycloakUser) *idp.User {
+	emailVerified := false
+	if kcUser.EmailVerified != nil {
+		emailVerified = *kcUser.EmailVerified
+	}
+	enabled := false
+	if kcUser.Enabled != nil {
+		enabled = *kcUser.Enabled
+	}
+
+	var creds []*idp.Credential
+	for _, kcCred := range kcUser.Credentials {
+		temporary := false
+		if kcCred.Temporary != nil {
+			temporary = *kcCred.Temporary
+		}
+		creds = append(creds, &idp.Credential{
+			Type:      kcCred.Type,
+			Value:     kcCred.Value,
+			Temporary: temporary,
+		})
+	}
+
+	return &idp.User{
+		ID:              kcUser.ID,
+		Username:        kcUser.Username,
+		Email:           kcUser.Email,
+		EmailVerified:   emailVerified,
+		Enabled:         enabled,
+		FirstName:       kcUser.FirstName,
+		LastName:        kcUser.LastName,
+		Attributes:      kcUser.Attributes,
+		Groups:          kcUser.Groups,
+		Credentials:     creds,
+		RequiredActions: kcUser.RequiredActions,
+	}
+}
+
+func toKeycloakRole(role *idp.Role) *keycloakRole {
+	composite := role.Composite
+	clientRole := role.ClientRole
+
+	return &keycloakRole{
+		ID:          role.ID,
+		Name:        role.Name,
+		Description: role.Description,
+		Composite:   &composite,
+		ClientRole:  &clientRole,
+		ContainerID: role.ContainerID,
+		Attributes:  role.Attributes,
+	}
+}
+
+func fromKeycloakRole(kcRole *keycloakRole) *idp.Role {
+	composite := false
+	if kcRole.Composite != nil {
+		composite = *kcRole.Composite
+	}
+	clientRole := false
+	if kcRole.ClientRole != nil {
+		clientRole = *kcRole.ClientRole
+	}
+
+	return &idp.Role{
+		ID:          kcRole.ID,
+		Name:        kcRole.Name,
+		Description: kcRole.Description,
+		Composite:   composite,
+		ClientRole:  clientRole,
+		ContainerID: kcRole.ContainerID,
+		Attributes:  kcRole.Attributes,
+	}
+}

--- a/internal/idp/manager.go
+++ b/internal/idp/manager.go
@@ -1,0 +1,316 @@
+/*
+Copyright (c) 2026 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package idp
+
+import (
+	"context"
+	"crypto/rand"
+	"errors"
+	"fmt"
+	"log/slog"
+	"math/big"
+	"time"
+)
+
+// OrganizationManager handles the lifecycle of IdP realms for organizations.
+// It works with any IdP client implementation.
+type OrganizationManager struct {
+	logger *slog.Logger
+	client Client
+}
+
+// OrganizationManagerBuilder builds the manager.
+type OrganizationManagerBuilder struct {
+	logger *slog.Logger
+	client Client
+}
+
+// NewOrganizationManager creates a builder for the organization manager.
+func NewOrganizationManager() *OrganizationManagerBuilder {
+	return &OrganizationManagerBuilder{}
+}
+
+// SetLogger sets the logger.
+func (b *OrganizationManagerBuilder) SetLogger(value *slog.Logger) *OrganizationManagerBuilder {
+	b.logger = value
+	return b
+}
+
+// SetClient sets the IdP client implementation.
+func (b *OrganizationManagerBuilder) SetClient(value Client) *OrganizationManagerBuilder {
+	b.client = value
+	return b
+}
+
+// Build creates the manager.
+func (b *OrganizationManagerBuilder) Build() (result *OrganizationManager, err error) {
+	if b.logger == nil {
+		err = errors.New("logger is mandatory")
+		return
+	}
+	if b.client == nil {
+		err = errors.New("IdP client is mandatory")
+		return
+	}
+
+	result = &OrganizationManager{
+		logger: b.logger,
+		client: b.client,
+	}
+	return
+}
+
+// OrganizationConfig contains configuration for creating an organization realm.
+type OrganizationConfig struct {
+	// Name is the unique identifier for the organization (used as realm name)
+	Name string
+
+	// DisplayName is the human-readable name
+	DisplayName string
+
+	// BreakGlassUsername is the username for the break-glass account
+	// If empty, defaults to "osac-break-glass"
+	BreakGlassUsername string
+
+	// BreakGlassEmail is the email for the break-glass account
+	// If empty, defaults to "break-glass@{organization-name}.osac.local"
+	BreakGlassEmail string
+
+	// BreakGlassPassword is the temporary password for the break-glass account
+	// This is mandatory and must be changed on first login
+	BreakGlassPassword string
+}
+
+// BreakGlassCredentials contains the credentials for the break-glass account.
+//
+// SECURITY NOTES:
+//   - Password is plaintext and MUST be handled securely
+//   - DO NOT log the password
+//   - Store in a secrets manager (Vault, Kubernetes Secrets, AWS Secrets Manager)
+//   - Transmit only over TLS
+//   - Clear from memory immediately after use
+//   - Password is temporary and must be changed on first login
+type BreakGlassCredentials struct {
+	// UserID is the unique identifier for the break-glass user in the IdP
+	UserID string
+
+	// Username is the username for the break-glass account
+	Username string
+
+	// Email is the email address for the break-glass account
+	Email string
+
+	// Password is the temporary password that must be changed on first login.
+	// This field is intentionally excluded from JSON marshaling to prevent
+	// accidental logging or exposure.
+	Password string `json:"-"`
+}
+
+// CreateOrganization creates a complete IdP organization setup with a break-glass account.
+// Returns the break-glass account credentials and error.
+func (m *OrganizationManager) CreateOrganization(ctx context.Context, config *OrganizationConfig) (*BreakGlassCredentials, error) {
+	if config == nil {
+		return nil, errors.New("OrganizationConfig is mandatory")
+	}
+
+	m.logger.InfoContext(ctx, "Creating IdP organization",
+		slog.String("organization", config.Name),
+	)
+
+	var (
+		// Track if the organization was created in case of error and rollback is needed
+		organizationCreated bool
+		credentials         *BreakGlassCredentials
+		err                 error
+	)
+
+	// Defer cleanup on error
+	defer func() {
+		if err != nil {
+			m.rollback(ctx, config.Name, organizationCreated)
+		}
+	}()
+
+	// Step 1: Create the organization
+	org := &Organization{
+		Name:        config.Name,
+		DisplayName: config.DisplayName,
+		Enabled:     true,
+	}
+	createdOrg, err := m.client.CreateOrganization(ctx, org)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create organization: %w", err)
+	}
+	organizationCreated = true
+	m.logger.InfoContext(ctx, "Organization created",
+		slog.String("organization", createdOrg.Name),
+	)
+
+	// Step 2: Create break-glass account
+	credentials, err = m.createBreakGlassAccount(ctx, config)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create break-glass account: %w", err)
+	}
+
+	// Step 3: Assign IdP manager permissions to break-glass account
+	err = m.assignIdpManagerPermissions(ctx, createdOrg.Name, credentials.UserID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to assign IdP manager permissions: %w", err)
+	}
+
+	m.logger.InfoContext(ctx, "IdP organization created successfully",
+		slog.String("organization", createdOrg.Name),
+	)
+	return credentials, nil
+}
+
+// rollback performs cleanup by deleting the organization.
+// Deleting the organization will cascade-delete all resources within it (users, roles, etc.).
+func (m *OrganizationManager) rollback(ctx context.Context, organizationName string, deleteOrg bool) {
+	if !deleteOrg {
+		return
+	}
+
+	// Use a fresh context for cleanup so rollback succeeds even if
+	// the original context was cancelled or timed out.
+	cleanupCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	m.logger.WarnContext(ctx, "Rolling back organization creation",
+		slog.String("organization", organizationName),
+	)
+
+	// Delete organization (cascade-deletes all users and resources within it)
+	if err := m.client.DeleteOrganization(cleanupCtx, organizationName); err != nil {
+		m.logger.ErrorContext(ctx, "Failed to rollback organization deletion",
+			slog.String("organization", organizationName),
+			slog.Any("error", err),
+		)
+	} else {
+		m.logger.InfoContext(ctx, "Rolled back organization deletion",
+			slog.String("organization", organizationName),
+		)
+	}
+}
+
+// createBreakGlassAccount creates the break-glass account for an organization.
+// Returns the break-glass credentials and error.
+// The break-glass account is a built-in OSAC user with limited privileges (idp-manager role)
+// that can manage IdP configuration and roles.
+func (m *OrganizationManager) createBreakGlassAccount(ctx context.Context, config *OrganizationConfig) (*BreakGlassCredentials, error) {
+	// Set defaults if not provided
+	username := config.BreakGlassUsername
+	if username == "" {
+		username = fmt.Sprintf("%s-osac-break-glass", config.Name)
+	}
+
+	email := config.BreakGlassEmail
+	if email == "" {
+		email = fmt.Sprintf("break-glass@%s.osac.local", config.Name)
+	}
+	password := config.BreakGlassPassword
+	if password == "" {
+		// Generate a secure random password using crypto/rand
+		const charset = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789!@#$%"
+		const passwordLength = 24
+		b := make([]byte, passwordLength)
+		for i := range b {
+			n, err := rand.Int(rand.Reader, big.NewInt(int64(len(charset))))
+			if err != nil {
+				return nil, fmt.Errorf("failed to generate random password: %w", err)
+			}
+			b[i] = charset[n.Int64()]
+		}
+		password = string(b)
+		m.logger.DebugContext(ctx, "Generated temporary break-glass password because it was not provided",
+			slog.String("organization", config.Name),
+			slog.String("username", username),
+		)
+	}
+
+	user := &User{
+		Username:      username,
+		Email:         email,
+		EmailVerified: true,
+		Enabled:       true,
+		FirstName:     "OSAC",
+		LastName:      "Break-Glass",
+		Credentials: []*Credential{
+			{
+				Type:      "password",
+				Value:     password,
+				Temporary: true, // User must change password on first login
+			},
+		},
+	}
+
+	createdUser, err := m.client.CreateUser(ctx, config.Name, user)
+	if err != nil {
+		return nil, err
+	}
+
+	credentials := &BreakGlassCredentials{
+		UserID:   createdUser.ID,
+		Username: username,
+		Email:    email,
+		Password: password,
+	}
+
+	m.logger.InfoContext(ctx, "Break-glass account created for organization",
+		slog.String("organization_name", config.Name),
+		slog.String("username", username),
+		slog.String("user_id", createdUser.ID),
+	)
+
+	return credentials, nil
+}
+
+// assignIdpManagerPermissions assigns limited IdP manager permissions to a user.
+// This grants the user permissions to manage users and identity providers but not
+// critical realm settings.
+// The implementation is provider-specific (delegated to the IdP client).
+func (m *OrganizationManager) assignIdpManagerPermissions(ctx context.Context, organizationName, userID string) error {
+	m.logger.InfoContext(ctx, "Assigning IdP manager permissions to user",
+		slog.String("organization", organizationName),
+		slog.String("user_id", userID),
+	)
+
+	err := m.client.AssignIdpManagerPermissions(ctx, organizationName, userID)
+	if err != nil {
+		return fmt.Errorf("failed to assign IdP manager permissions: %w", err)
+	}
+
+	m.logger.InfoContext(ctx, "IdP manager permissions assigned",
+		slog.String("organization", organizationName),
+		slog.String("user_id", userID),
+	)
+	return nil
+}
+
+// DeleteOrganizationRealm deletes an IdP organization and all its resources.
+func (m *OrganizationManager) DeleteOrganizationRealm(ctx context.Context, organizationName string) error {
+	m.logger.InfoContext(ctx, "Deleting IdP organization",
+		slog.String("organization", organizationName),
+	)
+
+	err := m.client.DeleteOrganization(ctx, organizationName)
+	if err != nil {
+		return fmt.Errorf("failed to delete organization: %w", err)
+	}
+
+	m.logger.InfoContext(ctx, "IdP organization deleted successfully",
+		slog.String("organization", organizationName),
+	)
+	return nil
+}

--- a/internal/idp/manager_test.go
+++ b/internal/idp/manager_test.go
@@ -1,0 +1,465 @@
+/*
+Copyright (c) 2026 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package idp
+
+import (
+	"context"
+	"fmt"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+// mockClient is a mock IdP client for testing.
+type mockClient struct {
+	createdRealm        *Organization
+	createdUsers        []*User
+	deletedRealm        string
+	deletedUsers        []string                      // Track deleted user IDs
+	userRoleAssignments map[string]map[string][]*Role // userID -> clientID -> roles
+	failUserCreation    bool                          // Trigger user creation failure
+	failRoleAssignment  bool                          // Trigger role assignment failure
+	failOrgDeletion     bool                          // Trigger organization deletion failure
+}
+
+func (m *mockClient) CreateOrganization(ctx context.Context, org *Organization) (*Organization, error) {
+	// Create a copy to avoid mutation
+	createdOrg := &Organization{
+		ID:          org.ID,
+		Name:        org.Name,
+		DisplayName: org.DisplayName,
+		Enabled:     org.Enabled,
+		Attributes:  org.Attributes,
+	}
+	m.createdRealm = createdOrg
+	return createdOrg, nil
+}
+
+func (m *mockClient) GetOrganization(ctx context.Context, name string) (*Organization, error) {
+	return m.createdRealm, nil
+}
+
+func (m *mockClient) DeleteOrganization(ctx context.Context, name string) error {
+	if m.failOrgDeletion {
+		return fmt.Errorf("simulated organization deletion failure")
+	}
+	m.deletedRealm = name
+	return nil
+}
+
+func (m *mockClient) CreateUser(ctx context.Context, organization string, user *User) (*User, error) {
+	if m.failUserCreation {
+		return nil, fmt.Errorf("simulated user creation failure")
+	}
+	// Create a copy with ID populated
+	userID := fmt.Sprintf("user-%d", len(m.createdUsers)+1)
+	createdUser := &User{
+		ID:              userID,
+		Username:        user.Username,
+		Email:           user.Email,
+		EmailVerified:   user.EmailVerified,
+		Enabled:         user.Enabled,
+		FirstName:       user.FirstName,
+		LastName:        user.LastName,
+		Attributes:      user.Attributes,
+		Groups:          user.Groups,
+		Credentials:     user.Credentials,
+		RequiredActions: user.RequiredActions,
+	}
+	m.createdUsers = append(m.createdUsers, createdUser)
+	return createdUser, nil
+}
+
+func (m *mockClient) GetUser(ctx context.Context, organization, userID string) (*User, error) {
+	for _, user := range m.createdUsers {
+		if user.ID == userID {
+			return user, nil
+		}
+	}
+	return nil, nil
+}
+
+func (m *mockClient) ListUsers(ctx context.Context, organization string) ([]*User, error) {
+	return m.createdUsers, nil
+}
+
+func (m *mockClient) DeleteUser(ctx context.Context, organization, userID string) error {
+	m.deletedUsers = append(m.deletedUsers, userID)
+	return nil
+}
+
+func (m *mockClient) ListOrganizationRoles(ctx context.Context, organization string) ([]*Role, error) {
+	return nil, nil
+}
+
+func (m *mockClient) ListClientRoles(ctx context.Context, organization, clientID string) ([]*Role, error) {
+	// Return full set of realm-management roles (matching Keycloak's standard roles)
+	if clientID == "realm-management" {
+		return []*Role{
+			{ID: "1", Name: "manage-realm", ClientRole: true},
+			{ID: "2", Name: "manage-users", ClientRole: true},
+			{ID: "3", Name: "manage-clients", ClientRole: true},
+			{ID: "4", Name: "manage-identity-providers", ClientRole: true},
+			{ID: "5", Name: "manage-authorization", ClientRole: true},
+			{ID: "6", Name: "manage-events", ClientRole: true},
+			{ID: "7", Name: "view-realm", ClientRole: true},
+			{ID: "8", Name: "view-users", ClientRole: true},
+			{ID: "9", Name: "view-clients", ClientRole: true},
+			{ID: "10", Name: "view-identity-providers", ClientRole: true},
+			{ID: "11", Name: "view-authorization", ClientRole: true},
+			{ID: "12", Name: "view-events", ClientRole: true},
+		}, nil
+	}
+	return nil, nil
+}
+
+func (m *mockClient) AssignOrganizationRolesToUser(ctx context.Context, organization, userID string, roles []*Role) error {
+	if m.userRoleAssignments == nil {
+		m.userRoleAssignments = make(map[string]map[string][]*Role)
+	}
+	if m.userRoleAssignments[userID] == nil {
+		m.userRoleAssignments[userID] = make(map[string][]*Role)
+	}
+	m.userRoleAssignments[userID]["realm"] = roles
+	return nil
+}
+
+func (m *mockClient) AssignClientRolesToUser(ctx context.Context, organization, userID, clientID string, roles []*Role) error {
+	if m.userRoleAssignments == nil {
+		m.userRoleAssignments = make(map[string]map[string][]*Role)
+	}
+	if m.userRoleAssignments[userID] == nil {
+		m.userRoleAssignments[userID] = make(map[string][]*Role)
+	}
+	m.userRoleAssignments[userID][clientID] = roles
+	return nil
+}
+
+func (m *mockClient) RemoveOrganizationRolesFromUser(ctx context.Context, organization, userID string, roles []*Role) error {
+	return nil
+}
+
+func (m *mockClient) RemoveClientRolesFromUser(ctx context.Context, organization, userID, clientID string, roles []*Role) error {
+	return nil
+}
+
+func (m *mockClient) GetUserOrganizationRoles(ctx context.Context, organization, userID string) ([]*Role, error) {
+	if m.userRoleAssignments != nil && m.userRoleAssignments[userID] != nil {
+		return m.userRoleAssignments[userID]["realm"], nil
+	}
+	return nil, nil
+}
+
+func (m *mockClient) GetUserClientRoles(ctx context.Context, organization, userID, clientID string) ([]*Role, error) {
+	if m.userRoleAssignments != nil && m.userRoleAssignments[userID] != nil {
+		return m.userRoleAssignments[userID][clientID], nil
+	}
+	return nil, nil
+}
+
+func (m *mockClient) AssignOrganizationAdminPermissions(ctx context.Context, organization, userID string) error {
+	if m.failRoleAssignment {
+		return fmt.Errorf("simulated role assignment failure")
+	}
+	// Simulate assigning full admin roles (matching keycloakRealmManagementRoles)
+	roles := []*Role{
+		{ID: "1", Name: "manage-realm", ClientRole: true},
+		{ID: "2", Name: "manage-users", ClientRole: true},
+		{ID: "3", Name: "manage-clients", ClientRole: true},
+		{ID: "4", Name: "manage-identity-providers", ClientRole: true},
+		{ID: "5", Name: "manage-authorization", ClientRole: true},
+		{ID: "6", Name: "manage-events", ClientRole: true},
+		{ID: "7", Name: "view-realm", ClientRole: true},
+		{ID: "8", Name: "view-users", ClientRole: true},
+		{ID: "9", Name: "view-clients", ClientRole: true},
+		{ID: "10", Name: "view-identity-providers", ClientRole: true},
+		{ID: "11", Name: "view-authorization", ClientRole: true},
+		{ID: "12", Name: "view-events", ClientRole: true},
+	}
+	return m.AssignClientRolesToUser(ctx, organization, userID, "realm-management", roles)
+}
+
+func (m *mockClient) AssignIdpManagerPermissions(ctx context.Context, organization, userID string) error {
+	if m.failRoleAssignment {
+		return fmt.Errorf("simulated role assignment failure")
+	}
+	// Simulate assigning limited IdP manager roles (matching keycloakIdpManagerRoles)
+	roles := []*Role{
+		{ID: "2", Name: "manage-users", ClientRole: true},
+		{ID: "8", Name: "view-users", ClientRole: true},
+		{ID: "4", Name: "manage-identity-providers", ClientRole: true},
+		{ID: "10", Name: "view-identity-providers", ClientRole: true},
+		{ID: "7", Name: "view-realm", ClientRole: true},
+	}
+	return m.AssignClientRolesToUser(ctx, organization, userID, "realm-management", roles)
+}
+
+var _ = Describe("OrganizationManager", func() {
+	var (
+		ctx     context.Context
+		mock    *mockClient
+		manager *OrganizationManager
+	)
+
+	BeforeEach(func() {
+		var err error
+		ctx = context.Background()
+		mock = &mockClient{}
+
+		manager, err = NewOrganizationManager().
+			SetLogger(logger).
+			SetClient(mock).
+			Build()
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	Describe("CreateOrganization", func() {
+		It("creates an organization with break-glass account", func() {
+			config := &OrganizationConfig{
+				Name:               "test-org",
+				DisplayName:        "Test Organization",
+				BreakGlassPassword: "breakglass123",
+			}
+
+			credentials, err := manager.CreateOrganization(ctx, config)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(credentials).ToNot(BeNil())
+
+			// Verify realm was created
+			Expect(mock.createdRealm).ToNot(BeNil())
+			Expect(mock.createdRealm.Name).To(Equal("test-org"))
+
+			// Verify break-glass user was created
+			Expect(mock.createdUsers).To(HaveLen(1))
+			breakGlassUser := mock.createdUsers[0]
+			Expect(breakGlassUser.Username).To(Equal("test-org-osac-break-glass"))
+			Expect(breakGlassUser.Email).To(Equal("break-glass@test-org.osac.local"))
+			Expect(breakGlassUser.FirstName).To(Equal("OSAC"))
+			Expect(breakGlassUser.LastName).To(Equal("Break-Glass"))
+
+			// Verify credentials were returned
+			Expect(credentials.UserID).To(Equal(breakGlassUser.ID))
+			Expect(credentials.Username).To(Equal("test-org-osac-break-glass"))
+			Expect(credentials.Email).To(Equal("break-glass@test-org.osac.local"))
+			Expect(credentials.Password).To(Equal("breakglass123"))
+
+			// Verify password is temporary
+			Expect(breakGlassUser.Credentials).To(HaveLen(1))
+			Expect(breakGlassUser.Credentials[0].Temporary).To(BeTrue())
+		})
+
+		It("assigns IdP manager roles to break-glass account", func() {
+			config := &OrganizationConfig{
+				Name:               "test-org",
+				DisplayName:        "Test Organization",
+				BreakGlassPassword: "breakglass123",
+			}
+
+			credentials, err := manager.CreateOrganization(ctx, config)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(credentials).ToNot(BeNil())
+			Expect(credentials.Username).ToNot(BeEmpty())
+			Expect(credentials.Email).ToNot(BeEmpty())
+			Expect(credentials.Password).ToNot(BeEmpty())
+			Expect(credentials.UserID).ToNot(BeEmpty())
+
+			// Verify break-glass user was created
+			Expect(mock.createdUsers).To(HaveLen(1))
+			breakGlassUserID := mock.createdUsers[0].ID
+			Expect(credentials.UserID).To(Equal(breakGlassUserID))
+
+			// Verify IdP manager roles were assigned
+			Expect(mock.userRoleAssignments).ToNot(BeNil())
+			Expect(mock.userRoleAssignments[breakGlassUserID]).ToNot(BeNil())
+
+			// Check for realm-management client role assignments (limited set)
+			breakGlassRoles := mock.userRoleAssignments[breakGlassUserID]["realm-management"]
+			Expect(breakGlassRoles).ToNot(BeEmpty())
+
+			// Verify specific IdP manager roles were assigned
+			roleNames := make([]string, len(breakGlassRoles))
+			for i, role := range breakGlassRoles {
+				roleNames[i] = role.Name
+			}
+
+			// Should contain all 5 IdP manager roles
+			Expect(roleNames).To(ContainElement("manage-users"))
+			Expect(roleNames).To(ContainElement("view-users"))
+			Expect(roleNames).To(ContainElement("manage-identity-providers"))
+			Expect(roleNames).To(ContainElement("view-identity-providers"))
+			Expect(roleNames).To(ContainElement("view-realm"))
+			// Should NOT contain full admin roles like manage-realm or manage-clients
+			Expect(roleNames).ToNot(ContainElement("manage-realm"))
+			Expect(roleNames).ToNot(ContainElement("manage-clients"))
+		})
+
+		It("uses custom break-glass username and email when provided", func() {
+			config := &OrganizationConfig{
+				Name:               "test-org",
+				DisplayName:        "Test Organization",
+				BreakGlassUsername: "custom-break-glass",
+				BreakGlassEmail:    "custom@example.com",
+				BreakGlassPassword: "breakglass123",
+			}
+
+			credentials, err := manager.CreateOrganization(ctx, config)
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(mock.createdUsers).To(HaveLen(1))
+			breakGlassUser := mock.createdUsers[0]
+			Expect(breakGlassUser.Username).To(Equal("custom-break-glass"))
+			Expect(breakGlassUser.Email).To(Equal("custom@example.com"))
+
+			Expect(credentials.Username).To(Equal("custom-break-glass"))
+			Expect(credentials.Email).To(Equal("custom@example.com"))
+			Expect(credentials.Password).To(Equal("breakglass123"))
+			Expect(credentials.UserID).To(Equal(breakGlassUser.ID))
+		})
+
+		It("generates password when not provided", func() {
+			config := &OrganizationConfig{
+				Name:        "test-org",
+				DisplayName: "Test Organization",
+				// BreakGlassPassword not set
+			}
+
+			credentials, err := manager.CreateOrganization(ctx, config)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(credentials.Username).To(Equal("test-org-osac-break-glass"))
+			Expect(credentials.Email).To(Equal("break-glass@test-org.osac.local"))
+			Expect(credentials.Password).ToNot(BeEmpty())
+			Expect(credentials.Password).To(HaveLen(24))
+			// Password should contain characters from the defined charset
+			Expect(credentials.Password).To(MatchRegexp(`^[A-Za-z0-9!@#$%]{24}$`))
+		})
+
+		It("rolls back organization on break-glass user creation failure", func() {
+			// Create a mock that fails on user creation
+			failingMock := &mockClient{
+				failUserCreation: true,
+			}
+
+			failingManager, err := NewOrganizationManager().
+				SetLogger(logger).
+				SetClient(failingMock).
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+
+			config := &OrganizationConfig{
+				Name:               "test-org",
+				DisplayName:        "Test Organization",
+				BreakGlassPassword: "breakglass123",
+			}
+
+			credentials, err := failingManager.CreateOrganization(ctx, config)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("failed to create break-glass account"))
+			Expect(credentials).To(BeNil())
+
+			// Verify organization was created then deleted (rollback)
+			Expect(failingMock.createdRealm).ToNot(BeNil())
+			Expect(failingMock.deletedRealm).To(Equal("test-org"))
+		})
+
+		It("rolls back organization on role assignment failure", func() {
+			// Create a mock that fails on role assignment
+			failingMock := &mockClient{
+				failRoleAssignment: true,
+			}
+
+			failingManager, err := NewOrganizationManager().
+				SetLogger(logger).
+				SetClient(failingMock).
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+
+			config := &OrganizationConfig{
+				Name:               "test-org",
+				DisplayName:        "Test Organization",
+				BreakGlassPassword: "breakglass123",
+			}
+
+			credentials, err := failingManager.CreateOrganization(ctx, config)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("failed to assign IdP manager permissions"))
+			Expect(credentials).To(BeNil())
+
+			// Verify user was created
+			Expect(failingMock.createdUsers).To(HaveLen(1))
+
+			// Verify organization was created then deleted (rollback)
+			// Deleting the organization cascade-deletes all users, so we don't
+			// need to explicitly delete the user
+			Expect(failingMock.createdRealm).ToNot(BeNil())
+			Expect(failingMock.deletedRealm).To(Equal("test-org"))
+		})
+
+		It("rolls back organization even when original context is cancelled", func() {
+			// Create a mock that fails on user creation
+			failingMock := &mockClient{
+				failUserCreation: true,
+			}
+
+			failingManager, err := NewOrganizationManager().
+				SetLogger(logger).
+				SetClient(failingMock).
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+
+			// Create a context that is already cancelled
+			cancelledCtx, cancel := context.WithCancel(context.Background())
+			cancel()
+
+			config := &OrganizationConfig{
+				Name:               "test-org",
+				DisplayName:        "Test Organization",
+				BreakGlassPassword: "breakglass123",
+			}
+
+			credentials, err := failingManager.CreateOrganization(cancelledCtx, config)
+			Expect(err).To(HaveOccurred())
+			Expect(credentials).To(BeNil())
+
+			// Verify organization was created then deleted (rollback)
+			// Even though the original context was cancelled, rollback should succeed
+			// because it uses a fresh context
+			Expect(failingMock.createdRealm).ToNot(BeNil())
+			Expect(failingMock.deletedRealm).To(Equal("test-org"))
+		})
+	})
+
+	Describe("DeleteOrganizationRealm", func() {
+		It("deletes the organization realm", func() {
+			err := manager.DeleteOrganizationRealm(ctx, "test-org")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(mock.deletedRealm).To(Equal("test-org"))
+		})
+
+		It("returns an error when deletion fails", func() {
+			failingMock := &mockClient{
+				failOrgDeletion: true,
+			}
+
+			failingManager, err := NewOrganizationManager().
+				SetLogger(logger).
+				SetClient(failingMock).
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+
+			err = failingManager.DeleteOrganizationRealm(ctx, "test-org")
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("failed to delete organization"))
+		})
+	})
+})

--- a/internal/idp/types.go
+++ b/internal/idp/types.go
@@ -1,0 +1,62 @@
+/*
+Copyright (c) 2026 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package idp
+
+// Organization represents a logical grouping of users, groups, and applications in an IdP.
+// Different providers call this different things:
+// - Keycloak: Realm
+// - Auth0: Tenant
+// - Okta: Organization
+// - Azure AD: Tenant
+type Organization struct {
+	ID          string
+	Name        string
+	DisplayName string
+	Enabled     bool
+	Attributes  map[string][]string
+}
+
+// User represents a user in the identity provider.
+type User struct {
+	ID              string
+	Username        string
+	Email           string
+	EmailVerified   bool
+	Enabled         bool
+	FirstName       string
+	LastName        string
+	Attributes      map[string][]string
+	Groups          []string
+	Credentials     []*Credential
+	RequiredActions []string
+}
+
+// Credential represents a user credential (password, OTP, etc.).
+type Credential struct {
+	Type      string
+	Value     string
+	Temporary bool
+}
+
+// Role represents a role that can be assigned to users.
+// Roles can be at the organization level or client level.
+type Role struct {
+	ID          string
+	Name        string
+	Description string
+	Composite   bool
+	ClientRole  bool   // true if client-level, false if organization-level
+	ContainerID string // The ID of the organization or client that contains this role
+	Attributes  map[string][]string
+}


### PR DESCRIPTION
Identity Provider APIs allow an admin to CRUD organizations and users.

Currently, Keycloak is used in OSAC, but there are no hooks from the fulfillment service to actually manage users, organizations, etc. This adds APIs to allow a cluster or tenant admin to be able to manage users and organizations directly from the fulfillment service to create a seamless experience from OSAC.

This change is one part of the [enhancement for OSAC authentication](https://github.com/osac-project/enhancement-proposals/blob/main/enhancements/organizations/README.md).

Assisted-by: Claude

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Identity provider public API: organization, user, credential and role models plus a Client interface for IdP operations
  * Keycloak backend integration and an organization manager with automated initial admin provisioning and role assignment
* **Tests**
  * HTTP integration tests for the Keycloak client and unit tests covering the organization manager and rollback behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->