### PR TITLE
NO-ISSUE: Rename `NewUniversal` to `NewUniversalSet`

### DIFF
--- a/internal/auth/tenancy_logic.go
+++ b/internal/auth/tenancy_logic.go
@@ -44,4 +44,4 @@ var SystemTenants = collections.NewSet("system")
 var SharedTenants = collections.NewSet("shared")
 
 // AllTenants is the set of all tenants that are possible.
-var AllTenants = collections.NewUniversal[string]()
+var AllTenants = collections.NewUniversalSet[string]()

--- a/internal/collections/sets.go
+++ b/internal/collections/sets.go
@@ -56,7 +56,7 @@ func NewSet[T comparable](items ...T) Set[T] {
 }
 
 // NewUniversalSet creates a set containing all possible elements.
-func NewUniversal[T comparable]() Set[T] {
+func NewUniversalSet[T comparable]() Set[T] {
 	return Set[T]{
 		infinite: true,
 		items:    nil,

--- a/internal/collections/sets_test.go
+++ b/internal/collections/sets_test.go
@@ -48,7 +48,7 @@ var _ = Describe("Sets", func() {
 		})
 
 		It("Can create and query a universal set", func() {
-			s := NewUniversal[int]()
+			s := NewUniversalSet[int]()
 			Expect(s.Contains(1)).To(BeTrue())
 			Expect(s.Contains(100)).To(BeTrue())
 			Expect(s.Empty()).To(BeFalse())
@@ -84,7 +84,7 @@ var _ = Describe("Sets", func() {
 		})
 
 		It("Panics when calling Inclusions on universal set", func() {
-			s := NewUniversal[int]()
+			s := NewUniversalSet[int]()
 			Expect(func() {
 				_ = s.Inclusions()
 			}).To(PanicWith("tried to get inclussions from an infinite set"))
@@ -98,7 +98,7 @@ var _ = Describe("Sets", func() {
 		})
 
 		It("Returns empty slice for universal set", func() {
-			s := NewUniversal[int]()
+			s := NewUniversalSet[int]()
 			exclusions := s.Exclusions()
 			Expect(exclusions).To(BeEmpty())
 		})
@@ -129,7 +129,7 @@ var _ = Describe("Sets", func() {
 
 			It("Union of positive and universal", func() {
 				a := NewSet(1, 2)
-				b := NewUniversal[int]()
+				b := NewUniversalSet[int]()
 				u := a.Union(b)
 				Expect(u.Universal()).To(BeTrue())
 			})
@@ -172,7 +172,7 @@ var _ = Describe("Sets", func() {
 
 			It("Intersection of positive and universal", func() {
 				a := NewSet(1, 2)
-				b := NewUniversal[int]()
+				b := NewUniversalSet[int]()
 				i := a.Intersection(b)
 				Expect(i.Equal(a)).To(BeTrue())
 			})
@@ -230,7 +230,7 @@ var _ = Describe("Sets", func() {
 			})
 
 			It("Negate Universal is Empty", func() {
-				negated := NewUniversal[int]().Negate()
+				negated := NewUniversalSet[int]().Negate()
 				Expect(negated.Empty()).To(BeTrue())
 				Expect(negated.Finite()).To(BeTrue())
 			})
@@ -250,9 +250,9 @@ var _ = Describe("Sets", func() {
 			})
 
 			It("Subset with Universal", func() {
-				Expect(NewSet(1, 2).Subset(NewUniversal[int]())).To(BeTrue())
-				Expect(NewUniversal[int]().Subset(NewSet(1, 2))).To(BeFalse())
-				Expect(NewUniversal[int]().Subset(NewUniversal[int]())).To(BeTrue())
+				Expect(NewSet(1, 2).Subset(NewUniversalSet[int]())).To(BeTrue())
+				Expect(NewUniversalSet[int]().Subset(NewSet(1, 2))).To(BeFalse())
+				Expect(NewUniversalSet[int]().Subset(NewUniversalSet[int]())).To(BeTrue())
 			})
 
 			It("Negative subsets", func() {

--- a/internal/database/dao/generic_dao_events_test.go
+++ b/internal/database/dao/generic_dao_events_test.go
@@ -73,7 +73,7 @@ var _ = Describe("Generic DAO events", func() {
 		// Create a tenancy logic without restrictions:
 		tenancy = auth.NewMockTenancyLogic(ctrl)
 		tenancy.EXPECT().DetermineVisibleTenants(gomock.Any()).
-			Return(collections.NewUniversal[string](), nil).
+			Return(collections.NewUniversalSet[string](), nil).
 			AnyTimes()
 	})
 

--- a/internal/database/dao/generic_dao_lock_test.go
+++ b/internal/database/dao/generic_dao_lock_test.go
@@ -75,7 +75,7 @@ var _ = Describe("Lock", func() {
 		// Create a tenancy logic without restrictions:
 		tenancy := auth.NewMockTenancyLogic(ctrl)
 		tenancy.EXPECT().DetermineVisibleTenants(gomock.Any()).
-			Return(collections.NewUniversal[string](), nil).
+			Return(collections.NewUniversalSet[string](), nil).
 			AnyTimes()
 		DeferCleanup(ctrl.Finish)
 

--- a/internal/database/dao/generic_dao_metrics_test.go
+++ b/internal/database/dao/generic_dao_metrics_test.go
@@ -81,7 +81,7 @@ var _ = Describe("Metrics", func() {
 		// Create a tenancy logic without restrictions:
 		tenancy = auth.NewMockTenancyLogic(ctrl)
 		tenancy.EXPECT().DetermineVisibleTenants(gomock.Any()).
-			Return(collections.NewUniversal[string](), nil).
+			Return(collections.NewUniversalSet[string](), nil).
 			AnyTimes()
 
 		// Create the DAO with metrics enabled:

--- a/internal/database/dao/generic_dao_tenancy_test.go
+++ b/internal/database/dao/generic_dao_tenancy_test.go
@@ -139,7 +139,7 @@ var _ = Describe("Tenancy logic", func() {
 		// Create a tenancy logic that makes all tenants visible to the user:
 		tenancy := auth.NewMockTenancyLogic(ctrl)
 		tenancy.EXPECT().DetermineVisibleTenants(gomock.Any()).
-			Return(collections.NewUniversal[string](), nil).
+			Return(collections.NewUniversalSet[string](), nil).
 			AnyTimes()
 
 		// Create the DAO:

--- a/internal/database/dao/generic_dao_test.go
+++ b/internal/database/dao/generic_dao_test.go
@@ -91,7 +91,7 @@ var _ = Describe("Generic DAO", func() {
 		// Create a tenancy logic without restrictions:
 		tenancy = auth.NewMockTenancyLogic(ctrl)
 		tenancy.EXPECT().DetermineVisibleTenants(gomock.Any()).
-			Return(collections.NewUniversal[string](), nil).
+			Return(collections.NewUniversalSet[string](), nil).
 			AnyTimes()
 	})
 

--- a/internal/database/dao/generic_dao_version_test.go
+++ b/internal/database/dao/generic_dao_version_test.go
@@ -77,7 +77,7 @@ var _ = Describe("Version", func() {
 		// Create a tenancy logic without restrictions:
 		tenancy = auth.NewMockTenancyLogic(ctrl)
 		tenancy.EXPECT().DetermineVisibleTenants(gomock.Any()).
-			Return(collections.NewUniversal[string](), nil).
+			Return(collections.NewUniversalSet[string](), nil).
 			AnyTimes()
 
 		// Create the DAO:

--- a/internal/servers/servers_suite_test.go
+++ b/internal/servers/servers_suite_test.go
@@ -62,7 +62,7 @@ var _ = BeforeSuite(func() {
 	Expect(err).ToNot(HaveOccurred())
 
 	// Create the set of visible tenants:
-	visibility = collections.NewUniversal[string]()
+	visibility = collections.NewUniversalSet[string]()
 
 	// Create the database server:
 	server = MakeDatabaseServer()


### PR DESCRIPTION
## Summary

- Rename the `NewUniversal` constructor to `NewUniversalSet` in the
  collections package for consistency with the existing `NewSet`
  constructor.
- Update all call sites across the codebase: auth package, DAO tests,
  server tests, and collection tests.

## Test plan

- [x] Verify `ginkgo run -r internal` passes with no failures.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal API naming conventions to improve code clarity and consistency across the codebase.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->