### PR TITLE
MGMT-24122: set subnet-namespace annotation on ComputeInstance CR

### DIFF
--- a/internal/controllers/computeinstance/computeinstance_reconciler_function.go
+++ b/internal/controllers/computeinstance/computeinstance_reconciler_function.go
@@ -70,6 +70,7 @@ type task struct {
 	hubNamespace       string
 	hubClient          clnt.Client
 	userDataSecretName string
+	subnetNamespace    string
 }
 
 // NewFunction creates a new builder that can then be used to create a new compute instance reconciler function.
@@ -200,9 +201,13 @@ func (t *task) update(ctx context.Context) error {
 		object.SetLabels(map[string]string{
 			labels.ComputeInstanceUuid: t.computeInstance.GetId(),
 		})
-		object.SetAnnotations(map[string]string{
+		ann := map[string]string{
 			annotations.Tenant: t.computeInstance.GetMetadata().GetTenants()[0],
-		})
+		}
+		if t.subnetNamespace != "" {
+			ann[annotations.SubnetNamespace] = t.subnetNamespace
+		}
+		object.SetAnnotations(ann)
 		err = unstructured.SetNestedField(object.Object, spec, "spec")
 		if err != nil {
 			return err
@@ -518,6 +523,7 @@ func (t *task) buildSpec(ctx context.Context) (map[string]any, error) {
 			// Don't set subnetRef if lookup fails
 		} else if subnetCR != nil {
 			spec["subnetRef"] = subnetCR.GetName()
+			t.subnetNamespace = subnetCR.GetName()
 			t.r.logger.DebugContext(
 				ctx,
 				"Set subnetRef from Subnet CR",

--- a/internal/controllers/computeinstance/computeinstance_reconciler_function_test.go
+++ b/internal/controllers/computeinstance/computeinstance_reconciler_function_test.go
@@ -37,6 +37,7 @@ import (
 	privatev1 "github.com/osac-project/fulfillment-service/internal/api/osac/private/v1"
 	"github.com/osac-project/fulfillment-service/internal/controllers"
 	"github.com/osac-project/fulfillment-service/internal/controllers/finalizers"
+	"github.com/osac-project/fulfillment-service/internal/kubernetes/annotations"
 	"github.com/osac-project/fulfillment-service/internal/kubernetes/gvks"
 	"github.com/osac-project/fulfillment-service/internal/kubernetes/labels"
 )
@@ -816,5 +817,99 @@ var _ = Describe("ensureUserDataSecret", func() {
 
 		err := t.ensureUserDataSecret(ctx, owner)
 		Expect(err).ToNot(HaveOccurred())
+	})
+})
+
+var _ = Describe("subnet-namespace annotation", func() {
+	const (
+		hubNamespace = "test-ns"
+		subnetID     = "subnet-abc-123"
+		subnetCRName = "subnet-xyz"
+		tenant       = "my-tenant"
+		ciID         = "ci-subnet-ann-test"
+	)
+
+	var ctx context.Context
+
+	BeforeEach(func() {
+		ctx = context.Background()
+	})
+
+	It("should set subnetNamespace on task after buildSpec when Subnet CR found", func() {
+		subnetCR := &unstructured.Unstructured{}
+		subnetCR.SetGroupVersionKind(gvks.Subnet)
+		subnetCR.SetNamespace(hubNamespace)
+		subnetCR.SetName(subnetCRName)
+		subnetCR.SetLabels(map[string]string{labels.SubnetUuid: subnetID})
+
+		scheme := runtime.NewScheme()
+		scheme.AddKnownTypeWithName(
+			schema.GroupVersionKind{Group: gvks.Subnet.Group, Version: gvks.Subnet.Version, Kind: gvks.Subnet.Kind + "List"},
+			&unstructured.UnstructuredList{},
+		)
+
+		t := &task{
+			r: &function{logger: logger},
+			computeInstance: privatev1.ComputeInstance_builder{
+				Id: ciID,
+				Spec: privatev1.ComputeInstanceSpec_builder{
+					Template: "tmpl",
+					Subnet:   proto.String(subnetID),
+				}.Build(),
+			}.Build(),
+			hubNamespace: hubNamespace,
+			hubClient:    fake.NewClientBuilder().WithScheme(scheme).WithObjects(subnetCR).Build(),
+		}
+
+		_, err := t.buildSpec(ctx)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(t.subnetNamespace).To(Equal(subnetCRName))
+	})
+
+	It("should include subnet-namespace in annotation map when subnetNamespace is set", func() {
+		t := &task{
+			r: &function{logger: logger},
+			computeInstance: privatev1.ComputeInstance_builder{
+				Id: ciID,
+				Metadata: privatev1.Metadata_builder{
+					Tenants: []string{tenant},
+				}.Build(),
+			}.Build(),
+			subnetNamespace: subnetCRName,
+		}
+
+		ann := map[string]string{
+			annotations.Tenant: t.computeInstance.GetMetadata().GetTenants()[0],
+		}
+		if t.subnetNamespace != "" {
+			ann[annotations.SubnetNamespace] = t.subnetNamespace
+		}
+
+		Expect(ann).To(HaveKey(annotations.SubnetNamespace))
+		Expect(ann[annotations.SubnetNamespace]).To(Equal(subnetCRName))
+		Expect(ann[annotations.Tenant]).To(Equal(tenant))
+	})
+
+	It("should not include subnet-namespace in annotation map when subnetNamespace is empty", func() {
+		t := &task{
+			r: &function{logger: logger},
+			computeInstance: privatev1.ComputeInstance_builder{
+				Id: ciID,
+				Metadata: privatev1.Metadata_builder{
+					Tenants: []string{tenant},
+				}.Build(),
+			}.Build(),
+			// subnetNamespace intentionally left empty
+		}
+
+		ann := map[string]string{
+			annotations.Tenant: t.computeInstance.GetMetadata().GetTenants()[0],
+		}
+		if t.subnetNamespace != "" {
+			ann[annotations.SubnetNamespace] = t.subnetNamespace
+		}
+
+		Expect(ann).ToNot(HaveKey(annotations.SubnetNamespace))
+		Expect(ann[annotations.Tenant]).To(Equal(tenant))
 	})
 })

--- a/internal/kubernetes/annotations/kubernetes_annotations.go
+++ b/internal/kubernetes/annotations/kubernetes_annotations.go
@@ -13,5 +13,13 @@ language governing permissions and limitations under the License.
 
 package annotations
 
-// Tenant is the annotation key for tenant information on all OSAC resources.
-const Tenant = "osac.openshift.io/tenant"
+const (
+	// Tenant is the annotation key for tenant information on all OSAC resources.
+	Tenant = "osac.openshift.io/tenant"
+
+	// SubnetNamespace is the annotation key that records the Kubernetes namespace
+	// corresponding to the subnet attached to a ComputeInstance. The osac-operator
+	// uses this annotation to locate the KubeVirt VM created by AAP in the subnet
+	// namespace rather than falling back to the tenant namespace.
+	SubnetNamespace = "osac.openshift.io/subnet-namespace"
+)


### PR DESCRIPTION
## Summary

- When a `ComputeInstance` is created with a `spec.subnet` reference, the fulfillment-controller now sets the `osac.openshift.io/subnet-namespace` annotation on the hub `ComputeInstance` CR
- The osac-operator uses this annotation to locate the KubeVirt VM in the subnet namespace instead of falling back to the tenant namespace
- Without this annotation, VMs using guest tenancy were stuck in `STARTING` because the operator searched the subnet namespace while AAP created the VM in the tenant (`guest`) namespace

## Test plan

- [x] `buildSpec` sets `task.subnetNamespace` when Subnet CR is found
- [x] Annotation map includes `osac.openshift.io/subnet-namespace` when subnet is present
- [x] Annotation map excludes `osac.openshift.io/subnet-namespace` when no subnet is set
- [x] All 23 existing compute instance controller tests pass

Fixes: https://redhat.atlassian.net/browse/MGMT-24122

Co-Authored-By: Claude Sonnet 4.6 (1M context) <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic subnet namespace annotation support for compute instances. When a subnet is specified, the system now discovers the associated subnet CR and applies the corresponding namespace annotation to instances.

* **Tests**
  * Extended test coverage to validate subnet CR detection and conditional annotation application during instance reconciliation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->