### PR TITLE
NO-ISSUE: Add separate external and internal API listeners to ingress proxy

### DIFF
--- a/.github/workflows/check-pull-request.yaml
+++ b/.github/workflows/check-pull-request.yaml
@@ -79,6 +79,7 @@ jobs:
     - uses: ./.github/actions/setup-go
     - run: |
         echo '127.0.0.1 fulfillment-api.osac.svc.cluster.local' | sudo tee -a /etc/hosts
+        echo '127.0.0.1 fulfillment-internal-api.osac.svc.cluster.local' | sudo tee -a /etc/hosts
         echo '127.0.0.1 keycloak.keycloak.svc.cluster.local' | sudo tee -a /etc/hosts
         IT_DEPLOY_MODE=helm ginkgo run -v it
     - if: always()
@@ -96,6 +97,7 @@ jobs:
     - uses: ./.github/actions/setup-go
     - run: |
         echo '127.0.0.1 fulfillment-api.osac.svc.cluster.local' | sudo tee -a /etc/hosts
+        echo '127.0.0.1 fulfillment-internal-api.osac.svc.cluster.local' | sudo tee -a /etc/hosts
         echo '127.0.0.1 keycloak.keycloak.svc.cluster.local' | sudo tee -a /etc/hosts
         IT_DEPLOY_MODE=kustomize ginkgo run -v it
     - if: always()

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,7 +57,8 @@ kind delete cluster --name fulfillment-service-it
 
 Requires `/etc/hosts` entries:
 - `127.0.0.1 keycloak.keycloak.svc.cluster.local`
-- `127.0.0.1 fulfillment-api.innabox.svc.cluster.local`
+- `127.0.0.1 fulfillment-api.osac.svc.cluster.local`
+- `127.0.0.1 fulfillment-internal-api.osac.svc.cluster.local`
 
 ### Running Locally
 

--- a/README.md
+++ b/README.md
@@ -249,13 +249,15 @@ through `127.0.0.1:8000` which is exposed by the Kind cluster.
 For the tests to work correctly, the following host names must resolve to `127.0.0.1`:
 
 - `keycloak.keycloak.svc.cluster.local` - The Keycloak identity provider used for authentication.
-- `fulfillment-api.osac.svc.cluster.local` - The fulfillment service API.
+- `fulfillment-api.osac.svc.cluster.local` - The fulfillment service external API.
+- `fulfillment-internal-api.osac.svc.cluster.local` - The fulfillment service internal API.
 
 Add the following entries to your `/etc/hosts` file:
 
-```
+```text
 127.0.0.1 keycloak.keycloak.svc.cluster.local
 127.0.0.1 fulfillment-api.osac.svc.cluster.local
+127.0.0.1 fulfillment-internal-api.osac.svc.cluster.local
 ```
 
 To run the integration tests:

--- a/charts/service/README.md
+++ b/charts/service/README.md
@@ -27,7 +27,8 @@ The following table lists the configurable parameters of the chart and their def
 | `certs.issuerRef.kind`     | Kind of _cert-manager_ issuer                                      | `ClusterIssuer`                                                |
 | `certs.issuerRef.name`     | Name of _cert-manager_ issuer                                      | None                                                           |
 | `certs.caBundle.configMap` | Name of configmap containing trusted CA certificates in PEM format | Required                                                       |
-| `hostname`                 | Hostname used to access the service from outside the cluster       | None                                                           |
+| `externalHostname`         | Hostname used to access the public API from outside the cluster (see note below) | None                                                |
+| `internalHostname`         | Hostname used to access both the public and private APIs (see note below)        | None                                                |
 | `auth.issuerUrl`           | OAuth issuer URL for authentication                                | `https://keycloak.keycloak.svc.cluster.local:8000/realms/osac` |
 | `log.level`                | Log level for all components (debug, info, warn, error)            | `info`                                                         |
 | `log.headers`              | Enable logging of HTTP/gRPC headers                                | `false`                                                        |
@@ -35,6 +36,15 @@ The following table lists the configurable parameters of the chart and their def
 | `images.service`           | Fulfillment service container image                                | `ghcr.io/osac/fulfillment-service:main`                        |
 | `images.envoy`             | Envoy proxy container image                                        | `docker.io/envoyproxy/envoy:v1.37.1`                           |
 | `database.connection`      | List of sources for database connection parameters (see below)     | `[]`                                                           |
+
+**Note on `internalHostname`:** The internal API exposes both the public and private APIs. The
+administrator is responsible for ensuring that this hostname is accessible only from the internal
+network and not accessible to regular users. This isn't strictly required because access is subject
+to authentication and authorization (regular users won't be authorized to use the private API), but
+it is good practice to restrict network-level access as an additional layer of defense. When
+`internalHostname` is not set, no Route (OpenShift) or TLSRoute (Kind) will be created for the
+internal API, allowing the administrator to manually configure ingress with custom settings such as
+a dedicated load balancer or a specific IP address.
 
 ### Example custom values
 
@@ -50,7 +60,8 @@ certs:
   caBundle:
     configMap: my-ca-bundle
 
-hostname: fulfillment-service.example.com
+externalHostname: fulfillment-service.example.com
+internalHostname: fulfillment-internal.example.com
 
 auth:
   issuerUrl: https://keycloak.example.com/realms/osac

--- a/charts/service/templates/_helpers.tpl
+++ b/charts/service/templates/_helpers.tpl
@@ -12,13 +12,25 @@ specific language governing permissions and limitations under the License.
 */}}
 
 {{/*
-Generate the hostname for the fulfillment API. If .Values.hostname is set, use it; otherwise, use the default
+Generate the hostname for the fulfillment API. If .Values.externalHostname is set, use it; otherwise, use the default
 Kubernetes service hostname based on the release namespace.
 */}}
 {{- define "fulfillment-api.hostname" -}}
-{{- if .Values.hostname -}}
-{{- .Values.hostname -}}
+{{- if .Values.externalHostname -}}
+{{- .Values.externalHostname -}}
 {{- else -}}
 {{- printf "fulfillment-api.%s.svc.cluster.local" .Release.Namespace -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Generate the hostname for the fulfillment internal API. If .Values.internalHostname is set, use it; otherwise, use the
+default Kubernetes service hostname based on the release namespace.
+*/}}
+{{- define "fulfillment-internal-api.hostname" -}}
+{{- if .Values.internalHostname -}}
+{{- .Values.internalHostname -}}
+{{- else -}}
+{{- printf "fulfillment-internal-api.%s.svc.cluster.local" .Release.Namespace -}}
 {{- end -}}
 {{- end -}}

--- a/charts/service/templates/controller/deployment.yaml
+++ b/charts/service/templates/controller/deployment.yaml
@@ -67,7 +67,7 @@ spec:
         - --log-bodies={{ .Values.log.bodies }}
         - --ca-file=/etc/fulfillment-controller/tls/cas
         - --token-file=/var/run/secrets/kubernetes.io/serviceaccount/token
-        - --grpc-server-address=fulfillment-api:8000
+        - --grpc-server-address=fulfillment-internal-api:8001
         - --grpc-keep-alive=5m
         - --grpc-listener-address=0.0.0.0:8000
         - --grpc-listener-tls-crt=/etc/fulfillment-controller/tls/tls.crt

--- a/charts/service/templates/ingress-proxy/_config.yaml.tpl
+++ b/charts/service/templates/ingress-proxy/_config.yaml.tpl
@@ -68,9 +68,9 @@ static_resources:
             typed_config:
               "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
 
-   # This listener receives traffic from outside, so it needs to be secured with CORS and TLS. Authentication and
-   # authorization are handled by the service itself.
-  - name: ingress
+   # This listener receives external traffic for the public API, so it needs to be secured with CORS and TLS.
+   # Authentication and authorization are handled by the service itself.
+  - name: external-api
     address:
       socket_address:
         address: 0.0.0.0
@@ -85,7 +85,97 @@ static_resources:
             typed_config:
               "@type": type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog
               path: /dev/stdout
-          stat_prefix: ingress
+          stat_prefix: external-api
+          route_config:
+            name: backend
+            virtual_hosts:
+            - name: all
+              domains:
+              - "*"
+              typed_per_filter_config:
+                envoy.filters.http.cors:
+                  "@type": type.googleapis.com/envoy.extensions.filters.http.cors.v3.CorsPolicy
+                  allow_origin_string_match:
+                  - safe_regex:
+                      regex: ".*"
+                  allow_methods: "GET,POST,PUT,PATCH,DELETE,OPTIONS"
+                  allow_headers: "Authorization,Content-Type,X-User-Agent,X-Grpc-Web, Accept"
+                  expose_headers: "Grpc-Status,Grpc-Message"
+                  allow_credentials: true
+                  max_age: "86400"
+              routes:
+
+              # This route is for the REST gateway. The public API endpoints use path prefixes
+              # like /api/fulfillment/ and /api/events/.
+              - name: rest-gateway
+                match:
+                  safe_regex:
+                    regex: /api/(fulfillment|events)(/.*)?
+                route:
+                  cluster: rest-gateway
+                  timeout: 300s
+
+              # This route is for the gRPC streaming requests used to watch events. Those streams can last very
+              # long, so we don't want to set a timeout, as that would cause the connection to be closed and
+              # events to be potentially lost.
+              - name: events
+                match:
+                  safe_regex:
+                    regex: /osac\.public\..*/Watch
+                route:
+                  cluster: grpc-server
+                  timeout: 0s
+                  idle_timeout: 0s
+
+              # This route is for public API and gRPC reflection unary requests.
+              - name: grpc-server
+                match:
+                  safe_regex:
+                    regex: /(osac\.public\.|grpc\.(reflection|health)\.).*
+                route:
+                  cluster: grpc-server
+                  timeout: 300s
+
+          http_filters:
+          - name: envoy.filters.http.cors
+            typed_config:
+              "@type": type.googleapis.com/envoy.extensions.filters.http.cors.v3.Cors
+          - name: envoy.filters.http.router
+            typed_config:
+              "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+
+      transport_socket:
+        name: envoy.transport_sockets.tls
+        typed_config:
+          "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.DownstreamTlsContext
+          common_tls_context:
+            alpn_protocols:
+            - http1.1
+            - h2
+            tls_certificates:
+            - certificate_chain:
+                filename: /etc/envoy/tls/tls.crt
+              private_key:
+                filename: /etc/envoy/tls/tls.key
+
+   # This listener receives internal traffic for both the public and private APIs, so it needs to be secured with
+   # CORS and TLS. Authentication and authorization are handled by the service itself.
+  - name: internal-api
+    address:
+      socket_address:
+        address: 0.0.0.0
+        port_value: 8001
+    filter_chains:
+    - filters:
+      - name: envoy.filters.network.http_connection_manager
+        typed_config:
+          "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+          access_log:
+          - name: envoy.access_loggers.file
+            typed_config:
+              "@type": type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog
+              path: /dev/stdout
+          stat_prefix: internal-api
           route_config:
             name: backend
             virtual_hosts:
@@ -113,9 +203,9 @@ static_resources:
                   cluster: rest-gateway
                   timeout: 300s
 
-              # This route is for the gRPC streaming requests used to watch events. Those streams can last very long,
-              # so we don't want to set a timeout, as that would cause the connection to be closed and events to be
-              # potentially lost.
+              # This route is for the gRPC streaming requests used to watch events. Those streams can last very
+              # long, so we don't want to set a timeout, as that would cause the connection to be closed and
+              # events to be potentially lost.
               - name: events
                 match:
                   safe_regex:
@@ -125,7 +215,7 @@ static_resources:
                   timeout: 0s
                   idle_timeout: 0s
 
-              # This route is for gRPC unary requests, which should be quite fast, so we can safely set a timeout.
+              # This route is for gRPC unary requests.
               - name: grpc-server
                 match:
                   prefix: /

--- a/charts/service/templates/ingress-proxy/certificate.yaml
+++ b/charts/service/templates/ingress-proxy/certificate.yaml
@@ -25,8 +25,14 @@ spec:
   - fulfillment-api
   - fulfillment-api.{{ .Release.Namespace }}
   - fulfillment-api.{{ .Release.Namespace }}.svc.cluster.local
-{{- if .Values.hostname }}
-  - {{ .Values.hostname }}
+  - fulfillment-internal-api
+  - fulfillment-internal-api.{{ .Release.Namespace }}
+  - fulfillment-internal-api.{{ .Release.Namespace }}.svc.cluster.local
+{{- if .Values.externalHostname }}
+  - {{ .Values.externalHostname | quote}}
+{{- end }}
+{{- if .Values.internalHostname }}
+  - {{ .Values.internalHostname | quote}}
 {{- end }}
   secretName: fulfillment-api-tls
   privateKey:

--- a/charts/service/templates/ingress-proxy/deployment.yaml
+++ b/charts/service/templates/ingress-proxy/deployment.yaml
@@ -46,9 +46,12 @@ spec:
         - --config-path
         - /etc/envoy/envoy.yaml
         ports:
-        - name: api
+        - name: external-api
           protocol: TCP
           containerPort: 8000
+        - name: internal-api
+          protocol: TCP
+          containerPort: 8001
         - name: metrics
           protocol: TCP
           containerPort: 8002

--- a/charts/service/templates/ingress-proxy/service.yaml
+++ b/charts/service/templates/ingress-proxy/service.yaml
@@ -16,6 +16,36 @@ kind: Service
 metadata:
   namespace: {{ .Release.Namespace }}
   name: fulfillment-api
+spec:
+  selector:
+    app: fulfillment-ingress-proxy
+  ports:
+  - name: external-api
+    port: 8000
+    targetPort: external-api
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  namespace: {{ .Release.Namespace }}
+  name: fulfillment-internal-api
+spec:
+  selector:
+    app: fulfillment-ingress-proxy
+  ports:
+  - name: internal-api
+    port: 8001
+    targetPort: internal-api
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  namespace: {{ .Release.Namespace }}
+  name: fulfillment-ingress-proxy-metrics
   annotations:
     prometheus.io/scrape: "true"
     prometheus.io/port: "8002"
@@ -23,9 +53,6 @@ spec:
   selector:
     app: fulfillment-ingress-proxy
   ports:
-  - name: api
-    port: 8000
-    targetPort: api
   - name: metrics
     port: 8002
     targetPort: metrics

--- a/charts/service/templates/rest-gateway/deployment.yaml
+++ b/charts/service/templates/rest-gateway/deployment.yaml
@@ -68,7 +68,7 @@ spec:
         - --http-listener-address=0.0.0.0:8000
         - --http-listener-tls-crt=/etc/fulfillment-rest-gateway/tls/tls.crt
         - --http-listener-tls-key=/etc/fulfillment-rest-gateway/tls/tls.key
-        - --grpc-server-address=fulfillment-api:8000
+        - --grpc-server-address=fulfillment-internal-api:8001
         - --grpc-keep-alive=5m
         - --metrics-listener-address=0.0.0.0:8002
         ports:

--- a/charts/service/templates/route.yaml
+++ b/charts/service/templates/route.yaml
@@ -18,13 +18,33 @@ metadata:
   namespace: {{ .Release.Namespace }}
   name: fulfillment-api
 spec:
+  host: {{ .Values.externalHostname }}
   to:
     kind: Service
     name: fulfillment-api
   port:
-    targetPort: api
+    targetPort: external-api
   tls:
     termination: passthrough
+
+{{ if .Values.internalHostname }}
+---
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  namespace: {{ .Release.Namespace }}
+  name: fulfillment-internal-api
+spec:
+  host: {{ .Values.internalHostname }}
+  to:
+    kind: Service
+    name: fulfillment-internal-api
+  port:
+    targetPort: internal-api
+  tls:
+    termination: passthrough
+{{ end }}
+
 {{ end }}
 
 {{ if eq .Values.variant "kind" }}
@@ -46,4 +66,27 @@ spec:
   - backendRefs:
     - name: fulfillment-api
       port: 8000
+
+{{ if .Values.internalHostname }}
+---
+apiVersion: gateway.networking.k8s.io/v1alpha3
+kind: TLSRoute
+metadata:
+  namespace: {{ .Release.Namespace }}
+  name: fulfillment-internal-api
+spec:
+  parentRefs:
+  - group: gateway.networking.k8s.io
+    kind: Gateway
+    namespace: envoy-gateway
+    name: default
+    sectionName: tls
+  hostnames:
+  - {{ include "fulfillment-internal-api.hostname" . }}
+  rules:
+  - backendRefs:
+    - name: fulfillment-internal-api
+      port: 8001
+{{ end }}
+
 {{ end }}

--- a/charts/service/values.yaml
+++ b/charts/service/values.yaml
@@ -32,10 +32,20 @@ certs:
   caBundle:
     configMap:
 
-# This defines the hostname used to access the service from outside the cluster. The default is to use the hostname of
-# the Kubernetes service. For example, if the application is deployed in a namespace named 'osac' then the default
+# This defines the hostname used to access the public API from outside the cluster. The default is to use the hostname
+# of the Kubernetes service. For example, if the application is deployed in a namespace named 'osac' then the default
 # hostname will be 'fulfillment-api.osac.svc.cluster.local'.
-hostname:
+externalHostname:
+
+# This defines the hostname used to access both the public and private APIs from outside the cluster. It is typically
+# accessible only from the administrator's internal network. The default is to use the hostname of the Kubernetes
+# service. For example, if the application is deployed in a namespace named 'osac' then the default hostname will be
+# 'fulfillment-internal-api.osac.svc.cluster.local'.
+#
+# The administrator is responsible for ensuring that this hostname is accessible only from the internal network and not
+# accessible to regular users. This isn't strictly required because access is subject to authentication and
+# authorization, but it is good practice to restrict network-level access as an additional layer of defense.
+internalHostname:
 
 # Authentication and authorization configuration:
 auth:

--- a/it/it_access_test.go
+++ b/it/it_access_test.go
@@ -34,61 +34,62 @@ var _ = Describe("Access control", func() {
 
 	Describe("Public API", func() {
 		It("Allows regular users to list cluster templates", func() {
-			client := publicv1.NewClusterTemplatesClient(tool.UserConn())
+			client := publicv1.NewClusterTemplatesClient(tool.ExternalView().UserConn())
 			_, err := client.List(ctx, publicv1.ClusterTemplatesListRequest_builder{}.Build())
 			Expect(err).ToNot(HaveOccurred())
 		})
 
 		It("Allows regular users to list clusters", func() {
-			client := publicv1.NewClustersClient(tool.UserConn())
+			client := publicv1.NewClustersClient(tool.ExternalView().UserConn())
 			_, err := client.List(ctx, publicv1.ClustersListRequest_builder{}.Build())
 			Expect(err).ToNot(HaveOccurred())
 		})
 
 		It("Allows regular users to list host types", func() {
-			client := publicv1.NewHostTypesClient(tool.UserConn())
+			client := publicv1.NewHostTypesClient(tool.ExternalView().UserConn())
 			_, err := client.List(ctx, publicv1.HostTypesListRequest_builder{}.Build())
 			Expect(err).ToNot(HaveOccurred())
 		})
 
 		It("Allows regular users to list compute instance templates", func() {
-			client := publicv1.NewComputeInstanceTemplatesClient(tool.UserConn())
+			client := publicv1.NewComputeInstanceTemplatesClient(tool.ExternalView().UserConn())
 			_, err := client.List(ctx, publicv1.ComputeInstanceTemplatesListRequest_builder{}.Build())
 			Expect(err).ToNot(HaveOccurred())
 		})
 
 		It("Allows regular users to list compute instances", func() {
-			client := publicv1.NewComputeInstancesClient(tool.UserConn())
+			client := publicv1.NewComputeInstancesClient(tool.ExternalView().UserConn())
 			_, err := client.List(ctx, publicv1.ComputeInstancesListRequest_builder{}.Build())
 			Expect(err).ToNot(HaveOccurred())
 		})
 
 		It("Allows admin users to list cluster templates", func() {
-			client := publicv1.NewClusterTemplatesClient(tool.AdminConn())
+			client := publicv1.NewClusterTemplatesClient(tool.ExternalView().AdminConn())
+
 			_, err := client.List(ctx, publicv1.ClusterTemplatesListRequest_builder{}.Build())
 			Expect(err).ToNot(HaveOccurred())
 		})
 
 		It("Allows admin users to list clusters", func() {
-			client := publicv1.NewClustersClient(tool.AdminConn())
+			client := publicv1.NewClustersClient(tool.ExternalView().AdminConn())
 			_, err := client.List(ctx, publicv1.ClustersListRequest_builder{}.Build())
 			Expect(err).ToNot(HaveOccurred())
 		})
 
 		It("Allows admin users to list host types", func() {
-			client := publicv1.NewHostTypesClient(tool.AdminConn())
+			client := publicv1.NewHostTypesClient(tool.ExternalView().AdminConn())
 			_, err := client.List(ctx, publicv1.HostTypesListRequest_builder{}.Build())
 			Expect(err).ToNot(HaveOccurred())
 		})
 
 		It("Allows admin users to list compute instance templates", func() {
-			client := publicv1.NewComputeInstanceTemplatesClient(tool.AdminConn())
+			client := publicv1.NewComputeInstanceTemplatesClient(tool.ExternalView().AdminConn())
 			_, err := client.List(ctx, publicv1.ComputeInstanceTemplatesListRequest_builder{}.Build())
 			Expect(err).ToNot(HaveOccurred())
 		})
 
 		It("Allows admin users to list compute instances", func() {
-			client := publicv1.NewComputeInstancesClient(tool.AdminConn())
+			client := publicv1.NewComputeInstancesClient(tool.ExternalView().AdminConn())
 			_, err := client.List(ctx, publicv1.ComputeInstancesListRequest_builder{}.Build())
 			Expect(err).ToNot(HaveOccurred())
 		})
@@ -96,43 +97,43 @@ var _ = Describe("Access control", func() {
 
 	Describe("Private API", func() {
 		It("Allows admin users to list host types", func() {
-			client := privatev1.NewHostTypesClient(tool.AdminConn())
+			client := privatev1.NewHostTypesClient(tool.InternalView().AdminConn())
 			_, err := client.List(ctx, privatev1.HostTypesListRequest_builder{}.Build())
 			Expect(err).ToNot(HaveOccurred())
 		})
 
 		It("Allows admin users to list cluster templates", func() {
-			client := privatev1.NewClusterTemplatesClient(tool.AdminConn())
+			client := privatev1.NewClusterTemplatesClient(tool.InternalView().AdminConn())
 			_, err := client.List(ctx, privatev1.ClusterTemplatesListRequest_builder{}.Build())
 			Expect(err).ToNot(HaveOccurred())
 		})
 
 		It("Allows admin users to list hubs", func() {
-			client := privatev1.NewHubsClient(tool.AdminConn())
+			client := privatev1.NewHubsClient(tool.InternalView().AdminConn())
 			_, err := client.List(ctx, privatev1.HubsListRequest_builder{}.Build())
 			Expect(err).ToNot(HaveOccurred())
 		})
 
 		It("Allows admin users to list private clusters", func() {
-			client := privatev1.NewClustersClient(tool.AdminConn())
+			client := privatev1.NewClustersClient(tool.InternalView().AdminConn())
 			_, err := client.List(ctx, privatev1.ClustersListRequest_builder{}.Build())
 			Expect(err).ToNot(HaveOccurred())
 		})
 
 		It("Allows admin users to list compute instance templates", func() {
-			client := privatev1.NewComputeInstanceTemplatesClient(tool.AdminConn())
+			client := privatev1.NewComputeInstanceTemplatesClient(tool.InternalView().AdminConn())
 			_, err := client.List(ctx, privatev1.ComputeInstanceTemplatesListRequest_builder{}.Build())
 			Expect(err).ToNot(HaveOccurred())
 		})
 
 		It("Allows admin users to list private compute instances", func() {
-			client := privatev1.NewComputeInstancesClient(tool.AdminConn())
+			client := privatev1.NewComputeInstancesClient(tool.InternalView().AdminConn())
 			_, err := client.List(ctx, privatev1.ComputeInstancesListRequest_builder{}.Build())
 			Expect(err).ToNot(HaveOccurred())
 		})
 
 		It("Denies regular users access to host types", func() {
-			client := privatev1.NewHostTypesClient(tool.UserConn())
+			client := privatev1.NewHostTypesClient(tool.InternalView().UserConn())
 			_, err := client.List(ctx, privatev1.HostTypesListRequest_builder{}.Build())
 			Expect(err).To(HaveOccurred())
 			status, ok := grpcstatus.FromError(err)
@@ -141,7 +142,7 @@ var _ = Describe("Access control", func() {
 		})
 
 		It("Denies regular users access to cluster templates", func() {
-			client := privatev1.NewClusterTemplatesClient(tool.UserConn())
+			client := privatev1.NewClusterTemplatesClient(tool.InternalView().UserConn())
 			_, err := client.List(ctx, privatev1.ClusterTemplatesListRequest_builder{}.Build())
 			Expect(err).To(HaveOccurred())
 			status, ok := grpcstatus.FromError(err)
@@ -150,7 +151,7 @@ var _ = Describe("Access control", func() {
 		})
 
 		It("Denies regular users access to hubs", func() {
-			client := privatev1.NewHubsClient(tool.UserConn())
+			client := privatev1.NewHubsClient(tool.InternalView().UserConn())
 			_, err := client.List(ctx, privatev1.HubsListRequest_builder{}.Build())
 			Expect(err).To(HaveOccurred())
 			status, ok := grpcstatus.FromError(err)
@@ -159,7 +160,7 @@ var _ = Describe("Access control", func() {
 		})
 
 		It("Denies regular users access to private clusters", func() {
-			client := privatev1.NewClustersClient(tool.UserConn())
+			client := privatev1.NewClustersClient(tool.InternalView().UserConn())
 			_, err := client.List(ctx, privatev1.ClustersListRequest_builder{}.Build())
 			Expect(err).To(HaveOccurred())
 			status, ok := grpcstatus.FromError(err)
@@ -168,7 +169,7 @@ var _ = Describe("Access control", func() {
 		})
 
 		It("Denies regular users access to compute instance templates", func() {
-			client := privatev1.NewComputeInstanceTemplatesClient(tool.UserConn())
+			client := privatev1.NewComputeInstanceTemplatesClient(tool.InternalView().UserConn())
 			_, err := client.List(ctx, privatev1.ComputeInstanceTemplatesListRequest_builder{}.Build())
 			Expect(err).To(HaveOccurred())
 			status, ok := grpcstatus.FromError(err)
@@ -177,7 +178,7 @@ var _ = Describe("Access control", func() {
 		})
 
 		It("Denies regular users access to private compute instances", func() {
-			client := privatev1.NewComputeInstancesClient(tool.UserConn())
+			client := privatev1.NewComputeInstancesClient(tool.InternalView().UserConn())
 			_, err := client.List(ctx, privatev1.ComputeInstancesListRequest_builder{}.Build())
 			Expect(err).To(HaveOccurred())
 			status, ok := grpcstatus.FromError(err)

--- a/it/it_annotations_test.go
+++ b/it/it_annotations_test.go
@@ -39,9 +39,9 @@ var _ = Describe("Annotations", func() {
 
 	BeforeEach(func() {
 		ctx = context.Background()
-		clustersClient = publicv1.NewClustersClient(tool.UserConn())
-		hostTypesClient = privatev1.NewHostTypesClient(tool.AdminConn())
-		templatesClient = privatev1.NewClusterTemplatesClient(tool.AdminConn())
+		clustersClient = publicv1.NewClustersClient(tool.ExternalView().UserConn())
+		hostTypesClient = privatev1.NewHostTypesClient(tool.InternalView().AdminConn())
+		templatesClient = privatev1.NewClusterTemplatesClient(tool.InternalView().AdminConn())
 
 		hostTypeId = fmt.Sprintf("my-host-type-%s", uuid.New())
 		_, err := hostTypesClient.Create(ctx, privatev1.HostTypesCreateRequest_builder{

--- a/it/it_cluster_reconciler_test.go
+++ b/it/it_cluster_reconciler_test.go
@@ -55,9 +55,9 @@ var _ = Describe("Cluster reconciler", func() {
 		ctx = context.Background()
 
 		// Create the clients:
-		clustersClient = publicv1.NewClustersClient(tool.UserConn())
-		hostTypesClient = privatev1.NewHostTypesClient(tool.AdminConn())
-		templatesClient = privatev1.NewClusterTemplatesClient(tool.AdminConn())
+		clustersClient = publicv1.NewClustersClient(tool.ExternalView().UserConn())
+		hostTypesClient = privatev1.NewHostTypesClient(tool.InternalView().AdminConn())
+		templatesClient = privatev1.NewClusterTemplatesClient(tool.InternalView().AdminConn())
 
 		// Create a host type for testing:
 		hostTypeId = fmt.Sprintf("my_host_type_%s", uuid.New())

--- a/it/it_compute_subnet_test.go
+++ b/it/it_compute_subnet_test.go
@@ -47,11 +47,11 @@ var _ = Describe("ComputeInstance with Subnet attachment", func() {
 		ctx = context.Background()
 
 		// Create clients
-		subnetsClient = privatev1.NewSubnetsClient(tool.AdminConn())
-		virtualNetworksClient = privatev1.NewVirtualNetworksClient(tool.AdminConn())
-		networkClassesClient = privatev1.NewNetworkClassesClient(tool.AdminConn())
-		computeInstancesClient = publicv1.NewComputeInstancesClient(tool.UserConn())
-		computeInstanceTemplatesClient = privatev1.NewComputeInstanceTemplatesClient(tool.AdminConn())
+		subnetsClient = privatev1.NewSubnetsClient(tool.InternalView().AdminConn())
+		virtualNetworksClient = privatev1.NewVirtualNetworksClient(tool.InternalView().AdminConn())
+		networkClassesClient = privatev1.NewNetworkClassesClient(tool.InternalView().AdminConn())
+		computeInstancesClient = publicv1.NewComputeInstancesClient(tool.ExternalView().UserConn())
+		computeInstanceTemplatesClient = privatev1.NewComputeInstanceTemplatesClient(tool.InternalView().AdminConn())
 
 		// Create ComputeInstanceTemplate
 		computeInstanceTemplateId = fmt.Sprintf("test-ci-template-%s", uuid.New())

--- a/it/it_emergency_access_test.go
+++ b/it/it_emergency_access_test.go
@@ -36,7 +36,7 @@ var _ = Describe("Emergency access", func() {
 
 	It("Can create objects using gRPC and the emergency admin service account", func() {
 		// Create the client:
-		client := privatev1.NewClusterTemplatesClient(tool.EmergencyConn())
+		client := privatev1.NewClusterTemplatesClient(tool.InternalView().EmergencyConn())
 
 		// Create the object:
 		id := fmt.Sprintf("emergency_grpc_%s", uuid.New())
@@ -56,7 +56,7 @@ var _ = Describe("Emergency access", func() {
 		Expect(err).ToNot(HaveOccurred())
 	})
 
-	It("Can create objects using REST the emergency admin service account", func() {
+	It("Can create objects using REST and the emergency admin service account", func() {
 		// Prepare the request body:
 		id := fmt.Sprintf("emergency_rest_%s", uuid.New())
 		requestBody := map[string]any{
@@ -68,20 +68,28 @@ var _ = Describe("Emergency access", func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		// Create the object:
-		createUrl := fmt.Sprintf("https://%s/api/private/v1/cluster_templates", serviceAddr)
-		createRequest, err := http.NewRequestWithContext(ctx, "POST", createUrl, bytes.NewReader(requestData))
+		createRequest, err := http.NewRequestWithContext(
+			ctx,
+			http.MethodPost,
+			"/api/private/v1/cluster_templates",
+			bytes.NewReader(requestData),
+		)
 		Expect(err).ToNot(HaveOccurred())
 		createRequest.Header.Set("Content-Type", "application/json")
-		createResponse, err := tool.EmergencyClient().Do(createRequest)
+		createResponse, err := tool.InternalView().EmergencyClient().Do(createRequest)
 		Expect(err).ToNot(HaveOccurred())
 		defer createResponse.Body.Close()
 		Expect(createResponse.StatusCode).To(Equal(http.StatusOK))
 
 		// Delete the object:
-		deleteUrl := fmt.Sprintf("https://%s/api/private/v1/cluster_templates/%s", serviceAddr, id)
-		deleteRequest, err := http.NewRequestWithContext(ctx, "DELETE", deleteUrl, nil)
+		deleteRequest, err := http.NewRequestWithContext(
+			ctx,
+			http.MethodDelete,
+			fmt.Sprintf("/api/private/v1/cluster_templates/%s", id),
+			nil,
+		)
 		Expect(err).ToNot(HaveOccurred())
-		deleteResponse, err := tool.EmergencyClient().Do(deleteRequest)
+		deleteResponse, err := tool.InternalView().EmergencyClient().Do(deleteRequest)
 		Expect(err).ToNot(HaveOccurred())
 		defer deleteResponse.Body.Close()
 		Expect(deleteResponse.StatusCode).To(Equal(http.StatusOK))

--- a/it/it_ingress_separation_test.go
+++ b/it/it_ingress_separation_test.go
@@ -1,0 +1,106 @@
+/*
+Copyright (c) 2026 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package it
+
+import (
+	"context"
+	"io"
+	"net/http"
+
+	. "github.com/onsi/ginkgo/v2/dsl/core"
+	. "github.com/onsi/gomega"
+	grpccodes "google.golang.org/grpc/codes"
+	grpcstatus "google.golang.org/grpc/status"
+
+	privatev1 "github.com/osac-project/fulfillment-service/internal/api/osac/private/v1"
+	publicv1 "github.com/osac-project/fulfillment-service/internal/api/osac/public/v1"
+)
+
+var _ = Describe("Ingress separation", func() {
+	var ctx context.Context
+
+	BeforeEach(func() {
+		ctx = context.Background()
+	})
+
+	It("Should be able to use the public gRPC public api via the external ingress", func() {
+		client := publicv1.NewClusterTemplatesClient(tool.ExternalView().UserConn())
+		response, err := client.List(ctx, nil)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(response).ToNot(BeNil())
+	})
+
+	It("Should be able to use the public gRPC API via the internal ingress", func() {
+		client := publicv1.NewClusterTemplatesClient(tool.InternalView().AdminConn())
+		response, err := client.List(ctx, nil)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(response).ToNot(BeNil())
+	})
+
+	It("Should not be able to use the private gRPC API via the external ingress", func() {
+		client := privatev1.NewClusterTemplatesClient(tool.ExternalView().AdminConn())
+		response, err := client.List(ctx, nil)
+		Expect(err).To(HaveOccurred())
+		Expect(response).To(BeNil())
+		status, ok := grpcstatus.FromError(err)
+		Expect(ok).To(BeTrue())
+		Expect(status.Code()).To(Equal(grpccodes.Unimplemented))
+	})
+
+	It("Should be able to use the public REST API via the external ingress", func() {
+		request, err := http.NewRequestWithContext(
+			ctx,
+			http.MethodGet,
+			"/api/fulfillment/v1/cluster_templates",
+			nil,
+		)
+		Expect(err).ToNot(HaveOccurred())
+		response, err := tool.ExternalView().UserClient().Do(request)
+		Expect(err).ToNot(HaveOccurred())
+		defer response.Body.Close()
+		Expect(response.StatusCode).To(Equal(http.StatusOK))
+		_, err = io.Copy(io.Discard, response.Body)
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	It("Should be able to use the private REST API via the internal ingress", func() {
+		request, err := http.NewRequestWithContext(
+			ctx,
+			http.MethodGet,
+			"/api/private/v1/cluster_templates",
+			nil,
+		)
+		Expect(err).ToNot(HaveOccurred())
+		response, err := tool.InternalView().AdminClient().Do(request)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(response).ToNot(BeNil())
+		defer response.Body.Close()
+		Expect(response.StatusCode).To(Equal(http.StatusOK))
+	})
+
+	It("Should not be able to use the private REST API via the external ingress", func() {
+		request, err := http.NewRequestWithContext(
+			ctx,
+			http.MethodGet,
+			"/api/private/v1/cluster_templates",
+			nil,
+		)
+		Expect(err).ToNot(HaveOccurred())
+		response, err := tool.ExternalView().AdminClient().Do(request)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(response).ToNot(BeNil())
+		defer response.Body.Close()
+		Expect(response.StatusCode).To(Equal(http.StatusNotFound))
+	})
+})

--- a/it/it_labels_test.go
+++ b/it/it_labels_test.go
@@ -39,9 +39,9 @@ var _ = Describe("Labels", func() {
 
 	BeforeEach(func() {
 		ctx = context.Background()
-		clustersClient = publicv1.NewClustersClient(tool.UserConn())
-		hostTypesClient = privatev1.NewHostTypesClient(tool.AdminConn())
-		templatesClient = privatev1.NewClusterTemplatesClient(tool.AdminConn())
+		clustersClient = publicv1.NewClustersClient(tool.ExternalView().UserConn())
+		hostTypesClient = privatev1.NewHostTypesClient(tool.InternalView().AdminConn())
+		templatesClient = privatev1.NewClusterTemplatesClient(tool.InternalView().AdminConn())
 
 		hostTypeId = fmt.Sprintf("my-host-type-%s", uuid.New())
 		_, err := hostTypesClient.Create(ctx, privatev1.HostTypesCreateRequest_builder{

--- a/it/it_multitenancy_test.go
+++ b/it/it_multitenancy_test.go
@@ -2,11 +2,9 @@ package it
 
 import (
 	"context"
-	"fmt"
 	"io"
 	"net/http"
 	"slices"
-	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -16,100 +14,70 @@ import (
 
 	privatev1 "github.com/osac-project/fulfillment-service/internal/api/osac/private/v1"
 	publicv1 "github.com/osac-project/fulfillment-service/internal/api/osac/public/v1"
-	"github.com/osac-project/fulfillment-service/internal/testing"
 )
 
 var _ = Describe("Multitenancy authentication error handling", Label("multitenancy", "autherrors"), func() {
+	var ctx context.Context
+
+	BeforeEach(func() {
+		ctx = context.Background()
+	})
+
 	DescribeTable(
-		"returns error when authenticating with invalid token",
-		func(testUrl string) {
-			invalidToken := testing.MakeTokenString("test", 0)
-
-			req, err := http.NewRequest("GET", testUrl, nil)
-			Expect(err).ToNot(HaveOccurred())
-
-			// Set invalid token in request header
-			req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", invalidToken))
-
-			// Make request with invalid token
-			resp, err := http.Get(testUrl)
-			Expect(err).ToNot(HaveOccurred())
-
-			// Check that unauthorized status code is returned
+		"Returns error when authenticating with invalid token",
+		func(endpoint string) {
 			Eventually(func(g Gomega) {
-				resp, err = http.Get(testUrl)
+				// Prepare a request with an invalid token:
+				request, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
 				g.Expect(err).ToNot(HaveOccurred())
-				g.Expect(resp).ToNot(BeNil())
-				Expect(resp.StatusCode).To(BeNumerically(">=", http.StatusUnauthorized))
-				g.Expect(resp.StatusCode).To(Equal(http.StatusUnauthorized))
-			}).WithTimeout(100 * time.Millisecond).WithPolling(10 * time.Millisecond).Should(Succeed())
+				request.Header.Set("Authorization", "Bearer junk")
 
-			defer resp.Body.Close()
+				// Send the request:
+				response, err := tool.ExternalView().AnonymousClient().Do(request)
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(response).ToNot(BeNil())
+				defer response.Body.Close()
 
-			// Check that permission denied error is returned in response body
-			body, err := io.ReadAll(resp.Body)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(body).To(ContainSubstring("permission denied"))
+				// Verify that the request is unauthorized:
+				g.Expect(response.StatusCode).To(Equal(http.StatusUnauthorized))
+
+				// Verify that error is returned in the response body:
+				body, err := io.ReadAll(response.Body)
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(body).To(ContainSubstring("permission denied"))
+			}).Should(Succeed())
 		},
-		Entry("clusters", fmt.Sprintf("https://%s/api/fulfillment/v1/clusters", serviceAddr)),
-		Entry("cluster templates", fmt.Sprintf("https://%s/api/fulfillment/v1/cluster_templates", serviceAddr)),
-		Entry("host types", fmt.Sprintf("https://%s/api/fulfillment/v1/host_types", serviceAddr)),
+		Entry("clusters", "/api/fulfillment/v1/clusters"),
+		Entry("Cluster templates", "/api/fulfillment/v1/cluster_templates"),
+		Entry("Host types", "/api/fulfillment/v1/host_types"),
 	)
 
 	DescribeTable(
-		"returns error when user is not authenticated",
-		func(testUrl string) {
-			var testUser string
-			var testTenant string
-
-			// Get a random user and tenant from map of users
-			for user, tenant := range ServiceAccountTenants {
-				testUser = user
-				testTenant = tenant
-				break
-			}
-
-			// Check that requests can be made with valid token
-			tokenSource, err := tool.makeKubernetesTokenSource(context.Background(), testUser, testTenant)
-			Expect(err).ToNot(HaveOccurred())
-
-			req, err := http.NewRequest("GET", testUrl, nil)
-			Expect(err).ToNot(HaveOccurred())
-
-			// Set token in request header
-			token, err := tokenSource.Token(context.Background())
-			Expect(err).ToNot(HaveOccurred())
-			req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", token.Access))
-
-			// Make request with valid token
+		"Returns error when user is not authenticated",
+		func(endpoint string) {
 			Eventually(func(g Gomega) {
-				resp, err := http.DefaultClient.Do(req)
+				// Prepare a request without a token:
+				req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
 				g.Expect(err).ToNot(HaveOccurred())
-				g.Expect(resp.StatusCode).To(Equal(http.StatusOK))
-			}).WithTimeout(100 * time.Millisecond).WithPolling(10 * time.Millisecond).Should(Succeed())
 
-			// Make request with invalid token
-			var resp *http.Response
-
-			// Check that unauthorized status code is returned
-			Eventually(func(g Gomega) {
-				resp, err = http.Get(testUrl)
+				// Send the request:
+				resp, err := tool.ExternalView().AnonymousClient().Do(req)
 				g.Expect(err).ToNot(HaveOccurred())
 				g.Expect(resp).ToNot(BeNil())
-				Expect(resp.StatusCode).To(BeNumerically(">=", http.StatusUnauthorized))
+				defer resp.Body.Close()
+
+				// Verify that the request is unauthorized:
 				g.Expect(resp.StatusCode).To(Equal(http.StatusUnauthorized))
-			}).WithTimeout(100 * time.Millisecond).WithPolling(10 * time.Millisecond).Should(Succeed())
 
-			defer resp.Body.Close()
-
-			// Check that permission denied error is returned in response body
-			body, err := io.ReadAll(resp.Body)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(body).To(ContainSubstring("permission denied"))
+				// Verify that error is returned in the response body:
+				body, err := io.ReadAll(resp.Body)
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(body).To(ContainSubstring("permission denied"))
+			}).Should(Succeed())
 		},
-		Entry("clusters", fmt.Sprintf("https://%s/api/fulfillment/v1/clusters", serviceAddr)),
-		Entry("cluster templates", fmt.Sprintf("https://%s/api/fulfillment/v1/cluster_templates", serviceAddr)),
-		Entry("host types", fmt.Sprintf("https://%s/api/fulfillment/v1/host_types", serviceAddr)),
+		Entry("Clusters", "/api/fulfillment/v1/clusters"),
+		Entry("Cluster templates", "/api/fulfillment/v1/cluster_templates"),
+		Entry("Host types", "/api/fulfillment/v1/host_types"),
 	)
 })
 
@@ -144,7 +112,7 @@ var _ = Describe("Multitenancy basic tenant isolation", Ordered, Label("multiten
 				tenantClusterMapping = make(map[string][]string)
 
 				// Create host type for testing
-				hostTypesClient := privatev1.NewHostTypesClient(tool.AdminConn())
+				hostTypesClient := privatev1.NewHostTypesClient(tool.InternalView().AdminConn())
 				hostTypeId := "basic-sa-isolation-hosttype"
 				_, err := hostTypesClient.Create(ctx, privatev1.HostTypesCreateRequest_builder{
 					Object: privatev1.HostType_builder{
@@ -161,7 +129,7 @@ var _ = Describe("Multitenancy basic tenant isolation", Ordered, Label("multiten
 
 				// Create cluster template for testing
 				templateId := "basic-sa-isolation-template"
-				templatesClient := privatev1.NewClusterTemplatesClient(tool.adminConn)
+				templatesClient := privatev1.NewClusterTemplatesClient(tool.InternalView().AdminConn())
 				_, err = templatesClient.Create(ctx, privatev1.ClusterTemplatesCreateRequest_builder{
 					Object: privatev1.ClusterTemplate_builder{
 						Id: templateId,
@@ -185,7 +153,7 @@ var _ = Describe("Multitenancy basic tenant isolation", Ordered, Label("multiten
 				for user, tenant := range ServiceAccountTenants {
 					tokenSource, err := tool.makeKubernetesTokenSource(ctx, user, tenant)
 					Expect(err).ToNot(HaveOccurred())
-					conn, err := tool.makeGrpcConn(tokenSource)
+					conn, err := tool.makeGrpcConn(externalServiceAddr, tokenSource)
 					Expect(err).ToNot(HaveOccurred())
 
 					clustersClient := publicv1.NewClustersClient(conn)
@@ -211,7 +179,7 @@ var _ = Describe("Multitenancy basic tenant isolation", Ordered, Label("multiten
 				for user, tenant := range ServiceAccountTenants {
 					tokenSource, err := tool.makeKubernetesTokenSource(ctx, user, tenant)
 					Expect(err).ToNot(HaveOccurred())
-					conn, err := tool.makeGrpcConn(tokenSource)
+					conn, err := tool.makeGrpcConn(externalServiceAddr, tokenSource)
 					Expect(err).ToNot(HaveOccurred())
 
 					response := listClusters(ctx, conn)
@@ -230,7 +198,7 @@ var _ = Describe("Multitenancy basic tenant isolation", Ordered, Label("multiten
 				for user, tenant := range ServiceAccountTenants {
 					tokenSource, err := tool.makeKubernetesTokenSource(ctx, user, tenant)
 					Expect(err).ToNot(HaveOccurred())
-					conn, err := tool.makeGrpcConn(tokenSource)
+					conn, err := tool.makeGrpcConn(externalServiceAddr, tokenSource)
 					Expect(err).ToNot(HaveOccurred())
 
 					response := listClusters(ctx, conn)
@@ -251,7 +219,7 @@ var _ = Describe("Multitenancy basic tenant isolation", Ordered, Label("multiten
 			It("assigned the correct tenant after creation", func() {
 				for tenant, clusters := range tenantClusterMapping {
 					for _, cluster := range clusters {
-						clustersClient := privatev1.NewClustersClient(tool.AdminConn())
+						clustersClient := privatev1.NewClustersClient(tool.InternalView().AdminConn())
 
 						clusterResponse, err := clustersClient.Get(ctx, privatev1.ClustersGetRequest_builder{
 							Id: cluster,
@@ -275,7 +243,7 @@ var _ = Describe("Multitenancy basic tenant isolation", Ordered, Label("multiten
 
 							tokenSource, err := tool.makeKubernetesTokenSource(ctx, user, userTenant)
 							Expect(err).ToNot(HaveOccurred())
-							conn, err := tool.makeGrpcConn(tokenSource)
+							conn, err := tool.makeGrpcConn(externalServiceAddr, tokenSource)
 							Expect(err).ToNot(HaveOccurred())
 
 							clustersClient := publicv1.NewClustersClient(conn)
@@ -352,7 +320,7 @@ var _ = Describe("Multitenancy basic tenant isolation", Ordered, Label("multiten
 
 				// Create host type for testing
 				hostTypeId := "basic-oidc-isolation-hosttype"
-				hostTypesClient := privatev1.NewHostTypesClient(tool.adminConn)
+				hostTypesClient := privatev1.NewHostTypesClient(tool.InternalView().AdminConn())
 				_, err := hostTypesClient.Create(ctx, privatev1.HostTypesCreateRequest_builder{
 					Object: privatev1.HostType_builder{
 						Id: hostTypeId,
@@ -368,7 +336,7 @@ var _ = Describe("Multitenancy basic tenant isolation", Ordered, Label("multiten
 
 				// Create cluster template for testing
 				templateId := "basic-oidc-isolation-template"
-				templatesClient := privatev1.NewClusterTemplatesClient(tool.adminConn)
+				templatesClient := privatev1.NewClusterTemplatesClient(tool.InternalView().AdminConn())
 				_, err = templatesClient.Create(ctx, privatev1.ClusterTemplatesCreateRequest_builder{
 					Object: privatev1.ClusterTemplate_builder{
 						Id: templateId,
@@ -392,7 +360,7 @@ var _ = Describe("Multitenancy basic tenant isolation", Ordered, Label("multiten
 				for user, tenants := range OIDCTenants {
 					tokenSource, err := tool.makeKeycloakTokenSource(ctx, user, usersPassword)
 					Expect(err).ToNot(HaveOccurred())
-					conn, err := tool.makeGrpcConn(tokenSource)
+					conn, err := tool.makeGrpcConn(externalServiceAddr, tokenSource)
 					Expect(err).ToNot(HaveOccurred())
 
 					clustersClient := publicv1.NewClustersClient(conn)
@@ -420,7 +388,7 @@ var _ = Describe("Multitenancy basic tenant isolation", Ordered, Label("multiten
 				for user, tenants := range OIDCTenants {
 					tokenSource, err := tool.makeKeycloakTokenSource(ctx, user, usersPassword)
 					Expect(err).ToNot(HaveOccurred())
-					conn, err := tool.makeGrpcConn(tokenSource)
+					conn, err := tool.makeGrpcConn(externalServiceAddr, tokenSource)
 					Expect(err).ToNot(HaveOccurred())
 
 					response := listClusters(ctx, conn)
@@ -440,7 +408,7 @@ var _ = Describe("Multitenancy basic tenant isolation", Ordered, Label("multiten
 				for user, tenants := range OIDCTenants {
 					tokenSource, err := tool.makeKeycloakTokenSource(ctx, user, usersPassword)
 					Expect(err).ToNot(HaveOccurred())
-					conn, err := tool.makeGrpcConn(tokenSource)
+					conn, err := tool.makeGrpcConn(externalServiceAddr, tokenSource)
 					Expect(err).ToNot(HaveOccurred())
 
 					response := listClusters(ctx, conn)
@@ -479,7 +447,7 @@ func listClusters(ctx context.Context, conn *grpc.ClientConn) *publicv1.Clusters
 }
 
 func deleteCluster(ctx context.Context, clusterId string) error {
-	clusterClient := privatev1.NewClustersClient(tool.AdminConn())
+	clusterClient := privatev1.NewClustersClient(tool.InternalView().AdminConn())
 	_, err := clusterClient.Delete(ctx, privatev1.ClustersDeleteRequest_builder{
 		Id: clusterId,
 	}.Build())

--- a/it/it_nodeset_removal_test.go
+++ b/it/it_nodeset_removal_test.go
@@ -40,9 +40,9 @@ var _ = Describe("Node set removal", func() {
 	BeforeEach(func() {
 		ctx = context.Background()
 
-		clustersClient = publicv1.NewClustersClient(tool.UserConn())
-		hostTypesClient = privatev1.NewHostTypesClient(tool.AdminConn())
-		templatesClient = privatev1.NewClusterTemplatesClient(tool.AdminConn())
+		clustersClient = publicv1.NewClustersClient(tool.ExternalView().UserConn())
+		hostTypesClient = privatev1.NewHostTypesClient(tool.InternalView().AdminConn())
+		templatesClient = privatev1.NewClusterTemplatesClient(tool.InternalView().AdminConn())
 
 		// Create worker host type:
 		workerHostTypeId = fmt.Sprintf("worker_type_%s", uuid.New())

--- a/it/it_private_cluster_templates_test.go
+++ b/it/it_private_cluster_templates_test.go
@@ -34,7 +34,7 @@ var _ = Describe("Private cluster templates", func() {
 
 	BeforeEach(func() {
 		ctx = context.Background()
-		client = privatev1.NewClusterTemplatesClient(tool.AdminConn())
+		client = privatev1.NewClusterTemplatesClient(tool.InternalView().AdminConn())
 	})
 
 	It("Can get the list of templates", func() {

--- a/it/it_private_host_types_test.go
+++ b/it/it_private_host_types_test.go
@@ -32,7 +32,7 @@ var _ = Describe("Private host types", func() {
 
 	BeforeEach(func() {
 		ctx = context.Background()
-		client = privatev1.NewHostTypesClient(tool.AdminConn())
+		client = privatev1.NewHostTypesClient(tool.InternalView().AdminConn())
 	})
 
 	It("Can get the list of host types", func() {

--- a/it/it_private_leases_test.go
+++ b/it/it_private_leases_test.go
@@ -34,7 +34,7 @@ var _ = Describe("Private leases", func() {
 
 	BeforeEach(func() {
 		ctx = context.Background()
-		client = privatev1.NewLeasesClient(tool.AdminConn())
+		client = privatev1.NewLeasesClient(tool.InternalView().AdminConn())
 	})
 
 	It("Can delete a lease", func() {

--- a/it/it_public_cluster_templates_test.go
+++ b/it/it_public_cluster_templates_test.go
@@ -30,7 +30,7 @@ var _ = Describe("Cluster templates", func() {
 
 	BeforeEach(func() {
 		ctx = context.Background()
-		client = publicv1.NewClusterTemplatesClient(tool.UserConn())
+		client = publicv1.NewClusterTemplatesClient(tool.ExternalView().UserConn())
 	})
 
 	It("Can get the list of templates", func() {

--- a/it/it_public_clusters_test.go
+++ b/it/it_public_clusters_test.go
@@ -49,9 +49,9 @@ var _ = Describe("Public clusters", func() {
 		ctx = context.Background()
 
 		// Create the clients:
-		clustersClient = publicv1.NewClustersClient(tool.UserConn())
-		hostTypesClient = privatev1.NewHostTypesClient(tool.AdminConn())
-		templatesClient = privatev1.NewClusterTemplatesClient(tool.AdminConn())
+		clustersClient = publicv1.NewClustersClient(tool.ExternalView().UserConn())
+		hostTypesClient = privatev1.NewHostTypesClient(tool.InternalView().AdminConn())
+		templatesClient = privatev1.NewClusterTemplatesClient(tool.InternalView().AdminConn())
 
 		// Create a host type for testing:
 		hostTypeId = fmt.Sprintf("my-host-type-%s", uuid.New())

--- a/it/it_rest_gateway_test.go
+++ b/it/it_rest_gateway_test.go
@@ -36,8 +36,8 @@ var _ = Describe("REST gateway", func() {
 
 	BeforeEach(func() {
 		ctx = context.Background()
-		templatesClient = privatev1.NewClusterTemplatesClient(tool.AdminConn())
-		hostTypesClient = privatev1.NewHostTypesClient(tool.AdminConn())
+		templatesClient = privatev1.NewClusterTemplatesClient(tool.InternalView().AdminConn())
+		hostTypesClient = privatev1.NewHostTypesClient(tool.InternalView().AdminConn())
 	})
 
 	It("Should use protobuf field names in JSON representation", func() {
@@ -102,10 +102,14 @@ var _ = Describe("REST gateway", func() {
 		})
 
 		// Retrieve the template via REST API:
-		url := fmt.Sprintf("https://%s/api/fulfillment/v1/cluster_templates/%s", serviceAddr, templateID)
-		request, err := http.NewRequestWithContext(ctx, "GET", url, nil)
+		request, err := http.NewRequestWithContext(
+			ctx,
+			http.MethodGet,
+			fmt.Sprintf("/api/fulfillment/v1/cluster_templates/%s", templateID),
+			nil,
+		)
 		Expect(err).ToNot(HaveOccurred())
-		response, err := tool.UserClient().Do(request)
+		response, err := tool.ExternalView().UserClient().Do(request)
 		Expect(err).ToNot(HaveOccurred())
 		defer response.Body.Close()
 		Expect(response.StatusCode).To(Equal(http.StatusOK))
@@ -181,10 +185,14 @@ var _ = Describe("REST gateway", func() {
 		})
 
 		// Retrieve the template via private REST API:
-		url := fmt.Sprintf("https://%s/api/private/v1/cluster_templates/%s", serviceAddr, templateID)
-		request, err := http.NewRequestWithContext(ctx, "GET", url, nil)
+		request, err := http.NewRequestWithContext(
+			ctx,
+			http.MethodGet,
+			fmt.Sprintf("/api/private/v1/cluster_templates/%s", templateID),
+			nil,
+		)
 		Expect(err).ToNot(HaveOccurred())
-		response, err := tool.AdminClient().Do(request)
+		response, err := tool.InternalView().AdminClient().Do(request)
 		Expect(err).ToNot(HaveOccurred())
 		defer response.Body.Close()
 		Expect(response.StatusCode).To(Equal(http.StatusOK))

--- a/it/it_tool.go
+++ b/it/it_tool.go
@@ -89,22 +89,31 @@ type ToolBuilder struct {
 // Tool is an instance of the integration test tool that sets up the test environment. Don't create instances of this
 // directly, use the NewTool function instead.
 type Tool struct {
-	logger          *slog.Logger
-	projectDir      string
-	crdFiles        []string
-	keepKind        bool
-	keepService     bool
-	deployMode      string
-	debug           bool
-	tmpDir          string
-	cluster         *testing.Kind
-	kubeClient      crclient.Client
-	kubeClientSet   *kubernetes.Clientset
-	caPool          *x509.CertPool
-	kcFile          string
+	logger        *slog.Logger
+	projectDir    string
+	crdFiles      []string
+	keepKind      bool
+	keepService   bool
+	deployMode    string
+	debug         bool
+	tmpDir        string
+	cluster       *testing.Kind
+	kubeClient    crclient.Client
+	kubeClientSet *kubernetes.Clientset
+	caPool        *x509.CertPool
+	kcFile        string
+	internalView  *ToolView
+	externalView  *ToolView
+}
+
+// ToolView contains the gRPC connections and HTTP clients that can be used to connect to the cluster. This is a
+// separate type to simplify having two copies: one for the internal API and another one for the external API.
+type ToolView struct {
+	anonymousConn   *grpc.ClientConn
 	emergencyConn   *grpc.ClientConn
 	adminConn       *grpc.ClientConn
 	userConn        *grpc.ClientConn
+	anonymousClient *http.Client
 	emergencyClient *http.Client
 	adminClient     *http.Client
 	userClient      *http.Client
@@ -244,7 +253,11 @@ func (t *Tool) Setup(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	err = t.checkAddress(ctx, serviceAddr)
+	err = t.checkAddress(ctx, externalServiceAddr)
+	if err != nil {
+		return err
+	}
+	err = t.checkAddress(ctx, internalServiceAddr)
 	if err != nil {
 		return err
 	}
@@ -971,9 +984,19 @@ func (t *Tool) deployService(ctx context.Context, imageRef string) error {
 
 func (t *Tool) deployServiceWithHelm(ctx context.Context, imageRef string) error {
 	// Prepare the values:
+	externalHostname, _, err := net.SplitHostPort(externalServiceAddr)
+	if err != nil {
+		return fmt.Errorf("failed to extract host from external service address: %w", err)
+	}
+	internalHostname, _, err := net.SplitHostPort(internalServiceAddr)
+	if err != nil {
+		return fmt.Errorf("failed to extract host from internal service address: %w", err)
+	}
 	valuesData := map[string]any{
-		"variant": "kind",
-		"debug":   t.debug,
+		"variant":          "kind",
+		"debug":            t.debug,
+		"externalHostname": externalHostname,
+		"internalHostname": internalHostname,
 		"log": map[string]any{
 			"level":   "debug",
 			"headers": true,
@@ -1240,23 +1263,50 @@ func (t *Tool) createClients(ctx context.Context) error {
 	}
 
 	// Create gRPC clients:
-	t.emergencyConn, err = t.makeGrpcConn(emergencyTokenSource)
+	t.internalView = &ToolView{}
+	t.internalView.anonymousConn, err = t.makeGrpcConn(internalServiceAddr, nil)
 	if err != nil {
 		return err
 	}
-	t.adminConn, err = t.makeGrpcConn(adminTokenSource)
+	t.internalView.emergencyConn, err = t.makeGrpcConn(internalServiceAddr, emergencyTokenSource)
 	if err != nil {
 		return err
 	}
-	t.userConn, err = t.makeGrpcConn(userTokenSource)
+	t.internalView.adminConn, err = t.makeGrpcConn(internalServiceAddr, adminTokenSource)
+	if err != nil {
+		return err
+	}
+	t.internalView.userConn, err = t.makeGrpcConn(internalServiceAddr, userTokenSource)
+	if err != nil {
+		return err
+	}
+	t.externalView = &ToolView{}
+	t.externalView.anonymousConn, err = t.makeGrpcConn(externalServiceAddr, nil)
+	if err != nil {
+		return err
+	}
+	t.externalView.emergencyConn, err = t.makeGrpcConn(externalServiceAddr, emergencyTokenSource)
+	if err != nil {
+		return err
+	}
+	t.externalView.adminConn, err = t.makeGrpcConn(externalServiceAddr, adminTokenSource)
+	if err != nil {
+		return err
+	}
+	t.externalView.userConn, err = t.makeGrpcConn(externalServiceAddr, userTokenSource)
 	if err != nil {
 		return err
 	}
 
 	// Create HTTP clients:
-	t.emergencyClient = t.makeHttpClient(emergencyTokenSource)
-	t.adminClient = t.makeHttpClient(adminTokenSource)
-	t.userClient = t.makeHttpClient(userTokenSource)
+	t.internalView.anonymousClient = t.makeHttpClient(internalServiceAddr, nil)
+	t.internalView.emergencyClient = t.makeHttpClient(internalServiceAddr, emergencyTokenSource)
+	t.internalView.adminClient = t.makeHttpClient(internalServiceAddr, adminTokenSource)
+	t.internalView.userClient = t.makeHttpClient(internalServiceAddr, userTokenSource)
+	t.externalView.anonymousClient = t.makeHttpClient(externalServiceAddr, nil)
+	t.externalView.emergencyClient = t.makeHttpClient(externalServiceAddr, emergencyTokenSource)
+	t.externalView.adminClient = t.makeHttpClient(externalServiceAddr, adminTokenSource)
+	t.externalView.userClient = t.makeHttpClient(externalServiceAddr, userTokenSource)
 
 	return nil
 }
@@ -1336,27 +1386,35 @@ func (t *Tool) makeKeycloakTokenSource(ctx context.Context, username, password s
 	return
 }
 
-func (t *Tool) makeGrpcConn(tokenSource auth.TokenSource) (result *grpc.ClientConn, err error) {
+// makeGrpcConn creates a gRPC connection that automatically adds the token to the request.
+func (t *Tool) makeGrpcConn(addr string, tokenSource auth.TokenSource) (result *grpc.ClientConn, err error) {
 	userAgent := fmt.Sprintf("%s/%s", userAgent, version.Get())
 	result, err = network.NewGrpcClient().
 		SetLogger(t.logger).
 		SetCaPool(t.caPool).
-		SetAddress(serviceAddr).
+		SetAddress(addr).
 		SetTokenSource(tokenSource).
 		SetUserAgent(userAgent).
 		Build()
 	return
 }
 
-func (t *Tool) makeHttpClient(tokenSource auth.TokenSource) *http.Client {
+// makeHttpClient creates an HTTP client that automatically adds the scheme, host and token to the request. Users of the
+// client only need to provide the URL path, and other headers as needed.
+func (t *Tool) makeHttpClient(addr string, tokenSource auth.TokenSource) *http.Client {
 	transport := &http.Transport{
 		TLSClientConfig: &tls.Config{
 			RootCAs: t.caPool,
 		},
 	}
-	return &http.Client{
-		Transport: ghttp.RoundTripperFunc(
-			func(request *http.Request) (response *http.Response, err error) {
+	tripper := ghttp.RoundTripperFunc(
+		func(request *http.Request) (response *http.Response, err error) {
+			// Replace the scheme and host, so that users of the client only need to provide the path:
+			request.URL.Scheme = "https"
+			request.URL.Host = addr
+
+			// Add the token if there is a token source available:
+			if tokenSource != nil {
 				token, err := tokenSource.Token(request.Context())
 				if err != nil {
 					return nil, err
@@ -1365,10 +1423,15 @@ func (t *Tool) makeHttpClient(tokenSource auth.TokenSource) *http.Client {
 					"Authorization",
 					fmt.Sprintf("Bearer %s", token.Access),
 				)
-				response, err = transport.RoundTrip(request)
-				return
-			},
-		),
+			}
+
+			// Forward the request:
+			response, err = transport.RoundTrip(request)
+			return
+		},
+	)
+	return &http.Client{
+		Transport: tripper,
 	}
 }
 
@@ -1382,7 +1445,7 @@ func (t *Tool) waitForServersReady(ctx context.Context) error {
 
 func (t *Tool) waitForGrpcServerReady(ctx context.Context) error {
 	t.logger.DebugContext(ctx, "Waiting for gRPC server to be ready")
-	client := publicv1.NewCapabilitiesClient(t.adminConn)
+	client := publicv1.NewCapabilitiesClient(t.externalView.adminConn)
 	request := publicv1.CapabilitiesGetRequest_builder{}.Build()
 	backOff := backoff.NewExponentialBackOff()
 	backOff.InitialInterval = 1 * time.Second
@@ -1403,8 +1466,12 @@ func (t *Tool) waitForGrpcServerReady(ctx context.Context) error {
 
 func (t *Tool) waitForRestGatewayReady(ctx context.Context) error {
 	t.logger.DebugContext(ctx, "Waiting for REST gateway to be ready")
-	endpoint := fmt.Sprintf("https://%s/api/fulfillment/v1/capabilities", serviceAddr)
-	request, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	request, err := http.NewRequestWithContext(
+		ctx,
+		http.MethodGet,
+		"/api/fulfillment/v1/capabilities",
+		nil,
+	)
 	if err != nil {
 		return fmt.Errorf("failed to create REST health check request: %w", err)
 	}
@@ -1413,7 +1480,7 @@ func (t *Tool) waitForRestGatewayReady(ctx context.Context) error {
 	backOff.MaxInterval = 10 * time.Second
 	backOff.MaxElapsedTime = 60 * time.Second
 	return backoff.Retry(func() error {
-		response, err := t.adminClient.Do(request)
+		response, err := t.externalView.adminClient.Do(request)
 		if err != nil {
 			t.logger.DebugContext(
 				ctx,
@@ -1468,7 +1535,7 @@ func (t *Tool) registerHub(ctx context.Context) error {
 	}
 
 	// Create the hubs client:
-	hubsClient := privatev1.NewHubsClient(t.adminConn)
+	hubsClient := privatev1.NewHubsClient(t.internalView.adminConn)
 
 	// Wait for Authorino authorization to be ready:
 	for range 30 {
@@ -1503,23 +1570,17 @@ func (t *Tool) registerHub(ctx context.Context) error {
 func (t *Tool) Cleanup(ctx context.Context) error {
 	var errs []error
 
-	// Close gRPC connections:
-	if t.emergencyConn != nil {
-		err := t.emergencyConn.Close()
+	// Close gRPC views:
+	if t.internalView != nil {
+		err := t.internalView.Close()
 		if err != nil {
-			errs = append(errs, fmt.Errorf("failed to close emergency adminstrator connection: %w", err))
+			errs = append(errs, fmt.Errorf("failed to close internal gRPC view: %w", err))
 		}
 	}
-	if t.adminConn != nil {
-		err := t.adminConn.Close()
+	if t.externalView != nil {
+		err := t.externalView.Close()
 		if err != nil {
-			errs = append(errs, fmt.Errorf("failed to close administrator connection: %w", err))
-		}
-	}
-	if t.userConn != nil {
-		err := t.userConn.Close()
-		if err != nil {
-			errs = append(errs, fmt.Errorf("failed to close regular connection: %w", err))
+			errs = append(errs, fmt.Errorf("failed to close external gRPC view: %w", err))
 		}
 	}
 
@@ -1576,34 +1637,77 @@ func (t *Tool) KubeClientSet() *kubernetes.Clientset {
 	return t.kubeClientSet
 }
 
-// EmergencyConn returns the gRPC client connection for the emergency administration service account.
-func (t *Tool) EmergencyConn() *grpc.ClientConn {
-	return t.emergencyConn
+// InternalView returns the view of the internal API.
+func (t *Tool) InternalView() *ToolView {
+	return t.internalView
 }
 
-// AdminConn returns the gRPC client connection for admnistration user.
-func (t *Tool) AdminConn() *grpc.ClientConn {
-	return t.adminConn
+// ExternalView returns the view of the external API.
+func (t *Tool) ExternalView() *ToolView {
+	return t.externalView
 }
 
-// UserConn returns the gRPC client connection for the regular user.
-func (t *Tool) UserConn() *grpc.ClientConn {
-	return t.userConn
+// AnonymousConn returns the gRPC connection for the anonymous user.
+func (v *ToolView) AnonymousConn() *grpc.ClientConn {
+	return v.anonymousConn
+}
+
+// EmergencyConn returns the gRPC connection for the emergency administration service account.
+func (v *ToolView) EmergencyConn() *grpc.ClientConn {
+	return v.emergencyConn
+}
+
+// AdminConn returns the gRPC connection for the administrator user.
+func (v *ToolView) AdminConn() *grpc.ClientConn {
+	return v.adminConn
+}
+
+// UserConn returns the gRPC connection for the regular user.
+func (v *ToolView) UserConn() *grpc.ClientConn {
+	return v.userConn
+}
+
+// AnonymousClient returns the HTTP client for the anonymous user.
+func (v *ToolView) AnonymousClient() *http.Client {
+	return v.anonymousClient
 }
 
 // EmergencyClient returns the HTTP client for the emergency administration service account.
-func (t *Tool) EmergencyClient() *http.Client {
-	return t.emergencyClient
+func (v *ToolView) EmergencyClient() *http.Client {
+	return v.emergencyClient
 }
 
 // AdminClient returns the HTTP client for the administrator user.
-func (t *Tool) AdminClient() *http.Client {
-	return t.adminClient
+func (v *ToolView) AdminClient() *http.Client {
+	return v.adminClient
 }
 
 // UserClient returns the HTTP client for the regular user.
-func (t *Tool) UserClient() *http.Client {
-	return t.userClient
+func (v *ToolView) UserClient() *http.Client {
+	return v.userClient
+}
+
+// Close closes the gRPC connections and HTTP clients of the view.
+func (v *ToolView) Close() error {
+	closeConn := func(conn *grpc.ClientConn) error {
+		if conn != nil {
+			return conn.Close()
+		}
+		return nil
+	}
+	closeClient := func(client *http.Client) error {
+		return nil
+	}
+	return errors.Join(
+		closeConn(v.anonymousConn),
+		closeConn(v.emergencyConn),
+		closeConn(v.adminConn),
+		closeConn(v.userConn),
+		closeClient(v.anonymousClient),
+		closeClient(v.emergencyClient),
+		closeClient(v.adminClient),
+		closeClient(v.userClient),
+	)
 }
 
 // ProjectDir returns the project directory.
@@ -1631,8 +1735,9 @@ const userAgent = "fulfillment-it-tool"
 
 // Service host name and address:
 const (
-	keycloakAddr = "keycloak.keycloak.svc.cluster.local:8000"
-	serviceAddr  = "fulfillment-api.osac.svc.cluster.local:8000"
+	keycloakAddr        = "keycloak.keycloak.svc.cluster.local:8000"
+	externalServiceAddr = "fulfillment-api.osac.svc.cluster.local:8000"
+	internalServiceAddr = "fulfillment-internal-api.osac.svc.cluster.local:8000"
 )
 
 // Names of the database-related Kubernetes resources.

--- a/it/it_version_test.go
+++ b/it/it_version_test.go
@@ -42,9 +42,9 @@ var _ = Describe("Version", func() {
 
 	BeforeEach(func() {
 		ctx = context.Background()
-		clustersClient = publicv1.NewClustersClient(tool.UserConn())
-		hostTypesClient = privatev1.NewHostTypesClient(tool.AdminConn())
-		templatesClient = privatev1.NewClusterTemplatesClient(tool.AdminConn())
+		clustersClient = publicv1.NewClustersClient(tool.ExternalView().UserConn())
+		hostTypesClient = privatev1.NewHostTypesClient(tool.InternalView().AdminConn())
+		templatesClient = privatev1.NewClusterTemplatesClient(tool.InternalView().AdminConn())
 
 		hostTypeId = fmt.Sprintf("my-host-type-%s", uuid.New())
 		_, err := hostTypesClient.Create(ctx, privatev1.HostTypesCreateRequest_builder{

--- a/manifests/base/controller/deployment.yaml
+++ b/manifests/base/controller/deployment.yaml
@@ -51,7 +51,7 @@ spec:
         - --log-bodies=false
         - --ca-file=/etc/fulfillment-controller/tls/cas
         - --token-file=/var/run/secrets/kubernetes.io/serviceaccount/token
-        - --grpc-server-address=fulfillment-api:8000
+        - --grpc-server-address=fulfillment-internal-api:8001
         - --grpc-keep-alive=5m
         - --grpc-listener-address=0.0.0.0:8000
         - --grpc-listener-tls-crt=/etc/fulfillment-controller/tls/tls.crt

--- a/manifests/base/ingress-proxy/certificate.yaml
+++ b/manifests/base/ingress-proxy/certificate.yaml
@@ -24,6 +24,9 @@ spec:
   - fulfillment-api
   - fulfillment-api.osac
   - fulfillment-api.osac.svc.cluster.local
+  - fulfillment-internal-api
+  - fulfillment-internal-api.osac
+  - fulfillment-internal-api.osac.svc.cluster.local
   secretName: fulfillment-api-tls
   privateKey:
     rotationPolicy: Always

--- a/manifests/base/ingress-proxy/configmap.yaml
+++ b/manifests/base/ingress-proxy/configmap.yaml
@@ -72,9 +72,9 @@ data:
                 typed_config:
                   "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
 
-      # This listener receives traffic from outside, so it needs to be secured with CORS and TLS. Authentication and
-      # authorization are handled by the service itself.
-      - name: ingress
+      # This listener receives external traffic for the public API, so it needs to be secured with CORS and TLS.
+      # Authentication and authorization are handled by the service itself.
+      - name: external-api
         address:
           socket_address:
             address: 0.0.0.0
@@ -89,7 +89,97 @@ data:
                 typed_config:
                   "@type": type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog
                   path: /dev/stdout
-              stat_prefix: ingress
+              stat_prefix: external-api
+              route_config:
+                name: backend
+                virtual_hosts:
+                - name: all
+                  domains:
+                  - "*"
+                  typed_per_filter_config:
+                    envoy.filters.http.cors:
+                      "@type": type.googleapis.com/envoy.extensions.filters.http.cors.v3.CorsPolicy
+                      allow_origin_string_match:
+                      - safe_regex:
+                          regex: ".*"
+                      allow_methods: "GET,POST,PUT,PATCH,DELETE,OPTIONS"
+                      allow_headers: "Authorization,Content-Type,X-User-Agent,X-Grpc-Web, Accept"
+                      expose_headers: "Grpc-Status,Grpc-Message"
+                      allow_credentials: true
+                      max_age: "86400"
+                  routes:
+
+                  # This route is for the REST gateway. The public API endpoints use path prefixes
+                  # like /api/fulfillment/ and /api/events/.
+                  - name: rest-gateway
+                    match:
+                      safe_regex:
+                        regex: /api/(fulfillment|events)(/.*)?
+                    route:
+                      cluster: rest-gateway
+                      timeout: 300s
+
+                  # This route is for the gRPC streaming requests used to watch events. Those streams can last very
+                  # long, so we don't want to set a timeout, as that would cause the connection to be closed and
+                  # events to be potentially lost.
+                  - name: events
+                    match:
+                      safe_regex:
+                        regex: /osac\.public\..*/Watch
+                    route:
+                      cluster: grpc-server
+                      timeout: 0s
+                      idle_timeout: 0s
+
+                  # This route is for public API and gRPC reflection unary requests.
+                  - name: grpc-server
+                    match:
+                      safe_regex:
+                        regex: /(osac\.public\.|grpc\.(reflection|health)\.).*
+                    route:
+                      cluster: grpc-server
+                      timeout: 300s
+
+              http_filters:
+              - name: envoy.filters.http.cors
+                typed_config:
+                  "@type": type.googleapis.com/envoy.extensions.filters.http.cors.v3.Cors
+              - name: envoy.filters.http.router
+                typed_config:
+                  "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+
+          transport_socket:
+            name: envoy.transport_sockets.tls
+            typed_config:
+              "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.DownstreamTlsContext
+              common_tls_context:
+                alpn_protocols:
+                - http1.1
+                - h2
+                tls_certificates:
+                - certificate_chain:
+                    filename: /etc/envoy/tls/tls.crt
+                  private_key:
+                    filename: /etc/envoy/tls/tls.key
+
+      # This listener receives internal traffic for both the public and private APIs, so it needs to be secured
+      # with CORS and TLS. Authentication and authorization are handled by the service itself.
+      - name: internal-api
+        address:
+          socket_address:
+            address: 0.0.0.0
+            port_value: 8001
+        filter_chains:
+        - filters:
+          - name: envoy.filters.network.http_connection_manager
+            typed_config:
+              "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+              access_log:
+              - name: envoy.access_loggers.file
+                typed_config:
+                  "@type": type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog
+                  path: /dev/stdout
+              stat_prefix: internal-api
               route_config:
                 name: backend
                 virtual_hosts:
@@ -117,30 +207,19 @@ data:
                       cluster: rest-gateway
                       timeout: 300s
 
-                  # This route is for the gRPC streaming requests used to watch events. Those streams can last very long,
-                  # so we don't want to set a timeout, as that would cause the connection to be closed and events to be
-                  # potentially lost.
+                  # This route is for the gRPC streaming requests used to watch events. Those streams can last very
+                  # long, so we don't want to set a timeout, as that would cause the connection to be closed and
+                  # events to be potentially lost.
                   - name: events
                     match:
                       safe_regex:
-                        regex: ^.*/Watch$
+                        regex: .*/Watch
                     route:
                       cluster: grpc-server
                       timeout: 0s
                       idle_timeout: 0s
 
-                  # This route is for the gRPC bidirectional streaming console sessions. Console sessions can last
-                  # up to 30 minutes (configurable), so we disable the timeout to avoid premature disconnects.
-                  - name: console
-                    match:
-                      safe_regex:
-                        regex: ^/osac\.public\.v1\.Console/Connect$
-                    route:
-                      cluster: grpc-server
-                      timeout: 0s
-                      idle_timeout: 0s
-
-                  # This route is for gRPC unary requests, which should be quite fast, so we can safely set a timeout.
+                  # This route is for gRPC unary requests.
                   - name: grpc-server
                     match:
                       prefix: /

--- a/manifests/base/ingress-proxy/deployment.yaml
+++ b/manifests/base/ingress-proxy/deployment.yaml
@@ -46,9 +46,12 @@ spec:
         - --config-path
         - /etc/envoy/envoy.yaml
         ports:
-        - name: api
+        - name: external-api
           protocol: TCP
           containerPort: 8000
+        - name: internal-api
+          protocol: TCP
+          containerPort: 8001
         - name: metrics
           protocol: TCP
           containerPort: 8002

--- a/manifests/base/ingress-proxy/service.yaml
+++ b/manifests/base/ingress-proxy/service.yaml
@@ -19,9 +19,37 @@ spec:
   selector:
     app: fulfillment-ingress-proxy
   ports:
-  - name: api
+  - name: external-api
     port: 8000
-    targetPort: api
+    targetPort: external-api
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: fulfillment-internal-api
+spec:
+  selector:
+    app: fulfillment-ingress-proxy
+  ports:
+  - name: internal-api
+    port: 8001
+    targetPort: internal-api
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: fulfillment-ingress-proxy-metrics
+  annotations:
+    prometheus.io/scrape: "true"
+    prometheus.io/port: "8002"
+spec:
+  selector:
+    app: fulfillment-ingress-proxy
+  ports:
   - name: metrics
     port: 8002
     targetPort: metrics

--- a/manifests/base/rest-gateway/deployment.yaml
+++ b/manifests/base/rest-gateway/deployment.yaml
@@ -52,7 +52,7 @@ spec:
         - --http-listener-address=0.0.0.0:8000
         - --http-listener-tls-crt=/etc/fulfillment-rest-gateway/tls/tls.crt
         - --http-listener-tls-key=/etc/fulfillment-rest-gateway/tls/tls.key
-        - --grpc-server-address=fulfillment-api:8000
+        - --grpc-server-address=fulfillment-internal-api:8001
         - --grpc-keep-alive=5m
         - --metrics-listener-address=0.0.0.0:8002
         ports:

--- a/manifests/overlays/kind/route.yaml
+++ b/manifests/overlays/kind/route.yaml
@@ -28,3 +28,23 @@ spec:
   - backendRefs:
     - name: fulfillment-api
       port: 8000
+
+---
+
+apiVersion: gateway.networking.k8s.io/v1alpha3
+kind: TLSRoute
+metadata:
+  name: fulfillment-internal-api
+spec:
+  parentRefs:
+  - group: gateway.networking.k8s.io
+    kind: Gateway
+    namespace: envoy-gateway
+    name: default
+    sectionName: tls
+  hostnames:
+  - fulfillment-internal-api.osac.svc.cluster.local
+  rules:
+  - backendRefs:
+    - name: fulfillment-internal-api
+      port: 8001

--- a/manifests/overlays/openshift/route.yaml
+++ b/manifests/overlays/openshift/route.yaml
@@ -20,6 +20,21 @@ spec:
     kind: Service
     name: fulfillment-api
   port:
-    targetPort: api
+    targetPort: external-api
+  tls:
+    termination: passthrough
+
+---
+
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: fulfillment-internal-api
+spec:
+  to:
+    kind: Service
+    name: fulfillment-internal-api
+  port:
+    targetPort: internal-api
   tls:
     termination: passthrough


### PR DESCRIPTION
## Summary

- Split the single `ingress` Envoy listener into two: `external-api` (port 8000, public API only) and `internal-api` (port 8001, both public and private APIs).
- Renamed Helm value `hostname` to `externalHostname` and added `internalHostname`. When `internalHostname` is not set, no Route/TLSRoute is created for the internal API, giving administrators flexibility to configure ingress manually.
- Created a separate `fulfillment-internal-api` Kubernetes service and moved metrics to `fulfillment-ingress-proxy-metrics`.
- Updated controller and REST gateway to connect through the internal-api listener since they require access to the private API.
- Migrated all integration tests to use the correct endpoint (external for public API, internal for private API) and added `it_ingress_separation_test.go` with positive and negative tests for the ingress boundary.
- Updated `/etc/hosts` documentation in README, CLAUDE.md, and CI workflows.

## Test plan

- [x] Integration tests pass with Helm deployment mode
- [x] Integration tests pass with Kustomize deployment mode
- [x] `it_ingress_separation_test.go` verifies public API works via external ingress
- [x] `it_ingress_separation_test.go` verifies private API is rejected via external ingress
- [x] `it_ingress_separation_test.go` verifies both APIs work via internal ingress
- [x] Verify that omitting `internalHostname` does not create an internal Route/TLSRoute

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Public and private APIs split onto distinct external and internal ingress paths with separate services, listener ports, and certificates; Envoy exposes external and internal API ports.
  * Routing updated with explicit external/internal listeners and refined CORS and timeout behavior.

* **Tests**
  * Added integration suite validating public/private API ingress isolation and updated tests to exercise external vs. internal endpoints.

* **Documentation**
  * Updated setup, Helm values, and /etc/hosts guidance to document external vs. internal hostnames and certificate mappings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->