### PR TITLE
NO-ISSUE: Drop unused indexes on `archived_public_ips` table

### DIFF
--- a/internal/database/migrations/32_drop_archived_public_ips_indexes.up.sql
+++ b/internal/database/migrations/32_drop_archived_public_ips_indexes.up.sql
@@ -1,0 +1,19 @@
+--
+-- Copyright (c) 2026 Red Hat Inc.
+--
+-- Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+-- the License. You may obtain a copy of the License at
+--
+--   http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+-- an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+-- specific language governing permissions and limitations under the License.
+--
+
+-- Drop indexes on the archived_public_ips table. No other archive table has indexes, and they are
+-- not currently used, so they just consume space.
+drop index if exists archived_public_ips_by_name;
+drop index if exists archived_public_ips_by_owner;
+drop index if exists archived_public_ips_by_tenant;
+drop index if exists archived_public_ips_by_label;


### PR DESCRIPTION
## Summary

- Migration 31 inadvertently created indexes on the `archived_public_ips` archive table. No other
  archive table has indexes, and they are not currently queried, so they just consume space.
- Adds migration 32 to drop the four indexes: `archived_public_ips_by_name`,
  `archived_public_ips_by_owner`, `archived_public_ips_by_tenant`, and
  `archived_public_ips_by_label`.

## Test plan

- Verify that the migration applies cleanly on a database that has migration 31 already applied.
- Confirm that no archive table queries rely on these indexes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized database indexes to improve performance and reduce storage overhead.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->