### PR TITLE
NO-ISSUE: Update Rego rules to version 1

### DIFF
--- a/charts/service/templates/grpc-server/authconfig.yaml
+++ b/charts/service/templates/grpc-server/authconfig.yaml
@@ -69,7 +69,7 @@ spec:
     "fulfillment-api":
       opa:
         rego: |
-          import future.keywords.in
+          import rego.v1
 
           # Define admin service accounts:
           admin_service_accounts := {
@@ -86,48 +86,48 @@ spec:
           grpc_method := input.context.request.http.path
 
           # Get the subject name:
-          subject_name = input.auth.identity.user.username {
+          subject_name = input.auth.identity.user.username if {
             input.auth.identity.authnMethod == "serviceaccount"
           }
-          subject_name = input.auth.identity.username {
+          subject_name = input.auth.identity.username if {
             input.auth.identity.authnMethod == "jwt"
           }
 
           # Get the subject groups:
-          subject_groups = input.auth.identity.user.groups {
+          subject_groups = input.auth.identity.user.groups if {
             input.auth.identity.authnMethod == "serviceaccount"
           }
-          subject_groups = input.auth.identity.groups {
+          subject_groups = input.auth.identity.groups if {
             input.auth.identity.authnMethod == "jwt"
           }
 
           # Function to check if an account is an admin account:
-          is_admin {
+          is_admin if {
             subject_name in admin_service_accounts
           }
-          is_admin {
+          is_admin if {
             some group in subject_groups
             group in admin_groups
           }
 
           # Function to check if an account is a client account:
-          is_client {
+          is_client if {
             not is_admin
           }
 
           # Allow metadata, reflection and health to everyone:
-          allow {
+          allow if {
             startswith(grpc_method, "/metadata.")
           }
-          allow {
+          allow if {
             startswith(grpc_method, "/grpc.reflection.")
           }
-          allow {
+          allow if {
             startswith(grpc_method, "/grpc.health.")
           }
 
           # Allow specific methods to clients:
-          allow {
+          allow if {
             is_client
             grpc_method in {
               "/osac.public.v1.ClusterTemplates/Get",
@@ -155,7 +155,7 @@ spec:
           }
 
           # Allow everything to admins:
-          allow {
+          allow if {
             is_admin
           }
   response:

--- a/internal/auth/auth_rules_test.go
+++ b/internal/auth/auth_rules_test.go
@@ -25,17 +25,12 @@ import (
 	. "github.com/onsi/ginkgo/v2/dsl/core"
 	. "github.com/onsi/ginkgo/v2/dsl/decorators"
 	. "github.com/onsi/gomega"
+	"github.com/open-policy-agent/opa/v1/ast"
+	"github.com/open-policy-agent/opa/v1/rego"
 	"gopkg.in/yaml.v3"
 
 	"github.com/osac-project/fulfillment-service/internal/jq"
 	"github.com/osac-project/fulfillment-service/internal/testing"
-
-	// We need to use these deprecated package because Authorino currently uses version 0 of the Rego language,
-	// which has some significant differences. For more details see here:
-	//
-	// https://github.com/Kuadrant/authorino/issues/546
-	"github.com/open-policy-agent/opa/ast"
-	"github.com/open-policy-agent/opa/rego"
 )
 
 var _ = Describe("Authorization rules", Ordered, func() {
@@ -150,7 +145,7 @@ var _ = Describe("Authorization rules", Ordered, func() {
 		// to do the same.
 		buffer := &strings.Builder{}
 		fmt.Fprintf(buffer, "package authz\n")
-		fmt.Fprintf(buffer, "default allow = false\n")
+		fmt.Fprintf(buffer, "default allow := false\n")
 		buffer.WriteString(rules)
 		rules = buffer.String()
 	})

--- a/manifests/base/grpc-server/authconfig.yaml
+++ b/manifests/base/grpc-server/authconfig.yaml
@@ -68,7 +68,7 @@ spec:
     "fulfillment-api":
       opa:
         rego: |
-          import future.keywords.in
+          import rego.v1
 
           # Define admin service accounts:
           admin_service_accounts := {
@@ -85,48 +85,48 @@ spec:
           grpc_method := input.context.request.http.path
 
           # Get the subject name:
-          subject_name = input.auth.identity.user.username {
+          subject_name = input.auth.identity.user.username if {
             input.auth.identity.authnMethod == "serviceaccount"
           }
-          subject_name = input.auth.identity.username {
+          subject_name = input.auth.identity.username if {
             input.auth.identity.authnMethod == "jwt"
           }
 
           # Get the subject groups:
-          subject_groups = input.auth.identity.user.groups {
+          subject_groups = input.auth.identity.user.groups if {
             input.auth.identity.authnMethod == "serviceaccount"
           }
-          subject_groups = input.auth.identity.groups {
+          subject_groups = input.auth.identity.groups if {
             input.auth.identity.authnMethod == "jwt"
           }
 
           # Function to check if an account is an admin account:
-          is_admin {
+          is_admin if {
             subject_name in admin_service_accounts
           }
-          is_admin {
+          is_admin if {
             some group in subject_groups
             group in admin_groups
           }
 
           # Function to check if an account is a client account:
-          is_client {
+          is_client if {
             not is_admin
           }
 
           # Allow metadata, reflection and health to everyone:
-          allow {
+          allow if {
             startswith(grpc_method, "/metadata.")
           }
-          allow {
+          allow if {
             startswith(grpc_method, "/grpc.reflection.")
           }
-          allow {
+          allow if {
             startswith(grpc_method, "/grpc.health.")
           }
 
           # Allow specific methods to clients:
-          allow {
+          allow if {
             is_client
             grpc_method in {
               "/osac.public.v1.ClusterTemplates/Get",
@@ -154,7 +154,7 @@ spec:
           }
 
           # Allow everything to admins:
-          allow {
+          allow if {
             is_admin
           }
   response:


### PR DESCRIPTION
## Summary

- Update the OPA Rego rules embedded in the Authorino `AuthConfig` manifests from
  legacy v0 syntax to Rego v1 by replacing `import future.keywords.in` with
  `import rego.v1` and adding the required `if` keyword to all rule bodies.
- Update the unit tests in `auth_rules_test.go` to use the v1 OPA library packages
  (`opa/v1/ast` and `opa/v1/rego`) instead of the deprecated v0 equivalents, and
  adjust the injected `default allow` line to use `:=`.

## Test plan

- [x] Unit tests pass (`ginkgo run -r internal` — all 39 suites green)
- [x] Integration tests with Authorino verify the rules are evaluated correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated authorization policy rule syntax across configuration and test files.
  * Updated imports in authorization tests to align with policy framework conventions.

* **Tests**
  * Modified test setup for authorization rule validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->