### PR TITLE
MGMT-23918: Fix Update without FieldMask clearing optional spec fields

### DIFF
--- a/internal/servers/cluster_templates_server.go
+++ b/internal/servers/cluster_templates_server.go
@@ -272,8 +272,8 @@ func (s *ClusterTemplatesServer) Update(ctx context.Context,
 	}
 	existingPrivateClusterTemplate := getResponse.GetObject()
 
-	// Map the public changes to the existing private object (preserving private data):
-	err = s.inMapper.Copy(ctx, publicClusterTemplate, existingPrivateClusterTemplate)
+	// Map the public changes to the existing private object, preserving absent fields:
+	err = s.inMapper.CopyUpdate(ctx, publicClusterTemplate, existingPrivateClusterTemplate)
 	if err != nil {
 		s.logger.ErrorContext(
 			ctx,

--- a/internal/servers/clusters_server.go
+++ b/internal/servers/clusters_server.go
@@ -334,7 +334,7 @@ func (s *ClustersServer) Update(ctx context.Context,
 		}
 		privateCluster = getResponse.GetObject()
 	}
-	err = s.inMapper.Copy(ctx, publicCluster, privateCluster)
+	err = s.inMapper.CopyUpdate(ctx, publicCluster, privateCluster)
 	if err != nil {
 		s.logger.ErrorContext(
 			ctx,

--- a/internal/servers/clusters_server_test.go
+++ b/internal/servers/clusters_server_test.go
@@ -1538,7 +1538,7 @@ var _ = Describe("Clusters server", func() {
 			Expect(labels).To(HaveKeyWithValue("example.com/my-label", "your-value"))
 		})
 
-		It("Updates label by updating without specifying the field mask", func() {
+		It("Clears labels using field mask", func() {
 			// Create the object:
 			createResponse, err := server.Create(ctx, publicv1.ClustersCreateRequest_builder{
 				Object: publicv1.Cluster_builder{
@@ -1555,7 +1555,8 @@ var _ = Describe("Clusters server", func() {
 			Expect(err).ToNot(HaveOccurred())
 			object := createResponse.GetObject()
 
-			// Delete the label:
+			// Delete labels using a field mask (the correct way to clear a
+			// map field, since proto3 cannot distinguish empty from absent):
 			updateResponse, err := server.Update(ctx, publicv1.ClustersUpdateRequest_builder{
 				Object: publicv1.Cluster_builder{
 					Id: object.GetId(),
@@ -1563,6 +1564,9 @@ var _ = Describe("Clusters server", func() {
 						Labels: map[string]string{},
 					}.Build(),
 				}.Build(),
+				UpdateMask: &fieldmaskpb.FieldMask{
+					Paths: []string{"metadata.labels"},
+				},
 			}.Build())
 			Expect(err).ToNot(HaveOccurred())
 			object = updateResponse.GetObject()

--- a/internal/servers/compute_instance_templates_server.go
+++ b/internal/servers/compute_instance_templates_server.go
@@ -272,8 +272,8 @@ func (s *ComputeInstanceTemplatesServer) Update(ctx context.Context,
 	}
 	existingPrivateComputeInstanceTemplate := getResponse.GetObject()
 
-	// Map the public changes to the existing private object (preserving private data):
-	err = s.inMapper.Copy(ctx, publicComputeInstanceTemplate, existingPrivateComputeInstanceTemplate)
+	// Map the public changes to the existing private object, preserving absent fields:
+	err = s.inMapper.CopyUpdate(ctx, publicComputeInstanceTemplate, existingPrivateComputeInstanceTemplate)
 	if err != nil {
 		s.logger.ErrorContext(
 			ctx,

--- a/internal/servers/compute_instances_server.go
+++ b/internal/servers/compute_instances_server.go
@@ -280,9 +280,7 @@ func (s *ComputeInstancesServer) Update(ctx context.Context,
 		}
 		privateComputeInstance = getResponse.GetObject()
 	}
-	// Merge the public changes into the existing private object. Merge (not Copy) preserves
-	// optional fields that are absent in the public request.
-	err = s.inMapper.Merge(ctx, publicComputeInstance, privateComputeInstance)
+	err = s.inMapper.CopyUpdate(ctx, publicComputeInstance, privateComputeInstance)
 	if err != nil {
 		s.logger.ErrorContext(
 			ctx,

--- a/internal/servers/compute_instances_server.go
+++ b/internal/servers/compute_instances_server.go
@@ -280,7 +280,9 @@ func (s *ComputeInstancesServer) Update(ctx context.Context,
 		}
 		privateComputeInstance = getResponse.GetObject()
 	}
-	err = s.inMapper.Copy(ctx, publicComputeInstance, privateComputeInstance)
+	// Merge the public changes into the existing private object. Merge (not Copy) preserves
+	// optional fields that are absent in the public request.
+	err = s.inMapper.Merge(ctx, publicComputeInstance, privateComputeInstance)
 	if err != nil {
 		s.logger.ErrorContext(
 			ctx,

--- a/internal/servers/compute_instances_server_test.go
+++ b/internal/servers/compute_instances_server_test.go
@@ -444,6 +444,64 @@ var _ = Describe("Compute instances server", func() {
 			Expect(getResponse).To(BeNil())
 		})
 
+		It("Preserves optional spec fields during update without field mask", func() {
+			// Create a template first:
+			createTemplate("general.small")
+
+			// Create an object with optional spec fields set:
+			createResponse, err := server.Create(ctx, publicv1.ComputeInstancesCreateRequest_builder{
+				Object: publicv1.ComputeInstance_builder{
+					Spec: publicv1.ComputeInstanceSpec_builder{
+						Template:    "general.small",
+						Cores:       proto.Int32(4),
+						MemoryGib:   proto.Int32(8),
+						RunStrategy: proto.String("Always"),
+						Image: publicv1.ComputeInstanceImage_builder{
+							SourceType: "registry",
+							SourceRef:  "quay.io/test:latest",
+						}.Build(),
+						BootDisk: publicv1.ComputeInstanceDisk_builder{
+							SizeGib: 20,
+						}.Build(),
+					}.Build(),
+				}.Build(),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+			id := createResponse.GetObject().GetId()
+
+			// Update WITHOUT a field mask, omitting optional spec fields. Only
+			// template is included — cores, memory_gib, etc. must survive.
+			updateResponse, err := server.Update(ctx, publicv1.ComputeInstancesUpdateRequest_builder{
+				Object: publicv1.ComputeInstance_builder{
+					Id: id,
+					Spec: publicv1.ComputeInstanceSpec_builder{
+						Template: "general.small",
+					}.Build(),
+				}.Build(),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+			object := updateResponse.GetObject()
+
+			// Verify optional spec fields were preserved:
+			Expect(object.GetSpec().GetCores()).To(BeNumerically("==", 4))
+			Expect(object.GetSpec().GetMemoryGib()).To(BeNumerically("==", 8))
+			Expect(object.GetSpec().GetRunStrategy()).To(Equal("Always"))
+			Expect(object.GetSpec().GetImage().GetSourceRef()).To(Equal("quay.io/test:latest"))
+			Expect(object.GetSpec().GetBootDisk().GetSizeGib()).To(BeNumerically("==", 20))
+
+			// Verify they survive a round-trip through the database:
+			getResponse, err := server.Get(ctx, publicv1.ComputeInstancesGetRequest_builder{
+				Id: id,
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+			fetched := getResponse.GetObject()
+			Expect(fetched.GetSpec().GetCores()).To(BeNumerically("==", 4))
+			Expect(fetched.GetSpec().GetMemoryGib()).To(BeNumerically("==", 8))
+			Expect(fetched.GetSpec().GetRunStrategy()).To(Equal("Always"))
+			Expect(fetched.GetSpec().GetImage().GetSourceRef()).To(Equal("quay.io/test:latest"))
+			Expect(fetched.GetSpec().GetBootDisk().GetSizeGib()).To(BeNumerically("==", 20))
+		})
+
 		It("Handles non-existent object", func() {
 			// Try to get a non-existent object:
 			getResponse, err := server.Get(ctx, publicv1.ComputeInstancesGetRequest_builder{

--- a/internal/servers/generic_mapper.go
+++ b/internal/servers/generic_mapper.go
@@ -225,10 +225,14 @@ func (m *GenericMapper[From, To]) copyMap(from, to protoreflect.Map, field proto
 }
 
 // CopyUpdate copies the data from the `from` object into the `to` object using update
-// semantics: fields present in `from` are written to `to` (replacing lists and maps entirely),
-// while fields absent in `from` are left unchanged in `to`. This is the correct behavior for
-// Update operations where the caller provides a partial object and expects unmentioned fields
-// to be preserved.
+// semantics: fields present in `from` are written to `to`, while fields absent in `from`
+// are left unchanged in `to`. This is the correct behavior for Update operations where
+// the caller provides a partial object and expects unmentioned fields to be preserved.
+//
+// For present fields, behavior varies by type: lists are replaced (truncated then copied),
+// maps are overlaid (keys from `from` are set on `to`, keys only in `to` are preserved),
+// and messages are recursively processed with the same update semantics. To remove a map
+// key or clear a collection entirely, use FieldMask.
 //
 // Compare with Copy (clears absent fields — destructive for partial updates) and Merge
 // (appends to lists instead of replacing — wrong for "set these rules" semantics).

--- a/internal/servers/generic_mapper.go
+++ b/internal/servers/generic_mapper.go
@@ -224,6 +224,80 @@ func (m *GenericMapper[From, To]) copyMap(from, to protoreflect.Map, field proto
 	return
 }
 
+// CopyUpdate copies the data from the `from` object into the `to` object using update
+// semantics: fields present in `from` are written to `to` (replacing lists and maps entirely),
+// while fields absent in `from` are left unchanged in `to`. This is the correct behavior for
+// Update operations where the caller provides a partial object and expects unmentioned fields
+// to be preserved.
+//
+// Compare with Copy (clears absent fields — destructive for partial updates) and Merge
+// (appends to lists instead of replacing — wrong for "set these rules" semantics).
+func (m *GenericMapper[From, To]) CopyUpdate(ctx context.Context, from From, to To) error {
+	fromReflect := from.ProtoReflect()
+	toReflect := to.ProtoReflect()
+	if !fromReflect.IsValid() || !toReflect.IsValid() {
+		return nil
+	}
+	return m.copyUpdateMessage(fromReflect, toReflect)
+}
+
+func (m *GenericMapper[From, To]) copyUpdateMessage(from, to protoreflect.Message) error {
+	fromFields := from.Descriptor().Fields()
+	toFields := to.Descriptor().Fields()
+	for i := range fromFields.Len() {
+		fromField := fromFields.Get(i)
+		if m.shouldIgnore(fromField) {
+			continue
+		}
+		toField := toFields.ByName(fromField.Name())
+		if toField == nil {
+			if m.strict {
+				return fmt.Errorf(
+					"type '%s' doesn't have a '%s' field",
+					to.Descriptor().FullName(),
+					fromField.Name(),
+				)
+			}
+			continue
+		}
+		if m.shouldIgnore(toField) {
+			continue
+		}
+		if !from.Has(fromField) {
+			continue
+		}
+		fromValue := from.Get(fromField)
+		switch {
+		case fromField.IsList():
+			fromList := fromValue.List()
+			toList := to.Mutable(toField).List()
+			err := m.copyList(fromList, toList, fromField)
+			if err != nil {
+				return err
+			}
+		case fromField.IsMap():
+			fromMap := fromValue.Map()
+			toMap := to.Mutable(toField).Map()
+			err := m.copyMap(fromMap, toMap, fromField.MapValue())
+			if err != nil {
+				return err
+			}
+		case fromField.Message() != nil:
+			fromMessage := fromValue.Message()
+			toMessage := to.Mutable(toField).Message()
+			err := m.copyUpdateMessage(fromMessage, toMessage)
+			if err != nil {
+				return err
+			}
+		case fromField.Kind() == protoreflect.BytesKind:
+			to.Set(toField, m.cloneBytes(fromValue))
+		default:
+			to.Set(toField, fromValue)
+		}
+	}
+	return nil
+}
+
 // Merge merges the data from the `from` object into the `to` object.
 func (m *GenericMapper[From, To]) Merge(ctx context.Context, from From, to To) error {
 	fromReflect := from.ProtoReflect()

--- a/internal/servers/generic_mapper_test.go
+++ b/internal/servers/generic_mapper_test.go
@@ -252,6 +252,165 @@ var _ = Describe("Generic mapper", func() {
 	)
 
 	DescribeTable(
+		"CopyUpdate compute instance public to private",
+		func(from *publicv1.ComputeInstance, to *privatev1.ComputeInstance, expected *privatev1.ComputeInstance) {
+			mapper, err := NewGenericMapper[*publicv1.ComputeInstance, *privatev1.ComputeInstance]().
+				SetLogger(logger).
+				SetStrict(false).
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+			err = mapper.CopyUpdate(ctx, from, to)
+			Expect(err).ToNot(HaveOccurred())
+			marshalOptions := protojson.MarshalOptions{
+				UseProtoNames: true,
+			}
+			actualJson, err := marshalOptions.Marshal(to)
+			Expect(err).ToNot(HaveOccurred())
+			expectedJson, err := marshalOptions.Marshal(expected)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(actualJson).To(MatchJSON(expectedJson))
+		},
+		Entry(
+			"Preserves absent optional scalar fields",
+			// From: only template set, cores/memory_gib absent
+			publicv1.ComputeInstance_builder{
+				Spec: publicv1.ComputeInstanceSpec_builder{
+					Template: "general.large",
+				}.Build(),
+			}.Build(),
+			// To: existing object with optional fields populated
+			privatev1.ComputeInstance_builder{
+				Id: "existing-id",
+				Spec: privatev1.ComputeInstanceSpec_builder{
+					Template:    "general.small",
+					Cores:       proto.Int32(4),
+					MemoryGib:   proto.Int32(8),
+					RunStrategy: proto.String("Always"),
+				}.Build(),
+			}.Build(),
+			// Expected: optional fields preserved
+			privatev1.ComputeInstance_builder{
+				Id: "existing-id",
+				Spec: privatev1.ComputeInstanceSpec_builder{
+					Template:    "general.large",
+					Cores:       proto.Int32(4),
+					MemoryGib:   proto.Int32(8),
+					RunStrategy: proto.String("Always"),
+				}.Build(),
+			}.Build(),
+		),
+		Entry(
+			"Replaces present repeated fields instead of appending",
+			// From: new security_groups list
+			publicv1.ComputeInstance_builder{
+				Spec: publicv1.ComputeInstanceSpec_builder{
+					Template:       "general.small",
+					SecurityGroups: []string{"sg-new"},
+				}.Build(),
+			}.Build(),
+			// To: existing object with different security_groups
+			privatev1.ComputeInstance_builder{
+				Id: "existing-id",
+				Spec: privatev1.ComputeInstanceSpec_builder{
+					Template:       "general.small",
+					SecurityGroups: []string{"sg-old-1", "sg-old-2"},
+				}.Build(),
+			}.Build(),
+			// Expected: security_groups replaced (not appended)
+			privatev1.ComputeInstance_builder{
+				Id: "existing-id",
+				Spec: privatev1.ComputeInstanceSpec_builder{
+					Template:       "general.small",
+					SecurityGroups: []string{"sg-new"},
+				}.Build(),
+			}.Build(),
+		),
+		Entry(
+			"Preserves absent repeated fields",
+			// From: no security_groups field
+			publicv1.ComputeInstance_builder{
+				Spec: publicv1.ComputeInstanceSpec_builder{
+					Template: "general.large",
+				}.Build(),
+			}.Build(),
+			// To: existing object with security_groups
+			privatev1.ComputeInstance_builder{
+				Id: "existing-id",
+				Spec: privatev1.ComputeInstanceSpec_builder{
+					Template:       "general.small",
+					SecurityGroups: []string{"sg-existing"},
+				}.Build(),
+			}.Build(),
+			// Expected: security_groups preserved
+			privatev1.ComputeInstance_builder{
+				Id: "existing-id",
+				Spec: privatev1.ComputeInstanceSpec_builder{
+					Template:       "general.large",
+					SecurityGroups: []string{"sg-existing"},
+				}.Build(),
+			}.Build(),
+		),
+		Entry(
+			"Overwrites present optional fields",
+			// From: cores set to new value
+			publicv1.ComputeInstance_builder{
+				Spec: publicv1.ComputeInstanceSpec_builder{
+					Template: "general.large",
+					Cores:    proto.Int32(16),
+				}.Build(),
+			}.Build(),
+			// To: existing object with different cores
+			privatev1.ComputeInstance_builder{
+				Id: "existing-id",
+				Spec: privatev1.ComputeInstanceSpec_builder{
+					Template:    "general.small",
+					Cores:       proto.Int32(4),
+					MemoryGib:   proto.Int32(8),
+					RunStrategy: proto.String("Always"),
+				}.Build(),
+			}.Build(),
+			// Expected: cores updated, other optionals preserved
+			privatev1.ComputeInstance_builder{
+				Id: "existing-id",
+				Spec: privatev1.ComputeInstanceSpec_builder{
+					Template:    "general.large",
+					Cores:       proto.Int32(16),
+					MemoryGib:   proto.Int32(8),
+					RunStrategy: proto.String("Always"),
+				}.Build(),
+			}.Build(),
+		),
+		Entry(
+			"Mixed: updates scalar, preserves absent optional, replaces list",
+			// From: new template, new security_groups, cores absent
+			publicv1.ComputeInstance_builder{
+				Spec: publicv1.ComputeInstanceSpec_builder{
+					Template:       "general.large",
+					SecurityGroups: []string{"sg-new-1", "sg-new-2"},
+				}.Build(),
+			}.Build(),
+			// To: existing object with cores and old security_groups
+			privatev1.ComputeInstance_builder{
+				Id: "existing-id",
+				Spec: privatev1.ComputeInstanceSpec_builder{
+					Template:       "general.small",
+					Cores:          proto.Int32(4),
+					SecurityGroups: []string{"sg-old"},
+				}.Build(),
+			}.Build(),
+			// Expected: template updated, cores preserved, security_groups replaced
+			privatev1.ComputeInstance_builder{
+				Id: "existing-id",
+				Spec: privatev1.ComputeInstanceSpec_builder{
+					Template:       "general.large",
+					Cores:          proto.Int32(4),
+					SecurityGroups: []string{"sg-new-1", "sg-new-2"},
+				}.Build(),
+			}.Build(),
+		),
+	)
+
+	DescribeTable(
 		"Merge cluster private to public",
 		func(from *privatev1.Cluster, to *publicv1.Cluster, expected *publicv1.Cluster) {
 			mapper, err := NewGenericMapper[*privatev1.Cluster, *publicv1.Cluster]().

--- a/internal/servers/generic_mapper_test.go
+++ b/internal/servers/generic_mapper_test.go
@@ -411,6 +411,104 @@ var _ = Describe("Generic mapper", func() {
 	)
 
 	DescribeTable(
+		"CopyUpdate cluster public to private (map fields)",
+		func(from *publicv1.Cluster, to *privatev1.Cluster, expected *privatev1.Cluster) {
+			mapper, err := NewGenericMapper[*publicv1.Cluster, *privatev1.Cluster]().
+				SetLogger(logger).
+				SetStrict(false).
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+			err = mapper.CopyUpdate(ctx, from, to)
+			Expect(err).ToNot(HaveOccurred())
+			marshalOptions := protojson.MarshalOptions{
+				UseProtoNames: true,
+			}
+			actualJson, err := marshalOptions.Marshal(to)
+			Expect(err).ToNot(HaveOccurred())
+			expectedJson, err := marshalOptions.Marshal(expected)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(actualJson).To(MatchJSON(expectedJson))
+		},
+		Entry(
+			"Preserves absent map field",
+			// From: spec without node_sets
+			publicv1.Cluster_builder{
+				Spec: publicv1.ClusterSpec_builder{
+					Template: "my_template",
+				}.Build(),
+			}.Build(),
+			// To: existing object with node_sets
+			privatev1.Cluster_builder{
+				Id: "existing-id",
+				Spec: privatev1.ClusterSpec_builder{
+					Template: "old_template",
+					NodeSets: map[string]*privatev1.ClusterNodeSet{
+						"compute": privatev1.ClusterNodeSet_builder{
+							Size: 3,
+						}.Build(),
+					},
+				}.Build(),
+			}.Build(),
+			// Expected: node_sets preserved, template updated
+			privatev1.Cluster_builder{
+				Id: "existing-id",
+				Spec: privatev1.ClusterSpec_builder{
+					Template: "my_template",
+					NodeSets: map[string]*privatev1.ClusterNodeSet{
+						"compute": privatev1.ClusterNodeSet_builder{
+							Size: 3,
+						}.Build(),
+					},
+				}.Build(),
+			}.Build(),
+		),
+		Entry(
+			"Overlays present map field (upserts keys, preserves target-only keys)",
+			// From: node_sets with one key
+			publicv1.Cluster_builder{
+				Spec: publicv1.ClusterSpec_builder{
+					Template: "my_template",
+					NodeSets: map[string]*publicv1.ClusterNodeSet{
+						"compute": publicv1.ClusterNodeSet_builder{
+							Size: 5,
+						}.Build(),
+					},
+				}.Build(),
+			}.Build(),
+			// To: existing object with two keys (compute + gpu)
+			privatev1.Cluster_builder{
+				Id: "existing-id",
+				Spec: privatev1.ClusterSpec_builder{
+					Template: "my_template",
+					NodeSets: map[string]*privatev1.ClusterNodeSet{
+						"compute": privatev1.ClusterNodeSet_builder{
+							Size: 3,
+						}.Build(),
+						"gpu": privatev1.ClusterNodeSet_builder{
+							Size: 1,
+						}.Build(),
+					},
+				}.Build(),
+			}.Build(),
+			// Expected: compute updated, gpu preserved (overlay, not replace)
+			privatev1.Cluster_builder{
+				Id: "existing-id",
+				Spec: privatev1.ClusterSpec_builder{
+					Template: "my_template",
+					NodeSets: map[string]*privatev1.ClusterNodeSet{
+						"compute": privatev1.ClusterNodeSet_builder{
+							Size: 5,
+						}.Build(),
+						"gpu": privatev1.ClusterNodeSet_builder{
+							Size: 1,
+						}.Build(),
+					},
+				}.Build(),
+			}.Build(),
+		),
+	)
+
+	DescribeTable(
 		"Merge cluster private to public",
 		func(from *privatev1.Cluster, to *publicv1.Cluster, expected *publicv1.Cluster) {
 			mapper, err := NewGenericMapper[*privatev1.Cluster, *publicv1.Cluster]().

--- a/internal/servers/host_types_server.go
+++ b/internal/servers/host_types_server.go
@@ -273,8 +273,8 @@ func (s *HostTypesServer) Update(ctx context.Context,
 	}
 	existingPrivateHostType := getResponse.GetObject()
 
-	// Map the public changes to the existing private object (preserving private data):
-	err = s.inMapper.Copy(ctx, publicHostType, existingPrivateHostType)
+	// Map the public changes to the existing private object, preserving absent fields:
+	err = s.inMapper.CopyUpdate(ctx, publicHostType, existingPrivateHostType)
 	if err != nil {
 		s.logger.ErrorContext(
 			ctx,

--- a/internal/servers/network_classes_server.go
+++ b/internal/servers/network_classes_server.go
@@ -273,8 +273,8 @@ func (s *NetworkClassesServer) Update(ctx context.Context,
 	}
 	existingPrivateNetworkClass := getResponse.GetObject()
 
-	// Map the public changes to the existing private object (preserving private data):
-	err = s.inMapper.Copy(ctx, publicNetworkClass, existingPrivateNetworkClass)
+	// Map the public changes to the existing private object, preserving absent fields:
+	err = s.inMapper.CopyUpdate(ctx, publicNetworkClass, existingPrivateNetworkClass)
 	if err != nil {
 		s.logger.ErrorContext(
 			ctx,

--- a/internal/servers/security_groups_server.go
+++ b/internal/servers/security_groups_server.go
@@ -273,8 +273,8 @@ func (s *SecurityGroupsServer) Update(ctx context.Context,
 	}
 	existingPrivateSecurityGroup := getResponse.GetObject()
 
-	// Map the public changes to the existing private object (preserving private data):
-	err = s.inMapper.Copy(ctx, publicSecurityGroup, existingPrivateSecurityGroup)
+	// Map the public changes to the existing private object, preserving absent fields:
+	err = s.inMapper.CopyUpdate(ctx, publicSecurityGroup, existingPrivateSecurityGroup)
 	if err != nil {
 		s.logger.ErrorContext(
 			ctx,

--- a/internal/servers/subnets_server.go
+++ b/internal/servers/subnets_server.go
@@ -273,8 +273,8 @@ func (s *SubnetsServer) Update(ctx context.Context,
 	}
 	existingPrivateSubnet := getResponse.GetObject()
 
-	// Map the public changes to the existing private object (preserving private data):
-	err = s.inMapper.Copy(ctx, publicSubnet, existingPrivateSubnet)
+	// Map the public changes to the existing private object, preserving absent fields:
+	err = s.inMapper.CopyUpdate(ctx, publicSubnet, existingPrivateSubnet)
 	if err != nil {
 		s.logger.ErrorContext(
 			ctx,

--- a/internal/servers/virtual_networks_server.go
+++ b/internal/servers/virtual_networks_server.go
@@ -278,8 +278,8 @@ func (s *VirtualNetworksServer) Update(ctx context.Context,
 	}
 	existingPrivateVirtualNetwork := getResponse.GetObject()
 
-	// Map the public changes to the existing private object (preserving private data):
-	err = s.inMapper.Copy(ctx, publicVirtualNetwork, existingPrivateVirtualNetwork)
+	// Map the public changes to the existing private object, preserving absent fields:
+	err = s.inMapper.CopyUpdate(ctx, publicVirtualNetwork, existingPrivateVirtualNetwork)
 	if err != nil {
 		s.logger.ErrorContext(
 			ctx,


### PR DESCRIPTION
## Summary

- Add `GenericMapper.CopyUpdate()` — a new mapping method with correct Update semantics: absent fields are preserved (like Merge), while present list and map fields are replaced entirely (like Copy)
- Switch all 9 public server Update paths from `Copy()` to `CopyUpdate()`
- Update Cluster label-clearing test to use FieldMask (proto3 cannot distinguish empty from absent)

## Context

Public server `Update` methods used `GenericMapper.Copy()` to map incoming public objects onto existing private objects. `Copy()` calls `to.Clear()` for any field where `!from.Has()`, silently erasing optional spec fields (cores, memory_gib, run_strategy, image, boot_disk, etc.) not included in the update request.

Neither `Copy` nor `Merge` is correct for Updates:
- **Copy**: clears absent optional fields (data loss)
- **Merge**: appends to lists instead of replacing (data corruption)

`CopyUpdate` combines both: `continue` for absent fields (Merge behavior), `copyList` for present lists (Copy behavior).

## Affected servers

All public servers with an Update path: ComputeInstances, Clusters, SecurityGroups, Subnets, VirtualNetworks, ClusterTemplates, ComputeInstanceTemplates, HostTypes, NetworkClasses.

## Test plan

- [x] 5 GenericMapper unit tests covering: preserve absent optionals, replace present lists, preserve absent lists, overwrite present optionals, mixed scenario
- [x] ComputeInstance server integration test: create with optional fields, update without them, verify preservation through DB round-trip
- [x] Full server test suite: 431/431 passing
- [x] `go build ./...` clean

## Behavioral change

Updates without FieldMask no longer clear absent map/list fields. To explicitly clear a collection field, use FieldMask. This aligns with proto3 semantics where empty collections are indistinguishable from absent fields.

Generated-By: Claude Code (Anthropic)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed partial update behavior across multiple resource types. When updating resources without specifying all fields, unspecified fields are now preserved instead of being cleared. This applies to Clusters, Compute Instances, Host Types, Network Classes, Security Groups, Subnets, Virtual Networks, and related templates.

* **Tests**
  * Added test coverage validating correct preservation of optional fields during partial updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->