### PR TITLE
MGMT-24090: the created VM doesn't match the provided computeinstance…

### DIFF
--- a/internal/controllers/computeinstance/computeinstance_reconciler_function.go
+++ b/internal/controllers/computeinstance/computeinstance_reconciler_function.go
@@ -196,7 +196,11 @@ func (t *task) update(ctx context.Context) error {
 		object = &unstructured.Unstructured{}
 		object.SetGroupVersionKind(gvks.ComputeInstance)
 		object.SetNamespace(t.hubNamespace)
-		object.SetGenerateName(objectPrefix)
+		if name := t.computeInstance.GetMetadata().GetName(); name != "" {
+			object.SetName(name)
+		} else {
+			object.SetGenerateName(objectPrefix)
+		}
 		object.SetLabels(map[string]string{
 			labels.ComputeInstanceUuid: t.computeInstance.GetId(),
 		})


### PR DESCRIPTION
… name

Creating a computeinstance will result in VM spawned with the same name as the computeinstance.

Co-Authored-By: Claude Opus 4.6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * ComputeInstance resource creation now uses explicitly provided names when available, falling back to auto-generated names when not specified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->