### PR TITLE
NO-ISSUE: Lock row when fetching object during update

### DIFF
--- a/internal/servers/generic_server.go
+++ b/internal/servers/generic_server.go
@@ -453,6 +453,7 @@ func (s *GenericServer[O]) Update(ctx context.Context, request any, response any
 	// Fetch the current representation of the object:
 	getResponse, err := s.dao.Get().
 		SetId(id).
+		SetLock(true).
 		Do(ctx)
 	if err != nil {
 		var notFoundErr *dao.ErrNotFound


### PR DESCRIPTION
## Summary

- Adds `SetLock(true)` to the `Get` call in `GenericServer.Update` to acquire a
  `SELECT ... FOR UPDATE` row-level lock before reading the object.
- Prevents a race condition in the read-modify-write sequence where two concurrent
  updates could both read the same version and silently overwrite each other.

## Test plan

- Existing unit tests continue to pass (`ginkgo run -r internal`).
- The change is a single-line addition that enables a well-tested DAO feature
  (`SetLock`) already used by the `Update` DAO method and verified in
  `generic_dao_version_test.go`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced concurrent update handling to ensure improved data consistency and reliability during object modifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->