### PR TITLE
MGMT-23763: Block IP pool deletion when allocated PublicIPs exist

### DIFF
--- a/internal/servers/private_public_ip_pools_server.go
+++ b/internal/servers/private_public_ip_pools_server.go
@@ -164,7 +164,9 @@ func (s *PrivatePublicIPPoolsServer) Delete(ctx context.Context,
 	return
 }
 
-// checkNoAllocatedIPs returns a FailedPrecondition error when at least one PublicIP still references the pool
+// checkNoAllocatedIPs returns a FailedPrecondition error when at least one PublicIP still
+// references this pool. Any database error is treated as a hard failure so that a transient
+// connectivity issue cannot silently bypass the referential-integrity check and orphan IPs.
 func (s *PrivatePublicIPPoolsServer) checkNoAllocatedIPs(ctx context.Context, poolID string) error {
 	filter := fmt.Sprintf("this.spec.pool == %q", poolID)
 	listResponse, err := s.publicIPDAO.List().
@@ -172,13 +174,17 @@ func (s *PrivatePublicIPPoolsServer) checkNoAllocatedIPs(ctx context.Context, po
 		SetLimit(1).
 		Do(ctx)
 	if err != nil {
-		s.logger.WarnContext(
+		s.logger.ErrorContext(
 			ctx,
-			"Unable to verify allocated public IPs, skipping referential-integrity check",
+			"Failed to verify allocated public IPs for pool",
 			slog.String("pool_id", poolID),
 			slog.Any("error", err),
 		)
-		return nil
+		return grpcstatus.Errorf(
+			grpccodes.Internal,
+			"failed to verify allocated public IPs for pool '%s'",
+			poolID,
+		)
 	}
 	if total := listResponse.GetTotal(); total > 0 {
 		return grpcstatus.Errorf(

--- a/internal/servers/private_public_ip_pools_server.go
+++ b/internal/servers/private_public_ip_pools_server.go
@@ -16,13 +16,17 @@ package servers
 import (
 	"context"
 	"errors"
+	"fmt"
 	"log/slog"
 
 	"github.com/prometheus/client_golang/prometheus"
+	grpccodes "google.golang.org/grpc/codes"
+	grpcstatus "google.golang.org/grpc/status"
 
 	privatev1 "github.com/osac-project/fulfillment-service/internal/api/osac/private/v1"
 	"github.com/osac-project/fulfillment-service/internal/auth"
 	"github.com/osac-project/fulfillment-service/internal/database"
+	"github.com/osac-project/fulfillment-service/internal/database/dao"
 )
 
 // PrivatePublicIPPoolsServerBuilder contains the data and logic needed to create a new private public IP pools server.
@@ -40,8 +44,9 @@ var _ privatev1.PublicIPPoolsServer = (*PrivatePublicIPPoolsServer)(nil)
 type PrivatePublicIPPoolsServer struct {
 	privatev1.UnimplementedPublicIPPoolsServer
 
-	logger  *slog.Logger
-	generic *GenericServer[*privatev1.PublicIPPool]
+	logger      *slog.Logger
+	generic     *GenericServer[*privatev1.PublicIPPool]
+	publicIPDAO *dao.GenericDAO[*privatev1.PublicIP]
 }
 
 // NewPrivatePublicIPPoolsServer creates a builder that can then be used to configure and create a new private public
@@ -92,6 +97,17 @@ func (b *PrivatePublicIPPoolsServerBuilder) Build() (result *PrivatePublicIPPool
 		return
 	}
 
+	// Create the PublicIP DAO used to check for allocated IPs on pool deletion:
+	publicIPDAO, err := dao.NewGenericDAO[*privatev1.PublicIP]().
+		SetLogger(b.logger).
+		SetTenancyLogic(b.tenancyLogic).
+		SetMetricsRegisterer(b.metricsRegisterer).
+		Build()
+	if err != nil {
+		err = fmt.Errorf("failed to create public IP DAO: %w", err)
+		return
+	}
+
 	generic, err := NewGenericServer[*privatev1.PublicIPPool]().
 		SetLogger(b.logger).
 		SetService(privatev1.PublicIPPools_ServiceDesc.ServiceName).
@@ -105,8 +121,9 @@ func (b *PrivatePublicIPPoolsServerBuilder) Build() (result *PrivatePublicIPPool
 	}
 
 	result = &PrivatePublicIPPoolsServer{
-		logger:  b.logger,
-		generic: generic,
+		logger:      b.logger,
+		generic:     generic,
+		publicIPDAO: publicIPDAO,
 	}
 	return
 }
@@ -137,8 +154,40 @@ func (s *PrivatePublicIPPoolsServer) Update(ctx context.Context,
 
 func (s *PrivatePublicIPPoolsServer) Delete(ctx context.Context,
 	request *privatev1.PublicIPPoolsDeleteRequest) (response *privatev1.PublicIPPoolsDeleteResponse, err error) {
+	if s.publicIPDAO != nil {
+		err = s.checkNoAllocatedIPs(ctx, request.GetId())
+		if err != nil {
+			return
+		}
+	}
 	err = s.generic.Delete(ctx, request, &response)
 	return
+}
+
+// checkNoAllocatedIPs returns a FailedPrecondition error when at least one PublicIP still references the pool
+func (s *PrivatePublicIPPoolsServer) checkNoAllocatedIPs(ctx context.Context, poolID string) error {
+	filter := fmt.Sprintf("this.spec.pool == %q", poolID)
+	listResponse, err := s.publicIPDAO.List().
+		SetFilter(filter).
+		SetLimit(1).
+		Do(ctx)
+	if err != nil {
+		s.logger.WarnContext(
+			ctx,
+			"Unable to verify allocated public IPs, skipping referential-integrity check",
+			slog.String("pool_id", poolID),
+			slog.Any("error", err),
+		)
+		return nil
+	}
+	if total := listResponse.GetTotal(); total > 0 {
+		return grpcstatus.Errorf(
+			grpccodes.FailedPrecondition,
+			"cannot delete public IP pool '%s': %d public IP(s) are still allocated from it",
+			poolID, total,
+		)
+	}
+	return nil
 }
 
 func (s *PrivatePublicIPPoolsServer) Signal(ctx context.Context,

--- a/internal/servers/private_public_ip_pools_server_test.go
+++ b/internal/servers/private_public_ip_pools_server_test.go
@@ -66,6 +66,8 @@ var _ = Describe("Private public IP pools server", func() {
 		// Create the tables:
 		err = dao.CreateTables[*privatev1.PublicIPPool](ctx)
 		Expect(err).ToNot(HaveOccurred())
+		err = dao.CreateTables[*privatev1.PublicIP](ctx)
+		Expect(err).ToNot(HaveOccurred())
 	})
 
 	Describe("Creation", func() {
@@ -109,13 +111,24 @@ var _ = Describe("Private public IP pools server", func() {
 	})
 
 	Describe("Behaviour", func() {
-		var poolsServer *PrivatePublicIPPoolsServer
+		var (
+			poolsServer *PrivatePublicIPPoolsServer
+			ipsServer   *PrivatePublicIPsServer
+		)
 
 		BeforeEach(func() {
 			var err error
 
-			// Create the server:
+			// Create the pools server:
 			poolsServer, err = NewPrivatePublicIPPoolsServer().
+				SetLogger(logger).
+				SetAttributionLogic(attribution).
+				SetTenancyLogic(tenancy).
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+
+			// Create the IPs server (used to seed PublicIP objects for deletion tests):
+			ipsServer, err = NewPrivatePublicIPsServer().
 				SetLogger(logger).
 				SetAttributionLogic(attribution).
 				SetTenancyLogic(tenancy).
@@ -273,6 +286,57 @@ var _ = Describe("Private public IP pools server", func() {
 			}.Build())
 			Expect(err).ToNot(HaveOccurred())
 			Expect(getResponse.GetObject().GetMetadata().GetDeletionTimestamp()).ToNot(BeNil())
+		})
+
+		It("Rejects deletion when allocated PublicIPs reference the pool", func() {
+			// Create a pool:
+			createPoolResponse, err := poolsServer.Create(ctx, privatev1.PublicIPPoolsCreateRequest_builder{
+				Object: privatev1.PublicIPPool_builder{
+					Spec: privatev1.PublicIPPoolSpec_builder{
+						Cidrs:    []string{"10.0.0.0/24"},
+						IpFamily: privatev1.IPFamily_IP_FAMILY_IPV4,
+					}.Build(),
+				}.Build(),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+			poolID := createPoolResponse.GetObject().GetId()
+
+			// Allocate a PublicIP from the pool:
+			_, err = ipsServer.Create(ctx, privatev1.PublicIPsCreateRequest_builder{
+				Object: privatev1.PublicIP_builder{
+					Spec: privatev1.PublicIPSpec_builder{
+						Pool: poolID,
+					}.Build(),
+				}.Build(),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+
+			// Attempt to delete the pool — must fail:
+			_, err = poolsServer.Delete(ctx, privatev1.PublicIPPoolsDeleteRequest_builder{
+				Id: poolID,
+			}.Build())
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("public IP(s) are still allocated"))
+		})
+
+		It("Allows deletion when no PublicIPs reference the pool", func() {
+			// Create a pool:
+			createPoolResponse, err := poolsServer.Create(ctx, privatev1.PublicIPPoolsCreateRequest_builder{
+				Object: privatev1.PublicIPPool_builder{
+					Spec: privatev1.PublicIPPoolSpec_builder{
+						Cidrs:    []string{"10.1.0.0/24"},
+						IpFamily: privatev1.IPFamily_IP_FAMILY_IPV4,
+					}.Build(),
+				}.Build(),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+			poolID := createPoolResponse.GetObject().GetId()
+
+			// No PublicIPs reference this pool — deletion must succeed:
+			_, err = poolsServer.Delete(ctx, privatev1.PublicIPPoolsDeleteRequest_builder{
+				Id: poolID,
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
 		})
 	})
 })


### PR DESCRIPTION
PrivatePublicIPPoolsServer.Delete now checks for allocated PublicIP objects before proceeding. If any PublicIP references the pool via spec.pool, the call is rejected with FailedPrecondition including the pool ID and remaining IP count. 

Added two unit tests cover the happy and rejection paths (both pass), Manully tested the below 4 scenarios:
1.  Create pool, delete immediately (no IPs) → 200 OK, deletionTimestamp set 
2.  Allocate 2 IPs from pool, attempt delete → FailedPrecondition: cannot delete public IP pool '…': 2 public IP(s) are still allocated from it 
3.  Delete both IPs, retry pool delete → 200 OK 
4.  IPs on pool-B don't block pool-A delete; pool-B still blocked 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevents deletion of IP pools that still have public IPs allocated; deletion now fails with an explicit error if allocations exist. Lookup failures are surfaced as errors to avoid unintended deletions.

* **Tests**
  * Added tests covering deletion rejection when a pool has allocated public IPs and successful deletion when unreferenced.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->