### PR TITLE
MGMT-23659: NetworkClass ID should always be a UUID

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -22,11 +22,19 @@ RUN \
   set -e; \
   go mod download
 
+# Version can be passed as a build arg to avoid requiring git inside the container.
+# This is necessary when building from a git worktree, where the .git reference
+# cannot be resolved inside the container context.
+ARG VERSION=""
+
 # Copy the rest of the source and build the binary:
 COPY . /source/
 RUN \
   set -e; \
-  version=$(git describe --tags --always); \
+  version="${VERSION}"; \
+  if [[ -z "${version}" ]]; then \
+    version=$(git describe --tags --always 2>/dev/null || echo "dev"); \
+  fi; \
   gcflags=""; \
   ldflags="-X github.com/osac-project/fulfillment-service/internal/version.id=${version}"; \
   if [[ "${DEBUG}" == "true" ]]; then \

--- a/internal/servers/network_classes_server_test.go
+++ b/internal/servers/network_classes_server_test.go
@@ -280,5 +280,19 @@ var _ = Describe("Network classes server", func() {
 			object := getResponse.GetObject()
 			Expect(object.GetMetadata().GetDeletionTimestamp()).ToNot(BeNil())
 		})
+
+		It("Generates UUID for id ignoring caller-provided value", func() {
+			callerProvidedId := "my-custom-id"
+			response, err := privateServer.Create(ctx, privatev1.NetworkClassesCreateRequest_builder{
+				Object: privatev1.NetworkClass_builder{
+					Id:                     callerProvidedId,
+					Title:                  "Test Network Class",
+					ImplementationStrategy: "ovn-kubernetes",
+				}.Build(),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+			Expect(response.GetObject().GetId()).ToNot(Equal(callerProvidedId))
+			Expect(response.GetObject().GetId()).ToNot(BeEmpty())
+		})
 	})
 })

--- a/internal/servers/private_network_classes_server.go
+++ b/internal/servers/private_network_classes_server.go
@@ -136,6 +136,9 @@ func (s *PrivateNetworkClassesServer) Create(ctx context.Context,
 	}
 	nc.Status.SetState(privatev1.NetworkClassState_NETWORK_CLASS_STATE_READY)
 
+	// Clear any caller-provided ID so the DAO always generates a UUID.
+	nc.SetId("")
+
 	err = s.generic.Create(ctx, request, &response)
 	return
 }

--- a/it/it_compute_subnet_test.go
+++ b/it/it_compute_subnet_test.go
@@ -65,15 +65,14 @@ var _ = Describe("ComputeInstance with Subnet attachment", func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		// Create NetworkClass
-		networkClassId = fmt.Sprintf("test-network-class-%s", uuid.New())
-		_, err = networkClassesClient.Create(ctx, privatev1.NetworkClassesCreateRequest_builder{
+		ncResp, err := networkClassesClient.Create(ctx, privatev1.NetworkClassesCreateRequest_builder{
 			Object: privatev1.NetworkClass_builder{
-				Id:                     networkClassId,
 				Title:                  "Test CUDN Network Class",
 				ImplementationStrategy: "cudn",
 			}.Build(),
 		}.Build())
 		Expect(err).ToNot(HaveOccurred())
+		networkClassId = ncResp.GetObject().GetId()
 
 		// Create VirtualNetwork
 		virtualNetworkId = fmt.Sprintf("test-vnet-%s", uuid.New())

--- a/it/it_tool.go
+++ b/it/it_tool.go
@@ -26,6 +26,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"slices"
+	"strings"
 	"time"
 
 	"github.com/cenkalti/backoff/v4"
@@ -403,6 +404,17 @@ func (t *Tool) buildImage(ctx context.Context) (result string, err error) {
 	t.logger.DebugContext(ctx, "Building image")
 	imageTag := time.Now().Format("20060102150405")
 	imageRef := fmt.Sprintf("%s:%s", imageName, imageTag)
+
+	// Resolve the version on the host so that the container build does not
+	// need access to the .git directory. This is required when building from
+	// a git worktree, where the .git file is a pointer that cannot be
+	// resolved inside the container context.
+	versionBytes, versionErr := exec.CommandContext(ctx, "git", "-C", t.projectDir, "describe", "--tags", "--always").Output()
+	gitVersion := "dev"
+	if versionErr == nil {
+		gitVersion = strings.TrimSpace(string(versionBytes))
+	}
+
 	buildCmd, err := testing.NewCommand().
 		SetLogger(t.logger).
 		SetHome(t.projectDir).
@@ -411,6 +423,7 @@ func (t *Tool) buildImage(ctx context.Context) (result string, err error) {
 		SetArgs(
 			"build",
 			"--build-arg", fmt.Sprintf("DEBUG=%t", t.debug),
+			"--build-arg", fmt.Sprintf("VERSION=%s", gitVersion),
 			"--tag", imageRef,
 			"--file", "Containerfile",
 			".",


### PR DESCRIPTION
## Summary
- Server always generates a UUID for NetworkClass `id`, ignoring any caller-provided value
- Fixes container image builds from git worktrees (VERSION build arg)
- Added unit test verifying caller-provided ID is ignored

## Jira
[MGMT-23659](https://redhat.atlassian.net/browse/MGMT-23659)

## Related
- osac-aap counterpart: updates publish_templates to match by `implementation_strategy`
- Supersedes #395 (dropped `fqn` field per review feedback — `implementation_strategy` is sufficient as upsert key)

## Test plan
- [x] All unit tests pass (35 suites)
- [x] Integration tests pass from worktree (88/88)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced container build version handling with flexible fallback: uses provided VERSION, falls back to Git metadata, then defaults to "dev" if unavailable.

* **Bug Fixes**
  * NetworkClass IDs are now automatically generated by the system; user-supplied IDs are cleared during creation to prevent conflicts.

* **Tests**
  * Updated integration tests to validate auto-generated NetworkClass ID behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->