### PR TITLE
Add compute instance scenario, mock server, and e2e test

### DIFF
--- a/cmd/test-server/main.go
+++ b/cmd/test-server/main.go
@@ -1,0 +1,78 @@
+/*
+Copyright (c) 2025 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package main
+
+import (
+	"flag"
+	"fmt"
+	"log"
+	"net"
+
+	publicv1 "github.com/osac-project/fulfillment-service/internal/api/osac/public/v1"
+	"github.com/osac-project/fulfillment-service/internal/testing"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/health"
+	"google.golang.org/grpc/health/grpc_health_v1"
+	"google.golang.org/grpc/reflection"
+)
+
+const (
+	serverPort            = "8080"
+	defaultCIScenarioFile = "internal/testing/testdata/compute-instance-scenario.yaml"
+)
+
+func main() {
+	ciScenarioFile := flag.String("ci-scenario", defaultCIScenarioFile, "Path to compute instance scenario YAML file")
+	flag.Parse()
+
+	// Load compute instance scenario
+	ciScenario, err := testing.LoadComputeInstanceScenarioFromFile(*ciScenarioFile)
+	if err != nil {
+		log.Fatalf("Failed to load compute instance scenario from %s: %v", *ciScenarioFile, err)
+	}
+	log.Printf("Loaded compute instance scenario: %s - %s", ciScenario.Name, ciScenario.Description)
+
+	listener, err := net.Listen("tcp", "127.0.0.1:"+serverPort)
+	if err != nil {
+		log.Fatalf("Failed to listen: %v", err)
+	}
+
+	grpcServer := grpc.NewServer()
+
+	// Register compute instance servers
+	publicv1.RegisterComputeInstancesServer(grpcServer, testing.NewMockComputeInstancesServer(ciScenario))
+	publicv1.RegisterComputeInstanceTemplatesServer(grpcServer, testing.NewMockComputeInstanceTemplatesServer(ciScenario))
+
+	// Health and reflection
+	healthServer := health.NewServer()
+	healthServer.SetServingStatus("", grpc_health_v1.HealthCheckResponse_SERVING)
+	grpc_health_v1.RegisterHealthServer(grpcServer, healthServer)
+	reflection.Register(grpcServer)
+
+	fmt.Println("========================================")
+	fmt.Println("Mock Fulfillment Service Started")
+	fmt.Println("========================================")
+	fmt.Printf("Listening on: %s\n", listener.Addr().String())
+	fmt.Println("")
+	fmt.Println("To test with the CLI:")
+	fmt.Printf("  fulfillment-cli login http://127.0.0.1:%s\n", serverPort)
+	fmt.Println("  fulfillment-cli get computeinstancetemplates")
+	fmt.Println("  fulfillment-cli create computeinstance -t small-instance -n my-instance")
+	fmt.Println("  fulfillment-cli get computeinstances")
+	fmt.Println("========================================")
+
+	if err := grpcServer.Serve(listener); err != nil {
+		log.Fatalf("Failed to serve: %v", err)
+	}
+}

--- a/internal/cmd/cli/create/computeinstance/computeinstance_e2e_test.go
+++ b/internal/cmd/cli/create/computeinstance/computeinstance_e2e_test.go
@@ -20,7 +20,9 @@ import (
 	. "github.com/onsi/gomega"
 	publicv1 "github.com/osac-project/fulfillment-service/internal/api/osac/public/v1"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/status"
 
 	"github.com/osac-project/fulfillment-service/internal/testing"
 )
@@ -151,5 +153,6 @@ var _ = Describe("Compute Instance E2E", func() {
 			Id: createdID,
 		})
 		Expect(err).To(HaveOccurred())
+		Expect(status.Code(err)).To(Equal(codes.NotFound))
 	})
 })

--- a/internal/cmd/cli/create/computeinstance/computeinstance_e2e_test.go
+++ b/internal/cmd/cli/create/computeinstance/computeinstance_e2e_test.go
@@ -16,9 +16,9 @@ package computeinstance
 import (
 	"context"
 
-	publicv1 "github.com/osac-project/fulfillment-service/internal/api/osac/public/v1"
 	. "github.com/onsi/ginkgo/v2/dsl/core"
 	. "github.com/onsi/gomega"
+	publicv1 "github.com/osac-project/fulfillment-service/internal/api/osac/public/v1"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 

--- a/internal/cmd/cli/create/computeinstance/computeinstance_e2e_test.go
+++ b/internal/cmd/cli/create/computeinstance/computeinstance_e2e_test.go
@@ -1,0 +1,155 @@
+/*
+Copyright (c) 2025 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package computeinstance
+
+import (
+	"context"
+
+	publicv1 "github.com/osac-project/fulfillment-service/internal/api/osac/public/v1"
+	. "github.com/onsi/ginkgo/v2/dsl/core"
+	. "github.com/onsi/gomega"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+
+	"github.com/osac-project/fulfillment-service/internal/testing"
+)
+
+var _ = Describe("Compute Instance E2E", func() {
+	var (
+		ctx            context.Context
+		cancel         context.CancelFunc
+		server         *testing.Server
+		conn           *grpc.ClientConn
+		instanceClient publicv1.ComputeInstancesClient
+		templateClient publicv1.ComputeInstanceTemplatesClient
+	)
+
+	BeforeEach(func() {
+		var err error
+
+		// Create cancellable context
+		ctx, cancel = context.WithCancel(context.Background())
+		DeferCleanup(cancel)
+
+		// Create test server
+		server = testing.NewServer()
+		DeferCleanup(server.Stop)
+
+		// Create and load compute instance scenario
+		scenario := &testing.ComputeInstanceScenario{
+			Name:        "e2e-test-scenario",
+			Description: "E2E test scenario for compute instances",
+			Templates: []*testing.TemplateData{
+				{
+					ID:          "tpl-test-001",
+					Name:        "test-template",
+					Title:       "Test Template",
+					Description: "A test compute instance template",
+				},
+			},
+			Instances: []*testing.InstanceData{
+				{
+					ID:        "ci-existing-001",
+					Name:      "existing-instance",
+					Template:  "tpl-test-001",
+					State:     publicv1.ComputeInstanceState_COMPUTE_INSTANCE_STATE_RUNNING,
+					IPAddress: "192.168.1.100",
+				},
+			},
+		}
+
+		// Create and register mock compute instance server
+		ciServer := testing.NewMockComputeInstancesServer(scenario)
+		publicv1.RegisterComputeInstancesServer(server.Registrar(), ciServer)
+
+		// Create and register mock compute instance templates server
+		citServer := testing.NewMockComputeInstanceTemplatesServer(scenario)
+		publicv1.RegisterComputeInstanceTemplatesServer(server.Registrar(), citServer)
+
+		// Start the server
+		server.Start()
+
+		// Create client connection
+		conn, err = grpc.NewClient(
+			server.Address(),
+			grpc.WithTransportCredentials(insecure.NewCredentials()),
+		)
+		Expect(err).ToNot(HaveOccurred())
+		DeferCleanup(conn.Close)
+
+		// Create clients
+		instanceClient = publicv1.NewComputeInstancesClient(conn)
+		templateClient = publicv1.NewComputeInstanceTemplatesClient(conn)
+	})
+
+	It("should create, list, and delete a compute instance", func() {
+		// Step 1: List templates to get a valid template
+		listTemplatesResp, err := templateClient.List(ctx, &publicv1.ComputeInstanceTemplatesListRequest{})
+		Expect(err).ToNot(HaveOccurred())
+		Expect(listTemplatesResp.Items).ToNot(BeEmpty())
+		template := listTemplatesResp.Items[0]
+
+		// Step 2: List existing instances (should have 1)
+		listResp, err := instanceClient.List(ctx, &publicv1.ComputeInstancesListRequest{})
+		Expect(err).ToNot(HaveOccurred())
+		initialCount := len(listResp.Items)
+		Expect(initialCount).To(Equal(1))
+
+		// Step 3: Create a new compute instance
+		createResp, err := instanceClient.Create(ctx, &publicv1.ComputeInstancesCreateRequest{
+			Object: &publicv1.ComputeInstance{
+				Metadata: &publicv1.Metadata{
+					Name: "new-test-instance",
+				},
+				Spec: &publicv1.ComputeInstanceSpec{
+					Template: template.Id,
+				},
+			},
+		})
+		Expect(err).ToNot(HaveOccurred())
+		Expect(createResp.Object).ToNot(BeNil())
+		Expect(createResp.Object.Id).ToNot(BeEmpty())
+		createdID := createResp.Object.Id
+
+		// Step 4: List instances again (should have 2 now)
+		listResp, err = instanceClient.List(ctx, &publicv1.ComputeInstancesListRequest{})
+		Expect(err).ToNot(HaveOccurred())
+		Expect(len(listResp.Items)).To(Equal(initialCount + 1))
+
+		// Step 5: Get the created instance by ID
+		getResp, err := instanceClient.Get(ctx, &publicv1.ComputeInstancesGetRequest{
+			Id: createdID,
+		})
+		Expect(err).ToNot(HaveOccurred())
+		Expect(getResp.Object.Id).To(Equal(createdID))
+		Expect(getResp.Object.Spec.Template).To(Equal(template.Id))
+
+		// Step 6: Delete the created instance
+		_, err = instanceClient.Delete(ctx, &publicv1.ComputeInstancesDeleteRequest{
+			Id: createdID,
+		})
+		Expect(err).ToNot(HaveOccurred())
+
+		// Step 7: List instances again (should be back to initial count)
+		listResp, err = instanceClient.List(ctx, &publicv1.ComputeInstancesListRequest{})
+		Expect(err).ToNot(HaveOccurred())
+		Expect(len(listResp.Items)).To(Equal(initialCount))
+
+		// Step 8: Verify the instance was deleted (Get should fail)
+		_, err = instanceClient.Get(ctx, &publicv1.ComputeInstancesGetRequest{
+			Id: createdID,
+		})
+		Expect(err).To(HaveOccurred())
+	})
+})

--- a/internal/cmd/cli/create/computeinstance/computeinstance_suite_test.go
+++ b/internal/cmd/cli/create/computeinstance/computeinstance_suite_test.go
@@ -1,0 +1,26 @@
+/*
+Copyright (c) 2025 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package computeinstance
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestComputeInstance(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Compute Instance Suite")
+}

--- a/internal/testing/compute_instance_scenario.go
+++ b/internal/testing/compute_instance_scenario.go
@@ -81,11 +81,11 @@ func LoadComputeInstanceScenarioFromFile(filename string) (*ComputeInstanceScena
 		return nil, fmt.Errorf("failed to parse scenario YAML: %w", err)
 	}
 
-	return file.toScenario(), nil
+	return file.toScenario()
 }
 
 // toScenario converts a computeInstanceScenarioFile to a ComputeInstanceScenario with proper proto enums
-func (f *computeInstanceScenarioFile) toScenario() *ComputeInstanceScenario {
+func (f *computeInstanceScenarioFile) toScenario() (*ComputeInstanceScenario, error) {
 	scenario := &ComputeInstanceScenario{
 		Name:        f.Name,
 		Description: f.Description,
@@ -103,16 +103,20 @@ func (f *computeInstanceScenarioFile) toScenario() *ComputeInstanceScenario {
 	}
 
 	for i, inst := range f.Instances {
+		rawState, ok := publicv1.ComputeInstanceState_value[inst.State]
+		if !ok {
+			return nil, fmt.Errorf("invalid compute instance state %q for instance %q", inst.State, inst.ID)
+		}
 		scenario.Instances[i] = &InstanceData{
 			ID:        inst.ID,
 			Name:      inst.Name,
 			Template:  inst.Template,
-			State:     publicv1.ComputeInstanceState(publicv1.ComputeInstanceState_value[inst.State]),
+			State:     publicv1.ComputeInstanceState(rawState),
 			IPAddress: inst.IPAddress,
 		}
 	}
 
-	return scenario
+	return scenario, nil
 }
 
 // ToProtoTemplate converts TemplateData to a proto ComputeInstanceTemplate

--- a/internal/testing/compute_instance_scenario.go
+++ b/internal/testing/compute_instance_scenario.go
@@ -1,0 +1,145 @@
+/*
+Copyright (c) 2025 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package testing
+
+import (
+	"fmt"
+	"os"
+
+	publicv1 "github.com/osac-project/fulfillment-service/internal/api/osac/public/v1"
+	"gopkg.in/yaml.v3"
+)
+
+// ComputeInstanceScenario represents test data for compute instances and templates
+type ComputeInstanceScenario struct {
+	Name        string
+	Description string
+	Templates   []*TemplateData
+	Instances   []*InstanceData
+}
+
+// TemplateData contains compute instance template data
+type TemplateData struct {
+	ID          string
+	Name        string
+	Title       string
+	Description string
+}
+
+// InstanceData contains compute instance data
+type InstanceData struct {
+	ID        string
+	Name      string
+	Template  string
+	State     publicv1.ComputeInstanceState
+	IPAddress string
+}
+
+// YAML parsing structures
+type computeInstanceScenarioFile struct {
+	Name        string          `yaml:"name"`
+	Description string          `yaml:"description"`
+	Templates   []*templateFile `yaml:"templates"`
+	Instances   []*instanceFile `yaml:"instances"`
+}
+
+type templateFile struct {
+	ID          string `yaml:"id"`
+	Name        string `yaml:"name"`
+	Title       string `yaml:"title"`
+	Description string `yaml:"description"`
+}
+
+type instanceFile struct {
+	ID        string `yaml:"id"`
+	Name      string `yaml:"name"`
+	Template  string `yaml:"template"`
+	State     string `yaml:"state"`
+	IPAddress string `yaml:"ipAddress"`
+}
+
+// LoadComputeInstanceScenarioFromFile loads a compute instance scenario from a YAML file
+func LoadComputeInstanceScenarioFromFile(filename string) (*ComputeInstanceScenario, error) {
+	data, err := os.ReadFile(filename)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read scenario file: %w", err)
+	}
+
+	var file computeInstanceScenarioFile
+	if err := yaml.Unmarshal(data, &file); err != nil {
+		return nil, fmt.Errorf("failed to parse scenario YAML: %w", err)
+	}
+
+	return file.toScenario(), nil
+}
+
+// toScenario converts a computeInstanceScenarioFile to a ComputeInstanceScenario with proper proto enums
+func (f *computeInstanceScenarioFile) toScenario() *ComputeInstanceScenario {
+	scenario := &ComputeInstanceScenario{
+		Name:        f.Name,
+		Description: f.Description,
+		Templates:   make([]*TemplateData, len(f.Templates)),
+		Instances:   make([]*InstanceData, len(f.Instances)),
+	}
+
+	for i, t := range f.Templates {
+		scenario.Templates[i] = &TemplateData{
+			ID:          t.ID,
+			Name:        t.Name,
+			Title:       t.Title,
+			Description: t.Description,
+		}
+	}
+
+	for i, inst := range f.Instances {
+		scenario.Instances[i] = &InstanceData{
+			ID:        inst.ID,
+			Name:      inst.Name,
+			Template:  inst.Template,
+			State:     publicv1.ComputeInstanceState(publicv1.ComputeInstanceState_value[inst.State]),
+			IPAddress: inst.IPAddress,
+		}
+	}
+
+	return scenario
+}
+
+// ToProtoTemplate converts TemplateData to a proto ComputeInstanceTemplate
+func (t *TemplateData) ToProtoTemplate() *publicv1.ComputeInstanceTemplate {
+	return &publicv1.ComputeInstanceTemplate{
+		Id: t.ID,
+		Metadata: &publicv1.Metadata{
+			Name: t.Name,
+		},
+		Title:       t.Title,
+		Description: t.Description,
+	}
+}
+
+// ToProtoInstance converts InstanceData to a proto ComputeInstance
+func (i *InstanceData) ToProtoInstance() *publicv1.ComputeInstance {
+	return &publicv1.ComputeInstance{
+		Id: i.ID,
+		Metadata: &publicv1.Metadata{
+			Name: i.Name,
+		},
+		Spec: &publicv1.ComputeInstanceSpec{
+			Template: i.Template,
+		},
+		Status: &publicv1.ComputeInstanceStatus{
+			State:     i.State,
+			IpAddress: i.IPAddress,
+		},
+	}
+}

--- a/internal/testing/mock_compute_instances_server.go
+++ b/internal/testing/mock_compute_instances_server.go
@@ -151,14 +151,16 @@ func (s *MockComputeInstanceTemplatesServer) Get(ctx context.Context, request *p
 }
 
 // List lists compute instance templates, with basic filter support.
-// Supports the CEL filter pattern used by the CLI: this.id == "X" || this.metadata.name == "X"
+// Matches quoted literal values from CEL filters like: this.id == "X" || this.metadata.name == "X"
 func (s *MockComputeInstanceTemplatesServer) List(ctx context.Context, request *publicv1.ComputeInstanceTemplatesListRequest) (*publicv1.ComputeInstanceTemplatesListResponse, error) {
 	filter := request.GetFilter()
 	var templates []*publicv1.ComputeInstanceTemplate
 	for _, templateData := range s.scenario.Templates {
 		if filter != "" {
-			// Basic filter: check if the filter contains the template's ID or name
-			if !strings.Contains(filter, templateData.ID) && !strings.Contains(filter, templateData.Name) {
+			// Match quoted literal values from the CEL filter expression
+			matchesID := strings.Contains(filter, fmt.Sprintf("%q", templateData.ID))
+			matchesName := strings.Contains(filter, fmt.Sprintf("%q", templateData.Name))
+			if !matchesID && !matchesName {
 				continue
 			}
 		}

--- a/internal/testing/mock_compute_instances_server.go
+++ b/internal/testing/mock_compute_instances_server.go
@@ -1,0 +1,176 @@
+/*
+Copyright (c) 2025 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package testing
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+
+	publicv1 "github.com/osac-project/fulfillment-service/internal/api/osac/public/v1"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// MockComputeInstancesServer is a mock implementation of the ComputeInstancesServer
+type MockComputeInstancesServer struct {
+	publicv1.UnimplementedComputeInstancesServer
+	scenario  *ComputeInstanceScenario
+	instances map[string]*publicv1.ComputeInstance
+	mu        sync.RWMutex
+	nextID    int
+}
+
+// NewMockComputeInstancesServer creates a new mock compute instances server
+func NewMockComputeInstancesServer(scenario *ComputeInstanceScenario) *MockComputeInstancesServer {
+	server := &MockComputeInstancesServer{
+		scenario:  scenario,
+		instances: make(map[string]*publicv1.ComputeInstance),
+		nextID:    1000,
+	}
+
+	// Pre-populate with scenario instances
+	for _, instanceData := range scenario.Instances {
+		server.instances[instanceData.ID] = instanceData.ToProtoInstance()
+	}
+
+	return server
+}
+
+// Create creates a new compute instance
+func (s *MockComputeInstancesServer) Create(ctx context.Context, request *publicv1.ComputeInstancesCreateRequest) (*publicv1.ComputeInstancesCreateResponse, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	instance := request.GetObject()
+	if instance == nil {
+		return nil, status.Error(codes.InvalidArgument, "object is required")
+	}
+
+	// Generate ID if not provided
+	if instance.Id == "" {
+		s.nextID++
+		instance.Id = fmt.Sprintf("ci-test-%d", s.nextID)
+	}
+
+	// Set state to STARTING if not set
+	if instance.Status == nil {
+		instance.Status = &publicv1.ComputeInstanceStatus{}
+	}
+	if instance.Status.State == publicv1.ComputeInstanceState_COMPUTE_INSTANCE_STATE_UNSPECIFIED {
+		instance.Status.State = publicv1.ComputeInstanceState_COMPUTE_INSTANCE_STATE_STARTING
+	}
+
+	// Store the instance
+	s.instances[instance.Id] = instance
+
+	return &publicv1.ComputeInstancesCreateResponse{Object: instance}, nil
+}
+
+// Get retrieves a compute instance by ID
+func (s *MockComputeInstancesServer) Get(ctx context.Context, request *publicv1.ComputeInstancesGetRequest) (*publicv1.ComputeInstancesGetResponse, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	instance, exists := s.instances[request.Id]
+	if !exists {
+		return nil, status.Errorf(codes.NotFound, "compute instance %q not found", request.Id)
+	}
+
+	return &publicv1.ComputeInstancesGetResponse{Object: instance}, nil
+}
+
+// List lists all compute instances
+func (s *MockComputeInstancesServer) List(ctx context.Context, request *publicv1.ComputeInstancesListRequest) (*publicv1.ComputeInstancesListResponse, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	instances := make([]*publicv1.ComputeInstance, 0, len(s.instances))
+	for _, instance := range s.instances {
+		instances = append(instances, instance)
+	}
+
+	size := int32(len(instances))
+	total := int32(len(instances))
+
+	return &publicv1.ComputeInstancesListResponse{
+		Items: instances,
+		Size:  size,
+		Total: total,
+	}, nil
+}
+
+// Delete deletes a compute instance by ID
+func (s *MockComputeInstancesServer) Delete(ctx context.Context, request *publicv1.ComputeInstancesDeleteRequest) (*publicv1.ComputeInstancesDeleteResponse, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if _, exists := s.instances[request.Id]; !exists {
+		return nil, status.Errorf(codes.NotFound, "compute instance %q not found", request.Id)
+	}
+
+	delete(s.instances, request.Id)
+
+	return &publicv1.ComputeInstancesDeleteResponse{}, nil
+}
+
+// MockComputeInstanceTemplatesServer is a mock implementation of the ComputeInstanceTemplatesServer
+type MockComputeInstanceTemplatesServer struct {
+	publicv1.UnimplementedComputeInstanceTemplatesServer
+	scenario *ComputeInstanceScenario
+}
+
+// NewMockComputeInstanceTemplatesServer creates a new mock compute instance templates server
+func NewMockComputeInstanceTemplatesServer(scenario *ComputeInstanceScenario) *MockComputeInstanceTemplatesServer {
+	return &MockComputeInstanceTemplatesServer{
+		scenario: scenario,
+	}
+}
+
+// Get retrieves a compute instance template by ID
+func (s *MockComputeInstanceTemplatesServer) Get(ctx context.Context, request *publicv1.ComputeInstanceTemplatesGetRequest) (*publicv1.ComputeInstanceTemplatesGetResponse, error) {
+	for _, templateData := range s.scenario.Templates {
+		if templateData.ID == request.Id {
+			return &publicv1.ComputeInstanceTemplatesGetResponse{Object: templateData.ToProtoTemplate()}, nil
+		}
+	}
+
+	return nil, status.Errorf(codes.NotFound, "compute instance template %q not found", request.Id)
+}
+
+// List lists compute instance templates, with basic filter support.
+// Supports the CEL filter pattern used by the CLI: this.id == "X" || this.metadata.name == "X"
+func (s *MockComputeInstanceTemplatesServer) List(ctx context.Context, request *publicv1.ComputeInstanceTemplatesListRequest) (*publicv1.ComputeInstanceTemplatesListResponse, error) {
+	filter := request.GetFilter()
+	var templates []*publicv1.ComputeInstanceTemplate
+	for _, templateData := range s.scenario.Templates {
+		if filter != "" {
+			// Basic filter: check if the filter contains the template's ID or name
+			if !strings.Contains(filter, templateData.ID) && !strings.Contains(filter, templateData.Name) {
+				continue
+			}
+		}
+		templates = append(templates, templateData.ToProtoTemplate())
+	}
+
+	size := int32(len(templates))
+	total := int32(len(templates))
+
+	return &publicv1.ComputeInstanceTemplatesListResponse{
+		Items: templates,
+		Size:  size,
+		Total: total,
+	}, nil
+}

--- a/internal/testing/mock_compute_instances_server.go
+++ b/internal/testing/mock_compute_instances_server.go
@@ -58,6 +58,19 @@ func (s *MockComputeInstancesServer) Create(ctx context.Context, request *public
 	if instance == nil {
 		return nil, status.Error(codes.InvalidArgument, "object is required")
 	}
+	if instance.GetSpec() == nil || instance.GetSpec().GetTemplate() == "" {
+		return nil, status.Error(codes.InvalidArgument, "object.spec.template is required")
+	}
+	templateFound := false
+	for _, t := range s.scenario.Templates {
+		if t.ID == instance.GetSpec().GetTemplate() {
+			templateFound = true
+			break
+		}
+	}
+	if !templateFound {
+		return nil, status.Errorf(codes.InvalidArgument, "unknown template %q", instance.GetSpec().GetTemplate())
+	}
 
 	// Generate ID if not provided
 	if instance.Id == "" {

--- a/internal/testing/testdata/compute-instance-scenario.yaml
+++ b/internal/testing/testdata/compute-instance-scenario.yaml
@@ -1,0 +1,17 @@
+name: default-compute-instance-scenario
+description: Default scenario with sample compute instance templates and instances
+templates:
+  - id: tpl-small-001
+    name: small-instance
+    title: Small Instance
+    description: A small compute instance with 2 CPUs and 4GB RAM
+  - id: tpl-gpu-001
+    name: gpu-instance
+    title: GPU Instance
+    description: A GPU-enabled compute instance with 8 CPUs, 32GB RAM, and 1 GPU
+instances:
+  - id: ci-mock-12345
+    name: mock-instance
+    template: tpl-small-001
+    state: COMPUTE_INSTANCE_STATE_RUNNING
+    ipAddress: "192.168.1.100"


### PR DESCRIPTION
## Summary
- Add ComputeInstanceScenario with YAML loader for test data
- Add MockComputeInstancesServer and MockComputeInstanceTemplatesServer with basic filter support
- Add e2e test validating full CRUD lifecycle (list templates, create/get/list/delete instances)
- Add standalone test server binary (`cmd/test-server`) for manual CLI testing

Ported from archived fulfillment-cli repo (PR #100).

## Test plan
- [x] All 35 unit test suites pass (`ginkgo run -r internal`)
- [x] E2e test passes: in-process gRPC server with mock scenario
- [x] Manual CLI lifecycle verified against test server: list templates, create, list, describe, delete, verify deleted

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added end-to-end tests validating compute instance create/list/get/delete workflows.
  * Added in-process mock gRPC servers to simulate compute instance and template behavior for deterministic test runs.
  * Added a test suite entrypoint to run the new specs.

* **Chores**
  * Added a local test-server tool to run a mock fulfillment service for development/CI.
  * Added scenario-driven test fixtures, test helpers/models, and YAML testdata to seed templates and instances for testing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->