### PR TITLE
MGMT-23856: reconnect listener after WaitForNotification timeout

### DIFF
--- a/internal/database/database_listener.go
+++ b/internal/database/database_listener.go
@@ -182,33 +182,35 @@ func (l *Listener) Listen(ctx context.Context) error {
 	}
 	l.runReadyCallbacks(ctx)
 
-	// Run the loop that waits for notifications and creates new connections in case of failure or timeout:
+	// Run the loop that waits for notifications and creates new connections in case of failure or timeout.
+	// When WaitForNotification returns due to context deadline or any other error, pgx puts the connection
+	// in an unusable state. We must reconnect (via listenLoop) to restore the LISTEN subscription.
 	for {
 		err := l.waitLoop(ctx)
 		if err == nil {
 			l.logger.DebugContext(ctx, "Wait finishied")
 			continue
 		}
-		if errors.Is(err, context.DeadlineExceeded) {
-			l.logger.InfoContext(
-				ctx,
-				"Wait timeout exceeded",
-				slog.Duration("timeout", l.waitTimeout),
-			)
-			continue
-		}
 		if errors.Is(err, context.Canceled) {
 			l.logger.DebugContext(ctx, "Wait canceled")
 			return err
 		}
-		l.logger.ErrorContext(
-			ctx,
-			"Wait failed",
-			slog.Any("error", err),
-		)
-		err = l.sleepBeforeRetry(ctx)
-		if err != nil {
-			return err
+		if errors.Is(err, context.DeadlineExceeded) {
+			l.logger.InfoContext(
+				ctx,
+				"Wait timeout exceeded, reconnecting",
+				slog.Duration("timeout", l.waitTimeout),
+			)
+		} else {
+			l.logger.ErrorContext(
+				ctx,
+				"Wait failed, reconnecting",
+				slog.Any("error", err),
+			)
+			err = l.sleepBeforeRetry(ctx)
+			if err != nil {
+				return err
+			}
 		}
 		err = l.listenLoop(ctx)
 		if err != nil {

--- a/internal/database/database_listener_test.go
+++ b/internal/database/database_listener_test.go
@@ -216,6 +216,23 @@ var _ = Describe("Listener", func() {
 			Expect(proto.Equal(received, sent)).To(BeTrue())
 		})
 
+		It("Receives notification after wait timeout", func() {
+			// Wait long enough for several timeout cycles (WaitTimeout is 100ms).
+			// After a timeout, pgx puts the connection in an unusable state.
+			// This verifies the listener reconnects and re-issues LISTEN.
+			time.Sleep(1 * time.Second)
+
+			var err error
+			sent := wrapperspb.String("after timeout")
+			runWithTx(func(ctx context.Context) {
+				err = notifier.Notify(ctx, sent)
+			})
+			Expect(err).ToNot(HaveOccurred())
+			var received *wrapperspb.StringValue
+			Eventually(payloads, 2*time.Second).Should(Receive(&received))
+			Expect(proto.Equal(received, sent)).To(BeTrue())
+		})
+
 		It("Receives multiple notifications", func() {
 			var err error
 			sent := []string{


### PR DESCRIPTION
https://redhat.atlassian.net/browse/MGMT-23856

pgx v5 closes the underlying connection when a context deadline expires during WaitForNotification (https://pkg.go.dev/github.com/jackc/pgx/v5/pgconn - "The default behavior when a context is canceled is for the method to immediately return. In most circumstances, this will also close the underlying connection."). The listener was catching DeadlineExceeded and retrying on the dead connection instead of reconnecting via listenLoop, so no notifications were delivered after the first 5 minute idle period. This broke all networking resource reconciliation (VirtualNetwork, Subnet, SecurityGroup) because they rely on event delivery to trigger the fulfillment controller.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced database listener error handling and reconnection logic for improved reliability.
* **Tests**
  * Added test coverage for notification delivery in timeout scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->