### PR TITLE
MGMT-24117: fix PublicIPPool buildSpec CRD field mapping

### DIFF
--- a/internal/controllers/publicippool/public_ip_pool_reconciler_function.go
+++ b/internal/controllers/publicippool/public_ip_pool_reconciler_function.go
@@ -36,8 +36,7 @@ import (
 )
 
 const (
-	objectPrefix                     = "publicippool-"
-	implementationStrategyAnnotation = "osac.openshift.io/implementation-strategy"
+	objectPrefix = "publicippool-"
 )
 
 var (
@@ -182,14 +181,9 @@ func (t *task) update(ctx context.Context) error {
 		object.SetLabels(map[string]string{
 			labels.PublicIPPoolUuid: t.publicIPPool.GetId(),
 		})
-		poolAnnotations := map[string]string{
+		object.SetAnnotations(map[string]string{
 			annotations.Tenant: t.publicIPPool.GetMetadata().GetTenants()[0],
-		}
-		implStrategy := t.publicIPPool.GetSpec().GetImplementationStrategy()
-		if implStrategy != "" {
-			poolAnnotations[implementationStrategyAnnotation] = implStrategy
-		}
-		object.SetAnnotations(poolAnnotations)
+		})
 		err = unstructured.SetNestedField(object.Object, spec, "spec")
 		if err != nil {
 			return err
@@ -396,16 +390,18 @@ func (t *task) buildSpec() map[string]any {
 	for i, c := range cidrs {
 		cidrList[i] = c
 	}
+	spec["cidrs"] = cidrList
 
 	switch t.publicIPPool.GetSpec().GetIpFamily() {
 	case privatev1.IPFamily_IP_FAMILY_IPV4:
-		spec["ipv4"] = map[string]any{
-			"cidrs": cidrList,
-		}
+		spec["ipFamily"] = "IPv4"
 	case privatev1.IPFamily_IP_FAMILY_IPV6:
-		spec["ipv6"] = map[string]any{
-			"cidrs": cidrList,
-		}
+		spec["ipFamily"] = "IPv6"
+	}
+
+	implStrategy := t.publicIPPool.GetSpec().GetImplementationStrategy()
+	if implStrategy != "" {
+		spec["implementationStrategy"] = implStrategy
 	}
 
 	return spec

--- a/internal/controllers/publicippool/public_ip_pool_reconciler_function_test.go
+++ b/internal/controllers/publicippool/public_ip_pool_reconciler_function_test.go
@@ -38,7 +38,7 @@ import (
 )
 
 var _ = Describe("buildSpec", func() {
-	It("Maps IPv4 family to spec.ipv4.cidrs", func() {
+	It("Maps IPv4 family to flat spec fields", func() {
 		t := &task{
 			publicIPPool: privatev1.PublicIPPool_builder{
 				Id: "pool-ipv4",
@@ -51,13 +51,13 @@ var _ = Describe("buildSpec", func() {
 
 		spec := t.buildSpec()
 
-		Expect(spec).To(HaveKey("ipv4"))
+		Expect(spec).ToNot(HaveKey("ipv4"))
 		Expect(spec).ToNot(HaveKey("ipv6"))
-		ipv4 := spec["ipv4"].(map[string]any)
-		Expect(ipv4["cidrs"]).To(Equal([]any{"203.0.113.0/24", "198.51.100.0/24"}))
+		Expect(spec["cidrs"]).To(Equal([]any{"203.0.113.0/24", "198.51.100.0/24"}))
+		Expect(spec["ipFamily"]).To(Equal("IPv4"))
 	})
 
-	It("Maps IPv6 family to spec.ipv6.cidrs", func() {
+	It("Maps IPv6 family to flat spec fields", func() {
 		t := &task{
 			publicIPPool: privatev1.PublicIPPool_builder{
 				Id: "pool-ipv6",
@@ -70,10 +70,43 @@ var _ = Describe("buildSpec", func() {
 
 		spec := t.buildSpec()
 
-		Expect(spec).To(HaveKey("ipv6"))
 		Expect(spec).ToNot(HaveKey("ipv4"))
-		ipv6 := spec["ipv6"].(map[string]any)
-		Expect(ipv6["cidrs"]).To(Equal([]any{"2001:db8::/32"}))
+		Expect(spec).ToNot(HaveKey("ipv6"))
+		Expect(spec["cidrs"]).To(Equal([]any{"2001:db8::/32"}))
+		Expect(spec["ipFamily"]).To(Equal("IPv6"))
+	})
+
+	It("Includes implementationStrategy when set", func() {
+		t := &task{
+			publicIPPool: privatev1.PublicIPPool_builder{
+				Id: "pool-impl-strategy",
+				Spec: privatev1.PublicIPPoolSpec_builder{
+					Cidrs:                  []string{"203.0.113.0/24"},
+					IpFamily:               privatev1.IPFamily_IP_FAMILY_IPV4,
+					ImplementationStrategy: "metallb-l2",
+				}.Build(),
+			}.Build(),
+		}
+
+		spec := t.buildSpec()
+
+		Expect(spec["implementationStrategy"]).To(Equal("metallb-l2"))
+	})
+
+	It("Omits implementationStrategy when empty", func() {
+		t := &task{
+			publicIPPool: privatev1.PublicIPPool_builder{
+				Id: "pool-no-impl-strategy",
+				Spec: privatev1.PublicIPPoolSpec_builder{
+					Cidrs:    []string{"203.0.113.0/24"},
+					IpFamily: privatev1.IPFamily_IP_FAMILY_IPV4,
+				}.Build(),
+			}.Build(),
+		}
+
+		spec := t.buildSpec()
+
+		Expect(spec).ToNot(HaveKey("implementationStrategy"))
 	})
 
 })
@@ -709,66 +742,8 @@ var _ = Describe("update", func() {
 		spec, found, err := unstructured.NestedMap(createdObj.Object, "spec")
 		Expect(err).ToNot(HaveOccurred())
 		Expect(found).To(BeTrue())
-		Expect(spec).To(HaveKey("ipv4"))
-	})
-
-	It("should include implementation strategy annotation when set", func() {
-		scheme := newSchemeWithPublicIPPoolList()
-		var createdObj *unstructured.Unstructured
-		fakeClient := fake.NewClientBuilder().
-			WithScheme(scheme).
-			WithInterceptorFuncs(interceptor.Funcs{
-				Create: func(ctx context.Context, client clnt.WithWatch, obj clnt.Object, opts ...clnt.CreateOption) error {
-					createdObj = obj.(*unstructured.Unstructured)
-					return nil
-				},
-			}).
-			Build()
-
-		hubCache := controllers.NewMockHubCache(ctrl)
-		hubCache.EXPECT().
-			Get(gomock.Any(), hubID).
-			Return(&controllers.HubEntry{
-				Namespace: hubNamespace,
-				Client:    fakeClient,
-			}, nil)
-
-		t := newTaskForUpdate(poolID, hubID, hubCache)
-		t.publicIPPool.GetSpec().SetImplementationStrategy("metallb-l2")
-
-		err := t.update(ctx)
-		Expect(err).ToNot(HaveOccurred())
-		Expect(createdObj.GetAnnotations()).To(
-			HaveKeyWithValue(implementationStrategyAnnotation, "metallb-l2"),
-		)
-	})
-
-	It("should not include implementation strategy annotation when empty", func() {
-		scheme := newSchemeWithPublicIPPoolList()
-		var createdObj *unstructured.Unstructured
-		fakeClient := fake.NewClientBuilder().
-			WithScheme(scheme).
-			WithInterceptorFuncs(interceptor.Funcs{
-				Create: func(ctx context.Context, client clnt.WithWatch, obj clnt.Object, opts ...clnt.CreateOption) error {
-					createdObj = obj.(*unstructured.Unstructured)
-					return nil
-				},
-			}).
-			Build()
-
-		hubCache := controllers.NewMockHubCache(ctrl)
-		hubCache.EXPECT().
-			Get(gomock.Any(), hubID).
-			Return(&controllers.HubEntry{
-				Namespace: hubNamespace,
-				Client:    fakeClient,
-			}, nil)
-
-		t := newTaskForUpdate(poolID, hubID, hubCache)
-
-		err := t.update(ctx)
-		Expect(err).ToNot(HaveOccurred())
-		Expect(createdObj.GetAnnotations()).ToNot(HaveKey(implementationStrategyAnnotation))
+		Expect(spec).To(HaveKey("cidrs"))
+		Expect(spec).To(HaveKey("ipFamily"))
 	})
 
 	It("should patch existing K8s object", func() {


### PR DESCRIPTION
## Summary

Fix the PublicIPPool reconciler's `buildSpec()` which produced a nested field structure
(`spec.ipv4.cidrs` / `spec.ipv6.cidrs`) that did not match the CRD's flat schema
(`spec.cidrs` + `spec.ipFamily`). This caused every PublicIPPool CR to be rejected by
CRD validation with `spec.cidrs: Required value, spec.ipFamily: Required value`,
preventing pools from getting a hub assigned ([MGMT-24117](https://redhat.atlassian.net/browse/MGMT-24117)).

Also removes the `implementationStrategy` annotation from the CR creation path. The
value is now in the spec where AAP can read it directly, matching the VirtualNetwork
pattern.

**Changes:**
- Rewrite `buildSpec()` to produce flat `cidrs`, `ipFamily`, `implementationStrategy`
- Remove `implementationStrategyAnnotation` constant and annotation-setting in `update()`
- Update buildSpec tests for flat fields, add implementationStrategy tests, remove annotation tests

## Testing

**Unit tests:**
```
$ ginkgo run -r internal/controllers/
Ginkgo ran 7 suites in 3.9s
Test Suite Passed

PublicIPPool controller: 36/36 specs passed
PublicIP controller: 25/25 specs passed (PR #441, included after rebase)
All controllers: 150/150 specs passed
```

Build passes: `go build ./...`

**E2E on edge22 (2026-04-24, clean-slate test):**

Deployed `quay.io/rh-ee-anadkarn/fulfillment-service:mgmt-24117-bugfix-2855865` with
osac-operator `quay.io/rh-ee-anadkarn/osac-operator:mgmt-24117-bugfix-d6f9e2f` and
osac-aap branch `mgmt-24117-bugfix-publicippool-aap`.

Cleaned all existing PublicIPPool/PublicIP resources (DB + K8s CRs) and tested from scratch.

| # | Test | Result |
|---|------|--------|
| 1 | PublicIPPool CRD field validation | **PASS** |
| 2 | Pool reaches Ready, AAP provisions MetalLB | **PASS** |
| 3 | PublicIP hub derivation from pool | **PASS** |

**Test 1: CRD field validation (the core fix)**

```yaml
# Before (broken, from MGMT-23734 Round 4 Test 13):
spec:
  ipv4:
    cidrs: ["192.168.127.200/29"]
# CRD rejected: spec.cidrs: Required value, spec.ipFamily: Required value

# After (fixed):
spec:
  cidrs: ["192.168.127.216/29"]
  implementationStrategy: metallb-l2
  ipFamily: IPv4
# CRD accepted
```

**Test 2: Pool reaches Ready with MetalLB provisioned**

Created PublicIPPool with CIDR `192.168.127.216/29`. Full lifecycle completed:

```
Pool state: PUBLIC_IP_POOL_STATE_READY
Pool hub: test-infra-cluster
K8s CR phase: Ready
AAP job 11703: Succeeded

CR spec:
  {"cidrs":["192.168.127.216/29"],"implementationStrategy":"metallb-l2","ipFamily":"IPv4"}

CR annotations (no implementation-strategy):
  {"osac.openshift.io/tenant":"tenant-akshay"}

MetalLB resources created by AAP:
  IPAddressPool/publicippool-gtxgq: ["192.168.127.216/29"]
  L2Advertisement/publicippool-gtxgq-l2adv: ["publicippool-gtxgq"]
```

Previously the pool never reached Ready because the CRD rejected the CR at admission.

**Test 3: Full PublicIPPool -> PublicIP flow (previously blocked)**

Created PublicIP referencing the Ready pool. The reconciler derived the hub from the pool
and created a K8s PublicIP CR on the hub:

```
PublicIP status:
  state: PUBLIC_IP_STATE_PENDING
  hub: test-infra-cluster  (derived from pool)

K8s CR:
  NAME             POOL                                   AGE
  publicip-xdh44   019dc144-eaef-753d-8403-610b5d134233   39s
```

This was the exact flow blocked in [MGMT-23734](https://redhat.atlassian.net/browse/MGMT-23734) Round 4 (Tests 13/15/16): pool never got
a hub, so PublicIP always hit the "pool has no hub assigned yet, skipping" guard clause.

## Related PRs

- osac-operator: [#201](https://github.com/osac-project/osac-operator/pull/201) (annotation-copy block removal)
- osac-aap: [#261](https://github.com/osac-project/osac-aap/pull/261) (playbook spec-read switch)

Merge order: this PR first, then osac-operator, then osac-aap.

## Ticket

[MGMT-24117](https://redhat.atlassian.net/browse/MGMT-24117)

<br>

<small>Assisted-by: Cursor/Claude</small>