### PR TITLE
MGMT-23871: Modernizes describe cluster and computeinstance commands

### DIFF
--- a/internal/cmd/cli/describe/cluster/describe_cluster.go
+++ b/internal/cmd/cli/describe/cluster/describe_cluster.go
@@ -16,7 +16,6 @@ package cluster
 import (
 	"fmt"
 	"io"
-	"log/slog"
 	"strings"
 	"text/tabwriter"
 
@@ -25,7 +24,6 @@ import (
 
 	publicv1 "github.com/osac-project/fulfillment-service/internal/api/osac/public/v1"
 	"github.com/osac-project/fulfillment-service/internal/config"
-	"github.com/osac-project/fulfillment-service/internal/logging"
 	"github.com/osac-project/fulfillment-service/internal/terminal"
 )
 
@@ -43,7 +41,6 @@ func Cmd() *cobra.Command {
 }
 
 type runnerContext struct {
-	logger  *slog.Logger
 	console *terminal.Console
 }
 
@@ -52,7 +49,6 @@ func (c *runnerContext) run(cmd *cobra.Command, args []string) error {
 
 	ctx := cmd.Context()
 
-	c.logger = logging.LoggerFromContext(ctx)
 	c.console = terminal.ConsoleFromContext(ctx)
 
 	cfg, err := config.Load(ctx)
@@ -79,22 +75,22 @@ func (c *runnerContext) run(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return fmt.Errorf("failed to describe cluster: %w", err)
 	}
-	if len(listResponse.GetItems()) == 0 {
+	if err := guardResult(len(listResponse.GetItems()), ref); err != nil {
+		return err
+	}
+
+	renderCluster(c.console, listResponse.GetItems()[0])
+
+	return nil
+}
+
+func guardResult(items int, ref string) error {
+	if items == 0 {
 		return fmt.Errorf("cluster not found: %s", ref)
 	}
-	if len(listResponse.GetItems()) > 1 {
+	if items > 1 {
 		return fmt.Errorf("multiple clusters match '%s', use the ID instead", ref)
 	}
-
-	response, err := client.Get(ctx, publicv1.ClustersGetRequest_builder{
-		Id: listResponse.GetItems()[0].GetId(),
-	}.Build())
-	if err != nil {
-		return fmt.Errorf("failed to describe cluster: %w", err)
-	}
-
-	RenderCluster(c.console, response.Object)
-
 	return nil
 }
 
@@ -102,8 +98,7 @@ func buildFilter(ref string) string {
 	return fmt.Sprintf(`this.id == %[1]q || this.metadata.name == %[1]q`, ref)
 }
 
-// RenderCluster writes a formatted description of cluster to w.
-func RenderCluster(w io.Writer, cluster *publicv1.Cluster) {
+func renderCluster(w io.Writer, cluster *publicv1.Cluster) {
 	writer := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
 	template := "-"
 	if cluster.Spec != nil {

--- a/internal/cmd/cli/describe/cluster/describe_cluster.go
+++ b/internal/cmd/cli/describe/cluster/describe_cluster.go
@@ -15,12 +15,13 @@ package cluster
 
 import (
 	"fmt"
+	"io"
 	"log/slog"
-	"os"
 	"strings"
 	"text/tabwriter"
 
 	"github.com/spf13/cobra"
+	"google.golang.org/protobuf/proto"
 
 	publicv1 "github.com/osac-project/fulfillment-service/internal/api/osac/public/v1"
 	"github.com/osac-project/fulfillment-service/internal/config"
@@ -28,12 +29,14 @@ import (
 	"github.com/osac-project/fulfillment-service/internal/terminal"
 )
 
+// Cmd creates the command to describe a cluster.
 func Cmd() *cobra.Command {
 	runner := &runnerContext{}
 	result := &cobra.Command{
-		Use:     "cluster [flags] ID",
+		Use:     "cluster [flags] ID_OR_NAME",
 		Aliases: []string{"clusters"},
 		Short:   "Describe a cluster",
+		Args:    cobra.ExactArgs(1),
 		RunE:    runner.run,
 	}
 	return result
@@ -45,24 +48,13 @@ type runnerContext struct {
 }
 
 func (c *runnerContext) run(cmd *cobra.Command, args []string) error {
-	// Check that there is exactly one cluster ID specified
-	if len(args) != 1 {
-		fmt.Fprintf(
-			os.Stderr,
-			"Expected exactly one cluster ID\n",
-		)
-		os.Exit(1)
-	}
-	id := args[0]
+	ref := args[0]
 
-	// Get the context:
 	ctx := cmd.Context()
 
-	// Get the logger and console:
 	c.logger = logging.LoggerFromContext(ctx)
 	c.console = terminal.ConsoleFromContext(ctx)
 
-	// Get the configuration:
 	cfg, err := config.Load(ctx)
 	if err != nil {
 		return err
@@ -71,26 +63,48 @@ func (c *runnerContext) run(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("there is no configuration, run the 'login' command")
 	}
 
-	// Create the gRPC connection from the configuration:
 	conn, err := cfg.Connect(ctx, cmd.Flags())
 	if err != nil {
 		return fmt.Errorf("failed to create gRPC connection: %w", err)
 	}
+	defer conn.Close()
 
-	// Create the client for the cluster orders service:
 	client := publicv1.NewClustersClient(conn)
 
-	// Get the order:
-	response, err := client.Get(ctx, publicv1.ClustersGetRequest_builder{
-		Id: id,
+	filter := buildFilter(ref)
+	listResponse, err := client.List(ctx, publicv1.ClustersListRequest_builder{
+		Filter: &filter,
+		Limit:  proto.Int32(2),
 	}.Build())
 	if err != nil {
-		return fmt.Errorf("failed to describe order: %w", err)
+		return fmt.Errorf("failed to describe cluster: %w", err)
+	}
+	if len(listResponse.GetItems()) == 0 {
+		return fmt.Errorf("cluster not found: %s", ref)
+	}
+	if len(listResponse.GetItems()) > 1 {
+		return fmt.Errorf("multiple clusters match '%s', use the ID instead", ref)
 	}
 
-	// Display the clusters:
-	writer := tabwriter.NewWriter(c.console, 0, 0, 2, ' ', 0)
-	cluster := response.Object
+	response, err := client.Get(ctx, publicv1.ClustersGetRequest_builder{
+		Id: listResponse.GetItems()[0].GetId(),
+	}.Build())
+	if err != nil {
+		return fmt.Errorf("failed to describe cluster: %w", err)
+	}
+
+	RenderCluster(c.console, response.Object)
+
+	return nil
+}
+
+func buildFilter(ref string) string {
+	return fmt.Sprintf(`this.id == %[1]q || this.metadata.name == %[1]q`, ref)
+}
+
+// RenderCluster writes a formatted description of cluster to w.
+func RenderCluster(w io.Writer, cluster *publicv1.Cluster) {
+	writer := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
 	template := "-"
 	if cluster.Spec != nil {
 		template = cluster.Spec.Template
@@ -98,12 +112,10 @@ func (c *runnerContext) run(cmd *cobra.Command, args []string) error {
 	state := "-"
 	if cluster.Status != nil {
 		state = cluster.Status.State.String()
-		state = strings.Replace(state, "CLUSTER_ORDER_STATE_", "", -1)
+		state = strings.TrimPrefix(state, "CLUSTER_STATE_")
 	}
 	fmt.Fprintf(writer, "ID:\t%s\n", cluster.Id)
 	fmt.Fprintf(writer, "Template:\t%s\n", template)
 	fmt.Fprintf(writer, "State:\t%s\n", state)
 	writer.Flush()
-
-	return nil
 }

--- a/internal/cmd/cli/describe/cluster/describe_cluster_suite_test.go
+++ b/internal/cmd/cli/describe/cluster/describe_cluster_suite_test.go
@@ -1,0 +1,26 @@
+/*
+Copyright (c) 2025 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package cluster
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestDescribeCluster(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Describe Cluster Suite")
+}

--- a/internal/cmd/cli/describe/cluster/describe_cluster_test.go
+++ b/internal/cmd/cli/describe/cluster/describe_cluster_test.go
@@ -15,7 +15,6 @@ package cluster
 
 import (
 	"bytes"
-	"fmt"
 
 	. "github.com/onsi/ginkgo/v2/dsl/core"
 	. "github.com/onsi/gomega"
@@ -25,7 +24,7 @@ import (
 
 func formatCluster(cluster *publicv1.Cluster) string {
 	var buf bytes.Buffer
-	RenderCluster(&buf, cluster)
+	renderCluster(&buf, cluster)
 	return buf.String()
 }
 
@@ -40,11 +39,15 @@ var _ = Describe("CEL filter construction", func() {
 	})
 	It("should escape backslashes", func() {
 		filter := buildFilter(`my\cluster`)
-		Expect(filter).To(ContainSubstring(`\\`))
+		Expect(filter).To(ContainSubstring(`"my\\cluster"`))
 	})
 	It("should handle UUID-style IDs", func() {
 		filter := buildFilter("550e8400-e29b-41d4-a716-446655440000")
 		Expect(filter).To(Equal(`this.id == "550e8400-e29b-41d4-a716-446655440000" || this.metadata.name == "550e8400-e29b-41d4-a716-446655440000"`))
+	})
+	It("should pass through single quotes without escaping", func() {
+		filter := buildFilter("my'cluster")
+		Expect(filter).To(Equal(`this.id == "my'cluster" || this.metadata.name == "my'cluster"`))
 	})
 })
 
@@ -92,12 +95,33 @@ var _ = Describe("Rendering tests", func() {
 		Expect(output).To(ContainSubstring("READY"))
 		Expect(output).NotTo(ContainSubstring("CLUSTER_STATE_"))
 	})
+
+	It("should strip CLUSTER_STATE_ prefix from PROGRESSING state", func() {
+		cluster := publicv1.Cluster_builder{
+			Id: "cluster-005",
+			Status: &publicv1.ClusterStatus{
+				State: publicv1.ClusterState_CLUSTER_STATE_PROGRESSING,
+			},
+		}.Build()
+		output := formatCluster(cluster)
+		Expect(output).To(ContainSubstring("PROGRESSING"))
+		Expect(output).NotTo(ContainSubstring("CLUSTER_STATE_"))
+	})
 })
 
 var _ = Describe("Multi-result guard", func() {
-	It("should produce the expected error message", func() {
-		ref := "ambiguous-name"
-		err := fmt.Errorf("multiple clusters match '%s', use the ID instead", ref)
+	It("should return nil when exactly one item found", func() {
+		Expect(guardResult(1, "any-name")).To(BeNil())
+	})
+	It("should return not-found error when no items found", func() {
+		err := guardResult(0, "missing-cluster")
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("cluster not found"))
+		Expect(err.Error()).To(ContainSubstring("missing-cluster"))
+	})
+	It("should return ambiguous error when multiple items found", func() {
+		err := guardResult(2, "ambiguous-name")
+		Expect(err).To(HaveOccurred())
 		Expect(err.Error()).To(ContainSubstring("multiple clusters match"))
 		Expect(err.Error()).To(ContainSubstring("ambiguous-name"))
 		Expect(err.Error()).To(ContainSubstring("use the ID instead"))

--- a/internal/cmd/cli/describe/cluster/describe_cluster_test.go
+++ b/internal/cmd/cli/describe/cluster/describe_cluster_test.go
@@ -1,0 +1,105 @@
+/*
+Copyright (c) 2025 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package cluster
+
+import (
+	"bytes"
+	"fmt"
+
+	. "github.com/onsi/ginkgo/v2/dsl/core"
+	. "github.com/onsi/gomega"
+
+	publicv1 "github.com/osac-project/fulfillment-service/internal/api/osac/public/v1"
+)
+
+func formatCluster(cluster *publicv1.Cluster) string {
+	var buf bytes.Buffer
+	RenderCluster(&buf, cluster)
+	return buf.String()
+}
+
+var _ = Describe("CEL filter construction", func() {
+	It("should produce valid CEL for a plain name", func() {
+		filter := buildFilter("my-cluster")
+		Expect(filter).To(Equal(`this.id == "my-cluster" || this.metadata.name == "my-cluster"`))
+	})
+	It("should escape double quotes", func() {
+		filter := buildFilter(`my"cluster`)
+		Expect(filter).To(ContainSubstring(`"my\"cluster"`))
+	})
+	It("should escape backslashes", func() {
+		filter := buildFilter(`my\cluster`)
+		Expect(filter).To(ContainSubstring(`\\`))
+	})
+	It("should handle UUID-style IDs", func() {
+		filter := buildFilter("550e8400-e29b-41d4-a716-446655440000")
+		Expect(filter).To(Equal(`this.id == "550e8400-e29b-41d4-a716-446655440000" || this.metadata.name == "550e8400-e29b-41d4-a716-446655440000"`))
+	})
+})
+
+var _ = Describe("Rendering tests", func() {
+	It("should display all fields when set", func() {
+		cluster := publicv1.Cluster_builder{
+			Id: "cluster-001",
+			Spec: &publicv1.ClusterSpec{
+				Template: "tpl-ha-001",
+			},
+			Status: &publicv1.ClusterStatus{
+				State: publicv1.ClusterState_CLUSTER_STATE_READY,
+			},
+		}.Build()
+		output := formatCluster(cluster)
+		Expect(output).To(ContainSubstring("cluster-001"))
+		Expect(output).To(ContainSubstring("tpl-ha-001"))
+		Expect(output).To(ContainSubstring("READY"))
+	})
+
+	It("should show '-' for template when spec is nil", func() {
+		cluster := publicv1.Cluster_builder{
+			Id: "cluster-002",
+		}.Build()
+		output := formatCluster(cluster)
+		Expect(output).To(MatchRegexp(`Template:\s+-`))
+	})
+
+	It("should show '-' for state when status is nil", func() {
+		cluster := publicv1.Cluster_builder{
+			Id: "cluster-003",
+		}.Build()
+		output := formatCluster(cluster)
+		Expect(output).To(MatchRegexp(`State:\s+-`))
+	})
+
+	It("should strip CLUSTER_STATE_ prefix from state", func() {
+		cluster := publicv1.Cluster_builder{
+			Id: "cluster-004",
+			Status: &publicv1.ClusterStatus{
+				State: publicv1.ClusterState_CLUSTER_STATE_READY,
+			},
+		}.Build()
+		output := formatCluster(cluster)
+		Expect(output).To(ContainSubstring("READY"))
+		Expect(output).NotTo(ContainSubstring("CLUSTER_STATE_"))
+	})
+})
+
+var _ = Describe("Multi-result guard", func() {
+	It("should produce the expected error message", func() {
+		ref := "ambiguous-name"
+		err := fmt.Errorf("multiple clusters match '%s', use the ID instead", ref)
+		Expect(err.Error()).To(ContainSubstring("multiple clusters match"))
+		Expect(err.Error()).To(ContainSubstring("ambiguous-name"))
+		Expect(err.Error()).To(ContainSubstring("use the ID instead"))
+	})
+})

--- a/internal/cmd/cli/describe/computeinstance/describe_computeinstance_cmd.go
+++ b/internal/cmd/cli/describe/computeinstance/describe_computeinstance_cmd.go
@@ -16,7 +16,6 @@ package computeinstance
 import (
 	"fmt"
 	"io"
-	"log/slog"
 	"strings"
 	"text/tabwriter"
 	"time"
@@ -26,7 +25,6 @@ import (
 
 	publicv1 "github.com/osac-project/fulfillment-service/internal/api/osac/public/v1"
 	"github.com/osac-project/fulfillment-service/internal/config"
-	"github.com/osac-project/fulfillment-service/internal/logging"
 	"github.com/osac-project/fulfillment-service/internal/terminal"
 )
 
@@ -34,42 +32,17 @@ import (
 func Cmd() *cobra.Command {
 	runner := &runnerContext{}
 	result := &cobra.Command{
-		Use:   "computeinstance [flags] ID_OR_NAME",
-		Short: "Describe a compute instance",
-		Args:  cobra.ExactArgs(1),
-		RunE:  runner.run,
+		Use:     "computeinstance [flags] ID_OR_NAME",
+		Aliases: []string{"computeinstances"},
+		Short:   "Describe a compute instance",
+		Args:    cobra.ExactArgs(1),
+		RunE:    runner.run,
 	}
 	return result
 }
 
 type runnerContext struct {
-	logger  *slog.Logger
 	console *terminal.Console
-}
-
-func buildFilter(ref string) string {
-	return fmt.Sprintf(`this.id == %[1]q || this.metadata.name == %[1]q`, ref)
-}
-
-// RenderComputeInstance writes a formatted description of ci to w.
-func RenderComputeInstance(w io.Writer, ci *publicv1.ComputeInstance) {
-	writer := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
-	template := "-"
-	if ci.Spec != nil {
-		template = ci.Spec.Template
-	}
-	state := "-"
-	if ci.Status != nil {
-		state = ci.Status.State.String()
-		state = strings.TrimPrefix(state, "COMPUTE_INSTANCE_STATE_")
-	}
-	fmt.Fprintf(writer, "ID:\t%s\n", ci.Id)
-	fmt.Fprintf(writer, "Template:\t%s\n", template)
-	fmt.Fprintf(writer, "State:\t%s\n", state)
-	if ci.Status != nil && ci.Status.GetLastRestartedAt() != nil {
-		fmt.Fprintf(writer, "Last Restarted At:\t%s\n", ci.Status.GetLastRestartedAt().AsTime().Format(time.RFC3339))
-	}
-	writer.Flush()
 }
 
 func (c *runnerContext) run(cmd *cobra.Command, args []string) error {
@@ -77,7 +50,6 @@ func (c *runnerContext) run(cmd *cobra.Command, args []string) error {
 
 	ctx := cmd.Context()
 
-	c.logger = logging.LoggerFromContext(ctx)
 	c.console = terminal.ConsoleFromContext(ctx)
 
 	cfg, err := config.Load(ctx)
@@ -104,21 +76,45 @@ func (c *runnerContext) run(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return fmt.Errorf("failed to describe compute instance: %w", err)
 	}
-	if len(listResponse.GetItems()) == 0 {
-		return fmt.Errorf("compute instance not found: %s", ref)
-	}
-	if len(listResponse.GetItems()) > 1 {
-		return fmt.Errorf("multiple compute instances match '%s', use the ID instead", ref)
+	if err := guardResult(len(listResponse.GetItems()), ref); err != nil {
+		return err
 	}
 
-	response, err := client.Get(ctx, publicv1.ComputeInstancesGetRequest_builder{
-		Id: listResponse.GetItems()[0].GetId(),
-	}.Build())
-	if err != nil {
-		return fmt.Errorf("failed to describe compute instance: %w", err)
-	}
-
-	RenderComputeInstance(c.console, response.Object)
+	renderComputeInstance(c.console, listResponse.GetItems()[0])
 
 	return nil
+}
+
+func guardResult(items int, ref string) error {
+	if items == 0 {
+		return fmt.Errorf("compute instance not found: %s", ref)
+	}
+	if items > 1 {
+		return fmt.Errorf("multiple compute instances match '%s', use the ID instead", ref)
+	}
+	return nil
+}
+
+func buildFilter(ref string) string {
+	return fmt.Sprintf(`this.id == %[1]q || this.metadata.name == %[1]q`, ref)
+}
+
+func renderComputeInstance(w io.Writer, ci *publicv1.ComputeInstance) {
+	writer := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
+	template := "-"
+	if ci.Spec != nil {
+		template = ci.Spec.Template
+	}
+	state := "-"
+	if ci.Status != nil {
+		state = ci.Status.State.String()
+		state = strings.TrimPrefix(state, "COMPUTE_INSTANCE_STATE_")
+	}
+	fmt.Fprintf(writer, "ID:\t%s\n", ci.Id)
+	fmt.Fprintf(writer, "Template:\t%s\n", template)
+	fmt.Fprintf(writer, "State:\t%s\n", state)
+	if ci.Status != nil && ci.Status.GetLastRestartedAt() != nil {
+		fmt.Fprintf(writer, "Last Restarted At:\t%s\n", ci.Status.GetLastRestartedAt().AsTime().Format(time.RFC3339))
+	}
+	writer.Flush()
 }

--- a/internal/cmd/cli/describe/computeinstance/describe_computeinstance_cmd.go
+++ b/internal/cmd/cli/describe/computeinstance/describe_computeinstance_cmd.go
@@ -15,13 +15,14 @@ package computeinstance
 
 import (
 	"fmt"
+	"io"
 	"log/slog"
-	"os"
 	"strings"
 	"text/tabwriter"
 	"time"
 
 	"github.com/spf13/cobra"
+	"google.golang.org/protobuf/proto"
 
 	publicv1 "github.com/osac-project/fulfillment-service/internal/api/osac/public/v1"
 	"github.com/osac-project/fulfillment-service/internal/config"
@@ -33,8 +34,9 @@ import (
 func Cmd() *cobra.Command {
 	runner := &runnerContext{}
 	result := &cobra.Command{
-		Use:   "computeinstance [flags] ID",
+		Use:   "computeinstance [flags] ID_OR_NAME",
 		Short: "Describe a compute instance",
+		Args:  cobra.ExactArgs(1),
 		RunE:  runner.run,
 	}
 	return result
@@ -45,66 +47,13 @@ type runnerContext struct {
 	console *terminal.Console
 }
 
-func (c *runnerContext) run(cmd *cobra.Command, args []string) error {
-	// Check that there is exactly one compute instance ID specified
-	if len(args) != 1 {
-		fmt.Fprintf(
-			os.Stderr,
-			"Expected exactly one compute instance ID\n",
-		)
-		os.Exit(1)
-	}
-	id := args[0]
+func buildFilter(ref string) string {
+	return fmt.Sprintf(`this.id == %[1]q || this.metadata.name == %[1]q`, ref)
+}
 
-	// Get the context:
-	ctx := cmd.Context()
-
-	// Get the logger and console:
-	c.logger = logging.LoggerFromContext(ctx)
-	c.console = terminal.ConsoleFromContext(ctx)
-
-	// Get the configuration:
-	cfg, err := config.Load(ctx)
-	if err != nil {
-		return err
-	}
-	if cfg.Address == "" {
-		return fmt.Errorf("there is no configuration, run the 'login' command")
-	}
-
-	// Create the gRPC connection from the configuration:
-	conn, err := cfg.Connect(ctx, cmd.Flags())
-	if err != nil {
-		return fmt.Errorf("failed to create gRPC connection: %w", err)
-	}
-	defer conn.Close()
-
-	// Create the client for the compute instances service:
-	client := publicv1.NewComputeInstancesClient(conn)
-
-	// Look up the compute instance by ID or name using a CEL filter:
-	filter := fmt.Sprintf("this.id in ['%s'] || this.metadata.name in ['%s']", id, id)
-	listResponse, err := client.List(ctx, publicv1.ComputeInstancesListRequest_builder{
-		Filter: &filter,
-	}.Build())
-	if err != nil {
-		return fmt.Errorf("failed to describe compute instance: %w", err)
-	}
-	if len(listResponse.GetItems()) == 0 {
-		return fmt.Errorf("compute instance not found: %s", id)
-	}
-
-	// Get the full object using the resolved UUID:
-	response, err := client.Get(ctx, publicv1.ComputeInstancesGetRequest_builder{
-		Id: listResponse.GetItems()[0].GetId(),
-	}.Build())
-	if err != nil {
-		return fmt.Errorf("failed to describe compute instance: %w", err)
-	}
-
-	// Display the compute instance:
-	writer := tabwriter.NewWriter(c.console, 0, 0, 2, ' ', 0)
-	ci := response.Object
+// RenderComputeInstance writes a formatted description of ci to w.
+func RenderComputeInstance(w io.Writer, ci *publicv1.ComputeInstance) {
+	writer := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
 	template := "-"
 	if ci.Spec != nil {
 		template = ci.Spec.Template
@@ -112,7 +61,7 @@ func (c *runnerContext) run(cmd *cobra.Command, args []string) error {
 	state := "-"
 	if ci.Status != nil {
 		state = ci.Status.State.String()
-		state = strings.Replace(state, "COMPUTE_INSTANCE_STATE_", "", -1)
+		state = strings.TrimPrefix(state, "COMPUTE_INSTANCE_STATE_")
 	}
 	fmt.Fprintf(writer, "ID:\t%s\n", ci.Id)
 	fmt.Fprintf(writer, "Template:\t%s\n", template)
@@ -121,6 +70,55 @@ func (c *runnerContext) run(cmd *cobra.Command, args []string) error {
 		fmt.Fprintf(writer, "Last Restarted At:\t%s\n", ci.Status.GetLastRestartedAt().AsTime().Format(time.RFC3339))
 	}
 	writer.Flush()
+}
+
+func (c *runnerContext) run(cmd *cobra.Command, args []string) error {
+	ref := args[0]
+
+	ctx := cmd.Context()
+
+	c.logger = logging.LoggerFromContext(ctx)
+	c.console = terminal.ConsoleFromContext(ctx)
+
+	cfg, err := config.Load(ctx)
+	if err != nil {
+		return err
+	}
+	if cfg.Address == "" {
+		return fmt.Errorf("there is no configuration, run the 'login' command")
+	}
+
+	conn, err := cfg.Connect(ctx, cmd.Flags())
+	if err != nil {
+		return fmt.Errorf("failed to create gRPC connection: %w", err)
+	}
+	defer conn.Close()
+
+	client := publicv1.NewComputeInstancesClient(conn)
+
+	filter := buildFilter(ref)
+	listResponse, err := client.List(ctx, publicv1.ComputeInstancesListRequest_builder{
+		Filter: &filter,
+		Limit:  proto.Int32(2),
+	}.Build())
+	if err != nil {
+		return fmt.Errorf("failed to describe compute instance: %w", err)
+	}
+	if len(listResponse.GetItems()) == 0 {
+		return fmt.Errorf("compute instance not found: %s", ref)
+	}
+	if len(listResponse.GetItems()) > 1 {
+		return fmt.Errorf("multiple compute instances match '%s', use the ID instead", ref)
+	}
+
+	response, err := client.Get(ctx, publicv1.ComputeInstancesGetRequest_builder{
+		Id: listResponse.GetItems()[0].GetId(),
+	}.Build())
+	if err != nil {
+		return fmt.Errorf("failed to describe compute instance: %w", err)
+	}
+
+	RenderComputeInstance(c.console, response.Object)
 
 	return nil
 }

--- a/internal/cmd/cli/describe/computeinstance/describe_computeinstance_test.go
+++ b/internal/cmd/cli/describe/computeinstance/describe_computeinstance_test.go
@@ -15,7 +15,6 @@ package computeinstance
 
 import (
 	"bytes"
-	"fmt"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2/dsl/core"
@@ -25,14 +24,49 @@ import (
 	publicv1 "github.com/osac-project/fulfillment-service/internal/api/osac/public/v1"
 )
 
-// formatComputeInstance formats a compute instance for display using RenderComputeInstance.
 func formatComputeInstance(ci *publicv1.ComputeInstance) string {
 	var buf bytes.Buffer
-	RenderComputeInstance(&buf, ci)
+	renderComputeInstance(&buf, ci)
 	return buf.String()
 }
 
 var _ = Describe("Describe Compute Instance", func() {
+	It("should display all fields when set", func() {
+		ci := &publicv1.ComputeInstance{
+			Id: "ci-001",
+			Spec: &publicv1.ComputeInstanceSpec{
+				Template: "tpl-small-001",
+			},
+			Status: &publicv1.ComputeInstanceStatus{
+				State: publicv1.ComputeInstanceState_COMPUTE_INSTANCE_STATE_RUNNING,
+			},
+		}
+		output := formatComputeInstance(ci)
+		Expect(output).To(ContainSubstring("ci-001"))
+		Expect(output).To(ContainSubstring("tpl-small-001"))
+		Expect(output).To(ContainSubstring("RUNNING"))
+	})
+
+	It("should strip COMPUTE_INSTANCE_STATE_ prefix from state", func() {
+		ci := &publicv1.ComputeInstance{
+			Id: "ci-002",
+			Status: &publicv1.ComputeInstanceStatus{
+				State: publicv1.ComputeInstanceState_COMPUTE_INSTANCE_STATE_RUNNING,
+			},
+		}
+		output := formatComputeInstance(ci)
+		Expect(output).To(ContainSubstring("RUNNING"))
+		Expect(output).NotTo(ContainSubstring("COMPUTE_INSTANCE_STATE_"))
+	})
+
+	It("should show '-' for template when spec is nil", func() {
+		ci := &publicv1.ComputeInstance{
+			Id: "ci-003",
+		}
+		output := formatComputeInstance(ci)
+		Expect(output).To(MatchRegexp(`Template:\s+-`))
+	})
+
 	It("should display last_restarted_at when set", func() {
 		restartTime := time.Date(2026, 3, 15, 10, 30, 0, 0, time.UTC)
 		ci := &publicv1.ComputeInstance{
@@ -100,12 +134,25 @@ var _ = Describe("CEL filter construction", func() {
 		filter := buildFilter("550e8400-e29b-41d4-a716-446655440000")
 		Expect(filter).To(Equal(`this.id == "550e8400-e29b-41d4-a716-446655440000" || this.metadata.name == "550e8400-e29b-41d4-a716-446655440000"`))
 	})
+	It("should pass through single quotes without escaping", func() {
+		filter := buildFilter("my'instance")
+		Expect(filter).To(Equal(`this.id == "my'instance" || this.metadata.name == "my'instance"`))
+	})
 })
 
 var _ = Describe("Multi-result guard", func() {
-	It("should produce the expected error message", func() {
-		ref := "ambiguous-name"
-		err := fmt.Errorf("multiple compute instances match '%s', use the ID instead", ref)
+	It("should return nil when exactly one item found", func() {
+		Expect(guardResult(1, "any-name")).To(BeNil())
+	})
+	It("should return not-found error when no items found", func() {
+		err := guardResult(0, "missing-instance")
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("compute instance not found"))
+		Expect(err.Error()).To(ContainSubstring("missing-instance"))
+	})
+	It("should return ambiguous error when multiple items found", func() {
+		err := guardResult(2, "ambiguous-name")
+		Expect(err).To(HaveOccurred())
 		Expect(err.Error()).To(ContainSubstring("multiple compute instances match"))
 		Expect(err.Error()).To(ContainSubstring("ambiguous-name"))
 		Expect(err.Error()).To(ContainSubstring("use the ID instead"))

--- a/internal/cmd/cli/describe/computeinstance/describe_computeinstance_test.go
+++ b/internal/cmd/cli/describe/computeinstance/describe_computeinstance_test.go
@@ -16,8 +16,6 @@ package computeinstance
 import (
 	"bytes"
 	"fmt"
-	"strings"
-	"text/tabwriter"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2/dsl/core"
@@ -27,28 +25,10 @@ import (
 	publicv1 "github.com/osac-project/fulfillment-service/internal/api/osac/public/v1"
 )
 
-// formatComputeInstance formats a compute instance for display, matching the logic in the describe command.
+// formatComputeInstance formats a compute instance for display using RenderComputeInstance.
 func formatComputeInstance(ci *publicv1.ComputeInstance) string {
 	var buf bytes.Buffer
-	writer := tabwriter.NewWriter(&buf, 0, 0, 2, ' ', 0)
-
-	template := "-"
-	if ci.Spec != nil {
-		template = ci.Spec.Template
-	}
-	state := "-"
-	if ci.Status != nil {
-		state = ci.Status.State.String()
-		state = strings.Replace(state, "COMPUTE_INSTANCE_STATE_", "", -1)
-	}
-	fmt.Fprintf(writer, "ID:\t%s\n", ci.Id)
-	fmt.Fprintf(writer, "Template:\t%s\n", template)
-	fmt.Fprintf(writer, "State:\t%s\n", state)
-	if ci.Status != nil && ci.Status.GetLastRestartedAt() != nil {
-		fmt.Fprintf(writer, "Last Restarted At:\t%s\n", ci.Status.GetLastRestartedAt().AsTime().Format(time.RFC3339))
-	}
-	writer.Flush()
-
+	RenderComputeInstance(&buf, ci)
 	return buf.String()
 }
 
@@ -97,5 +77,37 @@ var _ = Describe("Describe Compute Instance", func() {
 		output := formatComputeInstance(ci)
 		Expect(output).To(MatchRegexp(`State:\s+-`))
 		Expect(output).NotTo(ContainSubstring("Last Restarted At:"))
+	})
+})
+
+var _ = Describe("CEL filter construction", func() {
+	It("should produce valid CEL with == operator and quoted value for a plain name", func() {
+		filter := buildFilter("my-instance")
+		Expect(filter).To(Equal(`this.id == "my-instance" || this.metadata.name == "my-instance"`))
+	})
+
+	It("should escape double quotes in the reference value", func() {
+		filter := buildFilter(`my"instance`)
+		Expect(filter).To(ContainSubstring(`"my\"instance"`))
+	})
+
+	It("should escape backslashes in the reference value", func() {
+		filter := buildFilter(`my\instance`)
+		Expect(filter).To(ContainSubstring(`"my\\instance"`))
+	})
+
+	It("should produce valid CEL for a UUID-style ID", func() {
+		filter := buildFilter("550e8400-e29b-41d4-a716-446655440000")
+		Expect(filter).To(Equal(`this.id == "550e8400-e29b-41d4-a716-446655440000" || this.metadata.name == "550e8400-e29b-41d4-a716-446655440000"`))
+	})
+})
+
+var _ = Describe("Multi-result guard", func() {
+	It("should produce the expected error message", func() {
+		ref := "ambiguous-name"
+		err := fmt.Errorf("multiple compute instances match '%s', use the ID instead", ref)
+		Expect(err.Error()).To(ContainSubstring("multiple compute instances match"))
+		Expect(err.Error()).To(ContainSubstring("ambiguous-name"))
+		Expect(err.Error()).To(ContainSubstring("use the ID instead"))
 	})
 })


### PR DESCRIPTION
## Summary
- Adds multi-result guard to describe computeinstance (bug fix)
- Adds name-based lookup to describe cluster via List+filter pattern
- Fixes CLUSTER_ORDER_STATE_ prefix bug and missing conn.Close() in cluster describe