### PR TITLE
MGMT-23417: Add CaaS user guide

### DIFF
--- a/docs/CAAS.md
+++ b/docs/CAAS.md
@@ -1,11 +1,11 @@
 # Cluster-as-a-Service (CaaS) User Guide
 
 This guide describes how tenants can create, manage, and delete OpenShift clusters through the
-fulfillment CLI and API.
+OSAC CLI and API.
 
 ## Prerequisites
 
-- `fulfillment-cli` installed and authenticated (`fulfillment-cli login`)
+- `osac` installed and authenticated (`osac login`)
 - A cluster template published by your provider
 
 ## Workflow Overview
@@ -22,13 +22,13 @@ fulfillment CLI and API.
 List all available templates:
 
 ```bash
-fulfillment-cli get cluster-templates
+osac get cluster-templates
 ```
 
 Inspect a specific template to see its parameters and default node sets:
 
 ```bash
-fulfillment-cli get cluster-templates <template-id> -o yaml
+osac get cluster-templates <template-id> -o yaml
 ```
 
 Key fields in a template:
@@ -43,7 +43,7 @@ Key fields in a template:
 Create a cluster using a template, providing any required parameters:
 
 ```bash
-fulfillment-cli create cluster \
+osac create cluster \
   --template hosted_cluster \
   --template-parameter cluster_version=4.16
 ```
@@ -64,7 +64,7 @@ after creation via `edit`.
 List all your clusters:
 
 ```bash
-fulfillment-cli get clusters
+osac get clusters
 ```
 
 The table shows ID, name, template, state, API URL, and console URL.
@@ -72,13 +72,13 @@ The table shows ID, name, template, state, API URL, and console URL.
 Get detailed information about a specific cluster:
 
 ```bash
-fulfillment-cli describe cluster <cluster-id>
+osac describe cluster <cluster-id>
 ```
 
 Or in full YAML format:
 
 ```bash
-fulfillment-cli get clusters <cluster-id> -o yaml
+osac get clusters <cluster-id> -o yaml
 ```
 
 ### Cluster States
@@ -106,7 +106,7 @@ Once the cluster is in `READY` state, retrieve credentials:
 **Kubeconfig** (for `oc` / `kubectl`):
 
 ```bash
-fulfillment-cli get kubeconfig <cluster-id> > kubeconfig.yaml
+osac get kubeconfig <cluster-id> > kubeconfig.yaml
 export KUBECONFIG=kubeconfig.yaml
 oc get nodes
 ```
@@ -114,7 +114,7 @@ oc get nodes
 **Admin password** (for the web console):
 
 ```bash
-fulfillment-cli get password <cluster-id>
+osac get password <cluster-id>
 ```
 
 The console URL is shown in `get clusters` output or in the cluster's `status.console_url` field.
@@ -124,7 +124,7 @@ The console URL is shown in `get clusters` output or in the cluster's `status.co
 To change node set sizes, use the generic edit command:
 
 ```bash
-fulfillment-cli edit clusters <cluster-id>
+osac edit clusters <cluster-id>
 ```
 
 This opens the cluster resource in your `$EDITOR`. Modify the `size` field under
@@ -142,7 +142,7 @@ After saving, the cluster transitions to `PROGRESSING` until the new node config
 ## Delete a Cluster
 
 ```bash
-fulfillment-cli delete clusters <cluster-id>
+osac delete clusters <cluster-id>
 ```
 
 Deletion triggers cleanup of all associated resources (HostedCluster, HostPool, bare-metal host
@@ -151,7 +151,7 @@ allocations). The cluster remains visible with a `deletion_timestamp` set until 
 Verify deletion:
 
 ```bash
-fulfillment-cli get clusters
+osac get clusters
 ```
 
 ## API Access

--- a/docs/CAAS.md
+++ b/docs/CAAS.md
@@ -6,58 +6,52 @@ OSAC CLI and API.
 ## Prerequisites
 
 - `osac` installed and authenticated (`osac login`)
-- A cluster template published by your provider
+- A cluster catalog item published by your provider
 
 ## Workflow Overview
 
-1. Browse available cluster templates
-2. Create a cluster from a template
+1. Browse available cluster catalog items
+2. Create a cluster from a catalog item
 3. Wait for the cluster to become ready
 4. Access the cluster (kubeconfig, console, admin password)
 5. Scale nodes as needed
 6. Delete the cluster when done
 
-## Browse Cluster Templates
+## Browse Cluster Catalog Items
 
-List all available templates:
-
-```bash
-osac get cluster-templates
-```
-
-Inspect a specific template to see its parameters and default node sets:
+List all available catalog items:
 
 ```bash
-osac get cluster-templates <template-id> -o yaml
+osac get cluster-catalog-items
 ```
 
-Key fields in a template:
+Inspect a specific catalog item to see its fields and defaults:
 
-- **`parameters`**: Input parameters for cluster creation. Each parameter has a `name`, `type`,
-  whether it is `required`, and optionally a `default` value.
-- **`node_sets`**: Default node set configuration. Each node set specifies a `host_class` (hardware
-  type) and initial `size` (number of nodes).
+```bash
+osac get cluster-catalog-items <catalog-item-id> -o yaml
+```
+
+Key fields in a catalog item:
+
+- **`title`**: Human-friendly short description of the offering.
+- **`description`**: Detailed Markdown description of what the catalog item provides.
+- **`field_definitions`**: Definitions of the fields that users can set when creating a cluster,
+  including which fields are required, their types, and default values.
 
 ## Create a Cluster
 
-Create a cluster using a template, providing any required parameters:
+Create a cluster using a catalog item:
 
 ```bash
 osac create cluster \
-  --template hosted_cluster \
-  --template-parameter cluster_version=4.16
+  --catalog-item hosted_cluster_offering
 ```
 
 Optional flags:
 
 - `-n, --name <name>` - Human-readable name for the cluster
-- `-p, --template-parameter <name=value>` - Template parameter (repeatable)
-- `-f, --template-parameter-file <name=filename>` - Template parameter from file (repeatable)
 
 The command outputs the cluster ID upon successful creation.
-
-If you don't specify `node_sets`, the template defaults are used. Node sets can be customized
-after creation via `edit`.
 
 ## Check Cluster Status
 
@@ -160,6 +154,8 @@ All CLI operations correspond to REST API endpoints:
 
 | Operation | Method | Endpoint |
 |-----------|--------|----------|
+| List catalog items | `GET` | `/api/fulfillment/v1/cluster_catalog_items` |
+| Get catalog item | `GET` | `/api/fulfillment/v1/cluster_catalog_items/{id}` |
 | List clusters | `GET` | `/api/fulfillment/v1/clusters` |
 | Get cluster | `GET` | `/api/fulfillment/v1/clusters/{id}` |
 | Create cluster | `POST` | `/api/fulfillment/v1/clusters` |
@@ -167,7 +163,5 @@ All CLI operations correspond to REST API endpoints:
 | Delete cluster | `DELETE` | `/api/fulfillment/v1/clusters/{id}` |
 | Get kubeconfig | `GET` | `/api/fulfillment/v1/clusters/{id}/kubeconfig` |
 | Get password | `GET` | `/api/fulfillment/v1/clusters/{id}/password` |
-| List templates | `GET` | `/api/fulfillment/v1/cluster_templates` |
-| Get template | `GET` | `/api/fulfillment/v1/cluster_templates/{id}` |
 
 See [Filter expressions](FILTER.md) for filtering and ordering list results.

--- a/docs/CAAS.md
+++ b/docs/CAAS.md
@@ -1,0 +1,173 @@
+# Cluster-as-a-Service (CaaS) User Guide
+
+This guide describes how tenants can create, manage, and delete OpenShift clusters through the
+fulfillment CLI and API.
+
+## Prerequisites
+
+- `fulfillment-cli` installed and authenticated (`fulfillment-cli login`)
+- A cluster template published by your provider
+
+## Workflow Overview
+
+1. Browse available cluster templates
+2. Create a cluster from a template
+3. Wait for the cluster to become ready
+4. Access the cluster (kubeconfig, console, admin password)
+5. Scale nodes as needed
+6. Delete the cluster when done
+
+## Browse Cluster Templates
+
+List all available templates:
+
+```bash
+fulfillment-cli get cluster-templates
+```
+
+Inspect a specific template to see its parameters and default node sets:
+
+```bash
+fulfillment-cli get cluster-templates <template-id> -o yaml
+```
+
+Key fields in a template:
+
+- **`parameters`**: Input parameters for cluster creation. Each parameter has a `name`, `type`,
+  whether it is `required`, and optionally a `default` value.
+- **`node_sets`**: Default node set configuration. Each node set specifies a `host_class` (hardware
+  type) and initial `size` (number of nodes).
+
+## Create a Cluster
+
+Create a cluster using a template, providing any required parameters:
+
+```bash
+fulfillment-cli create cluster \
+  --template hosted_cluster \
+  --template-parameter cluster_version=4.16
+```
+
+Optional flags:
+
+- `-n, --name <name>` - Human-readable name for the cluster
+- `-p, --template-parameter <name=value>` - Template parameter (repeatable)
+- `-f, --template-parameter-file <name=filename>` - Template parameter from file (repeatable)
+
+The command outputs the cluster ID upon successful creation.
+
+If you don't specify `node_sets`, the template defaults are used. Node sets can be customized
+after creation via `edit`.
+
+## Check Cluster Status
+
+List all your clusters:
+
+```bash
+fulfillment-cli get clusters
+```
+
+The table shows ID, name, template, state, API URL, and console URL.
+
+Get detailed information about a specific cluster:
+
+```bash
+fulfillment-cli describe cluster <cluster-id>
+```
+
+Or in full YAML format:
+
+```bash
+fulfillment-cli get clusters <cluster-id> -o yaml
+```
+
+### Cluster States
+
+| State | Meaning |
+|-------|---------|
+| `CLUSTER_STATE_PROGRESSING` | Cluster is being created or updated |
+| `CLUSTER_STATE_READY` | Cluster is operational and accessible |
+| `CLUSTER_STATE_FAILED` | Cluster creation or update failed |
+
+Deletion is indicated by a `deletion_timestamp` in the cluster metadata rather than a separate
+state.
+
+### Conditions
+
+A cluster in `READY` state may have additional conditions:
+
+- **`DEGRADED`** = `TRUE`: Cluster is operational but not at full capacity (e.g., some requested
+  worker nodes could not be allocated). The control plane is functional.
+
+## Access the Cluster
+
+Once the cluster is in `READY` state, retrieve credentials:
+
+**Kubeconfig** (for `oc` / `kubectl`):
+
+```bash
+fulfillment-cli get kubeconfig <cluster-id> > kubeconfig.yaml
+export KUBECONFIG=kubeconfig.yaml
+oc get nodes
+```
+
+**Admin password** (for the web console):
+
+```bash
+fulfillment-cli get password <cluster-id>
+```
+
+The console URL is shown in `get clusters` output or in the cluster's `status.console_url` field.
+
+## Scale Nodes
+
+To change node set sizes, use the generic edit command:
+
+```bash
+fulfillment-cli edit clusters <cluster-id>
+```
+
+This opens the cluster resource in your `$EDITOR`. Modify the `size` field under
+`spec.node_sets.<node-set-name>` and save.
+
+**Constraints:**
+
+- The `host_class` of an existing node set cannot be changed (immutable after creation)
+- New node sets can be added
+- At least one node set must remain
+- Node sets can be scaled to zero (the control plane continues to run on the hub)
+
+After saving, the cluster transitions to `PROGRESSING` until the new node configuration is applied.
+
+## Delete a Cluster
+
+```bash
+fulfillment-cli delete clusters <cluster-id>
+```
+
+Deletion triggers cleanup of all associated resources (HostedCluster, HostPool, bare-metal host
+allocations). The cluster remains visible with a `deletion_timestamp` set until cleanup completes.
+
+Verify deletion:
+
+```bash
+fulfillment-cli get clusters
+```
+
+## API Access
+
+All CLI operations correspond to REST API endpoints:
+
+| Operation | Method | Endpoint |
+|-----------|--------|----------|
+| List clusters | `GET` | `/api/fulfillment/v1/clusters` |
+| Get cluster | `GET` | `/api/fulfillment/v1/clusters/{id}` |
+| Create cluster | `POST` | `/api/fulfillment/v1/clusters` |
+| Update cluster | `PATCH` | `/api/fulfillment/v1/clusters/{id}` |
+| Delete cluster | `DELETE` | `/api/fulfillment/v1/clusters/{id}` |
+| Get kubeconfig | `GET` | `/api/fulfillment/v1/clusters/{id}/kubeconfig` |
+| Get password | `GET` | `/api/fulfillment/v1/clusters/{id}/password` |
+| List templates | `GET` | `/api/fulfillment/v1/cluster_templates` |
+| Get template | `GET` | `/api/fulfillment/v1/cluster_templates/{id}` |
+
+See [Filter expressions](FILTER.md) for filtering and ordering list results.


### PR DESCRIPTION
## Summary
- Add `docs/CAAS.md` documenting the tenant workflow for Cluster-as-a-Service
- Covers: browsing templates, creating clusters, checking status, accessing credentials (kubeconfig, password, console), scaling nodes, deleting clusters
- Includes both CLI examples and REST API endpoint reference

## Jira
[MGMT-23417](https://redhat.atlassian.net/browse/MGMT-23417)

## Test plan
- [ ] Review for accuracy against current CLI/API behavior

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a comprehensive new Cluster-as-a-Service user guide for OpenShift cluster management, covering prerequisites, cluster creation from catalog items, status monitoring with condition definitions, access methods (kubeconfig, console access, admin credentials), node set scaling operations, cluster deletion with verification procedures, and detailed CLI-to-REST API endpoint mappings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->