### PR TITLE
MGMT-24114: Update IdentityProvider to return conflict errors

### DIFF
--- a/internal/idp/errors.go
+++ b/internal/idp/errors.go
@@ -1,0 +1,31 @@
+/*
+Copyright (c) 2026 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package idp
+
+import "fmt"
+
+// ConflictError is returned when attempting to create a resource that already exists in the IDP.
+type ConflictError struct {
+	ResourceType ResourceType
+	ResourceName string
+	Err          error // underlying error from the IDP client
+}
+
+func (e *ConflictError) Error() string {
+	return fmt.Sprintf("%s %q already exists", e.ResourceType, e.ResourceName)
+}
+
+func (e *ConflictError) Unwrap() error {
+	return e.Err
+}

--- a/internal/idp/keycloak/client.go
+++ b/internal/idp/keycloak/client.go
@@ -139,7 +139,11 @@ func (c *Client) CreateOrganization(ctx context.Context, org *idp.Organization) 
 	if err != nil {
 		var apiErr *apiclient.APIError
 		if errors.As(err, &apiErr) && apiErr.StatusCode == http.StatusConflict {
-			return nil, fmt.Errorf("organization %q already exists: %w", org.Name, err)
+			return nil, &idp.ConflictError{
+				ResourceType: idp.ResourceTypeOrganization,
+				ResourceName: org.Name,
+				Err:          err,
+			}
 		}
 		return nil, fmt.Errorf("failed to create organization: %w", err)
 	}
@@ -190,7 +194,11 @@ func (c *Client) CreateUser(ctx context.Context, organizationName string, user *
 	if err != nil {
 		var apiErr *apiclient.APIError
 		if errors.As(err, &apiErr) && apiErr.StatusCode == http.StatusConflict {
-			return nil, fmt.Errorf("user %q already exists: %w", user.Username, err)
+			return nil, &idp.ConflictError{
+				ResourceType: idp.ResourceTypeUser,
+				ResourceName: user.Username,
+				Err:          err,
+			}
 		}
 		return nil, fmt.Errorf("failed to create user: %w", err)
 	}

--- a/internal/idp/types.go
+++ b/internal/idp/types.go
@@ -13,6 +13,20 @@ language governing permissions and limitations under the License.
 
 package idp
 
+// ResourceType represents the type of IDP resource.
+type ResourceType string
+
+const (
+	// ResourceTypeOrganization represents an organization/realm/tenant in the IDP.
+	ResourceTypeOrganization ResourceType = "organization"
+
+	// ResourceTypeUser represents a user account in the IDP.
+	ResourceTypeUser ResourceType = "user"
+
+	// ResourceTypeRole represents a role in the IDP.
+	ResourceTypeRole ResourceType = "role"
+)
+
 // Organization represents a logical grouping of users, groups, and applications in an IdP.
 // Different providers call this different things:
 // - Keycloak: Realm


### PR DESCRIPTION
# Description
This will help in the future when the objects
being created already exist in the identity provider.

# Testing 

- [x] `go build ./...` compiles cleanly
- [x] All 520 unit test suites pass (`ginkgo run -r ./internal`)

Assisted-by: Claude

/cc @jhernand 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved error handling for identity management resource conflicts and duplicate creation attempts. Enhanced error messages now provide clearer, more structured feedback when attempting to create duplicate organizations, users, or roles within the system. Better error classification enables faster troubleshooting and issue resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->