### PR TITLE
NO_ISSUE: resolve network_class by implementation_strategy

### DIFF
--- a/internal/servers/private_virtual_networks_server.go
+++ b/internal/servers/private_virtual_networks_server.go
@@ -16,6 +16,7 @@ package servers
 import (
 	"context"
 	"errors"
+	"fmt"
 	"log/slog"
 	"net"
 
@@ -337,37 +338,41 @@ func validateImmutableFields(newVN *privatev1.VirtualNetwork, existingVN *privat
 func (s *PrivateVirtualNetworksServer) validateNetworkClassReference(ctx context.Context,
 	spec *privatev1.VirtualNetworkSpec) (implementationStrategy string, err error) {
 
-	networkClassID := spec.GetNetworkClass()
-	if networkClassID == "" {
+	networkClassRef := spec.GetNetworkClass()
+	if networkClassRef == "" {
 		err = grpcstatus.Errorf(grpccodes.InvalidArgument, "field 'spec.network_class' is required")
 		return
 	}
 
-	// Look up NetworkClass by ID
-	getResponse, err := s.networkClassDao.Get().
-		SetId(networkClassID).
+	// Look up NetworkClass by ID or implementation_strategy using a single List call.
+	// We avoid Get() here because a NotFound error from Get poisons the shared
+	// database transaction (via ReportError), causing subsequent writes to roll back.
+	listResponse, listErr := s.networkClassDao.List().
+		SetFilter(fmt.Sprintf(
+			"this.id == %[1]q || this.implementation_strategy == %[1]q",
+			networkClassRef,
+		)).
+		SetLimit(1).
 		Do(ctx)
-	if err != nil {
-		var notFoundErr *dao.ErrNotFound
-		if errors.As(err, &notFoundErr) {
-			err = grpcstatus.Errorf(grpccodes.InvalidArgument,
-				"network_class '%s' does not exist", networkClassID)
-			return
-		}
+	if listErr != nil {
 		s.logger.ErrorContext(ctx, "Failed to query NetworkClass",
-			slog.String("network_class", networkClassID),
-			slog.Any("error", err))
+			slog.String("network_class", networkClassRef),
+			slog.Any("error", listErr))
 		err = grpcstatus.Errorf(grpccodes.Internal, "failed to validate network_class")
 		return
 	}
-
-	networkClass := getResponse.GetObject()
+	if len(listResponse.GetItems()) == 0 {
+		err = grpcstatus.Errorf(grpccodes.InvalidArgument,
+			"network_class '%s' does not exist", networkClassRef)
+		return
+	}
+	networkClass := listResponse.GetItems()[0]
 
 	// VN-VAL-05: Check NetworkClass is READY
 	if networkClass.GetStatus().GetState() != privatev1.NetworkClassState_NETWORK_CLASS_STATE_READY {
 		err = grpcstatus.Errorf(grpccodes.FailedPrecondition,
 			"network_class '%s' is not in READY state (current state: %s)",
-			networkClassID, networkClass.GetStatus().GetState().String())
+			networkClassRef, networkClass.GetStatus().GetState().String())
 		return
 	}
 
@@ -377,17 +382,17 @@ func (s *PrivateVirtualNetworksServer) validateNetworkClassReference(ctx context
 	if vnCaps != nil && ncCaps != nil {
 		if vnCaps.GetEnableIpv4() && !ncCaps.GetSupportsIpv4() {
 			err = grpcstatus.Errorf(grpccodes.InvalidArgument,
-				"network_class '%s' does not support IPv4", networkClassID)
+				"network_class '%s' does not support IPv4", networkClassRef)
 			return
 		}
 		if vnCaps.GetEnableIpv6() && !ncCaps.GetSupportsIpv6() {
 			err = grpcstatus.Errorf(grpccodes.InvalidArgument,
-				"network_class '%s' does not support IPv6", networkClassID)
+				"network_class '%s' does not support IPv6", networkClassRef)
 			return
 		}
 		if vnCaps.GetEnableDualStack() && !ncCaps.GetSupportsDualStack() {
 			err = grpcstatus.Errorf(grpccodes.InvalidArgument,
-				"network_class '%s' does not support dual-stack", networkClassID)
+				"network_class '%s' does not support dual-stack", networkClassRef)
 			return
 		}
 	}


### PR DESCRIPTION
## Summary
- Allow `VirtualNetwork.spec.network_class` to be resolved by `implementation_strategy` (e.g., `cudn_net`) in addition to UUID
- The [proto documentation](https://github.com/osac-project/fulfillment-service/blob/main/proto/private/osac/private/v1/virtual_network_type.proto#L68-L69) explicitly states this field "references the `implementation_strategy` field of a NetworkClass resource", but the validation only did a direct ID lookup

## Problem
Creating a VirtualNetwork with `network_class: "cudn_net"` returns:
```
Code: InvalidArgument
Message: network_class 'cudn_net' does not exist
```
even though a NetworkClass with `implementation_strategy: cudn_net` exists and is in READY state.

## Fix
`validateNetworkClassReference()` now tries ID lookup first (fast path, backwards compatible with UUID usage), then falls back to filtering by `implementation_strategy`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation and resolution of network class references to provide clearer errors when a referenced network class is missing or invalid.
  * Enhanced diagnostic messages for readiness and capability mismatches, and more robust lookup behavior to reduce false negatives and aid troubleshooting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->