### PR TITLE
MGMT-23850: Fix gRPC connection leak in create hub command

### DIFF
--- a/internal/cmd/cli/create/hub/create_hub_cmd.go
+++ b/internal/cmd/cli/create/hub/create_hub_cmd.go
@@ -97,6 +97,7 @@ func (c *runnerContext) run(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return fmt.Errorf("failed to create gRPC connection: %w", err)
 	}
+	defer conn.Close()
 
 	// Create the client:
 	client := privatev1.NewHubsClient(conn)


### PR DESCRIPTION
## Summary
- Add missing `defer conn.Close()` after `cfg.Connect()` in `create_hub_cmd.go`
- All other create commands (`create_cluster`, `create_computeinstance`, `create_hostpool`) already close the connection — this was the only one missing

## Test plan
- [x] `go build ./...` passes
- [ ] Verify other `cfg.Connect()` call sites all have `defer conn.Close()` (confirmed via grep)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resource management to ensure gRPC connections are properly cleaned up in all scenarios, enhancing system stability and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->