### PR TITLE
PublicIPPool gRPC server

### DIFF
--- a/internal/cmd/service/start/grpcserver/start_grpc_server_cmd.go
+++ b/internal/cmd/service/start/grpcserver/start_grpc_server_cmd.go
@@ -717,6 +717,20 @@ func (c *runnerContext) run(cmd *cobra.Command, argv []string) error {
 	}
 	privatev1.RegisterPublicIPsServer(grpcServer, privatePublicIPsServer)
 
+	// Create the private public IP pools server:
+	c.logger.InfoContext(ctx, "Creating private public IP pools server")
+	privatePublicIPPoolsServer, err := servers.NewPrivatePublicIPPoolsServer().
+		SetLogger(c.logger).
+		SetNotifier(notifier).
+		SetAttributionLogic(privateAttributionLogic).
+		SetTenancyLogic(privateTenancyLogic).
+		SetMetricsRegisterer(metricsRegisterer).
+		Build()
+	if err != nil {
+		return fmt.Errorf("failed to create private public IP pools server: %w", err)
+	}
+	privatev1.RegisterPublicIPPoolsServer(grpcServer, privatePublicIPPoolsServer)
+
 	// Create the console manager and server:
 	c.logger.InfoContext(ctx, "Creating console server")
 	hubConfigProvider := console.HubConfigProviderFromKubeconfigs(

--- a/internal/cmd/service/start/restgateway/start_rest_gateway_cmd.go
+++ b/internal/cmd/service/start/restgateway/start_rest_gateway_cmd.go
@@ -247,6 +247,10 @@ func (c *runnerContext) run(cmd *cobra.Command, argv []string) error {
 	if err != nil {
 		return err
 	}
+	err = privatev1.RegisterPublicIPPoolsHandler(ctx, gatewayMux, c.grpcClient)
+	if err != nil {
+		return err
+	}
 
 	// Add the health endpoint:
 	c.logger.InfoContext(ctx, "Adding health endpoint")

--- a/internal/database/migrations/30_create_public_ip_pools_tables.up.sql
+++ b/internal/database/migrations/30_create_public_ip_pools_tables.up.sql
@@ -1,0 +1,62 @@
+--
+-- Copyright (c) 2026 Red Hat Inc.
+--
+-- Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+-- the License. You may obtain a copy of the License at
+--
+--   http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+-- an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+-- specific language governing permissions and limitations under the License.
+--
+
+-- Create the public_ip_pools tables:
+--
+-- This migration establishes the database schema for PublicIPPool resources following the generic schema pattern.
+-- PublicIPPool represents a pool of public IP addresses available for allocation to compute instances.
+--
+-- The data column stores:
+-- - spec: PublicIPPoolSpec (cidrs, ip_family, implementation_strategy)
+-- - status: PublicIPPoolStatus (state, message, hub, total, allocated, available)
+-- as JSONB.
+--
+create table public_ip_pools (
+  id text not null primary key,
+  name text not null default '',
+  creation_timestamp timestamp with time zone not null default now(),
+  deletion_timestamp timestamp with time zone not null default 'epoch',
+  finalizers text[] not null default '{}',
+  creators text[] not null default '{}',
+  tenants text[] not null default '{}',
+  labels jsonb not null default '{}'::jsonb,
+  annotations jsonb not null default '{}'::jsonb,
+  version integer not null default 0,
+  data jsonb not null
+);
+
+create table archived_public_ip_pools (
+  id text not null,
+  name text not null default '',
+  creation_timestamp timestamp with time zone not null,
+  deletion_timestamp timestamp with time zone not null,
+  archival_timestamp timestamp with time zone not null default now(),
+  creators text[] not null default '{}',
+  tenants text[] not null default '{}',
+  labels jsonb not null default '{}'::jsonb,
+  annotations jsonb not null default '{}'::jsonb,
+  version integer not null default 0,
+  data jsonb not null
+);
+
+-- Add indexes on the name column for fast lookups:
+create index public_ip_pools_by_name on public_ip_pools (name);
+
+-- Add indexes on the creators column for owner-based queries:
+create index public_ip_pools_by_owner on public_ip_pools using gin (creators);
+
+-- Add indexes on the tenants column for tenant isolation:
+create index public_ip_pools_by_tenant on public_ip_pools using gin (tenants);
+
+-- Add indexes on the labels column for label-based queries:
+create index public_ip_pools_by_label on public_ip_pools using gin (labels);

--- a/internal/servers/generic_server.go
+++ b/internal/servers/generic_server.go
@@ -840,6 +840,8 @@ func (s *GenericServer[O]) setPayload(event *privatev1.Event, object proto.Messa
 		event.SetLease(object)
 	case *privatev1.PublicIP:
 		event.SetPublicIp(object)
+	case *privatev1.PublicIPPool:
+		event.SetPublicIpPool(object)
 	default:
 		return fmt.Errorf("unknown object type '%T'", object)
 	}

--- a/internal/servers/private_public_ip_pools_server.go
+++ b/internal/servers/private_public_ip_pools_server.go
@@ -1,0 +1,148 @@
+/*
+Copyright (c) 2026 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package servers
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+
+	"github.com/prometheus/client_golang/prometheus"
+
+	privatev1 "github.com/osac-project/fulfillment-service/internal/api/osac/private/v1"
+	"github.com/osac-project/fulfillment-service/internal/auth"
+	"github.com/osac-project/fulfillment-service/internal/database"
+)
+
+// PrivatePublicIPPoolsServerBuilder contains the data and logic needed to create a new private public IP pools server.
+type PrivatePublicIPPoolsServerBuilder struct {
+	logger            *slog.Logger
+	notifier          *database.Notifier
+	attributionLogic  auth.AttributionLogic
+	tenancyLogic      auth.TenancyLogic
+	metricsRegisterer prometheus.Registerer
+}
+
+var _ privatev1.PublicIPPoolsServer = (*PrivatePublicIPPoolsServer)(nil)
+
+// PrivatePublicIPPoolsServer is the private server for public IP pools.
+type PrivatePublicIPPoolsServer struct {
+	privatev1.UnimplementedPublicIPPoolsServer
+
+	logger  *slog.Logger
+	generic *GenericServer[*privatev1.PublicIPPool]
+}
+
+// NewPrivatePublicIPPoolsServer creates a builder that can then be used to configure and create a new private public
+// IP pools server.
+func NewPrivatePublicIPPoolsServer() *PrivatePublicIPPoolsServerBuilder {
+	return &PrivatePublicIPPoolsServerBuilder{}
+}
+
+// SetLogger sets the logger to use. This is mandatory.
+func (b *PrivatePublicIPPoolsServerBuilder) SetLogger(value *slog.Logger) *PrivatePublicIPPoolsServerBuilder {
+	b.logger = value
+	return b
+}
+
+// SetNotifier sets the notifier used to publish change events.
+func (b *PrivatePublicIPPoolsServerBuilder) SetNotifier(value *database.Notifier) *PrivatePublicIPPoolsServerBuilder {
+	b.notifier = value
+	return b
+}
+
+// SetAttributionLogic sets the attribution logic used to determine the creators of objects.
+func (b *PrivatePublicIPPoolsServerBuilder) SetAttributionLogic(value auth.AttributionLogic) *PrivatePublicIPPoolsServerBuilder {
+	b.attributionLogic = value
+	return b
+}
+
+// SetTenancyLogic sets the tenancy logic used to determine the tenants of objects.
+func (b *PrivatePublicIPPoolsServerBuilder) SetTenancyLogic(value auth.TenancyLogic) *PrivatePublicIPPoolsServerBuilder {
+	b.tenancyLogic = value
+	return b
+}
+
+// SetMetricsRegisterer sets the Prometheus registerer used to register metrics for the underlying database access
+// objects. This is optional. If not set, no metrics will be recorded.
+func (b *PrivatePublicIPPoolsServerBuilder) SetMetricsRegisterer(value prometheus.Registerer) *PrivatePublicIPPoolsServerBuilder {
+	b.metricsRegisterer = value
+	return b
+}
+
+// Build uses the data stored in the builder to create a new private public IP pools server.
+func (b *PrivatePublicIPPoolsServerBuilder) Build() (result *PrivatePublicIPPoolsServer, err error) {
+	if b.logger == nil {
+		err = errors.New("logger is mandatory")
+		return
+	}
+	if b.tenancyLogic == nil {
+		err = errors.New("tenancy logic is mandatory")
+		return
+	}
+
+	generic, err := NewGenericServer[*privatev1.PublicIPPool]().
+		SetLogger(b.logger).
+		SetService(privatev1.PublicIPPools_ServiceDesc.ServiceName).
+		SetNotifier(b.notifier).
+		SetAttributionLogic(b.attributionLogic).
+		SetTenancyLogic(b.tenancyLogic).
+		SetMetricsRegisterer(b.metricsRegisterer).
+		Build()
+	if err != nil {
+		return
+	}
+
+	result = &PrivatePublicIPPoolsServer{
+		logger:  b.logger,
+		generic: generic,
+	}
+	return
+}
+
+func (s *PrivatePublicIPPoolsServer) List(ctx context.Context,
+	request *privatev1.PublicIPPoolsListRequest) (response *privatev1.PublicIPPoolsListResponse, err error) {
+	err = s.generic.List(ctx, request, &response)
+	return
+}
+
+func (s *PrivatePublicIPPoolsServer) Get(ctx context.Context,
+	request *privatev1.PublicIPPoolsGetRequest) (response *privatev1.PublicIPPoolsGetResponse, err error) {
+	err = s.generic.Get(ctx, request, &response)
+	return
+}
+
+func (s *PrivatePublicIPPoolsServer) Create(ctx context.Context,
+	request *privatev1.PublicIPPoolsCreateRequest) (response *privatev1.PublicIPPoolsCreateResponse, err error) {
+	err = s.generic.Create(ctx, request, &response)
+	return
+}
+
+func (s *PrivatePublicIPPoolsServer) Update(ctx context.Context,
+	request *privatev1.PublicIPPoolsUpdateRequest) (response *privatev1.PublicIPPoolsUpdateResponse, err error) {
+	err = s.generic.Update(ctx, request, &response)
+	return
+}
+
+func (s *PrivatePublicIPPoolsServer) Delete(ctx context.Context,
+	request *privatev1.PublicIPPoolsDeleteRequest) (response *privatev1.PublicIPPoolsDeleteResponse, err error) {
+	err = s.generic.Delete(ctx, request, &response)
+	return
+}
+
+func (s *PrivatePublicIPPoolsServer) Signal(ctx context.Context,
+	request *privatev1.PublicIPPoolsSignalRequest) (response *privatev1.PublicIPPoolsSignalResponse, err error) {
+	err = s.generic.Signal(ctx, request, &response)
+	return
+}

--- a/internal/servers/private_public_ip_pools_server_test.go
+++ b/internal/servers/private_public_ip_pools_server_test.go
@@ -1,0 +1,278 @@
+/*
+Copyright (c) 2026 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package servers
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/fieldmaskpb"
+
+	privatev1 "github.com/osac-project/fulfillment-service/internal/api/osac/private/v1"
+	"github.com/osac-project/fulfillment-service/internal/database"
+	"github.com/osac-project/fulfillment-service/internal/database/dao"
+)
+
+var _ = Describe("Private public IP pools server", func() {
+	var (
+		ctx context.Context
+		tx  database.Tx
+	)
+
+	BeforeEach(func() {
+		var err error
+
+		// Create a context:
+		ctx = context.Background()
+
+		// Prepare the database pool:
+		db := server.MakeDatabase()
+		DeferCleanup(db.Close)
+		pool, err := pgxpool.New(ctx, db.MakeURL())
+		Expect(err).ToNot(HaveOccurred())
+		DeferCleanup(pool.Close)
+
+		// Create the transaction manager:
+		tm, err := database.NewTxManager().
+			SetLogger(logger).
+			SetPool(pool).
+			Build()
+		Expect(err).ToNot(HaveOccurred())
+
+		// Start a transaction and add it to the context:
+		tx, err = tm.Begin(ctx)
+		Expect(err).ToNot(HaveOccurred())
+		DeferCleanup(func() {
+			err := tm.End(ctx, tx)
+			Expect(err).ToNot(HaveOccurred())
+		})
+		ctx = database.TxIntoContext(ctx, tx)
+
+		// Create the tables:
+		err = dao.CreateTables[*privatev1.PublicIPPool](ctx)
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	Describe("Creation", func() {
+		It("Can be built if all the required parameters are set", func() {
+			server, err := NewPrivatePublicIPPoolsServer().
+				SetLogger(logger).
+				SetAttributionLogic(attribution).
+				SetTenancyLogic(tenancy).
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(server).ToNot(BeNil())
+		})
+
+		It("Fails if logger is not set", func() {
+			server, err := NewPrivatePublicIPPoolsServer().
+				SetAttributionLogic(attribution).
+				SetTenancyLogic(tenancy).
+				Build()
+			Expect(err).To(MatchError("logger is mandatory"))
+			Expect(server).To(BeNil())
+		})
+
+		It("Fails if attribution logic is not set", func() {
+			server, err := NewPrivatePublicIPPoolsServer().
+				SetLogger(logger).
+				SetTenancyLogic(tenancy).
+				Build()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("attribution logic is mandatory"))
+			Expect(server).To(BeNil())
+		})
+
+		It("Fails if tenancy logic is not set", func() {
+			server, err := NewPrivatePublicIPPoolsServer().
+				SetLogger(logger).
+				SetAttributionLogic(attribution).
+				Build()
+			Expect(err).To(MatchError("tenancy logic is mandatory"))
+			Expect(server).To(BeNil())
+		})
+	})
+
+	Describe("Behaviour", func() {
+		var poolsServer *PrivatePublicIPPoolsServer
+
+		BeforeEach(func() {
+			var err error
+
+			// Create the server:
+			poolsServer, err = NewPrivatePublicIPPoolsServer().
+				SetLogger(logger).
+				SetAttributionLogic(attribution).
+				SetTenancyLogic(tenancy).
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("Creates a pool", func() {
+			response, err := poolsServer.Create(ctx, privatev1.PublicIPPoolsCreateRequest_builder{
+				Object: privatev1.PublicIPPool_builder{
+					Spec: privatev1.PublicIPPoolSpec_builder{
+						Cidrs:    []string{"192.168.1.0/24"},
+						IpFamily: privatev1.IPFamily_IP_FAMILY_IPV4,
+					}.Build(),
+				}.Build(),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+			Expect(response).ToNot(BeNil())
+			object := response.GetObject()
+			Expect(object.GetId()).ToNot(BeEmpty())
+			Expect(object.GetSpec().GetCidrs()).To(ConsistOf("192.168.1.0/24"))
+			Expect(object.GetSpec().GetIpFamily()).To(Equal(privatev1.IPFamily_IP_FAMILY_IPV4))
+		})
+
+		It("Lists pools", func() {
+			const count = 5
+			for i := range count {
+				_, err := poolsServer.Create(ctx, privatev1.PublicIPPoolsCreateRequest_builder{
+					Object: privatev1.PublicIPPool_builder{
+						Metadata: privatev1.Metadata_builder{
+							Name: fmt.Sprintf("pool-%d", i),
+						}.Build(),
+						Spec: privatev1.PublicIPPoolSpec_builder{
+							Cidrs:    []string{fmt.Sprintf("10.%d.0.0/24", i)},
+							IpFamily: privatev1.IPFamily_IP_FAMILY_IPV4,
+						}.Build(),
+					}.Build(),
+				}.Build())
+				Expect(err).ToNot(HaveOccurred())
+			}
+
+			response, err := poolsServer.List(ctx, privatev1.PublicIPPoolsListRequest_builder{}.Build())
+			Expect(err).ToNot(HaveOccurred())
+			Expect(response.GetItems()).To(HaveLen(count))
+		})
+
+		It("Lists pools with limit", func() {
+			const count = 5
+			for i := range count {
+				_, err := poolsServer.Create(ctx, privatev1.PublicIPPoolsCreateRequest_builder{
+					Object: privatev1.PublicIPPool_builder{
+						Spec: privatev1.PublicIPPoolSpec_builder{
+							Cidrs:    []string{fmt.Sprintf("10.%d.0.0/24", i)},
+							IpFamily: privatev1.IPFamily_IP_FAMILY_IPV4,
+						}.Build(),
+					}.Build(),
+				}.Build())
+				Expect(err).ToNot(HaveOccurred())
+			}
+
+			response, err := poolsServer.List(ctx, privatev1.PublicIPPoolsListRequest_builder{
+				Limit: proto.Int32(2),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+			Expect(response.GetSize()).To(BeNumerically("==", 2))
+		})
+
+		It("Lists pools with filter", func() {
+			createResponse, err := poolsServer.Create(ctx, privatev1.PublicIPPoolsCreateRequest_builder{
+				Object: privatev1.PublicIPPool_builder{
+					Spec: privatev1.PublicIPPoolSpec_builder{
+						Cidrs:    []string{"192.168.1.0/24"},
+						IpFamily: privatev1.IPFamily_IP_FAMILY_IPV4,
+					}.Build(),
+				}.Build(),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+			id := createResponse.GetObject().GetId()
+
+			response, err := poolsServer.List(ctx, privatev1.PublicIPPoolsListRequest_builder{
+				Filter: proto.String(fmt.Sprintf("this.id == '%s'", id)),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+			Expect(response.GetSize()).To(BeNumerically("==", 1))
+			Expect(response.GetItems()[0].GetId()).To(Equal(id))
+		})
+
+		It("Gets a pool", func() {
+			createResponse, err := poolsServer.Create(ctx, privatev1.PublicIPPoolsCreateRequest_builder{
+				Object: privatev1.PublicIPPool_builder{
+					Spec: privatev1.PublicIPPoolSpec_builder{
+						Cidrs:    []string{"192.168.1.0/24"},
+						IpFamily: privatev1.IPFamily_IP_FAMILY_IPV4,
+					}.Build(),
+				}.Build(),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+
+			getResponse, err := poolsServer.Get(ctx, privatev1.PublicIPPoolsGetRequest_builder{
+				Id: createResponse.GetObject().GetId(),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+			Expect(proto.Equal(createResponse.GetObject(), getResponse.GetObject())).To(BeTrue())
+		})
+
+		It("Updates a pool", func() {
+			createResponse, err := poolsServer.Create(ctx, privatev1.PublicIPPoolsCreateRequest_builder{
+				Object: privatev1.PublicIPPool_builder{
+					Spec: privatev1.PublicIPPoolSpec_builder{
+						Cidrs:    []string{"192.168.1.0/24"},
+						IpFamily: privatev1.IPFamily_IP_FAMILY_IPV4,
+					}.Build(),
+				}.Build(),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+			object := createResponse.GetObject()
+
+			updateResponse, err := poolsServer.Update(ctx, privatev1.PublicIPPoolsUpdateRequest_builder{
+				Object: privatev1.PublicIPPool_builder{
+					Id: object.GetId(),
+					Metadata: privatev1.Metadata_builder{
+						Name: "my-pool",
+					}.Build(),
+				}.Build(),
+				UpdateMask: &fieldmaskpb.FieldMask{
+					Paths: []string{"metadata.name"},
+				},
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+			Expect(updateResponse.GetObject().GetMetadata().GetName()).To(Equal("my-pool"))
+		})
+
+		It("Deletes a pool", func() {
+			createResponse, err := poolsServer.Create(ctx, privatev1.PublicIPPoolsCreateRequest_builder{
+				Object: privatev1.PublicIPPool_builder{
+					Metadata: privatev1.Metadata_builder{
+						Finalizers: []string{"test"},
+					}.Build(),
+					Spec: privatev1.PublicIPPoolSpec_builder{
+						Cidrs:    []string{"192.168.1.0/24"},
+						IpFamily: privatev1.IPFamily_IP_FAMILY_IPV4,
+					}.Build(),
+				}.Build(),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+			object := createResponse.GetObject()
+
+			_, err = poolsServer.Delete(ctx, privatev1.PublicIPPoolsDeleteRequest_builder{
+				Id: object.GetId(),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+
+			getResponse, err := poolsServer.Get(ctx, privatev1.PublicIPPoolsGetRequest_builder{
+				Id: object.GetId(),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+			Expect(getResponse.GetObject().GetMetadata().GetDeletionTimestamp()).ToNot(BeNil())
+		})
+	})
+})


### PR DESCRIPTION
Added the PublicIPPool resource to the private gRPC API. PublicIPPool represents a named pool of public IP address CIDR ranges (IPv4 or IPv6) from which individual PublicIP addresses can be allocated to compute instances. 

Testing done:
- Unit tests in private_public_ip_pools_server_test.go
- Manually verified end-to-end via REST gateway (curl) and gRPC (grpcurl) with a local PostgreSQL instance


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced the Public IP Pools API with full Create, Read, Update, and Delete operations, available through both gRPC and REST endpoints
  * Added database persistence with archival capabilities for public IP pool resources
  * Integrated event notification system to track and notify on public IP pool resource changes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->