### PR TITLE
MGMT-24096: Create Users server

### DIFF
--- a/internal/database/migrations/29_create_users_tables.down.sql
+++ b/internal/database/migrations/29_create_users_tables.down.sql
@@ -1,0 +1,26 @@
+--
+-- Copyright (c) 2026 Red Hat Inc.
+--
+-- Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+-- the License. You may obtain a copy of the License at
+--
+--   http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+-- an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+-- specific language governing permissions and limitations under the License.
+--
+
+-- Rollback: Drop the users tables:
+--
+drop index if exists users_by_label;
+
+drop index if exists users_by_tenant;
+
+drop index if exists users_by_owner;
+
+drop index if exists users_by_name;
+
+drop table if exists archived_users;
+
+drop table if exists users;

--- a/internal/database/migrations/29_create_users_tables.up.sql
+++ b/internal/database/migrations/29_create_users_tables.up.sql
@@ -1,0 +1,54 @@
+--
+-- Copyright (c) 2026 Red Hat Inc.
+--
+-- Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+-- the License. You may obtain a copy of the License at
+--
+--   http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+-- an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+-- specific language governing permissions and limitations under the License.
+--
+
+-- Create the users tables:
+--
+-- This migration establishes the database schema for User resources following the generic schema pattern.
+--
+
+create table users (
+  id text not null primary key,
+  name text not null default '',
+  creation_timestamp timestamp with time zone not null default now(),
+  deletion_timestamp timestamp with time zone not null default 'epoch',
+  finalizers text[] not null default '{}',
+  creators text[] not null default '{}',
+  tenants text[] not null default '{}',
+  labels jsonb not null default '{}'::jsonb,
+  annotations jsonb not null default '{}'::jsonb,
+  data jsonb not null,
+  version integer not null default 0
+);
+
+create table archived_users (
+  id text not null,
+  name text not null default '',
+  creation_timestamp timestamp with time zone not null,
+  deletion_timestamp timestamp with time zone not null,
+  archival_timestamp timestamp with time zone not null default now(),
+  finalizers text[] not null default '{}',
+  creators text[] not null default '{}',
+  tenants text[] not null default '{}',
+  labels jsonb not null default '{}'::jsonb,
+  annotations jsonb not null default '{}'::jsonb,
+  data jsonb not null,
+  version integer not null default 0
+);
+
+create index users_by_name on users (name);
+
+create index users_by_owner on users using gin (creators);
+
+create index users_by_tenant on users using gin (tenants);
+
+create index users_by_label on users using gin (labels);

--- a/internal/servers/private_users_server.go
+++ b/internal/servers/private_users_server.go
@@ -1,0 +1,141 @@
+/*
+Copyright (c) 2026 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package servers
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+
+	"github.com/prometheus/client_golang/prometheus"
+
+	privatev1 "github.com/osac-project/fulfillment-service/internal/api/osac/private/v1"
+	"github.com/osac-project/fulfillment-service/internal/auth"
+	"github.com/osac-project/fulfillment-service/internal/database"
+)
+
+type PrivateUsersServerBuilder struct {
+	logger            *slog.Logger
+	notifier          *database.Notifier
+	attributionLogic  auth.AttributionLogic
+	tenancyLogic      auth.TenancyLogic
+	metricsRegisterer prometheus.Registerer
+}
+
+var _ privatev1.UsersServer = (*PrivateUsersServer)(nil)
+
+type PrivateUsersServer struct {
+	privatev1.UnimplementedUsersServer
+	logger  *slog.Logger
+	generic *GenericServer[*privatev1.User]
+}
+
+func NewPrivateUsersServer() *PrivateUsersServerBuilder {
+	return &PrivateUsersServerBuilder{}
+}
+
+func (b *PrivateUsersServerBuilder) SetLogger(value *slog.Logger) *PrivateUsersServerBuilder {
+	b.logger = value
+	return b
+}
+
+func (b *PrivateUsersServerBuilder) SetNotifier(value *database.Notifier) *PrivateUsersServerBuilder {
+	b.notifier = value
+	return b
+}
+
+func (b *PrivateUsersServerBuilder) SetAttributionLogic(value auth.AttributionLogic) *PrivateUsersServerBuilder {
+	b.attributionLogic = value
+	return b
+}
+
+func (b *PrivateUsersServerBuilder) SetTenancyLogic(value auth.TenancyLogic) *PrivateUsersServerBuilder {
+	b.tenancyLogic = value
+	return b
+}
+
+// SetMetricsRegisterer sets the Prometheus registerer used to register the metrics for the underlying database
+// access objects. This is optional. If not set, no metrics will be recorded.
+func (b *PrivateUsersServerBuilder) SetMetricsRegisterer(value prometheus.Registerer) *PrivateUsersServerBuilder {
+	b.metricsRegisterer = value
+	return b
+}
+
+func (b *PrivateUsersServerBuilder) Build() (result *PrivateUsersServer, err error) {
+	// Check parameters:
+	if b.logger == nil {
+		err = errors.New("logger is mandatory")
+		return
+	}
+	if b.tenancyLogic == nil {
+		err = errors.New("tenancy logic is mandatory")
+		return
+	}
+
+	// Create the generic server:
+	generic, err := NewGenericServer[*privatev1.User]().
+		SetLogger(b.logger).
+		SetService(privatev1.Users_ServiceDesc.ServiceName).
+		SetNotifier(b.notifier).
+		SetAttributionLogic(b.attributionLogic).
+		SetTenancyLogic(b.tenancyLogic).
+		SetMetricsRegisterer(b.metricsRegisterer).
+		Build()
+	if err != nil {
+		return
+	}
+
+	// Create and populate the object:
+	result = &PrivateUsersServer{
+		logger:  b.logger,
+		generic: generic,
+	}
+	return
+}
+
+func (s *PrivateUsersServer) List(ctx context.Context,
+	request *privatev1.UsersListRequest) (response *privatev1.UsersListResponse, err error) {
+	err = s.generic.List(ctx, request, &response)
+	return
+}
+
+func (s *PrivateUsersServer) Get(ctx context.Context,
+	request *privatev1.UsersGetRequest) (response *privatev1.UsersGetResponse, err error) {
+	err = s.generic.Get(ctx, request, &response)
+	return
+}
+
+func (s *PrivateUsersServer) Create(ctx context.Context,
+	request *privatev1.UsersCreateRequest) (response *privatev1.UsersCreateResponse, err error) {
+	err = s.generic.Create(ctx, request, &response)
+	return
+}
+
+func (s *PrivateUsersServer) Update(ctx context.Context,
+	request *privatev1.UsersUpdateRequest) (response *privatev1.UsersUpdateResponse, err error) {
+	err = s.generic.Update(ctx, request, &response)
+	return
+}
+
+func (s *PrivateUsersServer) Delete(ctx context.Context,
+	request *privatev1.UsersDeleteRequest) (response *privatev1.UsersDeleteResponse, err error) {
+	err = s.generic.Delete(ctx, request, &response)
+	return
+}
+
+func (s *PrivateUsersServer) Signal(ctx context.Context,
+	request *privatev1.UsersSignalRequest) (response *privatev1.UsersSignalResponse, err error) {
+	err = s.generic.Signal(ctx, request, &response)
+	return
+}

--- a/internal/servers/private_users_server_test.go
+++ b/internal/servers/private_users_server_test.go
@@ -1,0 +1,208 @@
+/*
+Copyright (c) 2026 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package servers
+
+import (
+	"context"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	privatev1 "github.com/osac-project/fulfillment-service/internal/api/osac/private/v1"
+	"github.com/osac-project/fulfillment-service/internal/database"
+	"github.com/osac-project/fulfillment-service/internal/database/dao"
+)
+
+var _ = Describe("Users Server", func() {
+	var (
+		ctx           context.Context
+		tx            database.Tx
+		privateServer *PrivateUsersServer
+	)
+
+	BeforeEach(func() {
+		var err error
+
+		// Create context:
+		ctx = context.Background()
+
+		// Prepare the database pool:
+		db := server.MakeDatabase()
+		DeferCleanup(db.Close)
+		pool, err := pgxpool.New(ctx, db.MakeURL())
+		Expect(err).ToNot(HaveOccurred())
+		DeferCleanup(pool.Close)
+
+		// Create the transaction manager:
+		tm, err := database.NewTxManager().
+			SetLogger(logger).
+			SetPool(pool).
+			Build()
+		Expect(err).ToNot(HaveOccurred())
+
+		// Start a transaction and add it to the context:
+		tx, err = tm.Begin(ctx)
+		Expect(err).ToNot(HaveOccurred())
+		DeferCleanup(func() {
+			err := tm.End(ctx, tx)
+			Expect(err).ToNot(HaveOccurred())
+		})
+		ctx = database.TxIntoContext(ctx, tx)
+
+		// Create DAO tables:
+		err = dao.CreateTables[*privatev1.User](ctx)
+		Expect(err).ToNot(HaveOccurred())
+
+		// Create server (without notifier for testing):
+		privateServer, err = NewPrivateUsersServer().
+			SetLogger(logger).
+			SetAttributionLogic(attribution).
+			SetTenancyLogic(tenancy).
+			Build()
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	It("Creates a user", func() {
+		// Create request:
+		request := &privatev1.UsersCreateRequest{
+			Object: &privatev1.User{
+				Metadata: &privatev1.Metadata{
+					Name: "test-user",
+				},
+				Spec: &privatev1.UserSpec{
+					Username:       "testuser",
+					Email:          "test@example.com",
+					EmailVerified:  true,
+					Enabled:        true,
+					FirstName:      "Test",
+					LastName:       "User",
+					OrganizationId: "org-123",
+				},
+			},
+		}
+
+		// Create user:
+		response, err := privateServer.Create(ctx, request)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(response).ToNot(BeNil())
+		Expect(response.Object).ToNot(BeNil())
+		Expect(response.Object.Id).ToNot(BeEmpty())
+		Expect(response.Object.Metadata.Name).To(Equal("test-user"))
+		Expect(response.Object.Spec.Username).To(Equal("testuser"))
+	})
+
+	It("Lists users", func() {
+		// Create a user first:
+		createReq := &privatev1.UsersCreateRequest{
+			Object: &privatev1.User{
+				Metadata: &privatev1.Metadata{
+					Name: "test-user",
+				},
+				Spec: &privatev1.UserSpec{
+					Username: "testuser",
+					Email:    "test@example.com",
+				},
+			},
+		}
+		_, err := privateServer.Create(ctx, createReq)
+		Expect(err).ToNot(HaveOccurred())
+
+		// List users:
+		listResp, err := privateServer.List(ctx, &privatev1.UsersListRequest{})
+		Expect(err).ToNot(HaveOccurred())
+		Expect(listResp.Size).To(Equal(int32(1)))
+		Expect(listResp.Items).To(HaveLen(1))
+		Expect(listResp.Items[0].Metadata.Name).To(Equal("test-user"))
+	})
+
+	It("Gets a user by ID", func() {
+		// Create a user:
+		createReq := &privatev1.UsersCreateRequest{
+			Object: &privatev1.User{
+				Metadata: &privatev1.Metadata{
+					Name: "test-user",
+				},
+				Spec: &privatev1.UserSpec{
+					Username: "testuser",
+					Email:    "test@example.com",
+				},
+			},
+		}
+		createResp, err := privateServer.Create(ctx, createReq)
+		Expect(err).ToNot(HaveOccurred())
+
+		// Get the user:
+		getResp, err := privateServer.Get(ctx, &privatev1.UsersGetRequest{
+			Id: createResp.Object.Id,
+		})
+		Expect(err).ToNot(HaveOccurred())
+		Expect(getResp.Object.Id).To(Equal(createResp.Object.Id))
+		Expect(getResp.Object.Metadata.Name).To(Equal("test-user"))
+	})
+
+	It("Deletes a user", func() {
+		// Create a user:
+		createReq := &privatev1.UsersCreateRequest{
+			Object: &privatev1.User{
+				Metadata: &privatev1.Metadata{
+					Name: "test-user",
+				},
+				Spec: &privatev1.UserSpec{
+					Username: "testuser",
+					Email:    "test@example.com",
+				},
+			},
+		}
+		createResp, err := privateServer.Create(ctx, createReq)
+		Expect(err).ToNot(HaveOccurred())
+
+		// Delete the user:
+		_, err = privateServer.Delete(ctx, &privatev1.UsersDeleteRequest{
+			Id: createResp.Object.Id,
+		})
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	It("Updates a user", func() {
+		// Create a user:
+		createReq := &privatev1.UsersCreateRequest{
+			Object: &privatev1.User{
+				Metadata: &privatev1.Metadata{
+					Name: "test-user",
+				},
+				Spec: &privatev1.UserSpec{
+					Username:  "testuser",
+					Email:     "test@example.com",
+					FirstName: "Original",
+				},
+			},
+		}
+		createResp, err := privateServer.Create(ctx, createReq)
+		Expect(err).ToNot(HaveOccurred())
+
+		// Update the user:
+		updateReq := &privatev1.UsersUpdateRequest{
+			Object: &privatev1.User{
+				Id: createResp.Object.Id,
+				Spec: &privatev1.UserSpec{
+					FirstName: "Updated",
+				},
+			},
+		}
+		updateResp, err := privateServer.Update(ctx, updateReq)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(updateResp.Object.Spec.FirstName).To(Equal("Updated"))
+	})
+})

--- a/internal/servers/users_server.go
+++ b/internal/servers/users_server.go
@@ -1,0 +1,301 @@
+/*
+Copyright (c) 2026 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package servers
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+
+	"github.com/prometheus/client_golang/prometheus"
+
+	privatev1 "github.com/osac-project/fulfillment-service/internal/api/osac/private/v1"
+	publicv1 "github.com/osac-project/fulfillment-service/internal/api/osac/public/v1"
+	"github.com/osac-project/fulfillment-service/internal/auth"
+	"github.com/osac-project/fulfillment-service/internal/database"
+)
+
+type UsersServerBuilder struct {
+	logger            *slog.Logger
+	notifier          *database.Notifier
+	attributionLogic  auth.AttributionLogic
+	tenancyLogic      auth.TenancyLogic
+	metricsRegisterer prometheus.Registerer
+}
+
+var _ publicv1.UsersServer = (*UsersServer)(nil)
+
+type UsersServer struct {
+	publicv1.UnimplementedUsersServer
+
+	logger    *slog.Logger
+	private   privatev1.UsersServer
+	inMapper  *GenericMapper[*publicv1.User, *privatev1.User]
+	outMapper *GenericMapper[*privatev1.User, *publicv1.User]
+}
+
+func NewUsersServer() *UsersServerBuilder {
+	return &UsersServerBuilder{}
+}
+
+func (b *UsersServerBuilder) SetLogger(value *slog.Logger) *UsersServerBuilder {
+	b.logger = value
+	return b
+}
+
+func (b *UsersServerBuilder) SetNotifier(value *database.Notifier) *UsersServerBuilder {
+	b.notifier = value
+	return b
+}
+
+func (b *UsersServerBuilder) SetAttributionLogic(value auth.AttributionLogic) *UsersServerBuilder {
+	b.attributionLogic = value
+	return b
+}
+
+func (b *UsersServerBuilder) SetTenancyLogic(value auth.TenancyLogic) *UsersServerBuilder {
+	b.tenancyLogic = value
+	return b
+}
+
+// SetMetricsRegisterer sets the Prometheus registerer used to register the metrics for the underlying database
+// access objects. This is optional. If not set, no metrics will be recorded.
+func (b *UsersServerBuilder) SetMetricsRegisterer(value prometheus.Registerer) *UsersServerBuilder {
+	b.metricsRegisterer = value
+	return b
+}
+
+func (b *UsersServerBuilder) Build() (result *UsersServer, err error) {
+	// Check parameters:
+	if b.logger == nil {
+		err = errors.New("logger is mandatory")
+		return
+	}
+	if b.attributionLogic == nil {
+		err = errors.New("attribution logic is mandatory")
+		return
+	}
+	if b.tenancyLogic == nil {
+		err = errors.New("tenancy logic is mandatory")
+		return
+	}
+
+	// Create the mappers:
+	inMapper, err := NewGenericMapper[*publicv1.User, *privatev1.User]().
+		SetLogger(b.logger).
+		SetStrict(true).
+		Build()
+	if err != nil {
+		return
+	}
+	outMapper, err := NewGenericMapper[*privatev1.User, *publicv1.User]().
+		SetLogger(b.logger).
+		SetStrict(false).
+		Build()
+	if err != nil {
+		return
+	}
+
+	// Create the private server to delegate to:
+	delegate, err := NewPrivateUsersServer().
+		SetLogger(b.logger).
+		SetNotifier(b.notifier).
+		SetAttributionLogic(b.attributionLogic).
+		SetTenancyLogic(b.tenancyLogic).
+		SetMetricsRegisterer(b.metricsRegisterer).
+		Build()
+	if err != nil {
+		return
+	}
+
+	// Create and populate the object:
+	result = &UsersServer{
+		logger:    b.logger,
+		private:   delegate,
+		inMapper:  inMapper,
+		outMapper: outMapper,
+	}
+	return
+}
+
+func (s *UsersServer) List(ctx context.Context,
+	request *publicv1.UsersListRequest) (response *publicv1.UsersListResponse, err error) {
+	// Create private request with same parameters:
+	privateRequest := &privatev1.UsersListRequest{}
+	privateRequest.SetOffset(request.GetOffset())
+	privateRequest.SetLimit(request.GetLimit())
+	privateRequest.SetFilter(request.GetFilter())
+
+	// Delegate to private server:
+	privateResponse, err := s.private.List(ctx, privateRequest)
+	if err != nil {
+		return nil, err
+	}
+
+	// Map private response to public format:
+	privateItems := privateResponse.GetItems()
+	publicItems := make([]*publicv1.User, len(privateItems))
+	for i, privateItem := range privateItems {
+		publicItem := &publicv1.User{}
+		err = s.outMapper.Copy(ctx, privateItem, publicItem)
+		if err != nil {
+			s.logger.ErrorContext(
+				ctx,
+				"Failed to map private user to public",
+				slog.Any("error", err),
+			)
+			return nil, err
+		}
+		publicItems[i] = publicItem
+	}
+
+	// Build and return the response:
+	response = &publicv1.UsersListResponse{}
+	response.SetSize(privateResponse.GetSize())
+	response.SetTotal(privateResponse.GetTotal())
+	response.SetItems(publicItems)
+	return
+}
+
+func (s *UsersServer) Get(ctx context.Context,
+	request *publicv1.UsersGetRequest) (response *publicv1.UsersGetResponse, err error) {
+	// Create private request:
+	privateRequest := &privatev1.UsersGetRequest{}
+	privateRequest.SetId(request.GetId())
+
+	// Delegate to private server:
+	privateResponse, err := s.private.Get(ctx, privateRequest)
+	if err != nil {
+		return nil, err
+	}
+
+	// Map private response to public format:
+	publicObject := &publicv1.User{}
+	err = s.outMapper.Copy(ctx, privateResponse.GetObject(), publicObject)
+	if err != nil {
+		s.logger.ErrorContext(
+			ctx,
+			"Failed to map private user to public",
+			slog.Any("error", err),
+		)
+		return nil, err
+	}
+
+	// Build and return the response:
+	response = &publicv1.UsersGetResponse{}
+	response.SetObject(publicObject)
+	return
+}
+
+func (s *UsersServer) Create(ctx context.Context,
+	request *publicv1.UsersCreateRequest) (response *publicv1.UsersCreateResponse, err error) {
+	// Map public request to private format:
+	privateObject := &privatev1.User{}
+	err = s.inMapper.Copy(ctx, request.GetObject(), privateObject)
+	if err != nil {
+		s.logger.ErrorContext(
+			ctx,
+			"Failed to map public user to private",
+			slog.Any("error", err),
+		)
+		return nil, err
+	}
+
+	// Create private request:
+	privateRequest := &privatev1.UsersCreateRequest{}
+	privateRequest.SetObject(privateObject)
+
+	// Delegate to private server:
+	privateResponse, err := s.private.Create(ctx, privateRequest)
+	if err != nil {
+		return nil, err
+	}
+
+	// Map private response to public format:
+	publicObject := &publicv1.User{}
+	err = s.outMapper.Copy(ctx, privateResponse.GetObject(), publicObject)
+	if err != nil {
+		s.logger.ErrorContext(
+			ctx,
+			"Failed to map private user to public",
+			slog.Any("error", err),
+		)
+		return nil, err
+	}
+
+	// Build and return the response:
+	response = &publicv1.UsersCreateResponse{}
+	response.SetObject(publicObject)
+	return
+}
+
+func (s *UsersServer) Update(ctx context.Context,
+	request *publicv1.UsersUpdateRequest) (response *publicv1.UsersUpdateResponse, err error) {
+	// Map public request to private format:
+	privateObject := &privatev1.User{}
+	err = s.inMapper.Copy(ctx, request.GetObject(), privateObject)
+	if err != nil {
+		s.logger.ErrorContext(
+			ctx,
+			"Failed to map public user to private",
+			slog.Any("error", err),
+		)
+		return nil, err
+	}
+
+	// Create private request:
+	privateRequest := &privatev1.UsersUpdateRequest{}
+	privateRequest.SetObject(privateObject)
+	privateRequest.SetUpdateMask(request.GetUpdateMask())
+
+	// Delegate to private server:
+	privateResponse, err := s.private.Update(ctx, privateRequest)
+	if err != nil {
+		return nil, err
+	}
+
+	// Map private response to public format:
+	publicObject := &publicv1.User{}
+	err = s.outMapper.Copy(ctx, privateResponse.GetObject(), publicObject)
+	if err != nil {
+		s.logger.ErrorContext(
+			ctx,
+			"Failed to map private user to public",
+			slog.Any("error", err),
+		)
+		return nil, err
+	}
+
+	// Build and return the response:
+	response = &publicv1.UsersUpdateResponse{}
+	response.SetObject(publicObject)
+	return
+}
+
+func (s *UsersServer) Delete(ctx context.Context,
+	request *publicv1.UsersDeleteRequest) (response *publicv1.UsersDeleteResponse, err error) {
+	// Create private request:
+	privateRequest := &privatev1.UsersDeleteRequest{}
+	privateRequest.SetId(request.GetId())
+
+	// Delegate to private server:
+	_, err = s.private.Delete(ctx, privateRequest)
+	if err != nil {
+		return nil, err
+	}
+
+	// Build and return the response:
+	response = &publicv1.UsersDeleteResponse{}
+	return
+}

--- a/internal/servers/users_server_test.go
+++ b/internal/servers/users_server_test.go
@@ -1,0 +1,209 @@
+/*
+Copyright (c) 2026 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package servers
+
+import (
+	"context"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	privatev1 "github.com/osac-project/fulfillment-service/internal/api/osac/private/v1"
+	publicv1 "github.com/osac-project/fulfillment-service/internal/api/osac/public/v1"
+	"github.com/osac-project/fulfillment-service/internal/database"
+	"github.com/osac-project/fulfillment-service/internal/database/dao"
+)
+
+var _ = Describe("Public Users Server", func() {
+	var (
+		ctx          context.Context
+		tx           database.Tx
+		publicServer *UsersServer
+	)
+
+	BeforeEach(func() {
+		var err error
+
+		// Create context:
+		ctx = context.Background()
+
+		// Prepare the database pool:
+		db := server.MakeDatabase()
+		DeferCleanup(db.Close)
+		pool, err := pgxpool.New(ctx, db.MakeURL())
+		Expect(err).ToNot(HaveOccurred())
+		DeferCleanup(pool.Close)
+
+		// Create the transaction manager:
+		tm, err := database.NewTxManager().
+			SetLogger(logger).
+			SetPool(pool).
+			Build()
+		Expect(err).ToNot(HaveOccurred())
+
+		// Start a transaction and add it to the context:
+		tx, err = tm.Begin(ctx)
+		Expect(err).ToNot(HaveOccurred())
+		DeferCleanup(func() {
+			err := tm.End(ctx, tx)
+			Expect(err).ToNot(HaveOccurred())
+		})
+		ctx = database.TxIntoContext(ctx, tx)
+
+		// Create DAO tables:
+		err = dao.CreateTables[*privatev1.User](ctx)
+		Expect(err).ToNot(HaveOccurred())
+
+		// Create public server:
+		publicServer, err = NewUsersServer().
+			SetLogger(logger).
+			SetAttributionLogic(attribution).
+			SetTenancyLogic(tenancy).
+			Build()
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	It("Creates a user", func() {
+		// Create request:
+		request := &publicv1.UsersCreateRequest{
+			Object: &publicv1.User{
+				Metadata: &publicv1.Metadata{
+					Name: "test-user",
+				},
+				Spec: &publicv1.UserSpec{
+					Username:       "testuser",
+					Email:          "test@example.com",
+					EmailVerified:  true,
+					Enabled:        true,
+					FirstName:      "Test",
+					LastName:       "User",
+					OrganizationId: "org-123",
+				},
+			},
+		}
+
+		// Create user:
+		response, err := publicServer.Create(ctx, request)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(response).ToNot(BeNil())
+		Expect(response.Object).ToNot(BeNil())
+		Expect(response.Object.Id).ToNot(BeEmpty())
+		Expect(response.Object.Metadata.Name).To(Equal("test-user"))
+		Expect(response.Object.Spec.Username).To(Equal("testuser"))
+	})
+
+	It("Lists users", func() {
+		// Create a user first:
+		createReq := &publicv1.UsersCreateRequest{
+			Object: &publicv1.User{
+				Metadata: &publicv1.Metadata{
+					Name: "test-user",
+				},
+				Spec: &publicv1.UserSpec{
+					Username: "testuser",
+					Email:    "test@example.com",
+				},
+			},
+		}
+		_, err := publicServer.Create(ctx, createReq)
+		Expect(err).ToNot(HaveOccurred())
+
+		// List users:
+		listResp, err := publicServer.List(ctx, &publicv1.UsersListRequest{})
+		Expect(err).ToNot(HaveOccurred())
+		Expect(listResp.Size).To(Equal(int32(1)))
+		Expect(listResp.Items).To(HaveLen(1))
+		Expect(listResp.Items[0].Metadata.Name).To(Equal("test-user"))
+	})
+
+	It("Gets a user by ID", func() {
+		// Create a user:
+		createReq := &publicv1.UsersCreateRequest{
+			Object: &publicv1.User{
+				Metadata: &publicv1.Metadata{
+					Name: "test-user",
+				},
+				Spec: &publicv1.UserSpec{
+					Username: "testuser",
+					Email:    "test@example.com",
+				},
+			},
+		}
+		createResp, err := publicServer.Create(ctx, createReq)
+		Expect(err).ToNot(HaveOccurred())
+
+		// Get the user:
+		getResp, err := publicServer.Get(ctx, &publicv1.UsersGetRequest{
+			Id: createResp.Object.Id,
+		})
+		Expect(err).ToNot(HaveOccurred())
+		Expect(getResp.Object.Id).To(Equal(createResp.Object.Id))
+		Expect(getResp.Object.Metadata.Name).To(Equal("test-user"))
+	})
+
+	It("Deletes a user", func() {
+		// Create a user:
+		createReq := &publicv1.UsersCreateRequest{
+			Object: &publicv1.User{
+				Metadata: &publicv1.Metadata{
+					Name: "test-user",
+				},
+				Spec: &publicv1.UserSpec{
+					Username: "testuser",
+					Email:    "test@example.com",
+				},
+			},
+		}
+		createResp, err := publicServer.Create(ctx, createReq)
+		Expect(err).ToNot(HaveOccurred())
+
+		// Delete the user:
+		_, err = publicServer.Delete(ctx, &publicv1.UsersDeleteRequest{
+			Id: createResp.Object.Id,
+		})
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	It("Updates a user", func() {
+		// Create a user:
+		createReq := &publicv1.UsersCreateRequest{
+			Object: &publicv1.User{
+				Metadata: &publicv1.Metadata{
+					Name: "test-user",
+				},
+				Spec: &publicv1.UserSpec{
+					Username:  "testuser",
+					Email:     "test@example.com",
+					FirstName: "Original",
+				},
+			},
+		}
+		createResp, err := publicServer.Create(ctx, createReq)
+		Expect(err).ToNot(HaveOccurred())
+
+		// Update the user:
+		updateReq := &publicv1.UsersUpdateRequest{
+			Object: &publicv1.User{
+				Id: createResp.Object.Id,
+				Spec: &publicv1.UserSpec{
+					FirstName: "Updated",
+				},
+			},
+		}
+		updateResp, err := publicServer.Update(ctx, updateReq)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(updateResp.Object.Spec.FirstName).To(Equal("Updated"))
+	})
+})


### PR DESCRIPTION
# Description
Initial implementation of the tenant user server. This object is meant to represent the CRUD of a user within a tenant (organization) by a tenant admin. 

Future PRs will handle connecting the users server to the identity provider api to manage the users within the identity provider.

# Testing

Tested with 

```
go test -v ./internal/servers
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced users management service with full CRUD operations (Create, Read, Update, Delete)
  * Added List and Get operations to retrieve user information
  * Implemented user data storage with metadata support
  * Added signal operation for user notifications
  * Enabled user querying by name, ownership, and labels

<!-- end of auto-generated comment: release notes by coderabbit.ai -->