### PR TITLE
NO-ISSUE: Support universal tenant sets from Authorino

### DIFF
--- a/charts/service/templates/grpc-server/authconfig.yaml
+++ b/charts/service/templates/grpc-server/authconfig.yaml
@@ -66,8 +66,9 @@ spec:
         authnMethod:
           value: jwt
   authorization:
-    "fulfillment-api":
+    default:
       opa:
+        allValues: true
         rego: |
           import rego.v1
 
@@ -101,7 +102,8 @@ spec:
             input.auth.identity.authnMethod == "jwt"
           }
 
-          # Function to check if an account is an admin account:
+          # Check if an account is an admin account:
+          default is_admin = false
           is_admin if {
             subject_name in admin_service_accounts
           }
@@ -110,7 +112,8 @@ spec:
             group in admin_groups
           }
 
-          # Function to check if an account is a client account:
+          # Check if an account is a client account:
+          default is_client = false
           is_client if {
             not is_admin
           }
@@ -171,6 +174,8 @@ spec:
                     : auth.identity.user.username.split(":")[3]
               tenants:
                 expression: |
-                  auth.identity.authnMethod == "jwt"
-                    ? auth.identity.groups
-                    : [auth.identity.user.username.split(":")[2]]
+                  auth.authorization.default.is_admin
+                    ? ["*"]
+                    : auth.identity.authnMethod == "jwt"
+                      ? auth.identity.groups
+                      : [auth.identity.user.username.split(":")[2]]

--- a/internal/auth/auth_subject.go
+++ b/internal/auth/auth_subject.go
@@ -13,11 +13,80 @@ language governing permissions and limitations under the License.
 
 package auth
 
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/osac-project/fulfillment-service/internal/collections"
+)
+
 // Subject represents an entity, such as person or a service account.
 type Subject struct {
 	// User is the name of the user.
-	User string `json:"user"`
+	User string
 
-	// Tenants are the identifiers of the tenants that the subject belongs to.
+	// Tenants is the set of tenants that the subject belongs to. It may be the universal set if the subject has
+	// access to all tenants.
+	Tenants collections.Set[string]
+}
+
+// subjectJson is the JSON representation of a subject used internally for serialization and deserialization.
+type subjectJson struct {
+	User    string   `json:"user"`
 	Tenants []string `json:"tenants"`
 }
+
+// UnmarshalJSON implements custom JSON unmarshalling for Subject. It interprets the special value '*' in the tenants
+// array as meaning all tenants. This special value must not be combined with specific tenant names, that will be
+// considered as an error.
+func (s *Subject) UnmarshalJSON(data []byte) error {
+	var subject subjectJson
+	if err := json.Unmarshal(data, &subject); err != nil {
+		return err
+	}
+	s.User = subject.User
+	s.Tenants = collections.NewSet[string]()
+	universal := false
+	for _, tenant := range subject.Tenants {
+		if tenant == universalMarker {
+			universal = true
+			break
+		}
+	}
+	if universal {
+		if len(subject.Tenants) > 1 {
+			return fmt.Errorf(
+				"the universal marker '%s' cannot be combined with specific tenant names",
+				universalMarker,
+			)
+		}
+		s.Tenants = AllTenants
+	} else {
+		s.Tenants = collections.NewSet(subject.Tenants...)
+	}
+	return nil
+}
+
+// MarshalJSON implements custom JSON marshalling for Subject.
+func (s *Subject) MarshalJSON() (data []byte, err error) {
+	var tenants []string
+	if s.Tenants.Universal() {
+		tenants = []string{
+			universalMarker,
+		}
+	} else if s.Tenants.Finite() {
+		tenants = s.Tenants.Inclusions()
+	} else {
+		err = fmt.Errorf("the tenant set is infinite")
+		return
+	}
+	data, err = json.Marshal(subjectJson{
+		User:    s.User,
+		Tenants: tenants,
+	})
+	return
+}
+
+// universalMarker is the special value used in the subject's tenant list to indicate that the subject has access to all
+// tenants.
+const universalMarker = "*"

--- a/internal/auth/auth_subject_test.go
+++ b/internal/auth/auth_subject_test.go
@@ -1,0 +1,151 @@
+/*
+Copyright (c) 2026 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package auth
+
+import (
+	"encoding/json"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/osac-project/fulfillment-service/internal/collections"
+)
+
+var _ = Describe("Subject", func() {
+	Describe("JSON unmarshalling", func() {
+		It("Parses user and specific tenants", func() {
+			var subject Subject
+			err := json.Unmarshal(
+				[]byte(`{
+					"user": "alice",
+					"tenants": ["t1", "t2"]
+				}`),
+				&subject,
+			)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(subject.User).To(Equal("alice"))
+			Expect(subject.Tenants.Equal(collections.NewSet("t1", "t2"))).To(BeTrue())
+		})
+
+		It("Parses asterisk as universal set", func() {
+			var subject Subject
+			err := json.Unmarshal(
+				[]byte(`{
+					"user": "admin",
+					"tenants": ["*"]
+				}`),
+				&subject,
+			)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(subject.User).To(Equal("admin"))
+			Expect(subject.Tenants.Universal()).To(BeTrue())
+		})
+
+		It("Rejects asterisk mixed with specific tenants", func() {
+			var subject Subject
+			err := json.Unmarshal(
+				[]byte(`{
+					"user": "admin",
+					"tenants": ["*", "t1"]
+				}`),
+				&subject,
+			)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("cannot be combined"))
+		})
+
+		It("Parses empty tenants as empty set", func() {
+			var subject Subject
+			err := json.Unmarshal(
+				[]byte(`{
+					"user": "alice",
+					"tenants": []
+				}`),
+				&subject,
+			)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(subject.Tenants.Empty()).To(BeTrue())
+		})
+
+		It("Parses missing tenants as empty set", func() {
+			var subject Subject
+			err := json.Unmarshal(
+				[]byte(`{
+					"user": "alice"
+				}`),
+				&subject,
+			)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(subject.Tenants.Empty()).To(BeTrue())
+		})
+	})
+
+	Describe("JSON marshalling", func() {
+		It("Marshals specific tenants", func() {
+			subject := &Subject{
+				User:    "alice",
+				Tenants: collections.NewSet("t1"),
+			}
+			data, err := json.Marshal(subject)
+			Expect(err).ToNot(HaveOccurred())
+			var raw map[string]any
+			err = json.Unmarshal(data, &raw)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(raw["user"]).To(Equal("alice"))
+			Expect(raw["tenants"]).To(ConsistOf("t1"))
+		})
+
+		It("Marshals universal set as asterisk", func() {
+			subject := &Subject{
+				User:    "admin",
+				Tenants: AllTenants,
+			}
+			data, err := json.Marshal(subject)
+			Expect(err).ToNot(HaveOccurred())
+			var raw map[string]any
+			err = json.Unmarshal(data, &raw)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(raw["user"]).To(Equal("admin"))
+			Expect(raw["tenants"]).To(ConsistOf("*"))
+		})
+
+		It("Round-trips specific tenants", func() {
+			original := &Subject{
+				User:    "alice",
+				Tenants: collections.NewSet("t1", "t2"),
+			}
+			data, err := json.Marshal(original)
+			Expect(err).ToNot(HaveOccurred())
+			var restored Subject
+			err = json.Unmarshal(data, &restored)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(restored.User).To(Equal(original.User))
+			Expect(restored.Tenants.Equal(original.Tenants)).To(BeTrue())
+		})
+
+		It("Round-trips universal set", func() {
+			original := &Subject{
+				User:    "admin",
+				Tenants: AllTenants,
+			}
+			data, err := json.Marshal(original)
+			Expect(err).ToNot(HaveOccurred())
+			var restored Subject
+			err = json.Unmarshal(data, &restored)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(restored.User).To(Equal(original.User))
+			Expect(restored.Tenants.Universal()).To(BeTrue())
+		})
+	})
+})

--- a/internal/auth/default_tenancy_logic.go
+++ b/internal/auth/default_tenancy_logic.go
@@ -61,8 +61,8 @@ func (b *DefaultTenancyLogicBuilder) Build() (result *DefaultTenancyLogic, err e
 func (p *DefaultTenancyLogic) DetermineAssignableTenants(ctx context.Context) (result collections.Set[string],
 	err error) {
 	subject := SubjectFromContext(ctx)
-	result = collections.NewSet(subject.Tenants...)
-	if len(subject.Tenants) == 0 {
+	result = subject.Tenants
+	if result.Empty() {
 		p.logger.ErrorContext(
 			ctx,
 			"Subject has no tenants",
@@ -87,6 +87,9 @@ func (p *DefaultTenancyLogic) DetermineDefaultTenants(ctx context.Context) (resu
 func (p *DefaultTenancyLogic) DetermineVisibleTenants(ctx context.Context) (result collections.Set[string],
 	err error) {
 	subject := SubjectFromContext(ctx)
-	result = SharedTenants.Union(collections.NewSet(subject.Tenants...))
+	result = subject.Tenants
+	if result.Finite() {
+		result = SharedTenants.Union(result)
+	}
 	return
 }

--- a/internal/auth/default_tenancy_logic_test.go
+++ b/internal/auth/default_tenancy_logic_test.go
@@ -55,7 +55,7 @@ var _ = Describe("Default tenancy logic", func() {
 		It("Returns the tenants from the subject", func() {
 			subject := &Subject{
 				User:    "my_user",
-				Tenants: []string{"tenant-a", "tenant-b"},
+				Tenants: collections.NewSet("tenant-a", "tenant-b"),
 			}
 			ctx = ContextWithSubject(ctx, subject)
 			result, err := logic.DetermineAssignableTenants(ctx)
@@ -66,7 +66,7 @@ var _ = Describe("Default tenancy logic", func() {
 		It("Returns multiple tenants when present", func() {
 			subject := &Subject{
 				User:    "my_user",
-				Tenants: []string{"tenant-a", "tenant-b", "tenant-c"},
+				Tenants: collections.NewSet("tenant-a", "tenant-b", "tenant-c"),
 			}
 			ctx = ContextWithSubject(ctx, subject)
 			result, err := logic.DetermineAssignableTenants(ctx)
@@ -74,20 +74,21 @@ var _ = Describe("Default tenancy logic", func() {
 			Expect(result.Equal(collections.NewSet("tenant-a", "tenant-b", "tenant-c"))).To(BeTrue())
 		})
 
-		It("Fails if the subject has no tenants", func() {
-			subject := &Subject{
-				User: "my_user",
-			}
-			ctx = ContextWithSubject(ctx, subject)
-			_, err := logic.DetermineAssignableTenants(ctx)
-			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("at least one tenant"))
-		})
-
-		It("Fails if the subject has an empty tenants list", func() {
+		It("Returns universal set when tenants is universal", func() {
 			subject := &Subject{
 				User:    "my_user",
-				Tenants: []string{},
+				Tenants: AllTenants,
+			}
+			ctx = ContextWithSubject(ctx, subject)
+			result, err := logic.DetermineAssignableTenants(ctx)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result.Equal(AllTenants)).To(BeTrue())
+		})
+
+		It("Fails if the subject has an empty tenants set", func() {
+			subject := &Subject{
+				User:    "my_user",
+				Tenants: collections.NewSet[string](),
 			}
 			ctx = ContextWithSubject(ctx, subject)
 			_, err := logic.DetermineAssignableTenants(ctx)
@@ -100,7 +101,7 @@ var _ = Describe("Default tenancy logic", func() {
 		It("Returns the tenants from the subject", func() {
 			subject := &Subject{
 				User:    "my_user",
-				Tenants: []string{"tenant-a", "tenant-b"},
+				Tenants: collections.NewSet("tenant-a", "tenant-b"),
 			}
 			ctx = ContextWithSubject(ctx, subject)
 			result, err := logic.DetermineDefaultTenants(ctx)
@@ -108,9 +109,21 @@ var _ = Describe("Default tenancy logic", func() {
 			Expect(result.Equal(collections.NewSet("tenant-a", "tenant-b"))).To(BeTrue())
 		})
 
-		It("Fails if the subject has no tenants", func() {
+		It("Returns universal set when tenants is universal", func() {
 			subject := &Subject{
-				User: "my_user",
+				User:    "my_user",
+				Tenants: AllTenants,
+			}
+			ctx = ContextWithSubject(ctx, subject)
+			result, err := logic.DetermineDefaultTenants(ctx)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result.Equal(AllTenants)).To(BeTrue())
+		})
+
+		It("Fails if the subject has an empty tenants set", func() {
+			subject := &Subject{
+				User:    "my_user",
+				Tenants: collections.NewSet[string](),
 			}
 			ctx = ContextWithSubject(ctx, subject)
 			_, err := logic.DetermineDefaultTenants(ctx)
@@ -123,7 +136,7 @@ var _ = Describe("Default tenancy logic", func() {
 		It("Returns tenants and shared", func() {
 			subject := &Subject{
 				User:    "my_user",
-				Tenants: []string{"tenant-a", "tenant-b"},
+				Tenants: collections.NewSet("tenant-a", "tenant-b"),
 			}
 			ctx = ContextWithSubject(ctx, subject)
 			result, err := logic.DetermineVisibleTenants(ctx)
@@ -131,20 +144,21 @@ var _ = Describe("Default tenancy logic", func() {
 			Expect(result.Equal(SharedTenants.Union(collections.NewSet("tenant-a", "tenant-b")))).To(BeTrue())
 		})
 
-		It("Returns only shared when subject has no tenants", func() {
+		It("Returns universal set when tenants is universal", func() {
 			subject := &Subject{
-				User: "my_user",
+				User:    "my_user",
+				Tenants: AllTenants,
 			}
 			ctx = ContextWithSubject(ctx, subject)
 			result, err := logic.DetermineVisibleTenants(ctx)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(result.Equal(SharedTenants)).To(BeTrue())
+			Expect(result.Equal(AllTenants)).To(BeTrue())
 		})
 
 		It("Returns only shared when tenants is empty", func() {
 			subject := &Subject{
 				User:    "my_user",
-				Tenants: []string{},
+				Tenants: collections.NewSet[string](),
 			}
 			ctx = ContextWithSubject(ctx, subject)
 			result, err := logic.DetermineVisibleTenants(ctx)

--- a/internal/auth/grpc_external_auth_interceptor_test.go
+++ b/internal/auth/grpc_external_auth_interceptor_test.go
@@ -35,6 +35,7 @@ import (
 	grpcstatus "google.golang.org/grpc/status"
 
 	publicv1 "github.com/osac-project/fulfillment-service/internal/api/osac/public/v1"
+	"github.com/osac-project/fulfillment-service/internal/collections"
 	. "github.com/osac-project/fulfillment-service/internal/testing"
 )
 
@@ -226,10 +227,8 @@ var _ = Describe("External authentication and authorization interceptor", func()
 			mock.Func = func(ctx context.Context,
 				request *envoyauthv3.CheckRequest) (response *envoyauthv3.CheckResponse, err error) {
 				response = makeOkResponse(&Subject{
-					User: "my-user",
-					Tenants: []string{
-						"my-group",
-					},
+					User:    "my-user",
+					Tenants: collections.NewSet("my-group"),
 				})
 				return
 			}
@@ -270,10 +269,8 @@ var _ = Describe("External authentication and authorization interceptor", func()
 			mock.Func = func(ctx context.Context,
 				request *envoyauthv3.CheckRequest) (response *envoyauthv3.CheckResponse, err error) {
 				response = makeOkResponse(&Subject{
-					User: "my-user",
-					Tenants: []string{
-						"my-group",
-					},
+					User:    "my-user",
+					Tenants: collections.NewSet("my-group"),
 				})
 				return
 			}
@@ -281,9 +278,7 @@ var _ = Describe("External authentication and authorization interceptor", func()
 				subject := SubjectFromContext(ctx)
 				Expect(subject).ToNot(BeNil())
 				Expect(subject.User).To(Equal("my-user"))
-				Expect(subject.Tenants).To(ContainElements(
-					"my-group",
-				))
+				Expect(subject.Tenants.Contains("my-group")).To(BeTrue())
 				return nil, nil
 			}
 			info := &grpc.UnaryServerInfo{
@@ -317,9 +312,7 @@ var _ = Describe("External authentication and authorization interceptor", func()
 			mock.Func = func(ctx context.Context,
 				request *envoyauthv3.CheckRequest) (response *envoyauthv3.CheckResponse, err error) {
 				response = makeOkResponse(&Subject{
-					Tenants: []string{
-						"my-group",
-					},
+					Tenants: collections.NewSet("my-group"),
 				})
 				return
 			}
@@ -345,10 +338,8 @@ var _ = Describe("External authentication and authorization interceptor", func()
 				Expect(headers).To(HaveKeyWithValue("authorization", "Bearer my-token"))
 				Expect(headers).To(HaveKeyWithValue("x-my-header", "my-value"))
 				response = makeOkResponse(&Subject{
-					User: "my-user",
-					Tenants: []string{
-						"my-group",
-					},
+					User:    "my-user",
+					Tenants: collections.NewSet("my-group"),
 				})
 				return
 			}

--- a/manifests/base/grpc-server/authconfig.yaml
+++ b/manifests/base/grpc-server/authconfig.yaml
@@ -65,8 +65,9 @@ spec:
         authnMethod:
           value: jwt
   authorization:
-    "fulfillment-api":
+    default:
       opa:
+        allValues: true
         rego: |
           import rego.v1
 
@@ -100,7 +101,8 @@ spec:
             input.auth.identity.authnMethod == "jwt"
           }
 
-          # Function to check if an account is an admin account:
+          # Check if an account is an admin account:
+          default is_admin = false
           is_admin if {
             subject_name in admin_service_accounts
           }
@@ -109,7 +111,8 @@ spec:
             group in admin_groups
           }
 
-          # Function to check if an account is a client account:
+          # Check if an account is a client account:
+          default is_client = false
           is_client if {
             not is_admin
           }
@@ -170,6 +173,8 @@ spec:
                     : auth.identity.user.username.split(":")[3]
               tenants:
                 expression: |
-                  auth.identity.authnMethod == "jwt"
-                    ? auth.identity.groups
-                    : [auth.identity.user.username.split(":")[2]]
+                  auth.authorization.default.is_admin
+                    ? ["*"]
+                    : auth.identity.authnMethod == "jwt"
+                      ? auth.identity.groups
+                      : [auth.identity.user.username.split(":")[2]]


### PR DESCRIPTION
## Summary

- Update the Authorino `AuthConfig` to emit `["*"]` as the tenant list for admin
  accounts, enabling them to access all tenants without enumerating each one.
- Change the `Subject.Tenants` field from `[]string` to `collections.Set[string]` and
  add custom JSON marshal/unmarshal logic that interprets `"*"` as the universal set.
- Adapt the `DefaultTenancyLogic` so that universal tenant sets propagate correctly
  through assignable, default, and visible tenant determination, skipping the shared
  tenant union for universal sets.

## Test plan

- [x] Unit tests for `Subject` JSON marshalling/unmarshalling (round-trips, universal
  marker, error on mixed `*` with specific tenants).
- [x] Unit tests for `DefaultTenancyLogic` covering universal tenant sets in
  assignable, default, and visible tenant determination.
- [x] Updated interceptor tests to use `collections.Set` instead of string slices.