### PR TITLE
MGMT-23659: Validate UUID format in NetworkClass ID test

### DIFF
--- a/internal/servers/network_classes_server_test.go
+++ b/internal/servers/network_classes_server_test.go
@@ -17,6 +17,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgxpool"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -292,7 +293,8 @@ var _ = Describe("Network classes server", func() {
 			}.Build())
 			Expect(err).ToNot(HaveOccurred())
 			Expect(response.GetObject().GetId()).ToNot(Equal(callerProvidedId))
-			Expect(response.GetObject().GetId()).ToNot(BeEmpty())
+			_, err = uuid.Parse(response.GetObject().GetId())
+			Expect(err).ToNot(HaveOccurred())
 		})
 	})
 })


### PR DESCRIPTION
## Summary
- Assert generated NetworkClass ID is a valid UUID using `uuid.Parse` instead of only checking it differs from the caller-provided value
- Follow-up to #396 — the fix was pushed after the merge

## Jira
- [MGMT-23659](https://redhat.atlassian.net/browse/MGMT-23659)

## Test plan
- [x] `ginkgo run --focus="Generates UUID" internal/servers` passes

Generated with [Claude Code](https://claude.com/claude-code)