### PR TITLE
MGMT-23503: Support all hub kubeconfig auth methods for console connections

### DIFF
--- a/internal/console/kubevirt_backend.go
+++ b/internal/console/kubevirt_backend.go
@@ -141,8 +141,9 @@ func (b *kubeVirtBackend) Connect(ctx context.Context, target Target) (io.ReadWr
 		return nil, fmt.Errorf("failed to build auth headers for hub %q: %w", target.HubID, err)
 	}
 	for key, values := range authHeaders {
+		wsConfig.Header.Del(key)
 		for _, value := range values {
-			wsConfig.Header.Set(key, value)
+			wsConfig.Header.Add(key, value)
 		}
 	}
 
@@ -185,9 +186,17 @@ func authHeadersFromConfig(config *rest.Config) (http.Header, error) {
 
 	// RoundTrip populates the request with auth headers, then our capture
 	// round-tripper saves them and returns a sentinel error.
-	_, _ = rt.RoundTrip(req)
+	resp, err := rt.RoundTrip(req)
+	if resp != nil && resp.Body != nil {
+		_ = resp.Body.Close()
+	}
+	if err != nil && !errors.Is(err, errHeaderCaptureOnly) {
+		return nil, fmt.Errorf("failed to apply auth wrappers: %w", err)
+	}
 	return capture.headers, nil
 }
+
+var errHeaderCaptureOnly = errors.New("header capture only")
 
 // headerCaptureRoundTripper is a fake http.RoundTripper that saves the request
 // headers set by transport wrappers (auth, user-agent, impersonation) without
@@ -201,7 +210,7 @@ func (h *headerCaptureRoundTripper) RoundTrip(req *http.Request) (*http.Response
 	// Return an error rather than nil response — the RoundTripper contract
 	// requires a valid *http.Response or an error, and a nil response would
 	// panic any wrapper that tries to access it.
-	return nil, errors.New("header capture only")
+	return nil, errHeaderCaptureOnly
 }
 
 // HubConfigProviderFromKubeconfigs returns a HubConfigProvider that builds

--- a/internal/console/kubevirt_backend.go
+++ b/internal/console/kubevirt_backend.go
@@ -20,12 +20,14 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"net/http"
 	"net/url"
 	"strings"
 
 	"golang.org/x/net/websocket"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/client-go/transport"
 )
 
 // HubConfigProvider returns a *rest.Config for the given hub ID.
@@ -130,18 +132,18 @@ func (b *kubeVirtBackend) Connect(ctx context.Context, target Target) (io.ReadWr
 		wsConfig.TlsConfig = tlsConfig
 	}
 
-	// Add authentication headers from the REST config.
-	// TODO: Currently only BearerToken is supported. If hub kubeconfigs use
-	// BearerTokenFile, ExecProvider, or client certificates, the WebSocket
-	// connection will be unauthenticated. To support all auth methods, use
-	// k8s.io/client-go/transport.New() to build a round-tripper from the
-	// REST config and extract the headers.
-	if config.BearerToken != "" {
-		wsConfig.Header.Set("Authorization", "Bearer "+config.BearerToken)
-	} else {
-		b.logger.WarnContext(ctx, "Hub REST config has no BearerToken; WebSocket connection may be unauthenticated",
-			slog.String("hub", target.HubID),
-		)
+	// Extract authentication headers from the REST config using client-go's
+	// transport layer. This handles all auth methods: BearerToken, BearerTokenFile,
+	// ExecProvider, and basic auth. Client certificates are handled separately
+	// by the TLS config above.
+	authHeaders, err := authHeadersFromConfig(config)
+	if err != nil {
+		return nil, fmt.Errorf("failed to build auth headers for hub %q: %w", target.HubID, err)
+	}
+	for key, values := range authHeaders {
+		for _, value := range values {
+			wsConfig.Header.Set(key, value)
+		}
 	}
 
 	conn, err := websocket.DialConfig(wsConfig)
@@ -159,6 +161,47 @@ func (b *kubeVirtBackend) Connect(ctx context.Context, target Target) (io.ReadWr
 	)
 
 	return conn, nil
+}
+
+// authHeadersFromConfig extracts authentication headers from a rest.Config by
+// building the same transport wrapper chain that client-go uses internally, then
+// capturing the headers it sets on a dummy request.
+func authHeadersFromConfig(config *rest.Config) (http.Header, error) {
+	transportConfig, err := config.TransportConfig()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get transport config: %w", err)
+	}
+
+	capture := &headerCaptureRoundTripper{}
+	rt, err := transport.HTTPWrappersForConfig(transportConfig, capture)
+	if err != nil {
+		return nil, fmt.Errorf("failed to build auth wrappers: %w", err)
+	}
+
+	req, err := http.NewRequest(http.MethodGet, "https://placeholder", nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	// RoundTrip populates the request with auth headers, then our capture
+	// round-tripper saves them and returns a sentinel error.
+	_, _ = rt.RoundTrip(req)
+	return capture.headers, nil
+}
+
+// headerCaptureRoundTripper is a fake http.RoundTripper that saves the request
+// headers set by transport wrappers (auth, user-agent, impersonation) without
+// making a network call.
+type headerCaptureRoundTripper struct {
+	headers http.Header
+}
+
+func (h *headerCaptureRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	h.headers = req.Header.Clone()
+	// Return an error rather than nil response — the RoundTripper contract
+	// requires a valid *http.Response or an error, and a nil response would
+	// panic any wrapper that tries to access it.
+	return nil, errors.New("header capture only")
 }
 
 // HubConfigProviderFromKubeconfigs returns a HubConfigProvider that builds

--- a/internal/console/kubevirt_backend_integration_test.go
+++ b/internal/console/kubevirt_backend_integration_test.go
@@ -223,9 +223,9 @@ var _ = Describe("KubeVirt Backend Integration", func() {
 	})
 
 	It("should send BearerToken in Authorization header to the server", func() {
-		var receivedAuth string
+		receivedAuth := make(chan string, 1)
 		authServer, err := newMockWSServerWithHandler(func(ws *websocket.Conn) {
-			receivedAuth = ws.Request().Header.Get("Authorization")
+			receivedAuth <- ws.Request().Header.Get("Authorization")
 			ws.PayloadType = websocket.BinaryFrame
 			ws.Write([]byte("authenticated\r\n"))
 			ws.Close()
@@ -257,7 +257,7 @@ var _ = Describe("KubeVirt Backend Integration", func() {
 		n, err := conn.Read(buf)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(string(buf[:n])).To(Equal("authenticated\r\n"))
-		Expect(receivedAuth).To(Equal("Bearer test-token-123"))
+		Expect(receivedAuth).To(Receive(Equal("Bearer test-token-123")))
 	})
 
 	It("should send BearerTokenFile in Authorization header to the server", func() {
@@ -266,9 +266,9 @@ var _ = Describe("KubeVirt Backend Integration", func() {
 		err := os.WriteFile(tokenFile, []byte("file-token-456"), 0600)
 		Expect(err).NotTo(HaveOccurred())
 
-		var receivedAuth string
+		receivedAuth := make(chan string, 1)
 		authServer, err := newMockWSServerWithHandler(func(ws *websocket.Conn) {
-			receivedAuth = ws.Request().Header.Get("Authorization")
+			receivedAuth <- ws.Request().Header.Get("Authorization")
 			ws.PayloadType = websocket.BinaryFrame
 			ws.Write([]byte("ok\r\n"))
 			ws.Close()
@@ -300,6 +300,6 @@ var _ = Describe("KubeVirt Backend Integration", func() {
 		n, err := conn.Read(buf)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(string(buf[:n])).To(Equal("ok\r\n"))
-		Expect(receivedAuth).To(Equal("Bearer file-token-456"))
+		Expect(receivedAuth).To(Receive(Equal("Bearer file-token-456")))
 	})
 })

--- a/internal/console/kubevirt_backend_integration_test.go
+++ b/internal/console/kubevirt_backend_integration_test.go
@@ -15,6 +15,8 @@ package console
 
 import (
 	"context"
+	"os"
+	"path/filepath"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -218,5 +220,86 @@ var _ = Describe("KubeVirt Backend Integration", func() {
 		conn2, err := mgr.Connect(ctx, target, "user2")
 		Expect(err).NotTo(HaveOccurred())
 		conn2.Close()
+	})
+
+	It("should send BearerToken in Authorization header to the server", func() {
+		var receivedAuth string
+		authServer, err := newMockWSServerWithHandler(func(ws *websocket.Conn) {
+			receivedAuth = ws.Request().Header.Get("Authorization")
+			ws.PayloadType = websocket.BinaryFrame
+			ws.Write([]byte("authenticated\r\n"))
+			ws.Close()
+		})
+		Expect(err).NotTo(HaveOccurred())
+		DeferCleanup(authServer.Close)
+
+		backend, err := NewKubeVirtBackend().
+			SetLogger(logger).
+			SetHubConfigProvider(func(ctx context.Context, hubID string) (*rest.Config, error) {
+				return &rest.Config{
+					Host:        "ws://" + authServer.Addr(),
+					BearerToken: "test-token-123",
+				}, nil
+			}).
+			Build()
+		Expect(err).NotTo(HaveOccurred())
+
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+
+		conn, err := backend.Connect(ctx, Target{
+			HubID: "hub-1", Namespace: "test-ns", VMName: "test-vm",
+		})
+		Expect(err).NotTo(HaveOccurred())
+		defer conn.Close()
+
+		buf := make([]byte, 4096)
+		n, err := conn.Read(buf)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(string(buf[:n])).To(Equal("authenticated\r\n"))
+		Expect(receivedAuth).To(Equal("Bearer test-token-123"))
+	})
+
+	It("should send BearerTokenFile in Authorization header to the server", func() {
+		tokenDir := GinkgoT().TempDir()
+		tokenFile := filepath.Join(tokenDir, "token")
+		err := os.WriteFile(tokenFile, []byte("file-token-456"), 0600)
+		Expect(err).NotTo(HaveOccurred())
+
+		var receivedAuth string
+		authServer, err := newMockWSServerWithHandler(func(ws *websocket.Conn) {
+			receivedAuth = ws.Request().Header.Get("Authorization")
+			ws.PayloadType = websocket.BinaryFrame
+			ws.Write([]byte("ok\r\n"))
+			ws.Close()
+		})
+		Expect(err).NotTo(HaveOccurred())
+		DeferCleanup(authServer.Close)
+
+		backend, err := NewKubeVirtBackend().
+			SetLogger(logger).
+			SetHubConfigProvider(func(ctx context.Context, hubID string) (*rest.Config, error) {
+				return &rest.Config{
+					Host:            "ws://" + authServer.Addr(),
+					BearerTokenFile: tokenFile,
+				}, nil
+			}).
+			Build()
+		Expect(err).NotTo(HaveOccurred())
+
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+
+		conn, err := backend.Connect(ctx, Target{
+			HubID: "hub-1", Namespace: "test-ns", VMName: "test-vm",
+		})
+		Expect(err).NotTo(HaveOccurred())
+		defer conn.Close()
+
+		buf := make([]byte, 4096)
+		n, err := conn.Read(buf)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(string(buf[:n])).To(Equal("ok\r\n"))
+		Expect(receivedAuth).To(Equal("Bearer file-token-456"))
 	})
 })

--- a/internal/console/kubevirt_backend_test.go
+++ b/internal/console/kubevirt_backend_test.go
@@ -16,6 +16,8 @@ package console
 import (
 	"context"
 	"fmt"
+	"os"
+	"path/filepath"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -96,6 +98,84 @@ var _ = Describe("KubeVirt Backend", func() {
 			})
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("failed to connect"))
+		})
+	})
+
+	Describe("authHeadersFromConfig", func() {
+		It("should return Authorization header for BearerToken", func() {
+			config := &rest.Config{
+				Host:        "https://localhost:6443",
+				BearerToken: "my-test-token",
+			}
+			headers, err := authHeadersFromConfig(config)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(headers.Get("Authorization")).To(Equal("Bearer my-test-token"))
+		})
+
+		It("should return Authorization header for BearerTokenFile", func() {
+			tokenDir := GinkgoT().TempDir()
+			tokenFile := filepath.Join(tokenDir, "token")
+			err := os.WriteFile(tokenFile, []byte("file-based-token"), 0600)
+			Expect(err).NotTo(HaveOccurred())
+
+			config := &rest.Config{
+				Host:            "https://localhost:6443",
+				BearerTokenFile: tokenFile,
+			}
+			headers, err := authHeadersFromConfig(config)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(headers.Get("Authorization")).To(Equal("Bearer file-based-token"))
+		})
+
+		It("should read updated token from BearerTokenFile", func() {
+			tokenDir := GinkgoT().TempDir()
+			tokenFile := filepath.Join(tokenDir, "token")
+			err := os.WriteFile(tokenFile, []byte("initial-token"), 0600)
+			Expect(err).NotTo(HaveOccurred())
+
+			config := &rest.Config{
+				Host:            "https://localhost:6443",
+				BearerTokenFile: tokenFile,
+			}
+
+			headers, err := authHeadersFromConfig(config)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(headers.Get("Authorization")).To(Equal("Bearer initial-token"))
+
+			// Update the token file and verify the new token is read.
+			err = os.WriteFile(tokenFile, []byte("rotated-token"), 0600)
+			Expect(err).NotTo(HaveOccurred())
+
+			headers, err = authHeadersFromConfig(config)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(headers.Get("Authorization")).To(Equal("Bearer rotated-token"))
+		})
+
+		It("should return no Authorization header when no auth is configured", func() {
+			config := &rest.Config{
+				Host: "https://localhost:6443",
+			}
+			headers, err := authHeadersFromConfig(config)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(headers.Get("Authorization")).To(BeEmpty())
+		})
+
+		It("should prefer BearerTokenFile over BearerToken when both are set", func() {
+			tokenDir := GinkgoT().TempDir()
+			tokenFile := filepath.Join(tokenDir, "token")
+			err := os.WriteFile(tokenFile, []byte("file-token"), 0600)
+			Expect(err).NotTo(HaveOccurred())
+
+			config := &rest.Config{
+				Host:            "https://localhost:6443",
+				BearerToken:     "inline-token",
+				BearerTokenFile: tokenFile,
+			}
+			headers, err := authHeadersFromConfig(config)
+			Expect(err).NotTo(HaveOccurred())
+			// client-go treats BearerTokenFile as a refreshable source that
+			// takes precedence over the static BearerToken.
+			Expect(headers.Get("Authorization")).To(Equal("Bearer file-token"))
 		})
 	})
 


### PR DESCRIPTION
## Summary

- Replace the manual `BearerToken`-only auth header logic in the KubeVirt console backend with `client-go`'s `transport.HTTPWrappersForConfig()`
- Uses a header-capture pattern to extract auth headers from `rest.Config`, supporting all auth methods: BearerToken, BearerTokenFile, ExecProvider, and basic auth
- Client certificates were already handled by the existing TLS config and are unchanged

The previous implementation only checked `config.BearerToken` and logged a warning for all other auth methods. This is fragile as Kubernetes moves toward short-lived projected tokens (BearerTokenFile) and cloud providers use ExecProvider-based kubeconfigs.

**Jira:** [MGMT-23503](https://issues.redhat.com/browse/MGMT-23503)

## Test plan

- [x] 5 unit tests for `authHeadersFromConfig`: BearerToken, BearerTokenFile, token rotation, no auth, precedence when both are set
- [x] 2 integration tests verifying auth headers reach the mock WebSocket server end-to-end (BearerToken and BearerTokenFile)
- [x] All 29 console tests pass (`ginkgo run internal/console`)

Generated-By: Claude Code (Anthropic)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved WebSocket authentication handling to support comprehensive Kubernetes configuration authentication methods beyond Bearer tokens, enabling more flexible and robust authentication scenarios.

* **Tests**
  * Added integration tests for Bearer token and Bearer token file authentication verification.
  * Added unit tests for authentication header extraction across multiple configuration scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->