### PR TITLE
MGMT-23761: Add CIDR validation

### DIFF
--- a/internal/servers/private_public_ip_pools_server.go
+++ b/internal/servers/private_public_ip_pools_server.go
@@ -201,10 +201,14 @@ func (s *PrivatePublicIPPoolsServer) validateCreate(ctx context.Context,
 		}
 	}
 
+	if err := validateNoCIDRSelfOverlap(cidrs); err != nil {
+		return err
+	}
+
 	return s.validateNoPoolCIDROverlap(ctx, pool)
 }
 
-// validateUpdate validates a PublicIPPool update request. Only immutability of spec fields is checked 
+// validateUpdate validates a PublicIPPool update request. Only immutability of spec fields is checked
 func validateUpdate(newPool *privatev1.PublicIPPool, existing *privatev1.PublicIPPool) error {
 	if newPool == nil {
 		return grpcstatus.Errorf(grpccodes.InvalidArgument, "public IP pool is mandatory")
@@ -255,19 +259,30 @@ func validatePoolCIDRFormat(cidrStr string, ipFamily privatev1.IPFamily, idx int
 	return nil
 }
 
-// validateNoPoolCIDROverlap checks for CIDRs overlap with CIDRs from any existing pool
+// validateNoCIDRSelfOverlap checks that no two CIDRs within the same pool overlap each other.
+// This is called after format validation, so all CIDRs are known to be parseable.
+func validateNoCIDRSelfOverlap(cidrs []string) error {
+	for i := 0; i < len(cidrs); i++ {
+		for j := i + 1; j < len(cidrs); j++ {
+			overlap, err := cidrsOverlap(cidrs[i], cidrs[j])
+			if err != nil {
+				return grpcstatus.Errorf(grpccodes.Internal, "failed to check intra-pool CIDR overlap")
+			}
+			if overlap {
+				return grpcstatus.Errorf(grpccodes.InvalidArgument,
+					"field 'spec.cidrs[%d]' (%s) overlaps with 'spec.cidrs[%d]' (%s) within the same pool",
+					i, cidrs[i], j, cidrs[j])
+			}
+		}
+	}
+	return nil
+}
+
+// validateNoPoolCIDROverlap checks for CIDR overlap with CIDRs from any existing pool.
 func (s *PrivatePublicIPPoolsServer) validateNoPoolCIDROverlap(ctx context.Context,
 	pool *privatev1.PublicIPPool) error {
 
-	type parsedCIDR struct {
-		raw string
-		net *net.IPNet
-	}
-	newCIDRs := make([]parsedCIDR, 0, len(pool.GetSpec().GetCidrs()))
-	for _, cidr := range pool.GetSpec().GetCidrs() {
-		_, ipNet, _ := net.ParseCIDR(cidr)
-		newCIDRs = append(newCIDRs, parsedCIDR{raw: cidr, net: ipNet})
-	}
+	newCIDRs := pool.GetSpec().GetCidrs()
 
 	var offset int32
 	for {
@@ -280,16 +295,17 @@ func (s *PrivatePublicIPPoolsServer) validateNoPoolCIDROverlap(ctx context.Conte
 		}
 
 		for _, existing := range listResponse.GetItems() {
-			for _, existingCIDRStr := range existing.GetSpec().GetCidrs() {
-				_, existingNet, err := net.ParseCIDR(existingCIDRStr)
-				if err != nil {
-					continue
-				}
+			for _, existingCIDR := range existing.GetSpec().GetCidrs() {
 				for _, newCIDR := range newCIDRs {
-					if newCIDR.net.Contains(existingNet.IP) || existingNet.Contains(newCIDR.net.IP) {
+					overlap, err := cidrsOverlap(newCIDR, existingCIDR)
+					if err != nil {
+						s.logger.ErrorContext(ctx, "Failed to check CIDR overlap", slog.Any("error", err))
+						return grpcstatus.Errorf(grpccodes.Internal, "failed to validate CIDR overlap")
+					}
+					if overlap {
 						return grpcstatus.Errorf(grpccodes.AlreadyExists,
 							"CIDR '%s' overlaps with CIDR '%s' from existing pool '%s'",
-							newCIDR.raw, existingCIDRStr, existing.GetMetadata().GetName())
+							newCIDR, existingCIDR, existing.GetMetadata().GetName())
 					}
 				}
 			}
@@ -304,8 +320,7 @@ func (s *PrivatePublicIPPoolsServer) validateNoPoolCIDROverlap(ctx context.Conte
 	return nil
 }
 
-
-// calculatePoolCapacity returns the total number of usable IP addresses across all CIDRs in the pool 
+// calculatePoolCapacity returns the total number of usable IP addresses across all CIDRs in the pool
 func calculatePoolCapacity(cidrs []string, ipFamily privatev1.IPFamily) int64 {
 	var total int64
 	for _, cidr := range cidrs {

--- a/internal/servers/private_public_ip_pools_server.go
+++ b/internal/servers/private_public_ip_pools_server.go
@@ -17,6 +17,9 @@ import (
 	"context"
 	"errors"
 	"log/slog"
+	"math"
+	"net"
+	"sort"
 
 	"github.com/prometheus/client_golang/prometheus"
 	grpccodes "google.golang.org/grpc/codes"
@@ -127,14 +130,238 @@ func (s *PrivatePublicIPPoolsServer) Get(ctx context.Context,
 
 func (s *PrivatePublicIPPoolsServer) Create(ctx context.Context,
 	request *privatev1.PublicIPPoolsCreateRequest) (response *privatev1.PublicIPPoolsCreateResponse, err error) {
+	pool := request.GetObject()
+
+	err = s.validateCreate(ctx, pool)
+	if err != nil {
+		return
+	}
+
+	// At creation time nothing is allocated, so available == total.
+	total := calculatePoolCapacity(pool.GetSpec().GetCidrs(), pool.GetSpec().GetIpFamily())
+	pool.SetStatus(privatev1.PublicIPPoolStatus_builder{
+		Total:     total,
+		Available: total,
+	}.Build())
+
 	err = s.generic.Create(ctx, request, &response)
 	return
 }
 
 func (s *PrivatePublicIPPoolsServer) Update(ctx context.Context,
 	request *privatev1.PublicIPPoolsUpdateRequest) (response *privatev1.PublicIPPoolsUpdateResponse, err error) {
+	id := request.GetObject().GetId()
+	if id == "" {
+		err = grpcstatus.Errorf(grpccodes.InvalidArgument, "object identifier is mandatory")
+		return
+	}
+
+	getRequest := &privatev1.PublicIPPoolsGetRequest{}
+	getRequest.SetId(id)
+	var getResponse *privatev1.PublicIPPoolsGetResponse
+	err = s.generic.Get(ctx, getRequest, &getResponse)
+	if err != nil {
+		return
+	}
+
+	err = validateUpdate(request.GetObject(), getResponse.GetObject())
+	if err != nil {
+		return
+	}
+
 	err = s.generic.Update(ctx, request, &response)
 	return
+}
+
+// validateCreate validates a PublicIPPool creation request.
+func (s *PrivatePublicIPPoolsServer) validateCreate(ctx context.Context,
+	pool *privatev1.PublicIPPool) error {
+
+	if pool == nil {
+		return grpcstatus.Errorf(grpccodes.InvalidArgument, "public IP pool is mandatory")
+	}
+
+	spec := pool.GetSpec()
+	if spec == nil {
+		return grpcstatus.Errorf(grpccodes.InvalidArgument, "public IP pool spec is mandatory")
+	}
+
+	if spec.GetIpFamily() == privatev1.IPFamily_IP_FAMILY_UNSPECIFIED {
+		return grpcstatus.Errorf(grpccodes.InvalidArgument, "field 'spec.ip_family' is required")
+	}
+
+	cidrs := spec.GetCidrs()
+	if len(cidrs) == 0 {
+		return grpcstatus.Errorf(grpccodes.InvalidArgument, "field 'spec.cidrs' is required")
+	}
+
+	for i, cidr := range cidrs {
+		if err := validatePoolCIDRFormat(cidr, spec.GetIpFamily(), i); err != nil {
+			return err
+		}
+	}
+
+	return s.validateNoPoolCIDROverlap(ctx, pool)
+}
+
+// validateUpdate validates a PublicIPPool update request. Only immutability of spec fields is checked 
+func validateUpdate(newPool *privatev1.PublicIPPool, existing *privatev1.PublicIPPool) error {
+	if newPool == nil {
+		return grpcstatus.Errorf(grpccodes.InvalidArgument, "public IP pool is mandatory")
+	}
+
+	spec := newPool.GetSpec()
+	if spec == nil {
+		return nil
+	}
+
+	if spec.GetIpFamily() != privatev1.IPFamily_IP_FAMILY_UNSPECIFIED &&
+		spec.GetIpFamily() != existing.GetSpec().GetIpFamily() {
+		return grpcstatus.Errorf(grpccodes.InvalidArgument,
+			"field 'spec.ip_family' is immutable and cannot be changed from '%s' to '%s'",
+			existing.GetSpec().GetIpFamily().String(), spec.GetIpFamily().String())
+	}
+
+	if newCIDRs := spec.GetCidrs(); len(newCIDRs) > 0 && !cidrSlicesEqual(newCIDRs, existing.GetSpec().GetCidrs()) {
+		return grpcstatus.Errorf(grpccodes.InvalidArgument,
+			"field 'spec.cidrs' is immutable and cannot be changed after creation")
+	}
+
+	return nil
+}
+
+// validatePoolCIDRFormat validates CIDR string is parseable and belongs to the specified IP family
+func validatePoolCIDRFormat(cidrStr string, ipFamily privatev1.IPFamily, idx int) error {
+	_, network, err := net.ParseCIDR(cidrStr)
+	if err != nil {
+		return grpcstatus.Errorf(grpccodes.InvalidArgument,
+			"invalid CIDR format in field 'spec.cidrs[%d]': '%s': %v", idx, cidrStr, err)
+	}
+
+	isIPv4 := network.IP.To4() != nil
+	switch ipFamily {
+	case privatev1.IPFamily_IP_FAMILY_IPV4:
+		if !isIPv4 {
+			return grpcstatus.Errorf(grpccodes.InvalidArgument,
+				"field 'spec.cidrs[%d]' contains IPv6 address but pool ip_family is IPv4: %s", idx, cidrStr)
+		}
+	case privatev1.IPFamily_IP_FAMILY_IPV6:
+		if isIPv4 {
+			return grpcstatus.Errorf(grpccodes.InvalidArgument,
+				"field 'spec.cidrs[%d]' contains IPv4 address but pool ip_family is IPv6: %s", idx, cidrStr)
+		}
+	}
+
+	return nil
+}
+
+// validateNoPoolCIDROverlap checks for CIDRs overlap with CIDRs from any existing pool
+func (s *PrivatePublicIPPoolsServer) validateNoPoolCIDROverlap(ctx context.Context,
+	pool *privatev1.PublicIPPool) error {
+
+	type parsedCIDR struct {
+		raw string
+		net *net.IPNet
+	}
+	newCIDRs := make([]parsedCIDR, 0, len(pool.GetSpec().GetCidrs()))
+	for _, cidr := range pool.GetSpec().GetCidrs() {
+		_, ipNet, _ := net.ParseCIDR(cidr)
+		newCIDRs = append(newCIDRs, parsedCIDR{raw: cidr, net: ipNet})
+	}
+
+	var offset int32
+	for {
+		listRequest := &privatev1.PublicIPPoolsListRequest{}
+		listRequest.SetOffset(offset)
+		var listResponse *privatev1.PublicIPPoolsListResponse
+		if err := s.generic.List(ctx, listRequest, &listResponse); err != nil {
+			s.logger.ErrorContext(ctx, "Failed to list pools for overlap check", slog.Any("error", err))
+			return grpcstatus.Errorf(grpccodes.Internal, "failed to validate CIDR overlap")
+		}
+
+		for _, existing := range listResponse.GetItems() {
+			for _, existingCIDRStr := range existing.GetSpec().GetCidrs() {
+				_, existingNet, err := net.ParseCIDR(existingCIDRStr)
+				if err != nil {
+					continue
+				}
+				for _, newCIDR := range newCIDRs {
+					if newCIDR.net.Contains(existingNet.IP) || existingNet.Contains(newCIDR.net.IP) {
+						return grpcstatus.Errorf(grpccodes.AlreadyExists,
+							"CIDR '%s' overlaps with CIDR '%s' from existing pool '%s'",
+							newCIDR.raw, existingCIDRStr, existing.GetMetadata().GetName())
+					}
+				}
+			}
+		}
+
+		if offset+listResponse.GetSize() >= listResponse.GetTotal() {
+			break
+		}
+		offset += listResponse.GetSize()
+	}
+
+	return nil
+}
+
+
+// calculatePoolCapacity returns the total number of usable IP addresses across all CIDRs in the pool 
+func calculatePoolCapacity(cidrs []string, ipFamily privatev1.IPFamily) int64 {
+	var total int64
+	for _, cidr := range cidrs {
+		cap := calculateCIDRCapacity(cidr, ipFamily)
+		if total > math.MaxInt64-cap {
+			return math.MaxInt64
+		}
+		total += cap
+	}
+	return total
+}
+
+// calculateCIDRCapacity returns the number of usable IP addresses for a single CIDR
+func calculateCIDRCapacity(cidrStr string, ipFamily privatev1.IPFamily) int64 {
+	_, network, err := net.ParseCIDR(cidrStr)
+	if err != nil {
+		return 0
+	}
+	ones, bits := network.Mask.Size()
+	if ones == 0 && bits == 0 {
+		return 0
+	}
+	hostBits := bits - ones
+
+	if ipFamily == privatev1.IPFamily_IP_FAMILY_IPV4 {
+		total := int64(1) << hostBits
+		if hostBits >= 2 {
+			return total - 2 // subtract network and broadcast
+		}
+		return total // /31 = 2 (point-to-point), /32 = 1 (host route)
+	}
+
+	// IPv6: all addresses usable; cap at math.MaxInt64 for large prefix lengths.
+	if hostBits >= 63 {
+		return math.MaxInt64
+	}
+	return int64(1) << hostBits
+}
+
+// cidrSlicesEqual reports whether two CIDR slices contain the same set of CIDRs (order-independent).
+func cidrSlicesEqual(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	sortedA := make([]string, len(a))
+	sortedB := make([]string, len(b))
+	copy(sortedA, a)
+	copy(sortedB, b)
+	sort.Strings(sortedA)
+	sort.Strings(sortedB)
+	for i := range sortedA {
+		if sortedA[i] != sortedB[i] {
+			return false
+		}
+	}
+	return true
 }
 
 func (s *PrivatePublicIPPoolsServer) Delete(ctx context.Context,

--- a/internal/servers/private_public_ip_pools_server_test.go
+++ b/internal/servers/private_public_ip_pools_server_test.go
@@ -408,31 +408,7 @@ var _ = Describe("Private public IP pools server", func() {
 			})
 		})
 
-		Context("POOL-VAL-03: CIDR format validation", func() {
-			It("accepts valid IPv4 CIDR", func() {
-				pool := privatev1.PublicIPPool_builder{
-					Spec: privatev1.PublicIPPoolSpec_builder{
-						Cidrs:    []string{"10.0.0.0/24"},
-						IpFamily: privatev1.IPFamily_IP_FAMILY_IPV4,
-					}.Build(),
-				}.Build()
-
-				err := poolsServer.validateCreate(ctx, pool)
-				Expect(err).ToNot(HaveOccurred())
-			})
-
-			It("accepts valid IPv6 CIDR", func() {
-				pool := privatev1.PublicIPPool_builder{
-					Spec: privatev1.PublicIPPoolSpec_builder{
-						Cidrs:    []string{"2001:db8::/64"},
-						IpFamily: privatev1.IPFamily_IP_FAMILY_IPV6,
-					}.Build(),
-				}.Build()
-
-				err := poolsServer.validateCreate(ctx, pool)
-				Expect(err).ToNot(HaveOccurred())
-			})
-
+		Context("CIDR format validation", func() {
 			It("rejects malformed CIDR", func() {
 				pool := privatev1.PublicIPPool_builder{
 					Spec: privatev1.PublicIPPoolSpec_builder{
@@ -446,45 +422,6 @@ var _ = Describe("Private public IP pools server", func() {
 				status, ok := grpcstatus.FromError(err)
 				Expect(ok).To(BeTrue())
 				Expect(status.Code()).To(Equal(grpccodes.InvalidArgument))
-				Expect(err.Error()).To(ContainSubstring("invalid CIDR format"))
-			})
-
-			It("rejects CIDR with invalid prefix length (IPv4 /33)", func() {
-				pool := privatev1.PublicIPPool_builder{
-					Spec: privatev1.PublicIPPoolSpec_builder{
-						Cidrs:    []string{"10.0.0.0/33"},
-						IpFamily: privatev1.IPFamily_IP_FAMILY_IPV4,
-					}.Build(),
-				}.Build()
-
-				err := poolsServer.validateCreate(ctx, pool)
-				Expect(err).To(HaveOccurred())
-				Expect(err.Error()).To(ContainSubstring("invalid CIDR format"))
-			})
-
-			It("rejects CIDR with invalid prefix length (IPv6 /129)", func() {
-				pool := privatev1.PublicIPPool_builder{
-					Spec: privatev1.PublicIPPoolSpec_builder{
-						Cidrs:    []string{"2001:db8::/129"},
-						IpFamily: privatev1.IPFamily_IP_FAMILY_IPV6,
-					}.Build(),
-				}.Build()
-
-				err := poolsServer.validateCreate(ctx, pool)
-				Expect(err).To(HaveOccurred())
-				Expect(err.Error()).To(ContainSubstring("invalid CIDR format"))
-			})
-
-			It("rejects a bare IP address without prefix", func() {
-				pool := privatev1.PublicIPPool_builder{
-					Spec: privatev1.PublicIPPoolSpec_builder{
-						Cidrs:    []string{"10.0.0.1"},
-						IpFamily: privatev1.IPFamily_IP_FAMILY_IPV4,
-					}.Build(),
-				}.Build()
-
-				err := poolsServer.validateCreate(ctx, pool)
-				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("invalid CIDR format"))
 			})
 
@@ -502,7 +439,7 @@ var _ = Describe("Private public IP pools server", func() {
 			})
 		})
 
-		Context("POOL-VAL-04: IP family consistency", func() {
+		Context("IP family consistency", func() {
 			It("rejects IPv6 CIDR in an IPv4 pool", func() {
 				pool := privatev1.PublicIPPool_builder{
 					Spec: privatev1.PublicIPPoolSpec_builder{
@@ -564,20 +501,9 @@ var _ = Describe("Private public IP pools server", func() {
 				Expect(err).ToNot(HaveOccurred())
 			})
 
-			It("accepts multiple IPv6 CIDRs in an IPv6 pool", func() {
-				pool := privatev1.PublicIPPool_builder{
-					Spec: privatev1.PublicIPPoolSpec_builder{
-						Cidrs:    []string{"2001:db8:1::/64", "2001:db8:2::/64"},
-						IpFamily: privatev1.IPFamily_IP_FAMILY_IPV6,
-					}.Build(),
-				}.Build()
-
-				err := poolsServer.validateCreate(ctx, pool)
-				Expect(err).ToNot(HaveOccurred())
-			})
 		})
 
-		Context("POOL-VAL-06: Cross-pool CIDR overlap detection", func() {
+		Context("Cross-pool CIDR overlap detection", func() {
 			It("rejects a pool whose CIDR exactly matches an existing pool", func() {
 				_, err := poolsServer.Create(ctx, privatev1.PublicIPPoolsCreateRequest_builder{
 					Object: privatev1.PublicIPPool_builder{
@@ -697,7 +623,7 @@ var _ = Describe("Private public IP pools server", func() {
 						Spec: privatev1.PublicIPPoolSpec_builder{
 							Cidrs: []string{
 								"192.168.0.0/24", // safe
-								"10.0.0.0/24",   // overlaps first-pool
+								"10.0.0.0/24",    // overlaps first-pool
 							},
 							IpFamily: privatev1.IPFamily_IP_FAMILY_IPV4,
 						}.Build(),
@@ -711,7 +637,55 @@ var _ = Describe("Private public IP pools server", func() {
 			})
 		})
 
-		Context("POOL-CAP-01: Capacity calculation on Create", func() {
+		Context("Intra-pool CIDR overlap detection", func() {
+			It("rejects a pool whose second CIDR is a subset of the first", func() {
+				pool := privatev1.PublicIPPool_builder{
+					Spec: privatev1.PublicIPPoolSpec_builder{
+						Cidrs:    []string{"10.0.0.0/24", "10.0.0.0/25"},
+						IpFamily: privatev1.IPFamily_IP_FAMILY_IPV4,
+					}.Build(),
+				}.Build()
+
+				err := poolsServer.validateCreate(ctx, pool)
+				Expect(err).To(HaveOccurred())
+				status, ok := grpcstatus.FromError(err)
+				Expect(ok).To(BeTrue())
+				Expect(status.Code()).To(Equal(grpccodes.InvalidArgument))
+				Expect(err.Error()).To(ContainSubstring("cidrs[0]"))
+				Expect(err.Error()).To(ContainSubstring("cidrs[1]"))
+				Expect(err.Error()).To(ContainSubstring("overlaps"))
+			})
+
+			It("accepts a pool with non-overlapping CIDRs", func() {
+				pool := privatev1.PublicIPPool_builder{
+					Spec: privatev1.PublicIPPoolSpec_builder{
+						Cidrs:    []string{"10.0.0.0/24", "10.0.1.0/24", "10.0.2.0/24"},
+						IpFamily: privatev1.IPFamily_IP_FAMILY_IPV4,
+					}.Build(),
+				}.Build()
+
+				err := poolsServer.validateCreate(ctx, pool)
+				Expect(err).ToNot(HaveOccurred())
+			})
+
+			It("rejects an IPv6 pool with overlapping CIDRs", func() {
+				pool := privatev1.PublicIPPool_builder{
+					Spec: privatev1.PublicIPPoolSpec_builder{
+						Cidrs:    []string{"2001:db8::/32", "2001:db8::/64"},
+						IpFamily: privatev1.IPFamily_IP_FAMILY_IPV6,
+					}.Build(),
+				}.Build()
+
+				err := poolsServer.validateCreate(ctx, pool)
+				Expect(err).To(HaveOccurred())
+				status, ok := grpcstatus.FromError(err)
+				Expect(ok).To(BeTrue())
+				Expect(status.Code()).To(Equal(grpccodes.InvalidArgument))
+				Expect(err.Error()).To(ContainSubstring("overlaps"))
+			})
+		})
+
+		Context("Capacity calculation on Create", func() {
 			It("sets status.total to 254 for a /24 IPv4 CIDR", func() {
 				response, err := poolsServer.Create(ctx, privatev1.PublicIPPoolsCreateRequest_builder{
 					Object: privatev1.PublicIPPool_builder{
@@ -834,7 +808,7 @@ var _ = Describe("Private public IP pools server", func() {
 			})
 		})
 
-		Context("POOL-VAL-05: Immutability on Update", func() {
+		Context("Immutability on Update", func() {
 			It("prevents changing spec.cidrs after creation", func() {
 				createResponse, err := poolsServer.Create(ctx, privatev1.PublicIPPoolsCreateRequest_builder{
 					Object: privatev1.PublicIPPool_builder{
@@ -970,22 +944,6 @@ var _ = Describe("Private public IP pools server", func() {
 				Expect(result).To(BeNumerically("==", 0))
 			})
 
-			It("calculatePoolCapacity sums multiple CIDRs", func() {
-				// /24 → 254, /28 → 14: total = 268
-				result := calculatePoolCapacity(
-					[]string{"10.0.0.0/24", "10.1.0.0/28"},
-					privatev1.IPFamily_IP_FAMILY_IPV4,
-				)
-				Expect(result).To(BeNumerically("==", 268))
-			})
-
-			It("calculatePoolCapacity caps at MaxInt64 for large IPv6 ranges", func() {
-				result := calculatePoolCapacity(
-					[]string{"2001:db8::/64"},
-					privatev1.IPFamily_IP_FAMILY_IPV6,
-				)
-				Expect(result).To(BeNumerically("==", math.MaxInt64))
-			})
 		})
 	})
 })

--- a/internal/servers/private_public_ip_pools_server_test.go
+++ b/internal/servers/private_public_ip_pools_server_test.go
@@ -16,10 +16,13 @@ package servers
 import (
 	"context"
 	"fmt"
+	"math"
 
 	"github.com/jackc/pgx/v5/pgxpool"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	grpccodes "google.golang.org/grpc/codes"
+	grpcstatus "google.golang.org/grpc/status"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/fieldmaskpb"
 
@@ -354,6 +357,635 @@ var _ = Describe("Private public IP pools server", func() {
 				Id: poolID,
 			}.Build())
 			Expect(err).ToNot(HaveOccurred())
+		})
+	})
+
+	Describe("Validation tests", func() {
+		var poolsServer *PrivatePublicIPPoolsServer
+
+		BeforeEach(func() {
+			var err error
+
+			poolsServer, err = NewPrivatePublicIPPoolsServer().
+				SetLogger(logger).
+				SetAttributionLogic(attribution).
+				SetTenancyLogic(tenancy).
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		Context("POOL-VAL-01: ip_family validation", func() {
+			It("rejects pool with unspecified ip_family", func() {
+				pool := privatev1.PublicIPPool_builder{
+					Spec: privatev1.PublicIPPoolSpec_builder{
+						Cidrs: []string{"192.168.1.0/24"},
+					}.Build(),
+				}.Build()
+
+				err := poolsServer.validateCreate(ctx, pool)
+				Expect(err).To(HaveOccurred())
+				status, ok := grpcstatus.FromError(err)
+				Expect(ok).To(BeTrue())
+				Expect(status.Code()).To(Equal(grpccodes.InvalidArgument))
+				Expect(err.Error()).To(ContainSubstring("ip_family"))
+			})
+		})
+
+		Context("POOL-VAL-02: CIDRs required", func() {
+			It("rejects pool with no CIDRs", func() {
+				pool := privatev1.PublicIPPool_builder{
+					Spec: privatev1.PublicIPPoolSpec_builder{
+						IpFamily: privatev1.IPFamily_IP_FAMILY_IPV4,
+					}.Build(),
+				}.Build()
+
+				err := poolsServer.validateCreate(ctx, pool)
+				Expect(err).To(HaveOccurred())
+				status, ok := grpcstatus.FromError(err)
+				Expect(ok).To(BeTrue())
+				Expect(status.Code()).To(Equal(grpccodes.InvalidArgument))
+				Expect(err.Error()).To(ContainSubstring("cidrs"))
+			})
+		})
+
+		Context("POOL-VAL-03: CIDR format validation", func() {
+			It("accepts valid IPv4 CIDR", func() {
+				pool := privatev1.PublicIPPool_builder{
+					Spec: privatev1.PublicIPPoolSpec_builder{
+						Cidrs:    []string{"10.0.0.0/24"},
+						IpFamily: privatev1.IPFamily_IP_FAMILY_IPV4,
+					}.Build(),
+				}.Build()
+
+				err := poolsServer.validateCreate(ctx, pool)
+				Expect(err).ToNot(HaveOccurred())
+			})
+
+			It("accepts valid IPv6 CIDR", func() {
+				pool := privatev1.PublicIPPool_builder{
+					Spec: privatev1.PublicIPPoolSpec_builder{
+						Cidrs:    []string{"2001:db8::/64"},
+						IpFamily: privatev1.IPFamily_IP_FAMILY_IPV6,
+					}.Build(),
+				}.Build()
+
+				err := poolsServer.validateCreate(ctx, pool)
+				Expect(err).ToNot(HaveOccurred())
+			})
+
+			It("rejects malformed CIDR", func() {
+				pool := privatev1.PublicIPPool_builder{
+					Spec: privatev1.PublicIPPoolSpec_builder{
+						Cidrs:    []string{"not-a-cidr"},
+						IpFamily: privatev1.IPFamily_IP_FAMILY_IPV4,
+					}.Build(),
+				}.Build()
+
+				err := poolsServer.validateCreate(ctx, pool)
+				Expect(err).To(HaveOccurred())
+				status, ok := grpcstatus.FromError(err)
+				Expect(ok).To(BeTrue())
+				Expect(status.Code()).To(Equal(grpccodes.InvalidArgument))
+				Expect(err.Error()).To(ContainSubstring("invalid CIDR format"))
+			})
+
+			It("rejects CIDR with invalid prefix length (IPv4 /33)", func() {
+				pool := privatev1.PublicIPPool_builder{
+					Spec: privatev1.PublicIPPoolSpec_builder{
+						Cidrs:    []string{"10.0.0.0/33"},
+						IpFamily: privatev1.IPFamily_IP_FAMILY_IPV4,
+					}.Build(),
+				}.Build()
+
+				err := poolsServer.validateCreate(ctx, pool)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("invalid CIDR format"))
+			})
+
+			It("rejects CIDR with invalid prefix length (IPv6 /129)", func() {
+				pool := privatev1.PublicIPPool_builder{
+					Spec: privatev1.PublicIPPoolSpec_builder{
+						Cidrs:    []string{"2001:db8::/129"},
+						IpFamily: privatev1.IPFamily_IP_FAMILY_IPV6,
+					}.Build(),
+				}.Build()
+
+				err := poolsServer.validateCreate(ctx, pool)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("invalid CIDR format"))
+			})
+
+			It("rejects a bare IP address without prefix", func() {
+				pool := privatev1.PublicIPPool_builder{
+					Spec: privatev1.PublicIPPoolSpec_builder{
+						Cidrs:    []string{"10.0.0.1"},
+						IpFamily: privatev1.IPFamily_IP_FAMILY_IPV4,
+					}.Build(),
+				}.Build()
+
+				err := poolsServer.validateCreate(ctx, pool)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("invalid CIDR format"))
+			})
+
+			It("reports the correct index in the error message for an invalid CIDR", func() {
+				pool := privatev1.PublicIPPool_builder{
+					Spec: privatev1.PublicIPPoolSpec_builder{
+						Cidrs:    []string{"10.0.0.0/24", "bad-cidr"},
+						IpFamily: privatev1.IPFamily_IP_FAMILY_IPV4,
+					}.Build(),
+				}.Build()
+
+				err := poolsServer.validateCreate(ctx, pool)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("cidrs[1]"))
+			})
+		})
+
+		Context("POOL-VAL-04: IP family consistency", func() {
+			It("rejects IPv6 CIDR in an IPv4 pool", func() {
+				pool := privatev1.PublicIPPool_builder{
+					Spec: privatev1.PublicIPPoolSpec_builder{
+						Cidrs:    []string{"2001:db8::/64"},
+						IpFamily: privatev1.IPFamily_IP_FAMILY_IPV4,
+					}.Build(),
+				}.Build()
+
+				err := poolsServer.validateCreate(ctx, pool)
+				Expect(err).To(HaveOccurred())
+				status, ok := grpcstatus.FromError(err)
+				Expect(ok).To(BeTrue())
+				Expect(status.Code()).To(Equal(grpccodes.InvalidArgument))
+				Expect(err.Error()).To(ContainSubstring("IPv6"))
+				Expect(err.Error()).To(ContainSubstring("ip_family is IPv4"))
+			})
+
+			It("rejects IPv4 CIDR in an IPv6 pool", func() {
+				pool := privatev1.PublicIPPool_builder{
+					Spec: privatev1.PublicIPPoolSpec_builder{
+						Cidrs:    []string{"10.0.0.0/24"},
+						IpFamily: privatev1.IPFamily_IP_FAMILY_IPV6,
+					}.Build(),
+				}.Build()
+
+				err := poolsServer.validateCreate(ctx, pool)
+				Expect(err).To(HaveOccurred())
+				status, ok := grpcstatus.FromError(err)
+				Expect(ok).To(BeTrue())
+				Expect(status.Code()).To(Equal(grpccodes.InvalidArgument))
+				Expect(err.Error()).To(ContainSubstring("IPv4"))
+				Expect(err.Error()).To(ContainSubstring("ip_family is IPv6"))
+			})
+
+			It("rejects a pool with mixed IPv4 and IPv6 CIDRs (ip_family=IPv4)", func() {
+				pool := privatev1.PublicIPPool_builder{
+					Spec: privatev1.PublicIPPoolSpec_builder{
+						Cidrs:    []string{"10.0.0.0/24", "2001:db8::/64"},
+						IpFamily: privatev1.IPFamily_IP_FAMILY_IPV4,
+					}.Build(),
+				}.Build()
+
+				err := poolsServer.validateCreate(ctx, pool)
+				Expect(err).To(HaveOccurred())
+				// The IPv6 CIDR at index 1 fails the IPv4 family check.
+				Expect(err.Error()).To(ContainSubstring("cidrs[1]"))
+				Expect(err.Error()).To(ContainSubstring("ip_family is IPv4"))
+			})
+
+			It("accepts multiple IPv4 CIDRs in an IPv4 pool", func() {
+				pool := privatev1.PublicIPPool_builder{
+					Spec: privatev1.PublicIPPoolSpec_builder{
+						Cidrs:    []string{"10.0.0.0/24", "192.168.1.0/28"},
+						IpFamily: privatev1.IPFamily_IP_FAMILY_IPV4,
+					}.Build(),
+				}.Build()
+
+				err := poolsServer.validateCreate(ctx, pool)
+				Expect(err).ToNot(HaveOccurred())
+			})
+
+			It("accepts multiple IPv6 CIDRs in an IPv6 pool", func() {
+				pool := privatev1.PublicIPPool_builder{
+					Spec: privatev1.PublicIPPoolSpec_builder{
+						Cidrs:    []string{"2001:db8:1::/64", "2001:db8:2::/64"},
+						IpFamily: privatev1.IPFamily_IP_FAMILY_IPV6,
+					}.Build(),
+				}.Build()
+
+				err := poolsServer.validateCreate(ctx, pool)
+				Expect(err).ToNot(HaveOccurred())
+			})
+		})
+
+		Context("POOL-VAL-06: Cross-pool CIDR overlap detection", func() {
+			It("rejects a pool whose CIDR exactly matches an existing pool", func() {
+				_, err := poolsServer.Create(ctx, privatev1.PublicIPPoolsCreateRequest_builder{
+					Object: privatev1.PublicIPPool_builder{
+						Metadata: privatev1.Metadata_builder{Name: "pool-a"}.Build(),
+						Spec: privatev1.PublicIPPoolSpec_builder{
+							Cidrs:    []string{"10.0.0.0/24"},
+							IpFamily: privatev1.IPFamily_IP_FAMILY_IPV4,
+						}.Build(),
+					}.Build(),
+				}.Build())
+				Expect(err).ToNot(HaveOccurred())
+
+				_, err = poolsServer.Create(ctx, privatev1.PublicIPPoolsCreateRequest_builder{
+					Object: privatev1.PublicIPPool_builder{
+						Metadata: privatev1.Metadata_builder{Name: "pool-b"}.Build(),
+						Spec: privatev1.PublicIPPoolSpec_builder{
+							Cidrs:    []string{"10.0.0.0/24"},
+							IpFamily: privatev1.IPFamily_IP_FAMILY_IPV4,
+						}.Build(),
+					}.Build(),
+				}.Build())
+				Expect(err).To(HaveOccurred())
+				status, ok := grpcstatus.FromError(err)
+				Expect(ok).To(BeTrue())
+				Expect(status.Code()).To(Equal(grpccodes.AlreadyExists))
+				Expect(err.Error()).To(ContainSubstring("overlaps"))
+				Expect(err.Error()).To(ContainSubstring("pool-a"))
+			})
+
+			It("rejects a pool whose CIDR is a subset of an existing pool's CIDR", func() {
+				_, err := poolsServer.Create(ctx, privatev1.PublicIPPoolsCreateRequest_builder{
+					Object: privatev1.PublicIPPool_builder{
+						Metadata: privatev1.Metadata_builder{Name: "wide-pool"}.Build(),
+						Spec: privatev1.PublicIPPoolSpec_builder{
+							Cidrs:    []string{"10.0.0.0/16"},
+							IpFamily: privatev1.IPFamily_IP_FAMILY_IPV4,
+						}.Build(),
+					}.Build(),
+				}.Build())
+				Expect(err).ToNot(HaveOccurred())
+
+				_, err = poolsServer.Create(ctx, privatev1.PublicIPPoolsCreateRequest_builder{
+					Object: privatev1.PublicIPPool_builder{
+						Spec: privatev1.PublicIPPoolSpec_builder{
+							Cidrs:    []string{"10.0.1.0/24"},
+							IpFamily: privatev1.IPFamily_IP_FAMILY_IPV4,
+						}.Build(),
+					}.Build(),
+				}.Build())
+				Expect(err).To(HaveOccurred())
+				status, ok := grpcstatus.FromError(err)
+				Expect(ok).To(BeTrue())
+				Expect(status.Code()).To(Equal(grpccodes.AlreadyExists))
+			})
+
+			It("rejects a pool whose CIDR is a superset of an existing pool's CIDR", func() {
+				_, err := poolsServer.Create(ctx, privatev1.PublicIPPoolsCreateRequest_builder{
+					Object: privatev1.PublicIPPool_builder{
+						Spec: privatev1.PublicIPPoolSpec_builder{
+							Cidrs:    []string{"10.0.1.0/24"},
+							IpFamily: privatev1.IPFamily_IP_FAMILY_IPV4,
+						}.Build(),
+					}.Build(),
+				}.Build())
+				Expect(err).ToNot(HaveOccurred())
+
+				_, err = poolsServer.Create(ctx, privatev1.PublicIPPoolsCreateRequest_builder{
+					Object: privatev1.PublicIPPool_builder{
+						Spec: privatev1.PublicIPPoolSpec_builder{
+							Cidrs:    []string{"10.0.0.0/16"},
+							IpFamily: privatev1.IPFamily_IP_FAMILY_IPV4,
+						}.Build(),
+					}.Build(),
+				}.Build())
+				Expect(err).To(HaveOccurred())
+				status, ok := grpcstatus.FromError(err)
+				Expect(ok).To(BeTrue())
+				Expect(status.Code()).To(Equal(grpccodes.AlreadyExists))
+			})
+
+			It("accepts a pool with a non-overlapping CIDR", func() {
+				_, err := poolsServer.Create(ctx, privatev1.PublicIPPoolsCreateRequest_builder{
+					Object: privatev1.PublicIPPool_builder{
+						Spec: privatev1.PublicIPPoolSpec_builder{
+							Cidrs:    []string{"10.0.0.0/24"},
+							IpFamily: privatev1.IPFamily_IP_FAMILY_IPV4,
+						}.Build(),
+					}.Build(),
+				}.Build())
+				Expect(err).ToNot(HaveOccurred())
+
+				_, err = poolsServer.Create(ctx, privatev1.PublicIPPoolsCreateRequest_builder{
+					Object: privatev1.PublicIPPool_builder{
+						Spec: privatev1.PublicIPPoolSpec_builder{
+							Cidrs:    []string{"10.0.1.0/24"},
+							IpFamily: privatev1.IPFamily_IP_FAMILY_IPV4,
+						}.Build(),
+					}.Build(),
+				}.Build())
+				Expect(err).ToNot(HaveOccurred())
+			})
+
+			It("rejects when one of multiple new CIDRs overlaps with an existing pool", func() {
+				_, err := poolsServer.Create(ctx, privatev1.PublicIPPoolsCreateRequest_builder{
+					Object: privatev1.PublicIPPool_builder{
+						Metadata: privatev1.Metadata_builder{Name: "first-pool"}.Build(),
+						Spec: privatev1.PublicIPPoolSpec_builder{
+							Cidrs:    []string{"10.0.0.0/24"},
+							IpFamily: privatev1.IPFamily_IP_FAMILY_IPV4,
+						}.Build(),
+					}.Build(),
+				}.Build())
+				Expect(err).ToNot(HaveOccurred())
+
+				_, err = poolsServer.Create(ctx, privatev1.PublicIPPoolsCreateRequest_builder{
+					Object: privatev1.PublicIPPool_builder{
+						Spec: privatev1.PublicIPPoolSpec_builder{
+							Cidrs: []string{
+								"192.168.0.0/24", // safe
+								"10.0.0.0/24",   // overlaps first-pool
+							},
+							IpFamily: privatev1.IPFamily_IP_FAMILY_IPV4,
+						}.Build(),
+					}.Build(),
+				}.Build())
+				Expect(err).To(HaveOccurred())
+				status, ok := grpcstatus.FromError(err)
+				Expect(ok).To(BeTrue())
+				Expect(status.Code()).To(Equal(grpccodes.AlreadyExists))
+				Expect(err.Error()).To(ContainSubstring("overlaps"))
+			})
+		})
+
+		Context("POOL-CAP-01: Capacity calculation on Create", func() {
+			It("sets status.total to 254 for a /24 IPv4 CIDR", func() {
+				response, err := poolsServer.Create(ctx, privatev1.PublicIPPoolsCreateRequest_builder{
+					Object: privatev1.PublicIPPool_builder{
+						Spec: privatev1.PublicIPPoolSpec_builder{
+							Cidrs:    []string{"192.168.1.0/24"},
+							IpFamily: privatev1.IPFamily_IP_FAMILY_IPV4,
+						}.Build(),
+					}.Build(),
+				}.Build())
+				Expect(err).ToNot(HaveOccurred())
+				Expect(response.GetObject().GetStatus().GetTotal()).To(BeNumerically("==", 254))
+			})
+
+			It("sets status.available equal to status.total on a new pool (nothing allocated yet)", func() {
+				response, err := poolsServer.Create(ctx, privatev1.PublicIPPoolsCreateRequest_builder{
+					Object: privatev1.PublicIPPool_builder{
+						Spec: privatev1.PublicIPPoolSpec_builder{
+							Cidrs:    []string{"10.0.0.0/24"},
+							IpFamily: privatev1.IPFamily_IP_FAMILY_IPV4,
+						}.Build(),
+					}.Build(),
+				}.Build())
+				Expect(err).ToNot(HaveOccurred())
+				status := response.GetObject().GetStatus()
+				Expect(status.GetAvailable()).To(Equal(status.GetTotal()))
+				Expect(status.GetAllocated()).To(BeNumerically("==", 0))
+			})
+
+			It("sets status.total to 14 for a /28 IPv4 CIDR", func() {
+				response, err := poolsServer.Create(ctx, privatev1.PublicIPPoolsCreateRequest_builder{
+					Object: privatev1.PublicIPPool_builder{
+						Spec: privatev1.PublicIPPoolSpec_builder{
+							Cidrs:    []string{"10.0.0.0/28"},
+							IpFamily: privatev1.IPFamily_IP_FAMILY_IPV4,
+						}.Build(),
+					}.Build(),
+				}.Build())
+				Expect(err).ToNot(HaveOccurred())
+				Expect(response.GetObject().GetStatus().GetTotal()).To(BeNumerically("==", 14))
+			})
+
+			It("sets status.total to 2 for a /30 IPv4 CIDR", func() {
+				response, err := poolsServer.Create(ctx, privatev1.PublicIPPoolsCreateRequest_builder{
+					Object: privatev1.PublicIPPool_builder{
+						Spec: privatev1.PublicIPPoolSpec_builder{
+							Cidrs:    []string{"10.0.0.0/30"},
+							IpFamily: privatev1.IPFamily_IP_FAMILY_IPV4,
+						}.Build(),
+					}.Build(),
+				}.Build())
+				Expect(err).ToNot(HaveOccurred())
+				Expect(response.GetObject().GetStatus().GetTotal()).To(BeNumerically("==", 2))
+			})
+
+			It("sets status.total to 2 for a /31 IPv4 CIDR (point-to-point)", func() {
+				response, err := poolsServer.Create(ctx, privatev1.PublicIPPoolsCreateRequest_builder{
+					Object: privatev1.PublicIPPool_builder{
+						Spec: privatev1.PublicIPPoolSpec_builder{
+							Cidrs:    []string{"10.0.0.0/31"},
+							IpFamily: privatev1.IPFamily_IP_FAMILY_IPV4,
+						}.Build(),
+					}.Build(),
+				}.Build())
+				Expect(err).ToNot(HaveOccurred())
+				Expect(response.GetObject().GetStatus().GetTotal()).To(BeNumerically("==", 2))
+			})
+
+			It("sets status.total to 1 for a /32 IPv4 CIDR (host route)", func() {
+				response, err := poolsServer.Create(ctx, privatev1.PublicIPPoolsCreateRequest_builder{
+					Object: privatev1.PublicIPPool_builder{
+						Spec: privatev1.PublicIPPoolSpec_builder{
+							Cidrs:    []string{"10.0.0.1/32"},
+							IpFamily: privatev1.IPFamily_IP_FAMILY_IPV4,
+						}.Build(),
+					}.Build(),
+				}.Build())
+				Expect(err).ToNot(HaveOccurred())
+				Expect(response.GetObject().GetStatus().GetTotal()).To(BeNumerically("==", 1))
+			})
+
+			It("sums status.total across multiple CIDRs", func() {
+				// /24 → 254, /28 → 14: total = 268
+				response, err := poolsServer.Create(ctx, privatev1.PublicIPPoolsCreateRequest_builder{
+					Object: privatev1.PublicIPPool_builder{
+						Spec: privatev1.PublicIPPoolSpec_builder{
+							Cidrs:    []string{"10.0.0.0/24", "10.1.0.0/28"},
+							IpFamily: privatev1.IPFamily_IP_FAMILY_IPV4,
+						}.Build(),
+					}.Build(),
+				}.Build())
+				Expect(err).ToNot(HaveOccurred())
+				Expect(response.GetObject().GetStatus().GetTotal()).To(BeNumerically("==", 268))
+			})
+
+			It("sets correct status.total for an IPv6 /64 CIDR", func() {
+				response, err := poolsServer.Create(ctx, privatev1.PublicIPPoolsCreateRequest_builder{
+					Object: privatev1.PublicIPPool_builder{
+						Spec: privatev1.PublicIPPoolSpec_builder{
+							Cidrs:    []string{"2001:db8::/64"},
+							IpFamily: privatev1.IPFamily_IP_FAMILY_IPV6,
+						}.Build(),
+					}.Build(),
+				}.Build())
+				Expect(err).ToNot(HaveOccurred())
+				// /64 has 2^64 addresses; capped at math.MaxInt64.
+				Expect(response.GetObject().GetStatus().GetTotal()).To(BeNumerically("==", math.MaxInt64))
+			})
+
+			It("sets status.total to 1 for an IPv6 /128 CIDR", func() {
+				response, err := poolsServer.Create(ctx, privatev1.PublicIPPoolsCreateRequest_builder{
+					Object: privatev1.PublicIPPool_builder{
+						Spec: privatev1.PublicIPPoolSpec_builder{
+							Cidrs:    []string{"2001:db8::1/128"},
+							IpFamily: privatev1.IPFamily_IP_FAMILY_IPV6,
+						}.Build(),
+					}.Build(),
+				}.Build())
+				Expect(err).ToNot(HaveOccurred())
+				Expect(response.GetObject().GetStatus().GetTotal()).To(BeNumerically("==", 1))
+			})
+		})
+
+		Context("POOL-VAL-05: Immutability on Update", func() {
+			It("prevents changing spec.cidrs after creation", func() {
+				createResponse, err := poolsServer.Create(ctx, privatev1.PublicIPPoolsCreateRequest_builder{
+					Object: privatev1.PublicIPPool_builder{
+						Spec: privatev1.PublicIPPoolSpec_builder{
+							Cidrs:    []string{"10.0.0.0/24"},
+							IpFamily: privatev1.IPFamily_IP_FAMILY_IPV4,
+						}.Build(),
+					}.Build(),
+				}.Build())
+				Expect(err).ToNot(HaveOccurred())
+				id := createResponse.GetObject().GetId()
+
+				_, err = poolsServer.Update(ctx, privatev1.PublicIPPoolsUpdateRequest_builder{
+					Object: privatev1.PublicIPPool_builder{
+						Id: id,
+						Spec: privatev1.PublicIPPoolSpec_builder{
+							Cidrs:    []string{"10.0.1.0/24"},
+							IpFamily: privatev1.IPFamily_IP_FAMILY_IPV4,
+						}.Build(),
+					}.Build(),
+				}.Build())
+				Expect(err).To(HaveOccurred())
+				status, ok := grpcstatus.FromError(err)
+				Expect(ok).To(BeTrue())
+				Expect(status.Code()).To(Equal(grpccodes.InvalidArgument))
+				Expect(err.Error()).To(ContainSubstring("cidrs"))
+				Expect(err.Error()).To(ContainSubstring("immutable"))
+			})
+
+			It("prevents changing spec.ip_family after creation", func() {
+				createResponse, err := poolsServer.Create(ctx, privatev1.PublicIPPoolsCreateRequest_builder{
+					Object: privatev1.PublicIPPool_builder{
+						Spec: privatev1.PublicIPPoolSpec_builder{
+							Cidrs:    []string{"10.0.0.0/24"},
+							IpFamily: privatev1.IPFamily_IP_FAMILY_IPV4,
+						}.Build(),
+					}.Build(),
+				}.Build())
+				Expect(err).ToNot(HaveOccurred())
+				id := createResponse.GetObject().GetId()
+
+				_, err = poolsServer.Update(ctx, privatev1.PublicIPPoolsUpdateRequest_builder{
+					Object: privatev1.PublicIPPool_builder{
+						Id: id,
+						Spec: privatev1.PublicIPPoolSpec_builder{
+							IpFamily: privatev1.IPFamily_IP_FAMILY_IPV6,
+						}.Build(),
+					}.Build(),
+				}.Build())
+				Expect(err).To(HaveOccurred())
+				status, ok := grpcstatus.FromError(err)
+				Expect(ok).To(BeTrue())
+				Expect(status.Code()).To(Equal(grpccodes.InvalidArgument))
+				Expect(err.Error()).To(ContainSubstring("ip_family"))
+				Expect(err.Error()).To(ContainSubstring("immutable"))
+			})
+
+			It("allows providing identical CIDRs on Update without error", func() {
+				createResponse, err := poolsServer.Create(ctx, privatev1.PublicIPPoolsCreateRequest_builder{
+					Object: privatev1.PublicIPPool_builder{
+						Spec: privatev1.PublicIPPoolSpec_builder{
+							Cidrs:    []string{"10.0.0.0/24"},
+							IpFamily: privatev1.IPFamily_IP_FAMILY_IPV4,
+						}.Build(),
+					}.Build(),
+				}.Build())
+				Expect(err).ToNot(HaveOccurred())
+				id := createResponse.GetObject().GetId()
+
+				_, err = poolsServer.Update(ctx, privatev1.PublicIPPoolsUpdateRequest_builder{
+					Object: privatev1.PublicIPPool_builder{
+						Id: id,
+						Spec: privatev1.PublicIPPoolSpec_builder{
+							Cidrs:    []string{"10.0.0.0/24"},
+							IpFamily: privatev1.IPFamily_IP_FAMILY_IPV4,
+						}.Build(),
+						Metadata: privatev1.Metadata_builder{
+							Name: "renamed",
+						}.Build(),
+					}.Build(),
+				}.Build())
+				Expect(err).ToNot(HaveOccurred())
+			})
+
+			It("allows metadata-only Update (spec fields omitted)", func() {
+				createResponse, err := poolsServer.Create(ctx, privatev1.PublicIPPoolsCreateRequest_builder{
+					Object: privatev1.PublicIPPool_builder{
+						Spec: privatev1.PublicIPPoolSpec_builder{
+							Cidrs:    []string{"10.0.0.0/24"},
+							IpFamily: privatev1.IPFamily_IP_FAMILY_IPV4,
+						}.Build(),
+					}.Build(),
+				}.Build())
+				Expect(err).ToNot(HaveOccurred())
+				id := createResponse.GetObject().GetId()
+
+				updateResponse, err := poolsServer.Update(ctx, privatev1.PublicIPPoolsUpdateRequest_builder{
+					Object: privatev1.PublicIPPool_builder{
+						Id: id,
+						Metadata: privatev1.Metadata_builder{
+							Name: "my-pool",
+						}.Build(),
+					}.Build(),
+					UpdateMask: &fieldmaskpb.FieldMask{
+						Paths: []string{"metadata.name"},
+					},
+				}.Build())
+				Expect(err).ToNot(HaveOccurred())
+				Expect(updateResponse.GetObject().GetMetadata().GetName()).To(Equal("my-pool"))
+				// CIDRs must be preserved:
+				Expect(updateResponse.GetObject().GetSpec().GetCidrs()).To(ConsistOf("10.0.0.0/24"))
+			})
+		})
+
+		Context("Unit tests for capacity calculation helpers", func() {
+			DescribeTable("calculateCIDRCapacity",
+				func(cidr string, family privatev1.IPFamily, expected int64) {
+					Expect(calculateCIDRCapacity(cidr, family)).To(BeNumerically("==", expected))
+				},
+				Entry("IPv4 /24 → 254", "192.168.1.0/24", privatev1.IPFamily_IP_FAMILY_IPV4, int64(254)),
+				Entry("IPv4 /28 → 14", "10.0.0.0/28", privatev1.IPFamily_IP_FAMILY_IPV4, int64(14)),
+				Entry("IPv4 /30 → 2", "10.0.0.0/30", privatev1.IPFamily_IP_FAMILY_IPV4, int64(2)),
+				Entry("IPv4 /31 → 2", "10.0.0.0/31", privatev1.IPFamily_IP_FAMILY_IPV4, int64(2)),
+				Entry("IPv4 /32 → 1", "10.0.0.1/32", privatev1.IPFamily_IP_FAMILY_IPV4, int64(1)),
+				Entry("IPv4 /16 → 65534", "10.0.0.0/16", privatev1.IPFamily_IP_FAMILY_IPV4, int64(65534)),
+				Entry("IPv6 /128 → 1", "2001:db8::1/128", privatev1.IPFamily_IP_FAMILY_IPV6, int64(1)),
+				Entry("IPv6 /127 → 2", "2001:db8::/127", privatev1.IPFamily_IP_FAMILY_IPV6, int64(2)),
+				Entry("IPv6 /64 → MaxInt64", "2001:db8::/64", privatev1.IPFamily_IP_FAMILY_IPV6, int64(math.MaxInt64)),
+			)
+
+			It("calculateCIDRCapacity returns 0 for an unparseable CIDR", func() {
+				result := calculateCIDRCapacity("not-a-cidr", privatev1.IPFamily_IP_FAMILY_IPV4)
+				Expect(result).To(BeNumerically("==", 0))
+			})
+
+			It("calculatePoolCapacity sums multiple CIDRs", func() {
+				// /24 → 254, /28 → 14: total = 268
+				result := calculatePoolCapacity(
+					[]string{"10.0.0.0/24", "10.1.0.0/28"},
+					privatev1.IPFamily_IP_FAMILY_IPV4,
+				)
+				Expect(result).To(BeNumerically("==", 268))
+			})
+
+			It("calculatePoolCapacity caps at MaxInt64 for large IPv6 ranges", func() {
+				result := calculatePoolCapacity(
+					[]string{"2001:db8::/64"},
+					privatev1.IPFamily_IP_FAMILY_IPV6,
+				)
+				Expect(result).To(BeNumerically("==", math.MaxInt64))
+			})
 		})
 	})
 })


### PR DESCRIPTION
Added input validation, capacity tracking, and immutability enforcement to the PublicIPPool server.
- Validates CIDR format, prefix length, and IP-family consistency on create
- Rejects pools whose CIDRs overlap any existing pool (AlreadyExists)
- Computes status.total and status.available from the CIDRs at creation time; ignores any caller-supplied status fields
- Enforces spec.cidrs and spec.ip_family as immutable after creation; metadata-only updates are always allowed

Added unit tests to verify the following functionality (All Pass)

1. CIDR format — accepts valid IPv4/IPv6; rejects malformed strings, out-of-range prefixes, and bare IPs; error includes the correct field index
2. IP-family consistency — rejects mismatched CIDRs; accepts multiple same-family CIDRs
3. Cross-pool overlap — rejects exact matches, subsets, and supersets of existing CIDRs; accepts non-overlapping; fails if any one CIDR among many overlaps
4. Capacity on create — correct status.total for /24→254, /28→14, /30→2, /31→2, /32→1, IPv6 /128→1, /64→MaxInt64, and multi-CIDR sums; available==total and allocated==0 on a new pool
5. Immutability — rejects changes to cidrs or ip_family; allows identical spec resend and metadata-only updates



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * IP pools now automatically calculate and track total and available capacity based on provided CIDR ranges.
  * Enhanced validation prevents creation of pools with invalid or overlapping CIDR specifications.

* **Bug Fixes**
  * Stricter enforcement of IP family and CIDR immutability rules on pool updates with improved error messaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->