### PR TITLE
MGMT-23713: Add Claude Code hooks for automated pre-PR actions

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -2,7 +2,7 @@
   "hooks": {
     "PostToolUse": [
       {
-        "matcher": "Edit|Write",
+        "matcher": "Edit|MultiEdit|Write",
         "hooks": [
           {
             "type": "command",

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,26 @@
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "file_path=$(cat - | jq -r '.tool_input.file_path // .tool_input.filePath // empty') && case \"$file_path\" in *.proto) cd \"$CLAUDE_PROJECT_DIR\" && buf lint && buf generate ;; *go.mod) cd \"$CLAUDE_PROJECT_DIR\" && go mod tidy ;; esac"
+          }
+        ]
+      }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "cmd=$(cat - | jq -r '.tool_input.command // empty') && case \"$cmd\" in *'git commit'*) cd \"$CLAUDE_PROJECT_DIR\" && buf lint ;; *'gh pr create'*) cd \"$CLAUDE_PROJECT_DIR\" && buf lint && ginkgo run -r internal ;; esac"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -130,6 +130,17 @@ Tests use Ginkgo v2 + Gomega. Typical suite setup in `*_suite_test.go`:
 - `DeferCleanup` for teardown
 - `dao.CreateTables[T]()` dynamically creates test schemas
 
+## Claude Code Hooks
+
+Hooks are configured in `.claude/settings.json` and run automatically during Claude Code sessions:
+
+- **Proto changes** (`PostToolUse`): When a `.proto` file is edited, `buf lint && buf generate` runs automatically to keep generated Go code in sync.
+- **Go module changes** (`PostToolUse`): When `go.mod` is edited, `go mod tidy` runs automatically.
+- **Pre-commit** (`PreToolUse`): `buf lint` runs before every `git commit` to catch proto issues early.
+- **Pre-PR** (`PreToolUse`): `buf lint && ginkgo run -r internal` runs before `gh pr create` to ensure tests pass.
+
+To replicate this setup in another OSAC repo, copy `.claude/settings.json` and adjust the commands as needed.
+
 ## Common Pitfalls
 
 - Proto changes require both `buf lint` and `buf generate` before committing


### PR DESCRIPTION
## Summary
- Configure Claude Code hooks in `.claude/settings.json` to automate repetitive pre-PR tasks
- Proto file changes trigger `buf lint && buf generate` automatically
- `go.mod` edits trigger `go mod tidy` automatically
- `buf lint` runs before every commit, full test suite runs before PR creation
- Document hook setup in CLAUDE.md for team replication in other OSAC repos

## Test plan
- [x] Validated JSON syntax
- [x] Tested file pattern matching (`.proto`, `go.mod`) with simulated hook input
- [x] Tested command matching (`git commit`, `gh pr create`) with simulated hook input
- [x] Verified non-matching commands don't trigger hooks
- [x] Verified `buf lint` passes on current codebase
- [x] Verified `.claude/settings.json` is tracked by git (not gitignored)

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated code validation and build workflows that trigger during file edits and git operations (commits, PR creation)
  * Includes file-type-specific validation steps for enhanced development workflow

* **Documentation**
  * Documented automated workflow configuration and setup instructions
  * Provided guidance for replicating setup across repositories

<!-- end of auto-generated comment: release notes by coderabbit.ai -->