### PR TITLE
MGMT-23724: Networking resource subcommands

### DIFF
--- a/internal/cmd/cli/create/create_cmd.go
+++ b/internal/cmd/cli/create/create_cmd.go
@@ -31,6 +31,9 @@ import (
 	"github.com/osac-project/fulfillment-service/internal/cmd/cli/create/cluster"
 	"github.com/osac-project/fulfillment-service/internal/cmd/cli/create/computeinstance"
 	"github.com/osac-project/fulfillment-service/internal/cmd/cli/create/hub"
+	"github.com/osac-project/fulfillment-service/internal/cmd/cli/create/securitygroup"
+	"github.com/osac-project/fulfillment-service/internal/cmd/cli/create/subnet"
+	"github.com/osac-project/fulfillment-service/internal/cmd/cli/create/virtualnetwork"
 	"github.com/osac-project/fulfillment-service/internal/config"
 	"github.com/osac-project/fulfillment-service/internal/logging"
 	"github.com/osac-project/fulfillment-service/internal/reflection"
@@ -47,6 +50,9 @@ func Cmd() *cobra.Command {
 	result.AddCommand(cluster.Cmd())
 	result.AddCommand(computeinstance.Cmd())
 	result.AddCommand(hub.Cmd())
+	result.AddCommand(virtualnetwork.Cmd())
+	result.AddCommand(subnet.Cmd())
+	result.AddCommand(securitygroup.Cmd())
 	flags := result.Flags()
 	flags.StringVarP(
 		&runner.args.file,

--- a/internal/cmd/cli/create/create_cmd_test.go
+++ b/internal/cmd/cli/create/create_cmd_test.go
@@ -25,6 +25,9 @@ import (
 	"github.com/osac-project/fulfillment-service/internal/cmd/cli/create/cluster"
 	"github.com/osac-project/fulfillment-service/internal/cmd/cli/create/computeinstance"
 	"github.com/osac-project/fulfillment-service/internal/cmd/cli/create/hub"
+	"github.com/osac-project/fulfillment-service/internal/cmd/cli/create/securitygroup"
+	"github.com/osac-project/fulfillment-service/internal/cmd/cli/create/subnet"
+	"github.com/osac-project/fulfillment-service/internal/cmd/cli/create/virtualnetwork"
 )
 
 var _ = Describe("Create command", func() {
@@ -37,6 +40,9 @@ var _ = Describe("Create command", func() {
 		Entry("cluster", cluster.Cmd, (*publicv1.Cluster)(nil)),
 		Entry("computeinstance", computeinstance.Cmd, (*publicv1.ComputeInstance)(nil)),
 		Entry("hub", hub.Cmd, (*privatev1.Hub)(nil)),
+		Entry("virtualnetwork", virtualnetwork.Cmd, (*publicv1.VirtualNetwork)(nil)),
+		Entry("subnet", subnet.Cmd, (*publicv1.Subnet)(nil)),
+		Entry("securitygroup", securitygroup.Cmd, (*publicv1.SecurityGroup)(nil)),
 	)
 
 	Describe("Subcommands", func() {
@@ -49,7 +55,7 @@ var _ = Describe("Create command", func() {
 				subcommandNames = append(subcommandNames, subcmd.Name())
 			}
 
-			Expect(subcommandNames).To(ContainElements("cluster", "computeinstance", "hub"))
+			Expect(subcommandNames).To(ContainElements("cluster", "computeinstance", "hub", "virtualnetwork", "subnet", "securitygroup"))
 		})
 	})
 })

--- a/internal/cmd/cli/create/netutil/netutil_suite_test.go
+++ b/internal/cmd/cli/create/netutil/netutil_suite_test.go
@@ -1,0 +1,26 @@
+/*
+Copyright (c) 2025 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package netutil
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2/dsl/core"
+	. "github.com/onsi/gomega"
+)
+
+func TestNetutil(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Netutil Suite")
+}

--- a/internal/cmd/cli/create/netutil/validate.go
+++ b/internal/cmd/cli/create/netutil/validate.go
@@ -1,0 +1,53 @@
+/*
+Copyright (c) 2025 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package netutil
+
+import (
+	"fmt"
+	"net/netip"
+)
+
+// ValidateVirtualNetwork checks that a virtual network ID is provided.
+func ValidateVirtualNetwork(virtualNetwork string) error {
+	if virtualNetwork == "" {
+		return fmt.Errorf("virtual network is required")
+	}
+	return nil
+}
+
+// ValidateCIDRs checks that at least one CIDR is provided and that each is valid for its address family.
+func ValidateCIDRs(ipv4Cidr, ipv6Cidr string) error {
+	if ipv4Cidr == "" && ipv6Cidr == "" {
+		return fmt.Errorf("at least one of --ipv4-cidr or --ipv6-cidr is required")
+	}
+	if ipv4Cidr != "" {
+		prefix, err := netip.ParsePrefix(ipv4Cidr)
+		if err != nil || !prefix.Addr().Is4() {
+			if err == nil {
+				err = fmt.Errorf("address is not IPv4")
+			}
+			return fmt.Errorf("invalid IPv4 CIDR %q: %w", ipv4Cidr, err)
+		}
+	}
+	if ipv6Cidr != "" {
+		prefix, err := netip.ParsePrefix(ipv6Cidr)
+		if err != nil || !prefix.Addr().Is6() {
+			if err == nil {
+				err = fmt.Errorf("address is not IPv6")
+			}
+			return fmt.Errorf("invalid IPv6 CIDR %q: %w", ipv6Cidr, err)
+		}
+	}
+	return nil
+}

--- a/internal/cmd/cli/create/netutil/validate_test.go
+++ b/internal/cmd/cli/create/netutil/validate_test.go
@@ -1,0 +1,70 @@
+/*
+Copyright (c) 2025 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package netutil
+
+import (
+	. "github.com/onsi/ginkgo/v2/dsl/core"
+	. "github.com/onsi/ginkgo/v2/dsl/table"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("ValidateCIDRs", func() {
+	DescribeTable("valid cases",
+		func(ipv4Cidr, ipv6Cidr string) {
+			err := ValidateCIDRs(ipv4Cidr, ipv6Cidr)
+			Expect(err).NotTo(HaveOccurred())
+		},
+		Entry("valid IPv4 CIDR only", "10.0.0.0/16", ""),
+		Entry("valid IPv6 CIDR only", "", "fd00::/48"),
+		Entry("valid dual-stack", "10.0.0.0/16", "fd00::/48"),
+		Entry("IPv4 /0 network", "0.0.0.0/0", ""),
+		Entry("IPv6 /0 network", "", "::/0"),
+	)
+
+	DescribeTable("error cases",
+		func(ipv4Cidr, ipv6Cidr, errSubstring string) {
+			err := ValidateCIDRs(ipv4Cidr, ipv6Cidr)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring(errSubstring))
+		},
+		Entry("missing both CIDRs",
+			"", "", "at least one of --ipv4-cidr or --ipv6-cidr is required",
+		),
+		Entry("invalid IPv4 CIDR",
+			"not-a-cidr", "", "invalid IPv4 CIDR",
+		),
+		Entry("IPv6 address in --ipv4-cidr flag",
+			"fd00::/48", "", "invalid IPv4 CIDR",
+		),
+		Entry("invalid IPv6 CIDR",
+			"", "not-a-cidr", "invalid IPv6 CIDR",
+		),
+		Entry("IPv4 address in --ipv6-cidr flag",
+			"", "10.0.0.0/16", "invalid IPv6 CIDR",
+		),
+	)
+})
+
+var _ = Describe("ValidateVirtualNetwork", func() {
+	It("should return an error when virtual network is empty", func() {
+		err := ValidateVirtualNetwork("")
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("virtual network is required"))
+	})
+
+	It("should return nil when virtual network is provided", func() {
+		err := ValidateVirtualNetwork("vnet-abc123")
+		Expect(err).NotTo(HaveOccurred())
+	})
+})

--- a/internal/cmd/cli/create/securitygroup/create_securitygroup_cmd.go
+++ b/internal/cmd/cli/create/securitygroup/create_securitygroup_cmd.go
@@ -1,0 +1,276 @@
+/*
+Copyright (c) 2025 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package securitygroup
+
+import (
+	"fmt"
+	"log/slog"
+	"net/netip"
+	"strconv"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"google.golang.org/protobuf/proto"
+
+	publicv1 "github.com/osac-project/fulfillment-service/internal/api/osac/public/v1"
+	"github.com/osac-project/fulfillment-service/internal/cmd/cli/create/netutil"
+	"github.com/osac-project/fulfillment-service/internal/config"
+	"github.com/osac-project/fulfillment-service/internal/logging"
+	"github.com/osac-project/fulfillment-service/internal/terminal"
+)
+
+func Cmd() *cobra.Command {
+	runner := &runnerContext{}
+	result := &cobra.Command{
+		Use:     "securitygroup [flags]",
+		Aliases: []string{string(proto.MessageName((*publicv1.SecurityGroup)(nil)))},
+		Short:   "Create a security group",
+		Long: "Create a security group with optional ingress and egress firewall rules. " +
+			"Rules are specified using key=value pairs separated by commas (e.g. protocol=tcp,port-from=80,port-to=80,ipv4-cidr=0.0.0.0/0). " +
+			"Supported keys: protocol (required: tcp, udp, icmp, all), port-from, port-to, ipv4-cidr, ipv6-cidr.",
+		Example: `  # Create a security group with an HTTP ingress rule
+  osac create securitygroup --name web-sg --virtual-network vnet-abc123 \
+    --ingress protocol=tcp,port-from=80,port-to=80,ipv4-cidr=0.0.0.0/0
+
+  # Create a security group with multiple rules
+  osac create securitygroup --name app-sg --virtual-network vnet-abc123 \
+    --ingress protocol=tcp,port-from=443,port-to=443,ipv4-cidr=0.0.0.0/0 \
+    --ingress protocol=icmp,ipv4-cidr=10.0.0.0/8 \
+    --egress protocol=all`,
+		Args: cobra.NoArgs,
+		RunE: runner.run,
+	}
+	flags := result.Flags()
+	flags.StringVarP(
+		&runner.args.name,
+		"name",
+		"n",
+		"",
+		"Name of the security group.",
+	)
+	flags.StringVar(
+		&runner.args.virtualNetwork,
+		"virtual-network",
+		"",
+		"ID of the virtual network to associate with this security group.",
+	)
+	flags.StringArrayVar(
+		&runner.args.ingressRules,
+		"ingress",
+		nil,
+		"Ingress rule in key=value,... format (e.g. protocol=tcp,port-from=80,port-to=80,ipv4-cidr=0.0.0.0/0). Can be specified multiple times.",
+	)
+	flags.StringArrayVar(
+		&runner.args.egressRules,
+		"egress",
+		nil,
+		"Egress rule in key=value,... format (e.g. protocol=all). Can be specified multiple times.",
+	)
+	return result
+}
+
+type runnerContext struct {
+	args struct {
+		name           string
+		virtualNetwork string
+		ingressRules   []string
+		egressRules    []string
+	}
+	logger  *slog.Logger
+	console *terminal.Console
+}
+
+func (c *runnerContext) run(cmd *cobra.Command, args []string) error {
+	ctx := cmd.Context()
+
+	c.logger = logging.LoggerFromContext(ctx)
+	c.console = terminal.ConsoleFromContext(ctx)
+
+	cfg, err := config.Load(ctx)
+	if err != nil {
+		return err
+	}
+	if cfg.Address == "" {
+		return fmt.Errorf("there is no configuration, run the 'login' command")
+	}
+
+	if err := netutil.ValidateVirtualNetwork(c.args.virtualNetwork); err != nil {
+		return err
+	}
+
+	ingress, err := parseSecurityRules(c.args.ingressRules)
+	if err != nil {
+		return fmt.Errorf("invalid ingress rule: %w", err)
+	}
+	egress, err := parseSecurityRules(c.args.egressRules)
+	if err != nil {
+		return fmt.Errorf("invalid egress rule: %w", err)
+	}
+
+	conn, err := cfg.Connect(ctx, cmd.Flags())
+	if err != nil {
+		return fmt.Errorf("failed to create gRPC connection: %w", err)
+	}
+	defer conn.Close()
+
+	client := publicv1.NewSecurityGroupsClient(conn)
+
+	sg := publicv1.SecurityGroup_builder{
+		Metadata: publicv1.Metadata_builder{Name: c.args.name}.Build(),
+		Spec: publicv1.SecurityGroupSpec_builder{
+			VirtualNetwork: c.args.virtualNetwork,
+			Ingress:        ingress,
+			Egress:         egress,
+		}.Build(),
+	}.Build()
+
+	response, err := client.Create(ctx, publicv1.SecurityGroupsCreateRequest_builder{Object: sg}.Build())
+	if err != nil {
+		return fmt.Errorf("failed to create security group: %w", err)
+	}
+
+	c.console.Infof(ctx, "Created security group '%s' (ID: %s).\n", response.Object.GetMetadata().GetName(), response.Object.GetId())
+
+	return nil
+}
+
+// parseSecurityRules parses a slice of rule strings in key=value,... format into SecurityRule protos.
+// Returns nil, nil for empty input (no rules is valid).
+func parseSecurityRules(ruleArgs []string) ([]*publicv1.SecurityRule, error) {
+	if len(ruleArgs) == 0 {
+		return nil, nil
+	}
+
+	rules := make([]*publicv1.SecurityRule, 0, len(ruleArgs))
+	for i, ruleArg := range ruleArgs {
+		rule, err := parseSecurityRule(ruleArg)
+		if err != nil {
+			return nil, fmt.Errorf("rule %d (%q): %w", i+1, ruleArg, err)
+		}
+		rules = append(rules, rule)
+	}
+	return rules, nil
+}
+
+func parseSecurityRule(ruleArg string) (*publicv1.SecurityRule, error) {
+	pairs := strings.Split(ruleArg, ",")
+
+	seen := make(map[string]bool)
+	var protocol publicv1.Protocol
+	var protocolSet bool
+	var portFrom, portTo *int32
+	var ipv4Cidr, ipv6Cidr *string
+
+	for _, pair := range pairs {
+		parts := strings.SplitN(pair, "=", 2)
+		if len(parts) != 2 {
+			return nil, fmt.Errorf("invalid key=value pair: %q", pair)
+		}
+		key := parts[0]
+		value := parts[1]
+
+		if seen[key] {
+			return nil, fmt.Errorf("duplicate key %q in rule", key)
+		}
+		seen[key] = true
+
+		switch key {
+		case "protocol":
+			p, err := parseProtocol(value)
+			if err != nil {
+				return nil, err
+			}
+			protocol = p
+			protocolSet = true
+		case "port-from":
+			port, err := parsePort(value)
+			if err != nil {
+				return nil, fmt.Errorf("invalid port-from: %w", err)
+			}
+			portFrom = &port
+		case "port-to":
+			port, err := parsePort(value)
+			if err != nil {
+				return nil, fmt.Errorf("invalid port-to: %w", err)
+			}
+			portTo = &port
+		case "ipv4-cidr":
+			prefix, err := netip.ParsePrefix(value)
+			if err != nil {
+				return nil, fmt.Errorf("invalid ipv4-cidr %q: %w", value, err)
+			}
+			if !prefix.Addr().Is4() {
+				return nil, fmt.Errorf("invalid ipv4-cidr %q: address is not IPv4", value)
+			}
+			ipv4Cidr = &value
+		case "ipv6-cidr":
+			prefix, err := netip.ParsePrefix(value)
+			if err != nil {
+				return nil, fmt.Errorf("invalid ipv6-cidr %q: %w", value, err)
+			}
+			if !prefix.Addr().Is6() {
+				return nil, fmt.Errorf("invalid ipv6-cidr %q: address is not IPv6", value)
+			}
+			ipv6Cidr = &value
+		default:
+			return nil, fmt.Errorf("unknown key %q in rule", key)
+		}
+	}
+
+	if !protocolSet {
+		return nil, fmt.Errorf("protocol is required in rule %q", ruleArg)
+	}
+
+	// Validate port range consistency
+	if (portFrom == nil) != (portTo == nil) {
+		return nil, fmt.Errorf("port-from and port-to must both be specified or both be omitted")
+	}
+	if portFrom != nil && portTo != nil && *portFrom > *portTo {
+		return nil, fmt.Errorf("port-from (%d) must be less than or equal to port-to (%d)", *portFrom, *portTo)
+	}
+
+	return publicv1.SecurityRule_builder{
+		Protocol: protocol,
+		PortFrom: portFrom,
+		PortTo:   portTo,
+		Ipv4Cidr: ipv4Cidr,
+		Ipv6Cidr: ipv6Cidr,
+	}.Build(), nil
+}
+
+func parseProtocol(value string) (publicv1.Protocol, error) {
+	switch strings.ToLower(value) {
+	case "tcp":
+		return publicv1.Protocol_PROTOCOL_TCP, nil
+	case "udp":
+		return publicv1.Protocol_PROTOCOL_UDP, nil
+	case "icmp":
+		return publicv1.Protocol_PROTOCOL_ICMP, nil
+	case "all":
+		return publicv1.Protocol_PROTOCOL_ALL, nil
+	default:
+		return publicv1.Protocol_PROTOCOL_UNSPECIFIED, fmt.Errorf("invalid protocol %q: must be one of tcp, udp, icmp, all", value)
+	}
+}
+
+func parsePort(value string) (int32, error) {
+	n, err := strconv.ParseInt(value, 10, 32)
+	if err != nil {
+		return 0, fmt.Errorf("invalid port value %q: %w", value, err)
+	}
+	if n < 1 || n > 65535 {
+		return 0, fmt.Errorf("port %d is out of range (1-65535)", n)
+	}
+	return int32(n), nil
+}

--- a/internal/cmd/cli/create/securitygroup/create_securitygroup_cmd_test.go
+++ b/internal/cmd/cli/create/securitygroup/create_securitygroup_cmd_test.go
@@ -1,0 +1,187 @@
+/*
+Copyright (c) 2025 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package securitygroup
+
+import (
+	. "github.com/onsi/ginkgo/v2/dsl/core"
+	. "github.com/onsi/ginkgo/v2/dsl/table"
+	. "github.com/onsi/gomega"
+
+	publicv1 "github.com/osac-project/fulfillment-service/internal/api/osac/public/v1"
+)
+
+var _ = Describe("parseSecurityRules", func() {
+	DescribeTable("valid cases",
+		func(ruleArgs []string, validate func([]*publicv1.SecurityRule)) {
+			rules, err := parseSecurityRules(ruleArgs)
+			Expect(err).NotTo(HaveOccurred())
+			if validate != nil {
+				validate(rules)
+			}
+		},
+		Entry("empty input returns nil",
+			[]string{},
+			func(rules []*publicv1.SecurityRule) {
+				Expect(rules).To(BeNil())
+			},
+		),
+		Entry("single TCP rule with all fields",
+			[]string{"protocol=tcp,port-from=80,port-to=80,ipv4-cidr=0.0.0.0/0"},
+			func(rules []*publicv1.SecurityRule) {
+				Expect(rules).To(HaveLen(1))
+				Expect(rules[0].GetProtocol()).To(Equal(publicv1.Protocol_PROTOCOL_TCP))
+				Expect(rules[0].HasPortFrom()).To(BeTrue())
+				Expect(rules[0].GetPortFrom()).To(Equal(int32(80)))
+				Expect(rules[0].HasPortTo()).To(BeTrue())
+				Expect(rules[0].GetPortTo()).To(Equal(int32(80)))
+				Expect(rules[0].GetIpv4Cidr()).To(Equal("0.0.0.0/0"))
+			},
+		),
+		Entry("ICMP rule without ports",
+			[]string{"protocol=icmp,ipv4-cidr=0.0.0.0/0"},
+			func(rules []*publicv1.SecurityRule) {
+				Expect(rules).To(HaveLen(1))
+				Expect(rules[0].GetProtocol()).To(Equal(publicv1.Protocol_PROTOCOL_ICMP))
+				Expect(rules[0].HasPortFrom()).To(BeFalse())
+				Expect(rules[0].HasPortTo()).To(BeFalse())
+				Expect(rules[0].GetIpv4Cidr()).To(Equal("0.0.0.0/0"))
+			},
+		),
+		Entry("ALL traffic protocol",
+			[]string{"protocol=all"},
+			func(rules []*publicv1.SecurityRule) {
+				Expect(rules).To(HaveLen(1))
+				Expect(rules[0].GetProtocol()).To(Equal(publicv1.Protocol_PROTOCOL_ALL))
+			},
+		),
+		Entry("protocol-only TCP rule",
+			[]string{"protocol=tcp"},
+			func(rules []*publicv1.SecurityRule) {
+				Expect(rules).To(HaveLen(1))
+				Expect(rules[0].GetProtocol()).To(Equal(publicv1.Protocol_PROTOCOL_TCP))
+				Expect(rules[0].HasPortFrom()).To(BeFalse())
+				Expect(rules[0].HasPortTo()).To(BeFalse())
+			},
+		),
+		Entry("dual-stack rule with both IPv4 and IPv6 CIDRs",
+			[]string{"protocol=tcp,port-from=443,port-to=443,ipv4-cidr=0.0.0.0/0,ipv6-cidr=::/0"},
+			func(rules []*publicv1.SecurityRule) {
+				Expect(rules).To(HaveLen(1))
+				Expect(rules[0].GetIpv4Cidr()).To(Equal("0.0.0.0/0"))
+				Expect(rules[0].GetIpv6Cidr()).To(Equal("::/0"))
+			},
+		),
+		Entry("multiple rules",
+			[]string{
+				"protocol=tcp,port-from=80,port-to=80",
+				"protocol=icmp",
+			},
+			func(rules []*publicv1.SecurityRule) {
+				Expect(rules).To(HaveLen(2))
+				Expect(rules[0].GetProtocol()).To(Equal(publicv1.Protocol_PROTOCOL_TCP))
+				Expect(rules[1].GetProtocol()).To(Equal(publicv1.Protocol_PROTOCOL_ICMP))
+			},
+		),
+		Entry("case-insensitive protocol TCP",
+			[]string{"protocol=TCP"},
+			func(rules []*publicv1.SecurityRule) {
+				Expect(rules).To(HaveLen(1))
+				Expect(rules[0].GetProtocol()).To(Equal(publicv1.Protocol_PROTOCOL_TCP))
+			},
+		),
+		Entry("UDP protocol",
+			[]string{"protocol=udp,port-from=53,port-to=53"},
+			func(rules []*publicv1.SecurityRule) {
+				Expect(rules).To(HaveLen(1))
+				Expect(rules[0].GetProtocol()).To(Equal(publicv1.Protocol_PROTOCOL_UDP))
+			},
+		),
+		Entry("port boundary: minimum port 1",
+			[]string{"protocol=tcp,port-from=1,port-to=1"},
+			func(rules []*publicv1.SecurityRule) {
+				Expect(rules).To(HaveLen(1))
+				Expect(rules[0].GetPortFrom()).To(Equal(int32(1)))
+				Expect(rules[0].GetPortTo()).To(Equal(int32(1)))
+			},
+		),
+		Entry("port boundary: maximum port 65535",
+			[]string{"protocol=tcp,port-from=65535,port-to=65535"},
+			func(rules []*publicv1.SecurityRule) {
+				Expect(rules).To(HaveLen(1))
+				Expect(rules[0].GetPortFrom()).To(Equal(int32(65535)))
+				Expect(rules[0].GetPortTo()).To(Equal(int32(65535)))
+			},
+		),
+	)
+
+	DescribeTable("error cases",
+		func(ruleArgs []string, errMatcher OmegaMatcher) {
+			_, err := parseSecurityRules(ruleArgs)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(errMatcher)
+		},
+		Entry("missing protocol",
+			[]string{"port-from=80,port-to=80"},
+			ContainSubstring("protocol"),
+		),
+		Entry("invalid protocol value",
+			[]string{"protocol=ftp"},
+			ContainSubstring("invalid protocol"),
+		),
+		Entry("port below range (port-from=0)",
+			[]string{"protocol=tcp,port-from=0,port-to=80"},
+			ContainSubstring("out of range"),
+		),
+		Entry("port above range (port-from=65536)",
+			[]string{"protocol=tcp,port-from=65536,port-to=65536"},
+			ContainSubstring("out of range"),
+		),
+		Entry("unknown key",
+			[]string{"protocol=tcp,foo=bar"},
+			ContainSubstring("foo"),
+		),
+		Entry("half-specified ports: port-from without port-to",
+			[]string{"protocol=tcp,port-from=80"},
+			ContainSubstring("both be specified or both be omitted"),
+		),
+		Entry("half-specified ports: port-to without port-from",
+			[]string{"protocol=tcp,port-to=80"},
+			ContainSubstring("both be specified or both be omitted"),
+		),
+		Entry("reversed ports (port-from > port-to)",
+			[]string{"protocol=tcp,port-from=443,port-to=80"},
+			ContainSubstring("less than or equal to"),
+		),
+		Entry("duplicate keys",
+			[]string{"protocol=tcp,protocol=udp"},
+			ContainSubstring("duplicate key"),
+		),
+		Entry("invalid CIDR notation",
+			[]string{"protocol=tcp,ipv4-cidr=not-a-cidr"},
+			ContainSubstring("invalid ipv4-cidr"),
+		),
+		Entry("IPv4 address in ipv6-cidr field",
+			[]string{"protocol=tcp,ipv6-cidr=192.168.0.0/16"},
+			ContainSubstring("not IPv6"),
+		),
+		Entry("IPv6 address in ipv4-cidr field",
+			[]string{"protocol=tcp,ipv4-cidr=::/0"},
+			ContainSubstring("not IPv4"),
+		),
+		Entry("no equals sign in pair",
+			[]string{"protocol=tcp,nodash"},
+			ContainSubstring("invalid key=value pair"),
+		),
+	)
+})

--- a/internal/cmd/cli/create/securitygroup/securitygroup_suite_test.go
+++ b/internal/cmd/cli/create/securitygroup/securitygroup_suite_test.go
@@ -1,0 +1,26 @@
+/*
+Copyright (c) 2025 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package securitygroup
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2/dsl/core"
+	. "github.com/onsi/gomega"
+)
+
+func TestSecurityGroup(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "SecurityGroup command")
+}

--- a/internal/cmd/cli/create/subnet/create_subnet_cmd.go
+++ b/internal/cmd/cli/create/subnet/create_subnet_cmd.go
@@ -1,0 +1,137 @@
+/*
+Copyright (c) 2025 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package subnet
+
+import (
+	"fmt"
+	"log/slog"
+
+	"github.com/spf13/cobra"
+	"google.golang.org/protobuf/proto"
+
+	publicv1 "github.com/osac-project/fulfillment-service/internal/api/osac/public/v1"
+	"github.com/osac-project/fulfillment-service/internal/cmd/cli/create/netutil"
+	"github.com/osac-project/fulfillment-service/internal/config"
+	"github.com/osac-project/fulfillment-service/internal/logging"
+	"github.com/osac-project/fulfillment-service/internal/terminal"
+)
+
+func Cmd() *cobra.Command {
+	runner := &runnerContext{}
+	result := &cobra.Command{
+		Use:     "subnet [flags]",
+		Aliases: []string{string(proto.MessageName((*publicv1.Subnet)(nil)))},
+		Short:   "Create a subnet",
+		Long: "Create a subnet within an existing virtual network. " +
+			"At least one of --ipv4-cidr or --ipv6-cidr must be provided.",
+		Example: `  # Create an IPv4-only subnet
+  osac create subnet --name my-subnet --virtual-network vnet-abc123 --ipv4-cidr 10.0.1.0/24
+
+  # Create a dual-stack subnet
+  osac create subnet --name my-subnet --virtual-network vnet-abc123 --ipv4-cidr 10.0.1.0/24 --ipv6-cidr fd00:1234::/64`,
+		Args: cobra.NoArgs,
+		RunE: runner.run,
+	}
+	flags := result.Flags()
+	flags.StringVarP(
+		&runner.args.name,
+		"name",
+		"n",
+		"",
+		"Name of the subnet.",
+	)
+	flags.StringVar(
+		&runner.args.virtualNetwork,
+		"virtual-network",
+		"",
+		"ID of the parent virtual network.",
+	)
+	flags.StringVar(
+		&runner.args.ipv4Cidr,
+		"ipv4-cidr",
+		"",
+		"IPv4 CIDR block for this subnet (e.g. 10.0.1.0/24).",
+	)
+	flags.StringVar(
+		&runner.args.ipv6Cidr,
+		"ipv6-cidr",
+		"",
+		"IPv6 CIDR block for this subnet (e.g. fd00:1234::/64).",
+	)
+	return result
+}
+
+type runnerContext struct {
+	args struct {
+		name           string
+		virtualNetwork string
+		ipv4Cidr       string
+		ipv6Cidr       string
+	}
+	logger  *slog.Logger
+	console *terminal.Console
+}
+
+func (c *runnerContext) run(cmd *cobra.Command, args []string) error {
+	ctx := cmd.Context()
+
+	c.logger = logging.LoggerFromContext(ctx)
+	c.console = terminal.ConsoleFromContext(ctx)
+
+	cfg, err := config.Load(ctx)
+	if err != nil {
+		return err
+	}
+	if cfg.Address == "" {
+		return fmt.Errorf("there is no configuration, run the 'login' command")
+	}
+
+	if err := netutil.ValidateVirtualNetwork(c.args.virtualNetwork); err != nil {
+		return err
+	}
+	if err := netutil.ValidateCIDRs(c.args.ipv4Cidr, c.args.ipv6Cidr); err != nil {
+		return err
+	}
+
+	conn, err := cfg.Connect(ctx, cmd.Flags())
+	if err != nil {
+		return fmt.Errorf("failed to create gRPC connection: %w", err)
+	}
+	defer conn.Close()
+
+	client := publicv1.NewSubnetsClient(conn)
+
+	spec := publicv1.SubnetSpec_builder{
+		VirtualNetwork: c.args.virtualNetwork,
+	}
+	if c.args.ipv4Cidr != "" {
+		spec.Ipv4Cidr = &c.args.ipv4Cidr
+	}
+	if c.args.ipv6Cidr != "" {
+		spec.Ipv6Cidr = &c.args.ipv6Cidr
+	}
+	subnet := publicv1.Subnet_builder{
+		Metadata: publicv1.Metadata_builder{Name: c.args.name}.Build(),
+		Spec:     spec.Build(),
+	}.Build()
+
+	response, err := client.Create(ctx, publicv1.SubnetsCreateRequest_builder{Object: subnet}.Build())
+	if err != nil {
+		return fmt.Errorf("failed to create subnet: %w", err)
+	}
+
+	c.console.Infof(ctx, "Created subnet '%s' (ID: %s).\n", response.Object.GetMetadata().GetName(), response.Object.GetId())
+
+	return nil
+}

--- a/internal/cmd/cli/create/virtualnetwork/create_virtualnetwork_cmd.go
+++ b/internal/cmd/cli/create/virtualnetwork/create_virtualnetwork_cmd.go
@@ -1,0 +1,153 @@
+/*
+Copyright (c) 2025 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package virtualnetwork
+
+import (
+	"fmt"
+	"log/slog"
+
+	"github.com/spf13/cobra"
+	"google.golang.org/protobuf/proto"
+
+	publicv1 "github.com/osac-project/fulfillment-service/internal/api/osac/public/v1"
+	"github.com/osac-project/fulfillment-service/internal/cmd/cli/create/netutil"
+	"github.com/osac-project/fulfillment-service/internal/config"
+	"github.com/osac-project/fulfillment-service/internal/logging"
+	"github.com/osac-project/fulfillment-service/internal/terminal"
+)
+
+func Cmd() *cobra.Command {
+	runner := &runnerContext{}
+	result := &cobra.Command{
+		Use:     "virtualnetwork [flags]",
+		Aliases: []string{string(proto.MessageName((*publicv1.VirtualNetwork)(nil)))},
+		Short:   "Create a virtual network",
+		Long: "Create a virtual network with the specified network class and IP addressing configuration. " +
+			"At least one of --ipv4-cidr or --ipv6-cidr must be provided.",
+		Example: `  # Create an IPv4-only virtual network
+  osac create virtualnetwork --name my-network --network-class udn-net --ipv4-cidr 10.0.0.0/16
+
+  # Create a dual-stack virtual network
+  osac create virtualnetwork --name my-network --network-class udn-net --ipv4-cidr 10.0.0.0/16 --ipv6-cidr fd00::/64`,
+		Args: cobra.NoArgs,
+		RunE: runner.run,
+	}
+	flags := result.Flags()
+	flags.StringVarP(
+		&runner.args.name,
+		"name",
+		"n",
+		"",
+		"Name of the virtual network.",
+	)
+	flags.StringVar(
+		&runner.args.networkClass,
+		"network-class",
+		"",
+		"Network class to use for this virtual network.",
+	)
+	flags.StringVar(
+		&runner.args.ipv4Cidr,
+		"ipv4-cidr",
+		"",
+		"IPv4 CIDR block for this network (e.g. 10.0.0.0/16).",
+	)
+	flags.StringVar(
+		&runner.args.ipv6Cidr,
+		"ipv6-cidr",
+		"",
+		"IPv6 CIDR block for this network (e.g. fd00::/64).",
+	)
+	return result
+}
+
+type runnerContext struct {
+	args struct {
+		name         string
+		networkClass string
+		ipv4Cidr     string
+		ipv6Cidr     string
+	}
+	logger  *slog.Logger
+	console *terminal.Console
+}
+
+func (c *runnerContext) run(cmd *cobra.Command, args []string) error {
+	ctx := cmd.Context()
+
+	c.logger = logging.LoggerFromContext(ctx)
+	c.console = terminal.ConsoleFromContext(ctx)
+
+	cfg, err := config.Load(ctx)
+	if err != nil {
+		return err
+	}
+	if cfg.Address == "" {
+		return fmt.Errorf("there is no configuration, run the 'login' command")
+	}
+
+	if err := validateNetworkClass(c.args.networkClass); err != nil {
+		return err
+	}
+	if err := netutil.ValidateCIDRs(c.args.ipv4Cidr, c.args.ipv6Cidr); err != nil {
+		return err
+	}
+
+	conn, err := cfg.Connect(ctx, cmd.Flags())
+	if err != nil {
+		return fmt.Errorf("failed to create gRPC connection: %w", err)
+	}
+	defer conn.Close()
+
+	client := publicv1.NewVirtualNetworksClient(conn)
+
+	enableIpv4 := c.args.ipv4Cidr != ""
+	enableIpv6 := c.args.ipv6Cidr != ""
+	enableDualStack := enableIpv4 && enableIpv6
+
+	spec := publicv1.VirtualNetworkSpec_builder{
+		NetworkClass: c.args.networkClass,
+		Capabilities: publicv1.VirtualNetworkCapabilities_builder{
+			EnableIpv4:      enableIpv4,
+			EnableIpv6:      enableIpv6,
+			EnableDualStack: enableDualStack,
+		}.Build(),
+	}
+	if c.args.ipv4Cidr != "" {
+		spec.Ipv4Cidr = &c.args.ipv4Cidr
+	}
+	if c.args.ipv6Cidr != "" {
+		spec.Ipv6Cidr = &c.args.ipv6Cidr
+	}
+	vn := publicv1.VirtualNetwork_builder{
+		Metadata: publicv1.Metadata_builder{Name: c.args.name}.Build(),
+		Spec:     spec.Build(),
+	}.Build()
+
+	response, err := client.Create(ctx, publicv1.VirtualNetworksCreateRequest_builder{Object: vn}.Build())
+	if err != nil {
+		return fmt.Errorf("failed to create virtual network: %w", err)
+	}
+
+	c.console.Infof(ctx, "Created virtual network '%s' (ID: %s).\n", response.Object.GetMetadata().GetName(), response.Object.GetId())
+
+	return nil
+}
+
+func validateNetworkClass(networkClass string) error {
+	if networkClass == "" {
+		return fmt.Errorf("network class is required")
+	}
+	return nil
+}

--- a/internal/cmd/cli/create/virtualnetwork/create_virtualnetwork_cmd_test.go
+++ b/internal/cmd/cli/create/virtualnetwork/create_virtualnetwork_cmd_test.go
@@ -1,0 +1,32 @@
+/*
+Copyright (c) 2025 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package virtualnetwork
+
+import (
+	. "github.com/onsi/ginkgo/v2/dsl/core"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("validateNetworkClass", func() {
+	It("should return an error when network class is empty", func() {
+		err := validateNetworkClass("")
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("network class is required"))
+	})
+
+	It("should return nil when network class is provided", func() {
+		err := validateNetworkClass("udn-net")
+		Expect(err).NotTo(HaveOccurred())
+	})
+})

--- a/internal/cmd/cli/create/virtualnetwork/virtualnetwork_suite_test.go
+++ b/internal/cmd/cli/create/virtualnetwork/virtualnetwork_suite_test.go
@@ -1,0 +1,26 @@
+/*
+Copyright (c) 2025 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package virtualnetwork
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2/dsl/core"
+	. "github.com/onsi/gomega"
+)
+
+func TestCreateVirtualNetwork(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "CreateVirtualNetwork command")
+}

--- a/internal/cmd/cli/describe/describe_cmd.go
+++ b/internal/cmd/cli/describe/describe_cmd.go
@@ -18,6 +18,9 @@ import (
 
 	"github.com/osac-project/fulfillment-service/internal/cmd/cli/describe/cluster"
 	"github.com/osac-project/fulfillment-service/internal/cmd/cli/describe/computeinstance"
+	"github.com/osac-project/fulfillment-service/internal/cmd/cli/describe/securitygroup"
+	"github.com/osac-project/fulfillment-service/internal/cmd/cli/describe/subnet"
+	"github.com/osac-project/fulfillment-service/internal/cmd/cli/describe/virtualnetwork"
 )
 
 func Cmd() *cobra.Command {
@@ -27,5 +30,8 @@ func Cmd() *cobra.Command {
 	}
 	result.AddCommand(cluster.Cmd())
 	result.AddCommand(computeinstance.Cmd())
+	result.AddCommand(virtualnetwork.Cmd())
+	result.AddCommand(subnet.Cmd())
+	result.AddCommand(securitygroup.Cmd())
 	return result
 }

--- a/internal/cmd/cli/describe/describe_cmd_test.go
+++ b/internal/cmd/cli/describe/describe_cmd_test.go
@@ -1,0 +1,102 @@
+/*
+Copyright (c) 2025 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package describe
+
+import (
+	"fmt"
+
+	. "github.com/onsi/ginkgo/v2/dsl/core"
+	. "github.com/onsi/ginkgo/v2/dsl/table"
+	. "github.com/onsi/gomega"
+	"github.com/spf13/cobra"
+
+	"github.com/osac-project/fulfillment-service/internal/cmd/cli/describe/cluster"
+	"github.com/osac-project/fulfillment-service/internal/cmd/cli/describe/computeinstance"
+	"github.com/osac-project/fulfillment-service/internal/cmd/cli/describe/securitygroup"
+	"github.com/osac-project/fulfillment-service/internal/cmd/cli/describe/subnet"
+	"github.com/osac-project/fulfillment-service/internal/cmd/cli/describe/virtualnetwork"
+)
+
+var _ = Describe("Describe command", func() {
+	DescribeTable("Subcommand aliases",
+		func(cmdFunc func() *cobra.Command, expectedAlias string) {
+			cmd := cmdFunc()
+			Expect(cmd.Aliases).To(ContainElement(expectedAlias))
+		},
+		Entry("cluster", cluster.Cmd, "clusters"),
+		Entry("virtualnetwork", virtualnetwork.Cmd, "virtualnetworks"),
+		Entry("subnet", subnet.Cmd, "subnets"),
+		Entry("securitygroup", securitygroup.Cmd, "securitygroups"),
+	)
+
+	Describe("Subcommands", func() {
+		It("should have all expected subcommands", func() {
+			cmd := Cmd()
+			subcommands := cmd.Commands()
+
+			var subcommandNames []string
+			for _, subcmd := range subcommands {
+				subcommandNames = append(subcommandNames, subcmd.Name())
+			}
+
+			Expect(subcommandNames).To(ContainElements("cluster", "computeinstance", "virtualnetwork", "subnet", "securitygroup"))
+		})
+	})
+
+	Describe("computeinstance has no aliases", func() {
+		It("should have no aliases", func() {
+			cmd := computeinstance.Cmd()
+			Expect(cmd.Aliases).To(BeEmpty())
+		})
+	})
+
+	Describe("CEL filter construction", func() {
+		It("should produce valid CEL for a plain name", func() {
+			ref := "example-resource"
+			filter := fmt.Sprintf(`this.id == %[1]q || this.metadata.name == %[1]q`, ref)
+			Expect(filter).To(Equal(`this.id == "example-resource" || this.metadata.name == "example-resource"`))
+		})
+
+		It("should escape single quotes in names", func() {
+			ref := "example'resource"
+			filter := fmt.Sprintf(`this.id == %[1]q || this.metadata.name == %[1]q`, ref)
+			Expect(filter).To(ContainSubstring(`"example'resource"`))
+			Expect(filter).NotTo(ContainSubstring(`'example'`))
+		})
+
+		It("should escape backticks in names", func() {
+			ref := "example`resource"
+			filter := fmt.Sprintf(`this.id == %[1]q || this.metadata.name == %[1]q`, ref)
+			Expect(filter).To(ContainSubstring(`"example` + "`" + `resource"`))
+		})
+
+		It("should escape backslashes in names", func() {
+			ref := `example\resource`
+			filter := fmt.Sprintf(`this.id == %[1]q || this.metadata.name == %[1]q`, ref)
+			Expect(filter).To(ContainSubstring(`"example\\resource"`))
+		})
+
+		It("should escape double quotes properly", func() {
+			ref := `example"resource`
+			filter := fmt.Sprintf(`this.id == %[1]q || this.metadata.name == %[1]q`, ref)
+			Expect(filter).To(ContainSubstring(`"example\"resource"`))
+		})
+
+		It("should produce valid CEL for a UUID-style ID", func() {
+			ref := "550e8400-e29b-41d4-a716-446655440000"
+			filter := fmt.Sprintf(`this.id == %[1]q || this.metadata.name == %[1]q`, ref)
+			Expect(filter).To(Equal(`this.id == "550e8400-e29b-41d4-a716-446655440000" || this.metadata.name == "550e8400-e29b-41d4-a716-446655440000"`))
+		})
+	})
+})

--- a/internal/cmd/cli/describe/describe_suite_test.go
+++ b/internal/cmd/cli/describe/describe_suite_test.go
@@ -1,0 +1,26 @@
+/*
+Copyright (c) 2025 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package describe
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2/dsl/core"
+	. "github.com/onsi/gomega"
+)
+
+func TestDescribe(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Describe command")
+}

--- a/internal/cmd/cli/describe/securitygroup/describe_securitygroup_cmd.go
+++ b/internal/cmd/cli/describe/securitygroup/describe_securitygroup_cmd.go
@@ -1,0 +1,171 @@
+/*
+Copyright (c) 2025 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package securitygroup
+
+import (
+	"fmt"
+	"io"
+	"log/slog"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/spf13/cobra"
+
+	publicv1 "github.com/osac-project/fulfillment-service/internal/api/osac/public/v1"
+	"github.com/osac-project/fulfillment-service/internal/config"
+	"github.com/osac-project/fulfillment-service/internal/logging"
+	"github.com/osac-project/fulfillment-service/internal/terminal"
+)
+
+// Cmd creates the command to describe a security group.
+func Cmd() *cobra.Command {
+	runner := &runnerContext{}
+	result := &cobra.Command{
+		Use:     "securitygroup [flags] ID_OR_NAME",
+		Aliases: []string{"securitygroups"},
+		Short:   "Describe a security group",
+		Long:    "Display detailed information about a security group, identified by ID or name, including its ingress and egress rules.",
+		Example: `  # Describe a security group by ID
+  osac describe securitygroup sg-abc123
+
+  # Describe a security group by name
+  osac describe securitygroup web-sg`,
+		Args: cobra.ExactArgs(1),
+		RunE: runner.run,
+	}
+	return result
+}
+
+type runnerContext struct {
+	logger  *slog.Logger
+	console *terminal.Console
+}
+
+func (c *runnerContext) run(cmd *cobra.Command, args []string) error {
+	ref := args[0]
+
+	ctx := cmd.Context()
+
+	c.logger = logging.LoggerFromContext(ctx)
+	c.console = terminal.ConsoleFromContext(ctx)
+
+	cfg, err := config.Load(ctx)
+	if err != nil {
+		return err
+	}
+	if cfg.Address == "" {
+		return fmt.Errorf("there is no configuration, run the 'login' command")
+	}
+
+	conn, err := cfg.Connect(ctx, cmd.Flags())
+	if err != nil {
+		return fmt.Errorf("failed to create gRPC connection: %w", err)
+	}
+	defer conn.Close()
+
+	client := publicv1.NewSecurityGroupsClient(conn)
+
+	filter := fmt.Sprintf(`this.id == %[1]q || this.metadata.name == %[1]q`, ref)
+	listResponse, err := client.List(ctx, publicv1.SecurityGroupsListRequest_builder{
+		Filter: &filter,
+	}.Build())
+	if err != nil {
+		return fmt.Errorf("failed to describe security group: %w", err)
+	}
+	if len(listResponse.GetItems()) == 0 {
+		return fmt.Errorf("security group not found: %s", ref)
+	}
+	if len(listResponse.GetItems()) > 1 {
+		return fmt.Errorf("multiple security groups match '%s', use the ID instead", ref)
+	}
+
+	response, err := client.Get(ctx, publicv1.SecurityGroupsGetRequest_builder{
+		Id: listResponse.GetItems()[0].GetId(),
+	}.Build())
+	if err != nil {
+		return fmt.Errorf("failed to describe security group: %w", err)
+	}
+
+	sg := response.Object
+	RenderSecurityGroup(c.console, sg)
+
+	return nil
+}
+
+// RenderSecurityGroup writes a formatted description of sg to w.
+func RenderSecurityGroup(w io.Writer, sg *publicv1.SecurityGroup) {
+	writer := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
+
+	name := "-"
+	if v := sg.GetMetadata().GetName(); v != "" {
+		name = v
+	}
+
+	state := "-"
+	message := "-"
+	if sg.GetStatus() != nil {
+		state = strings.TrimPrefix(sg.GetStatus().GetState().String(), "SECURITY_GROUP_STATE_")
+		if v := sg.GetStatus().GetMessage(); v != "" {
+			message = v
+		}
+	}
+
+	fmt.Fprintf(writer, "ID:\t%s\n", sg.GetId())
+	fmt.Fprintf(writer, "Name:\t%s\n", name)
+	fmt.Fprintf(writer, "Virtual Network:\t%s\n", sg.GetSpec().GetVirtualNetwork())
+	fmt.Fprintf(writer, "State:\t%s\n", state)
+	fmt.Fprintf(writer, "Message:\t%s\n", message)
+	writer.Flush()
+	fmt.Fprintln(w)
+
+	renderRules(w, "Ingress Rules", sg.GetSpec().GetIngress())
+	renderRules(w, "Egress Rules", sg.GetSpec().GetEgress())
+}
+
+func renderRules(w io.Writer, label string, rules []*publicv1.SecurityRule) {
+	if len(rules) == 0 {
+		fmt.Fprintf(w, "%s:  (none)\n", label)
+		return
+	}
+
+	fmt.Fprintf(w, "%s:\n", label)
+	ruleWriter := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
+	fmt.Fprintf(ruleWriter, "  PROTOCOL\tPORT-FROM\tPORT-TO\tIPV4-CIDR\tIPV6-CIDR\n")
+	for _, rule := range rules {
+		protocol := strings.ToLower(strings.TrimPrefix(rule.GetProtocol().String(), "PROTOCOL_"))
+
+		portFrom := "-"
+		if rule.HasPortFrom() {
+			portFrom = fmt.Sprintf("%d", rule.GetPortFrom())
+		}
+
+		portTo := "-"
+		if rule.HasPortTo() {
+			portTo = fmt.Sprintf("%d", rule.GetPortTo())
+		}
+
+		ipv4Cidr := "-"
+		if v := rule.GetIpv4Cidr(); v != "" {
+			ipv4Cidr = v
+		}
+
+		ipv6Cidr := "-"
+		if v := rule.GetIpv6Cidr(); v != "" {
+			ipv6Cidr = v
+		}
+
+		fmt.Fprintf(ruleWriter, "  %s\t%s\t%s\t%s\t%s\n", protocol, portFrom, portTo, ipv4Cidr, ipv6Cidr)
+	}
+	ruleWriter.Flush()
+}

--- a/internal/cmd/cli/describe/securitygroup/describe_securitygroup_suite_test.go
+++ b/internal/cmd/cli/describe/securitygroup/describe_securitygroup_suite_test.go
@@ -1,0 +1,26 @@
+/*
+Copyright (c) 2025 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package securitygroup
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2/dsl/core"
+	. "github.com/onsi/gomega"
+)
+
+func TestDescribeSecurityGroup(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Describe SecurityGroup Suite")
+}

--- a/internal/cmd/cli/describe/securitygroup/describe_securitygroup_test.go
+++ b/internal/cmd/cli/describe/securitygroup/describe_securitygroup_test.go
@@ -1,0 +1,198 @@
+/*
+Copyright (c) 2025 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package securitygroup
+
+import (
+	"bytes"
+
+	. "github.com/onsi/ginkgo/v2/dsl/core"
+	. "github.com/onsi/gomega"
+
+	"google.golang.org/protobuf/proto"
+
+	publicv1 "github.com/osac-project/fulfillment-service/internal/api/osac/public/v1"
+)
+
+func formatSecurityGroup(sg *publicv1.SecurityGroup) string {
+	var buf bytes.Buffer
+	RenderSecurityGroup(&buf, sg)
+	return buf.String()
+}
+
+var _ = Describe("Describe Security Group", func() {
+	Describe("Rendering tests", func() {
+		It("should show (none) for ingress and egress when no rules", func() {
+			sg := publicv1.SecurityGroup_builder{
+				Id: "sg-001",
+				Spec: publicv1.SecurityGroupSpec_builder{
+					VirtualNetwork: "vnet-abc123",
+				}.Build(),
+			}.Build()
+
+			output := formatSecurityGroup(sg)
+			Expect(output).To(ContainSubstring("Ingress Rules:  (none)"))
+			Expect(output).To(ContainSubstring("Egress Rules:  (none)"))
+		})
+
+		It("should render TCP ingress rule with port 80", func() {
+			sg := publicv1.SecurityGroup_builder{
+				Id: "sg-002",
+				Spec: publicv1.SecurityGroupSpec_builder{
+					VirtualNetwork: "vnet-abc123",
+					Ingress: []*publicv1.SecurityRule{
+						publicv1.SecurityRule_builder{
+							Protocol: publicv1.Protocol_PROTOCOL_TCP,
+							PortFrom: proto.Int32(80),
+							PortTo:   proto.Int32(80),
+							Ipv4Cidr: proto.String("0.0.0.0/0"),
+						}.Build(),
+					},
+				}.Build(),
+			}.Build()
+
+			output := formatSecurityGroup(sg)
+			Expect(output).To(ContainSubstring("tcp"))
+			Expect(output).To(ContainSubstring("80"))
+			Expect(output).To(ContainSubstring("0.0.0.0/0"))
+		})
+
+		It("should show '-' for ports when ICMP rule has no ports", func() {
+			sg := publicv1.SecurityGroup_builder{
+				Id: "sg-003",
+				Spec: publicv1.SecurityGroupSpec_builder{
+					VirtualNetwork: "vnet-abc123",
+					Ingress: []*publicv1.SecurityRule{
+						publicv1.SecurityRule_builder{
+							Protocol: publicv1.Protocol_PROTOCOL_ICMP,
+							Ipv4Cidr: proto.String("10.0.0.0/8"),
+						}.Build(),
+					},
+				}.Build(),
+			}.Build()
+
+			output := formatSecurityGroup(sg)
+			Expect(output).To(ContainSubstring("icmp"))
+			Expect(output).To(MatchRegexp(`icmp\s+-\s+-\s+`))
+		})
+
+		It("should show '-' for IPV4-CIDR and IPV6-CIDR when not set", func() {
+			sg := publicv1.SecurityGroup_builder{
+				Id: "sg-004",
+				Spec: publicv1.SecurityGroupSpec_builder{
+					VirtualNetwork: "vnet-abc123",
+					Ingress: []*publicv1.SecurityRule{
+						publicv1.SecurityRule_builder{
+							Protocol: publicv1.Protocol_PROTOCOL_ALL,
+						}.Build(),
+					},
+				}.Build(),
+			}.Build()
+
+			output := formatSecurityGroup(sg)
+			Expect(output).To(MatchRegexp(`all\s+-\s+-\s+-\s+-`))
+		})
+
+		It("should strip PROTOCOL_ prefix and lowercase for protocol display", func() {
+			sg := publicv1.SecurityGroup_builder{
+				Id: "sg-005",
+				Spec: publicv1.SecurityGroupSpec_builder{
+					VirtualNetwork: "vnet-abc123",
+					Ingress: []*publicv1.SecurityRule{
+						publicv1.SecurityRule_builder{
+							Protocol: publicv1.Protocol_PROTOCOL_TCP,
+							PortFrom: proto.Int32(443),
+							PortTo:   proto.Int32(443),
+						}.Build(),
+					},
+				}.Build(),
+			}.Build()
+
+			output := formatSecurityGroup(sg)
+			Expect(output).To(ContainSubstring("tcp"))
+			Expect(output).NotTo(ContainSubstring("PROTOCOL_TCP"))
+		})
+
+		It("should strip SECURITY_GROUP_STATE_ prefix from state", func() {
+			sg := publicv1.SecurityGroup_builder{
+				Id: "sg-006",
+				Spec: publicv1.SecurityGroupSpec_builder{
+					VirtualNetwork: "vnet-abc123",
+				}.Build(),
+				Status: publicv1.SecurityGroupStatus_builder{
+					State: publicv1.SecurityGroupState_SECURITY_GROUP_STATE_READY,
+				}.Build(),
+			}.Build()
+
+			output := formatSecurityGroup(sg)
+			Expect(output).To(ContainSubstring("READY"))
+			Expect(output).NotTo(ContainSubstring("SECURITY_GROUP_STATE_"))
+		})
+
+		It("should show '-' for state and message when status is nil", func() {
+			sg := publicv1.SecurityGroup_builder{
+				Id: "sg-007",
+				Spec: publicv1.SecurityGroupSpec_builder{
+					VirtualNetwork: "vnet-abc123",
+				}.Build(),
+			}.Build()
+
+			output := formatSecurityGroup(sg)
+			Expect(output).To(MatchRegexp(`State:\s+-`))
+			Expect(output).To(MatchRegexp(`Message:\s+-`))
+		})
+
+		It("should display all header fields when set", func() {
+			msg := "Security group active"
+			sg := publicv1.SecurityGroup_builder{
+				Id: "sg-008",
+				Metadata: publicv1.Metadata_builder{
+					Name: "web-sg",
+				}.Build(),
+				Spec: publicv1.SecurityGroupSpec_builder{
+					VirtualNetwork: "vnet-abc123",
+				}.Build(),
+				Status: publicv1.SecurityGroupStatus_builder{
+					State:   publicv1.SecurityGroupState_SECURITY_GROUP_STATE_READY,
+					Message: &msg,
+				}.Build(),
+			}.Build()
+
+			output := formatSecurityGroup(sg)
+			Expect(output).To(ContainSubstring("sg-008"))
+			Expect(output).To(ContainSubstring("web-sg"))
+			Expect(output).To(ContainSubstring("vnet-abc123"))
+			Expect(output).To(ContainSubstring("READY"))
+			Expect(output).To(ContainSubstring("Security group active"))
+		})
+
+		It("should render egress rules separately from ingress rules", func() {
+			sg := publicv1.SecurityGroup_builder{
+				Id: "sg-009",
+				Spec: publicv1.SecurityGroupSpec_builder{
+					VirtualNetwork: "vnet-abc123",
+					Egress: []*publicv1.SecurityRule{
+						publicv1.SecurityRule_builder{
+							Protocol: publicv1.Protocol_PROTOCOL_ALL,
+						}.Build(),
+					},
+				}.Build(),
+			}.Build()
+
+			output := formatSecurityGroup(sg)
+			Expect(output).To(ContainSubstring("Ingress Rules:  (none)"))
+			Expect(output).To(ContainSubstring("Egress Rules:"))
+			Expect(output).To(ContainSubstring("all"))
+		})
+	})
+})

--- a/internal/cmd/cli/describe/subnet/describe_subnet_cmd.go
+++ b/internal/cmd/cli/describe/subnet/describe_subnet_cmd.go
@@ -1,0 +1,142 @@
+/*
+Copyright (c) 2025 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package subnet
+
+import (
+	"fmt"
+	"io"
+	"log/slog"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/spf13/cobra"
+
+	publicv1 "github.com/osac-project/fulfillment-service/internal/api/osac/public/v1"
+	"github.com/osac-project/fulfillment-service/internal/config"
+	"github.com/osac-project/fulfillment-service/internal/logging"
+	"github.com/osac-project/fulfillment-service/internal/terminal"
+)
+
+// Cmd creates the command to describe a subnet.
+func Cmd() *cobra.Command {
+	runner := &runnerContext{}
+	result := &cobra.Command{
+		Use:     "subnet [flags] ID_OR_NAME",
+		Aliases: []string{"subnets"},
+		Short:   "Describe a subnet",
+		Long:    "Display detailed information about a subnet, identified by ID or name.",
+		Example: `  # Describe a subnet by ID
+  osac describe subnet subnet-abc123
+
+  # Describe a subnet by name
+  osac describe subnet my-subnet`,
+		Args: cobra.ExactArgs(1),
+		RunE: runner.run,
+	}
+	return result
+}
+
+type runnerContext struct {
+	logger  *slog.Logger
+	console *terminal.Console
+}
+
+func (c *runnerContext) run(cmd *cobra.Command, args []string) error {
+	ref := args[0]
+
+	ctx := cmd.Context()
+
+	c.logger = logging.LoggerFromContext(ctx)
+	c.console = terminal.ConsoleFromContext(ctx)
+
+	cfg, err := config.Load(ctx)
+	if err != nil {
+		return err
+	}
+	if cfg.Address == "" {
+		return fmt.Errorf("there is no configuration, run the 'login' command")
+	}
+
+	conn, err := cfg.Connect(ctx, cmd.Flags())
+	if err != nil {
+		return fmt.Errorf("failed to create gRPC connection: %w", err)
+	}
+	defer conn.Close()
+
+	client := publicv1.NewSubnetsClient(conn)
+
+	filter := fmt.Sprintf(`this.id == %[1]q || this.metadata.name == %[1]q`, ref)
+	listResponse, err := client.List(ctx, publicv1.SubnetsListRequest_builder{
+		Filter: &filter,
+	}.Build())
+	if err != nil {
+		return fmt.Errorf("failed to describe subnet: %w", err)
+	}
+	if len(listResponse.GetItems()) == 0 {
+		return fmt.Errorf("subnet not found: %s", ref)
+	}
+	if len(listResponse.GetItems()) > 1 {
+		return fmt.Errorf("multiple subnets match '%s', use the ID instead", ref)
+	}
+
+	response, err := client.Get(ctx, publicv1.SubnetsGetRequest_builder{
+		Id: listResponse.GetItems()[0].GetId(),
+	}.Build())
+	if err != nil {
+		return fmt.Errorf("failed to describe subnet: %w", err)
+	}
+
+	s := response.Object
+	RenderSubnet(c.console, s)
+
+	return nil
+}
+
+// RenderSubnet writes a formatted description of s to w.
+func RenderSubnet(w io.Writer, s *publicv1.Subnet) {
+	writer := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
+
+	name := "-"
+	if v := s.GetMetadata().GetName(); v != "" {
+		name = v
+	}
+
+	ipv4Cidr := "-"
+	if v := s.GetSpec().GetIpv4Cidr(); v != "" {
+		ipv4Cidr = v
+	}
+
+	ipv6Cidr := "-"
+	if v := s.GetSpec().GetIpv6Cidr(); v != "" {
+		ipv6Cidr = v
+	}
+
+	state := "-"
+	message := "-"
+	if s.GetStatus() != nil {
+		state = strings.TrimPrefix(s.GetStatus().GetState().String(), "SUBNET_STATE_")
+		if v := s.GetStatus().GetMessage(); v != "" {
+			message = v
+		}
+	}
+
+	fmt.Fprintf(writer, "ID:\t%s\n", s.GetId())
+	fmt.Fprintf(writer, "Name:\t%s\n", name)
+	fmt.Fprintf(writer, "Virtual Network:\t%s\n", s.GetSpec().GetVirtualNetwork())
+	fmt.Fprintf(writer, "IPv4 CIDR:\t%s\n", ipv4Cidr)
+	fmt.Fprintf(writer, "IPv6 CIDR:\t%s\n", ipv6Cidr)
+	fmt.Fprintf(writer, "State:\t%s\n", state)
+	fmt.Fprintf(writer, "Message:\t%s\n", message)
+	writer.Flush()
+}

--- a/internal/cmd/cli/describe/subnet/describe_subnet_suite_test.go
+++ b/internal/cmd/cli/describe/subnet/describe_subnet_suite_test.go
@@ -1,0 +1,26 @@
+/*
+Copyright (c) 2025 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package subnet
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2/dsl/core"
+	. "github.com/onsi/gomega"
+)
+
+func TestDescribeSubnet(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Describe Subnet Suite")
+}

--- a/internal/cmd/cli/describe/subnet/describe_subnet_test.go
+++ b/internal/cmd/cli/describe/subnet/describe_subnet_test.go
@@ -1,0 +1,136 @@
+/*
+Copyright (c) 2025 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package subnet
+
+import (
+	"bytes"
+
+	. "github.com/onsi/ginkgo/v2/dsl/core"
+	. "github.com/onsi/gomega"
+
+	"google.golang.org/protobuf/proto"
+
+	publicv1 "github.com/osac-project/fulfillment-service/internal/api/osac/public/v1"
+)
+
+func formatSubnet(s *publicv1.Subnet) string {
+	var buf bytes.Buffer
+	RenderSubnet(&buf, s)
+	return buf.String()
+}
+
+var _ = Describe("Describe Subnet", func() {
+	Describe("Rendering tests", func() {
+		It("should display all fields when set", func() {
+			msg := "Subnet ready"
+			s := publicv1.Subnet_builder{
+				Id: "subnet-001",
+				Metadata: publicv1.Metadata_builder{
+					Name: "example-subnet",
+				}.Build(),
+				Spec: publicv1.SubnetSpec_builder{
+					VirtualNetwork: "vnet-abc123",
+					Ipv4Cidr:       proto.String("10.0.1.0/24"),
+					Ipv6Cidr:       proto.String("2001:db8::/64"),
+				}.Build(),
+				Status: publicv1.SubnetStatus_builder{
+					State:   publicv1.SubnetState_SUBNET_STATE_READY,
+					Message: &msg,
+				}.Build(),
+			}.Build()
+
+			output := formatSubnet(s)
+			Expect(output).To(ContainSubstring("subnet-001"))
+			Expect(output).To(ContainSubstring("example-subnet"))
+			Expect(output).To(ContainSubstring("vnet-abc123"))
+			Expect(output).To(ContainSubstring("10.0.1.0/24"))
+			Expect(output).To(ContainSubstring("2001:db8::/64"))
+			Expect(output).To(ContainSubstring("READY"))
+			Expect(output).To(ContainSubstring("Subnet ready"))
+		})
+
+		It("should show '-' for state and message when status is nil", func() {
+			s := publicv1.Subnet_builder{
+				Id: "subnet-002",
+				Spec: publicv1.SubnetSpec_builder{
+					VirtualNetwork: "vnet-abc123",
+				}.Build(),
+			}.Build()
+
+			output := formatSubnet(s)
+			Expect(output).To(MatchRegexp(`Name:\s+-`))
+			Expect(output).To(MatchRegexp(`State:\s+-`))
+			Expect(output).To(MatchRegexp(`Message:\s+-`))
+		})
+
+		It("should show '-' for IPv4 CIDR when not set", func() {
+			s := publicv1.Subnet_builder{
+				Id: "subnet-003",
+				Spec: publicv1.SubnetSpec_builder{
+					VirtualNetwork: "vnet-abc123",
+					Ipv6Cidr:       proto.String("2001:db8::/64"),
+				}.Build(),
+			}.Build()
+
+			output := formatSubnet(s)
+			Expect(output).To(MatchRegexp(`IPv4 CIDR:\s+-`))
+			Expect(output).To(ContainSubstring("2001:db8::/64"))
+		})
+
+		It("should strip SUBNET_STATE_ prefix from state", func() {
+			s := publicv1.Subnet_builder{
+				Id: "subnet-004",
+				Spec: publicv1.SubnetSpec_builder{
+					VirtualNetwork: "vnet-abc123",
+				}.Build(),
+				Status: publicv1.SubnetStatus_builder{
+					State: publicv1.SubnetState_SUBNET_STATE_READY,
+				}.Build(),
+			}.Build()
+
+			output := formatSubnet(s)
+			Expect(output).To(ContainSubstring("READY"))
+			Expect(output).NotTo(ContainSubstring("SUBNET_STATE_"))
+		})
+
+		It("should show '-' for IPv6 CIDR when not set", func() {
+			s := publicv1.Subnet_builder{
+				Id: "subnet-006",
+				Spec: publicv1.SubnetSpec_builder{
+					VirtualNetwork: "vnet-abc123",
+					Ipv4Cidr:       proto.String("10.0.1.0/24"),
+				}.Build(),
+			}.Build()
+
+			output := formatSubnet(s)
+			Expect(output).To(ContainSubstring("10.0.1.0/24"))
+			Expect(output).To(MatchRegexp(`IPv6 CIDR:\s+-`))
+		})
+
+		It("should show '-' for message when status has no message", func() {
+			s := publicv1.Subnet_builder{
+				Id: "subnet-005",
+				Spec: publicv1.SubnetSpec_builder{
+					VirtualNetwork: "vnet-abc123",
+				}.Build(),
+				Status: publicv1.SubnetStatus_builder{
+					State: publicv1.SubnetState_SUBNET_STATE_PENDING,
+				}.Build(),
+			}.Build()
+
+			output := formatSubnet(s)
+			Expect(output).To(MatchRegexp(`Message:\s+-`))
+		})
+	})
+})

--- a/internal/cmd/cli/describe/virtualnetwork/describe_virtualnetwork_cmd.go
+++ b/internal/cmd/cli/describe/virtualnetwork/describe_virtualnetwork_cmd.go
@@ -1,0 +1,142 @@
+/*
+Copyright (c) 2025 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package virtualnetwork
+
+import (
+	"fmt"
+	"io"
+	"log/slog"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/spf13/cobra"
+
+	publicv1 "github.com/osac-project/fulfillment-service/internal/api/osac/public/v1"
+	"github.com/osac-project/fulfillment-service/internal/config"
+	"github.com/osac-project/fulfillment-service/internal/logging"
+	"github.com/osac-project/fulfillment-service/internal/terminal"
+)
+
+// Cmd creates the command to describe a virtual network.
+func Cmd() *cobra.Command {
+	runner := &runnerContext{}
+	result := &cobra.Command{
+		Use:     "virtualnetwork [flags] ID_OR_NAME",
+		Aliases: []string{"virtualnetworks"},
+		Short:   "Describe a virtual network",
+		Long:    "Display detailed information about a virtual network, identified by ID or name.",
+		Example: `  # Describe a virtual network by ID
+  osac describe virtualnetwork vnet-abc123
+
+  # Describe a virtual network by name
+  osac describe virtualnetwork my-network`,
+		Args: cobra.ExactArgs(1),
+		RunE: runner.run,
+	}
+	return result
+}
+
+type runnerContext struct {
+	logger  *slog.Logger
+	console *terminal.Console
+}
+
+func (c *runnerContext) run(cmd *cobra.Command, args []string) error {
+	ref := args[0]
+
+	ctx := cmd.Context()
+
+	c.logger = logging.LoggerFromContext(ctx)
+	c.console = terminal.ConsoleFromContext(ctx)
+
+	cfg, err := config.Load(ctx)
+	if err != nil {
+		return err
+	}
+	if cfg.Address == "" {
+		return fmt.Errorf("there is no configuration, run the 'login' command")
+	}
+
+	conn, err := cfg.Connect(ctx, cmd.Flags())
+	if err != nil {
+		return fmt.Errorf("failed to create gRPC connection: %w", err)
+	}
+	defer conn.Close()
+
+	client := publicv1.NewVirtualNetworksClient(conn)
+
+	filter := fmt.Sprintf(`this.id == %[1]q || this.metadata.name == %[1]q`, ref)
+	listResponse, err := client.List(ctx, publicv1.VirtualNetworksListRequest_builder{
+		Filter: &filter,
+	}.Build())
+	if err != nil {
+		return fmt.Errorf("failed to describe virtual network: %w", err)
+	}
+	if len(listResponse.GetItems()) == 0 {
+		return fmt.Errorf("virtual network not found: %s", ref)
+	}
+	if len(listResponse.GetItems()) > 1 {
+		return fmt.Errorf("multiple virtual networks match '%s', use the ID instead", ref)
+	}
+
+	response, err := client.Get(ctx, publicv1.VirtualNetworksGetRequest_builder{
+		Id: listResponse.GetItems()[0].GetId(),
+	}.Build())
+	if err != nil {
+		return fmt.Errorf("failed to describe virtual network: %w", err)
+	}
+
+	vn := response.Object
+	RenderVirtualNetwork(c.console, vn)
+
+	return nil
+}
+
+// RenderVirtualNetwork writes a formatted description of vn to w.
+func RenderVirtualNetwork(w io.Writer, vn *publicv1.VirtualNetwork) {
+	writer := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
+
+	name := "-"
+	if v := vn.GetMetadata().GetName(); v != "" {
+		name = v
+	}
+
+	ipv4Cidr := "-"
+	if v := vn.GetSpec().GetIpv4Cidr(); v != "" {
+		ipv4Cidr = v
+	}
+
+	ipv6Cidr := "-"
+	if v := vn.GetSpec().GetIpv6Cidr(); v != "" {
+		ipv6Cidr = v
+	}
+
+	state := "-"
+	message := "-"
+	if vn.GetStatus() != nil {
+		state = strings.TrimPrefix(vn.GetStatus().GetState().String(), "VIRTUAL_NETWORK_STATE_")
+		if v := vn.GetStatus().GetMessage(); v != "" {
+			message = v
+		}
+	}
+
+	fmt.Fprintf(writer, "ID:\t%s\n", vn.GetId())
+	fmt.Fprintf(writer, "Name:\t%s\n", name)
+	fmt.Fprintf(writer, "Network Class:\t%s\n", vn.GetSpec().GetNetworkClass())
+	fmt.Fprintf(writer, "IPv4 CIDR:\t%s\n", ipv4Cidr)
+	fmt.Fprintf(writer, "IPv6 CIDR:\t%s\n", ipv6Cidr)
+	fmt.Fprintf(writer, "State:\t%s\n", state)
+	fmt.Fprintf(writer, "Message:\t%s\n", message)
+	writer.Flush()
+}

--- a/internal/cmd/cli/describe/virtualnetwork/describe_virtualnetwork_suite_test.go
+++ b/internal/cmd/cli/describe/virtualnetwork/describe_virtualnetwork_suite_test.go
@@ -1,0 +1,26 @@
+/*
+Copyright (c) 2025 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package virtualnetwork
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2/dsl/core"
+	. "github.com/onsi/gomega"
+)
+
+func TestDescribeVirtualNetwork(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Describe Virtual Network Suite")
+}

--- a/internal/cmd/cli/describe/virtualnetwork/describe_virtualnetwork_test.go
+++ b/internal/cmd/cli/describe/virtualnetwork/describe_virtualnetwork_test.go
@@ -1,0 +1,136 @@
+/*
+Copyright (c) 2025 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package virtualnetwork
+
+import (
+	"bytes"
+
+	. "github.com/onsi/ginkgo/v2/dsl/core"
+	. "github.com/onsi/gomega"
+
+	"google.golang.org/protobuf/proto"
+
+	publicv1 "github.com/osac-project/fulfillment-service/internal/api/osac/public/v1"
+)
+
+func formatVirtualNetwork(vn *publicv1.VirtualNetwork) string {
+	var buf bytes.Buffer
+	RenderVirtualNetwork(&buf, vn)
+	return buf.String()
+}
+
+var _ = Describe("Describe Virtual Network", func() {
+	Describe("Rendering tests", func() {
+		It("should display all fields when set", func() {
+			msg := "Network ready"
+			vn := publicv1.VirtualNetwork_builder{
+				Id: "vnet-001",
+				Metadata: publicv1.Metadata_builder{
+					Name: "example-vn",
+				}.Build(),
+				Spec: publicv1.VirtualNetworkSpec_builder{
+					NetworkClass: "udn-net",
+					Ipv4Cidr:     proto.String("10.0.0.0/16"),
+					Ipv6Cidr:     proto.String("2001:db8::/48"),
+				}.Build(),
+				Status: publicv1.VirtualNetworkStatus_builder{
+					State:   publicv1.VirtualNetworkState_VIRTUAL_NETWORK_STATE_READY,
+					Message: &msg,
+				}.Build(),
+			}.Build()
+
+			output := formatVirtualNetwork(vn)
+			Expect(output).To(ContainSubstring("vnet-001"))
+			Expect(output).To(ContainSubstring("example-vn"))
+			Expect(output).To(ContainSubstring("udn-net"))
+			Expect(output).To(ContainSubstring("10.0.0.0/16"))
+			Expect(output).To(ContainSubstring("2001:db8::/48"))
+			Expect(output).To(ContainSubstring("READY"))
+			Expect(output).To(ContainSubstring("Network ready"))
+		})
+
+		It("should show '-' for name, state, and message when status is nil", func() {
+			vn := publicv1.VirtualNetwork_builder{
+				Id: "vnet-002",
+				Spec: publicv1.VirtualNetworkSpec_builder{
+					NetworkClass: "udn-net",
+				}.Build(),
+			}.Build()
+
+			output := formatVirtualNetwork(vn)
+			Expect(output).To(MatchRegexp(`Name:\s+-`))
+			Expect(output).To(MatchRegexp(`State:\s+-`))
+			Expect(output).To(MatchRegexp(`Message:\s+-`))
+		})
+
+		It("should show '-' for IPv4 CIDR when not set", func() {
+			vn := publicv1.VirtualNetwork_builder{
+				Id: "vnet-003",
+				Spec: publicv1.VirtualNetworkSpec_builder{
+					NetworkClass: "udn-net",
+					Ipv6Cidr:     proto.String("2001:db8::/48"),
+				}.Build(),
+			}.Build()
+
+			output := formatVirtualNetwork(vn)
+			Expect(output).To(MatchRegexp(`IPv4 CIDR:\s+-`))
+			Expect(output).To(ContainSubstring("2001:db8::/48"))
+		})
+
+		It("should show '-' for IPv6 CIDR when not set", func() {
+			vn := publicv1.VirtualNetwork_builder{
+				Id: "vnet-004",
+				Spec: publicv1.VirtualNetworkSpec_builder{
+					NetworkClass: "udn-net",
+					Ipv4Cidr:     proto.String("10.0.0.0/16"),
+				}.Build(),
+			}.Build()
+
+			output := formatVirtualNetwork(vn)
+			Expect(output).To(ContainSubstring("10.0.0.0/16"))
+			Expect(output).To(MatchRegexp(`IPv6 CIDR:\s+-`))
+		})
+
+		It("should strip VIRTUAL_NETWORK_STATE_ prefix from state", func() {
+			vn := publicv1.VirtualNetwork_builder{
+				Id: "vnet-005",
+				Spec: publicv1.VirtualNetworkSpec_builder{
+					NetworkClass: "udn-net",
+				}.Build(),
+				Status: publicv1.VirtualNetworkStatus_builder{
+					State: publicv1.VirtualNetworkState_VIRTUAL_NETWORK_STATE_READY,
+				}.Build(),
+			}.Build()
+
+			output := formatVirtualNetwork(vn)
+			Expect(output).To(ContainSubstring("READY"))
+			Expect(output).NotTo(ContainSubstring("VIRTUAL_NETWORK_STATE_"))
+		})
+
+		It("should show '-' for message when status has no message", func() {
+			vn := publicv1.VirtualNetwork_builder{
+				Id: "vnet-006",
+				Spec: publicv1.VirtualNetworkSpec_builder{
+					NetworkClass: "udn-net",
+				}.Build(),
+				Status: publicv1.VirtualNetworkStatus_builder{
+					State: publicv1.VirtualNetworkState_VIRTUAL_NETWORK_STATE_PENDING,
+				}.Build(),
+			}.Build()
+
+			output := formatVirtualNetwork(vn)
+			Expect(output).To(MatchRegexp(`Message:\s+-`))
+		})
+	})
+})

--- a/internal/rendering/tables/osac.private.v1.SecurityGroup.yaml
+++ b/internal/rendering/tables/osac.private.v1.SecurityGroup.yaml
@@ -1,0 +1,35 @@
+#
+# Copyright (c) 2025 Red Hat Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+# the License. You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+columns:
+
+- header: ID
+  value: this.id
+
+- header: NAME
+  value: "has(this.metadata.name)? this.metadata.name: '-'"
+
+- header: VIRTUAL-NETWORK
+  value: this.spec.virtual_network
+  type: osac.private.v1.VirtualNetwork
+  lookup: true
+
+- header: INGRESS-RULES
+  value: '"%d".format([size(this.spec.ingress)])'
+
+- header: EGRESS-RULES
+  value: '"%d".format([size(this.spec.egress)])'
+
+- header: STATE
+  value: this.status.state
+  type: osac.private.v1.SecurityGroupState

--- a/internal/rendering/tables/osac.private.v1.Subnet.yaml
+++ b/internal/rendering/tables/osac.private.v1.Subnet.yaml
@@ -1,0 +1,40 @@
+#
+# Copyright (c) 2025 Red Hat Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+# the License. You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+columns:
+
+- header: ID
+  value: this.id
+
+- header: NAME
+  value: "has(this.metadata.name)? this.metadata.name: '-'"
+
+- header: VIRTUAL-NETWORK
+  value: this.spec.virtual_network
+  type: osac.private.v1.VirtualNetwork
+  lookup: true
+
+- header: IPV4-CIDR
+  value: "has(this.spec.ipv4_cidr)? this.spec.ipv4_cidr: '-'"
+
+- header: IPV6-CIDR
+  value: "has(this.spec.ipv6_cidr)? this.spec.ipv6_cidr: '-'"
+
+- header: STATE
+  value: this.status.state
+  type: osac.private.v1.SubnetState
+
+- header: HUB
+  value: this.status.hub
+  type: osac.private.v1.Hub
+  lookup: true

--- a/internal/rendering/tables/osac.private.v1.VirtualNetwork.yaml
+++ b/internal/rendering/tables/osac.private.v1.VirtualNetwork.yaml
@@ -1,0 +1,46 @@
+#
+# Copyright (c) 2025 Red Hat Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+# the License. You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+columns:
+
+- header: ID
+  value: this.id
+
+- header: NAME
+  value: "has(this.metadata.name)? this.metadata.name: '-'"
+
+- header: REGION
+  value: this.spec.region
+
+- header: NETWORK-CLASS
+  value: this.spec.network_class
+  type: osac.private.v1.NetworkClass
+  lookup: true
+
+- header: IPV4-CIDR
+  value: "has(this.spec.ipv4_cidr)? this.spec.ipv4_cidr: '-'"
+
+- header: IPV6-CIDR
+  value: "has(this.spec.ipv6_cidr)? this.spec.ipv6_cidr: '-'"
+
+- header: IMPL-STRATEGY
+  value: this.spec.implementation_strategy
+
+- header: STATE
+  value: this.status.state
+  type: osac.private.v1.VirtualNetworkState
+
+- header: HUB
+  value: this.status.hub
+  type: osac.private.v1.Hub
+  lookup: true

--- a/internal/rendering/tables/osac.public.v1.SecurityGroup.yaml
+++ b/internal/rendering/tables/osac.public.v1.SecurityGroup.yaml
@@ -1,0 +1,35 @@
+#
+# Copyright (c) 2025 Red Hat Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+# the License. You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+columns:
+
+- header: ID
+  value: this.id
+
+- header: NAME
+  value: "has(this.metadata.name)? this.metadata.name: '-'"
+
+- header: VIRTUAL-NETWORK
+  value: this.spec.virtual_network
+  type: osac.public.v1.VirtualNetwork
+  lookup: true
+
+- header: INGRESS-RULES
+  value: '"%d".format([size(this.spec.ingress)])'
+
+- header: EGRESS-RULES
+  value: '"%d".format([size(this.spec.egress)])'
+
+- header: STATE
+  value: this.status.state
+  type: osac.public.v1.SecurityGroupState

--- a/internal/rendering/tables/osac.public.v1.Subnet.yaml
+++ b/internal/rendering/tables/osac.public.v1.Subnet.yaml
@@ -1,0 +1,35 @@
+#
+# Copyright (c) 2025 Red Hat Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+# the License. You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+columns:
+
+- header: ID
+  value: this.id
+
+- header: NAME
+  value: "has(this.metadata.name)? this.metadata.name: '-'"
+
+- header: VIRTUAL-NETWORK
+  value: this.spec.virtual_network
+  type: osac.public.v1.VirtualNetwork
+  lookup: true
+
+- header: IPV4-CIDR
+  value: "has(this.spec.ipv4_cidr)? this.spec.ipv4_cidr: '-'"
+
+- header: IPV6-CIDR
+  value: "has(this.spec.ipv6_cidr)? this.spec.ipv6_cidr: '-'"
+
+- header: STATE
+  value: this.status.state
+  type: osac.public.v1.SubnetState

--- a/internal/rendering/tables/osac.public.v1.VirtualNetwork.yaml
+++ b/internal/rendering/tables/osac.public.v1.VirtualNetwork.yaml
@@ -1,0 +1,35 @@
+#
+# Copyright (c) 2025 Red Hat Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+# the License. You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+columns:
+
+- header: ID
+  value: this.id
+
+- header: NAME
+  value: "has(this.metadata.name)? this.metadata.name: '-'"
+
+- header: NETWORK-CLASS
+  value: this.spec.network_class
+  type: osac.public.v1.NetworkClass
+  lookup: true
+
+- header: IPV4-CIDR
+  value: "has(this.spec.ipv4_cidr)? this.spec.ipv4_cidr: '-'"
+
+- header: IPV6-CIDR
+  value: "has(this.spec.ipv6_cidr)? this.spec.ipv6_cidr: '-'"
+
+- header: STATE
+  value: this.status.state
+  type: osac.public.v1.VirtualNetworkState


### PR DESCRIPTION
## Summary
- Adds create/describe CLI subcommands for VirtualNetwork, Subnet, and SecurityGroup
- Adds table YAML definitions for get output (public + private)
- Fixes CEL injection in describe computeinstance (pre-existing bug)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added create/describe commands for Virtual Network, Subnet, and Security Group.
  * Security Group create supports named groups, virtual network association, and ingress/egress rule args.
  * Virtual Network and Subnet creation support IPv4/IPv6 (including dual-stack) and network-class flags.

* **Bug Fixes**
  * Improved compute instance lookup/filtering for more accurate results.

* **UI Rendering**
  * New table views for Virtual Network, Subnet, and Security Group.

* **Tests**
  * Comprehensive tests added for new commands and validation logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->