### PR TITLE
feat: add tenant annotation to ClusterOrder CRs

### DIFF
--- a/internal/controllers/cluster/cluster_reconciler_function.go
+++ b/internal/controllers/cluster/cluster_reconciler_function.go
@@ -30,6 +30,7 @@ import (
 	privatev1 "github.com/osac-project/fulfillment-service/internal/api/osac/private/v1"
 	"github.com/osac-project/fulfillment-service/internal/controllers"
 	"github.com/osac-project/fulfillment-service/internal/controllers/finalizers"
+	"github.com/osac-project/fulfillment-service/internal/kubernetes/annotations"
 	"github.com/osac-project/fulfillment-service/internal/kubernetes/gvks"
 	"github.com/osac-project/fulfillment-service/internal/kubernetes/labels"
 	"github.com/osac-project/fulfillment-service/internal/masks"
@@ -153,6 +154,11 @@ func (t *task) update(ctx context.Context) error {
 	// Set the default values:
 	t.setDefaults()
 
+	// Validate that exactly one tenant is assigned:
+	if err := t.validateTenant(); err != nil {
+		return err
+	}
+
 	// Do nothing if the order isn't progressing:
 	if t.cluster.GetStatus().GetState() != privatev1.ClusterState_CLUSTER_STATE_PROGRESSING {
 		return nil
@@ -207,6 +213,9 @@ func (t *task) update(ctx context.Context) error {
 		object.SetGenerateName(objectPrefix)
 		object.SetLabels(map[string]string{
 			labels.ClusterOrderUuid: t.cluster.GetId(),
+		})
+		object.SetAnnotations(map[string]string{
+			annotations.Tenant: t.cluster.GetMetadata().GetTenants()[0],
 		})
 		err = unstructured.SetNestedField(object.Object, spec, "spec")
 		if err != nil {
@@ -273,6 +282,13 @@ func (t *task) setConditionDefaults(value privatev1.ClusterConditionType) {
 		}.Build())
 		t.cluster.GetStatus().SetConditions(conditions)
 	}
+}
+
+func (t *task) validateTenant() error {
+	if !t.cluster.HasMetadata() || len(t.cluster.GetMetadata().GetTenants()) != 1 {
+		return errors.New("Cluster must have exactly one tenant assigned")
+	}
+	return nil
 }
 
 func (t *task) prepareNodeRequests() any {

--- a/internal/controllers/cluster/cluster_reconciler_function_test.go
+++ b/internal/controllers/cluster/cluster_reconciler_function_test.go
@@ -1,0 +1,173 @@
+/*
+Copyright (c) 2025 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package cluster
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"go.uber.org/mock/gomock"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	privatev1 "github.com/osac-project/fulfillment-service/internal/api/osac/private/v1"
+	"github.com/osac-project/fulfillment-service/internal/controllers"
+	"github.com/osac-project/fulfillment-service/internal/controllers/finalizers"
+	"github.com/osac-project/fulfillment-service/internal/kubernetes/annotations"
+	"github.com/osac-project/fulfillment-service/internal/kubernetes/gvks"
+	"github.com/osac-project/fulfillment-service/internal/kubernetes/labels"
+)
+
+var _ = Describe("validateTenant", func() {
+	It("should succeed when exactly one tenant is assigned", func() {
+		t := &task{
+			cluster: privatev1.Cluster_builder{
+				Id: "test-cluster",
+				Metadata: privatev1.Metadata_builder{
+					Tenants: []string{"tenant-1"},
+				}.Build(),
+			}.Build(),
+		}
+
+		err := t.validateTenant()
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	It("should fail when no tenants are assigned", func() {
+		t := &task{
+			cluster: privatev1.Cluster_builder{
+				Id: "test-cluster",
+				Metadata: privatev1.Metadata_builder{
+					Tenants: []string{},
+				}.Build(),
+			}.Build(),
+		}
+
+		err := t.validateTenant()
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("exactly one tenant"))
+	})
+
+	It("should fail when multiple tenants are assigned", func() {
+		t := &task{
+			cluster: privatev1.Cluster_builder{
+				Id: "test-cluster",
+				Metadata: privatev1.Metadata_builder{
+					Tenants: []string{"tenant-1", "tenant-2"},
+				}.Build(),
+			}.Build(),
+		}
+
+		err := t.validateTenant()
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("exactly one tenant"))
+	})
+
+	It("should fail when metadata is missing", func() {
+		t := &task{
+			cluster: privatev1.Cluster_builder{
+				Id: "test-cluster",
+			}.Build(),
+		}
+
+		err := t.validateTenant()
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("exactly one tenant"))
+	})
+})
+
+var _ = Describe("update tenant annotation", func() {
+	const (
+		clusterID    = "test-cluster-id"
+		tenantName   = "my-tenant"
+		hubID        = "test-hub"
+		hubNamespace = "test-ns"
+	)
+
+	var (
+		ctx  context.Context
+		ctrl *gomock.Controller
+	)
+
+	BeforeEach(func() {
+		ctx = context.Background()
+		ctrl = gomock.NewController(GinkgoT())
+		DeferCleanup(ctrl.Finish)
+	})
+
+	It("should set tenant annotation when creating a new ClusterOrder CR", func() {
+		scheme := runtime.NewScheme()
+		scheme.AddKnownTypeWithName(
+			schema.GroupVersionKind{
+				Group:   gvks.ClusterOrder.Group,
+				Version: gvks.ClusterOrder.Version,
+				Kind:    gvks.ClusterOrder.Kind + "List",
+			},
+			&unstructured.UnstructuredList{},
+		)
+
+		fakeClient := fake.NewClientBuilder().
+			WithScheme(scheme).
+			Build()
+
+		hubCache := controllers.NewMockHubCache(ctrl)
+		hubCache.EXPECT().
+			Get(gomock.Any(), hubID).
+			Return(&controllers.HubEntry{
+				Namespace: hubNamespace,
+				Client:    fakeClient,
+			}, nil)
+
+		cluster := privatev1.Cluster_builder{
+			Id: clusterID,
+			Metadata: privatev1.Metadata_builder{
+				Finalizers: []string{finalizers.Controller},
+				Tenants:    []string{tenantName},
+			}.Build(),
+			Spec: privatev1.ClusterSpec_builder{
+				Template: "test-template",
+			}.Build(),
+			Status: privatev1.ClusterStatus_builder{
+				State: privatev1.ClusterState_CLUSTER_STATE_PROGRESSING,
+				Hub:   hubID,
+			}.Build(),
+		}.Build()
+
+		t := &task{
+			r: &function{
+				logger:         logger,
+				hubCache:       hubCache,
+				maskCalculator: nil,
+			},
+			cluster: cluster,
+		}
+
+		err := t.update(ctx)
+		Expect(err).ToNot(HaveOccurred())
+
+		// Verify the ClusterOrder CR was created with the tenant annotation
+		list := &unstructured.UnstructuredList{}
+		list.SetGroupVersionKind(gvks.ClusterOrderList)
+		err = fakeClient.List(ctx, list)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(list.Items).To(HaveLen(1))
+
+		createdCR := list.Items[0]
+		Expect(createdCR.GetAnnotations()).To(HaveKeyWithValue(annotations.Tenant, tenantName))
+		Expect(createdCR.GetLabels()).To(HaveKeyWithValue(labels.ClusterOrderUuid, clusterID))
+	})
+})

--- a/internal/controllers/cluster/cluster_suite_test.go
+++ b/internal/controllers/cluster/cluster_suite_test.go
@@ -1,0 +1,44 @@
+/*
+Copyright (c) 2025 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package cluster
+
+import (
+	"log/slog"
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2/dsl/core"
+	. "github.com/onsi/gomega"
+
+	"github.com/osac-project/fulfillment-service/internal/logging"
+)
+
+func TestCluster(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Cluster controller")
+}
+
+// Logger used for tests:
+var logger *slog.Logger
+
+var _ = BeforeSuite(func() {
+	var err error
+
+	// Create a logger that writes to the Ginkgo writer, so that the log messages will be attached to the output of
+	// the right test:
+	logger, err = logging.NewLogger().
+		SetLevel(slog.LevelDebug.String()).
+		SetWriter(GinkgoWriter).
+		Build()
+	Expect(err).ToNot(HaveOccurred())
+})


### PR DESCRIPTION
Propagate the osac.openshift.io/tenant annotation onto ClusterOrder CRs created on hub clusters, matching the existing pattern used by the ComputeInstance controller. Adds tenant validation to ensure exactly one tenant is assigned before reconciliation proceeds.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Implemented tenant validation to ensure each cluster is configured with exactly one tenant.
  * Cluster orders now include tenant metadata annotation.

* **Tests**
  * Added test coverage for tenant validation and cluster order creation workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->