### PR TITLE
MGMT-23849: fixes unsafe CEL interpolation in describe computeinstance

### DIFF
--- a/internal/cmd/cli/describe/describe_cmd_test.go
+++ b/internal/cmd/cli/describe/describe_cmd_test.go
@@ -35,6 +35,7 @@ var _ = Describe("Describe command", func() {
 			Expect(cmd.Aliases).To(ContainElement(expectedAlias))
 		},
 		Entry("cluster", cluster.Cmd, "clusters"),
+		Entry("computeinstance", computeinstance.Cmd, "computeinstances"),
 		Entry("virtualnetwork", virtualnetwork.Cmd, "virtualnetworks"),
 		Entry("subnet", subnet.Cmd, "subnets"),
 		Entry("securitygroup", securitygroup.Cmd, "securitygroups"),
@@ -51,13 +52,6 @@ var _ = Describe("Describe command", func() {
 			}
 
 			Expect(subcommandNames).To(ContainElements("cluster", "computeinstance", "virtualnetwork", "subnet", "securitygroup"))
-		})
-	})
-
-	Describe("computeinstance has no aliases", func() {
-		It("should have no aliases", func() {
-			cmd := computeinstance.Cmd()
-			Expect(cmd.Aliases).To(BeEmpty())
 		})
 	})
 

--- a/internal/database/dao/filter_translator_test.go
+++ b/internal/database/dao/filter_translator_test.go
@@ -257,5 +257,25 @@ var _ = Describe("Filter translator", func() {
 			`'mylabel' in this.metadata.labels`,
 			`labels ? 'mylabel'`,
 		),
+		Entry(
+			"Double-quoted string with single quote from %q",
+			`this.id == "it's"`,
+			`id = e'it\'s'`,
+		),
+		Entry(
+			"Double-quoted string with escaped double quote from %q",
+			`this.id == "say \"hello\""`,
+			`id = 'say "hello"'`,
+		),
+		Entry(
+			"Double-quoted string with backslash from %q",
+			`this.id == "path\\to\\thing"`,
+			`id = 'path\\to\\thing'`,
+		),
+		Entry(
+			"Double-quoted string with CEL injection attempt from %q",
+			`this.id == "'] || true || this.id in ['"`,
+			`id = e'\'] || true || this.id in [\''`,
+		),
 	)
 })

--- a/internal/servers/private_subnets_server.go
+++ b/internal/servers/private_subnets_server.go
@@ -361,7 +361,7 @@ func (s *PrivateSubnetsServer) validateNoCIDROverlap(ctx context.Context,
 	spec *privatev1.SubnetSpec) error {
 
 	// Fetch all existing subnets for the same VirtualNetwork using pagination:
-	filter := fmt.Sprintf("this.spec.virtual_network == '%s'", spec.GetVirtualNetwork())
+	filter := fmt.Sprintf("this.spec.virtual_network == %q", spec.GetVirtualNetwork())
 	var allSubnets []*privatev1.Subnet
 	var offset int32
 	for {

--- a/internal/servers/private_subnets_server_test.go
+++ b/internal/servers/private_subnets_server_test.go
@@ -1060,7 +1060,7 @@ var _ = Describe("Private subnets server", func() {
 
 			// List subnets for vn1 only
 			response, err := generic.List().
-				SetFilter(fmt.Sprintf("this.spec.virtual_network == '%s'", vn1.GetId())).
+				SetFilter(fmt.Sprintf("this.spec.virtual_network == %q", vn1.GetId())).
 				Do(ctx)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(response.GetItems()).To(HaveLen(3))


### PR DESCRIPTION
## Summary
- Replaces unsafe '%s' CEL interpolation with %q format verb to prevent injection

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of special characters in filter expressions to ensure proper escaping of quotes and backslashes.

* **Tests**
  * Added test coverage for edge cases in filter translation including special characters and escape sequence handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->