### PR TITLE
NO-ISSUE: Display identifier if object doesn't have a name

### DIFF
--- a/internal/rendering/table_renderer.go
+++ b/internal/rendering/table_renderer.go
@@ -481,6 +481,9 @@ func (r *TableRenderer) lookupName(ctx context.Context, messageFullName protoref
 	object := listResult.Items[0]
 	metadata := helper.GetMetadata(object)
 	result = metadata.GetName()
+	if result == "" {
+		result = key
+	}
 	return
 }
 


### PR DESCRIPTION
## Summary

- When rendering table columns that use the lookup feature, if the referenced object
  doesn't have a name, the cell was left empty. This change falls back to displaying
  the identifier itself instead of an empty cell.

## Test plan

- Run `fulfillment-cli get computeinstances` (or any resource with lookup columns) where
  a referenced object has no name and verify the identifier is displayed instead of a blank.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a display issue where table cells could appear blank when lookup results were unavailable. The system now properly displays the original key as a fallback instead of showing empty values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->