### PR TITLE
MGMT-24157: Add delete functionality to Organizations controller

### DIFF
--- a/internal/controllers/organization/organization_reconciler_function.go
+++ b/internal/controllers/organization/organization_reconciler_function.go
@@ -100,7 +100,12 @@ func (r *function) Run(ctx context.Context, organization *privatev1.Organization
 		organization: organization,
 	}
 
-	err := task.update(ctx)
+	var err error
+	if organization.HasMetadata() && organization.GetMetadata().HasDeletionTimestamp() {
+		err = task.delete(ctx)
+	} else {
+		err = task.update(ctx)
+	}
 	if err != nil {
 		return err
 	}
@@ -136,14 +141,20 @@ func (t *task) update(ctx context.Context) error {
 	}
 
 	state := t.organization.GetStatus().GetState()
-	if state == privatev1.OrganizationState_ORGANIZATION_STATE_SYNCED {
-		return nil
-	}
 
+	// Skip reconciliation only for terminal failure state.
+	// This prevents infinite retry loops when IDP operations fail.
 	if state == privatev1.OrganizationState_ORGANIZATION_STATE_FAILED {
 		return nil
 	}
 
+	// For synced organizations, no updates are needed since spec is empty.
+	// TODO: When fields are added to OrganizationSpec in the future, update logic would go here.
+	if state == privatev1.OrganizationState_ORGANIZATION_STATE_SYNCED {
+		return nil
+	}
+
+	// Organization is PENDING or UNSPECIFIED, perform initial sync to IDP
 	return t.syncToIDP(ctx)
 }
 
@@ -158,9 +169,8 @@ func (t *task) syncToIDP(ctx context.Context) error {
 
 	credentials, err := t.r.idpManager.CreateOrganization(ctx, config)
 	if err != nil {
-		msg := fmt.Sprintf("IDP sync failed: %v", err)
 		t.organization.GetStatus().SetState(privatev1.OrganizationState_ORGANIZATION_STATE_FAILED)
-		t.organization.GetStatus().SetMessage(msg)
+		t.organization.GetStatus().SetMessage(fmt.Sprintf("Organization creation in IDP failed: %v", err))
 		return nil
 	}
 
@@ -174,7 +184,7 @@ func (t *task) syncToIDP(ctx context.Context) error {
 	}.Build()
 	t.organization.GetStatus().SetBreakGlassCredentials(breakGlassCredentials)
 
-	t.r.logger.InfoContext(ctx, "Organization synced to IDP",
+	t.r.logger.DebugContext(ctx, "Organization synced to IDP",
 		slog.String("organization_id", t.organization.GetId()),
 		slog.String("organization_name", orgName),
 	)
@@ -203,6 +213,9 @@ func (t *task) validateTenant() error {
 // addFinalizer adds the controller finalizer to the organization if not already present.
 // Returns true if the finalizer was added (indicating the update should be saved immediately).
 func (t *task) addFinalizer() bool {
+	if !t.organization.HasMetadata() {
+		t.organization.SetMetadata(&privatev1.Metadata{})
+	}
 	list := t.organization.GetMetadata().GetFinalizers()
 	if !slices.Contains(list, finalizers.Controller) {
 		list = append(list, finalizers.Controller)
@@ -210,4 +223,47 @@ func (t *task) addFinalizer() bool {
 		return true
 	}
 	return false
+}
+
+// removeFinalizer removes the controller finalizer from the organization.
+func (t *task) removeFinalizer() {
+	if !t.organization.HasMetadata() {
+		return
+	}
+	list := t.organization.GetMetadata().GetFinalizers()
+	if slices.Contains(list, finalizers.Controller) {
+		list = slices.DeleteFunc(list, func(item string) bool {
+			return item == finalizers.Controller
+		})
+		t.organization.GetMetadata().SetFinalizers(list)
+	}
+}
+
+// delete performs the deletion cleanup for an organization.
+func (t *task) delete(ctx context.Context) error {
+	// Skip if not synced to IDP yet
+	if t.organization.GetStatus().GetState() != privatev1.OrganizationState_ORGANIZATION_STATE_SYNCED {
+		t.removeFinalizer()
+		return nil
+	}
+
+	// Delete from IDP
+	orgName := t.organization.GetStatus().GetIdpOrganizationName()
+	if orgName == "" {
+		t.removeFinalizer()
+		return nil
+	}
+
+	err := t.r.idpManager.DeleteOrganizationRealm(ctx, orgName)
+	if err != nil {
+		return fmt.Errorf("failed to delete IDP organization: %w", err)
+	}
+
+	t.r.logger.DebugContext(ctx, "Deleted organization from IDP",
+		slog.String("organization_id", t.organization.GetId()),
+		slog.String("idp_name", orgName),
+	)
+
+	t.removeFinalizer()
+	return nil
 }

--- a/internal/controllers/organization/organization_reconciler_function_test.go
+++ b/internal/controllers/organization/organization_reconciler_function_test.go
@@ -16,10 +16,12 @@ package organization
 import (
 	"context"
 	"fmt"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"go.uber.org/mock/gomock"
+	"google.golang.org/protobuf/types/known/timestamppb"
 
 	privatev1 "github.com/osac-project/fulfillment-service/internal/api/osac/private/v1"
 	"github.com/osac-project/fulfillment-service/internal/controllers/finalizers"
@@ -318,7 +320,7 @@ var _ = Describe("IDP Sync", func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		Expect(organization.GetStatus().GetState()).To(Equal(privatev1.OrganizationState_ORGANIZATION_STATE_FAILED))
-		Expect(organization.GetStatus().GetMessage()).To(ContainSubstring("IDP sync failed"))
+		Expect(organization.GetStatus().GetMessage()).To(ContainSubstring("Organization creation in IDP failed"))
 		Expect(organization.GetStatus().GetMessage()).To(ContainSubstring("IDP connection timeout"))
 		Expect(organization.GetStatus().GetIdpOrganizationName()).To(BeEmpty())
 		Expect(organization.GetStatus().GetBreakGlassUserId()).To(BeEmpty())
@@ -345,6 +347,179 @@ var _ = Describe("IDP Sync", func() {
 
 		err := task.update(ctx)
 		Expect(err).ToNot(HaveOccurred())
+	})
+})
+
+var _ = Describe("Deletion", func() {
+	var (
+		ctx        context.Context
+		ctrl       *gomock.Controller
+		mockClient *idp.MockClient
+		idpManager *idp.OrganizationManager
+		reconciler *function
+	)
+
+	BeforeEach(func() {
+		var err error
+		ctx = context.Background()
+		ctrl = gomock.NewController(GinkgoT())
+		mockClient = idp.NewMockClient(ctrl)
+
+		idpManager, err = idp.NewOrganizationManager().
+			SetLogger(logger).
+			SetClient(mockClient).
+			Build()
+		Expect(err).ToNot(HaveOccurred())
+
+		reconciler = &function{
+			logger:     logger,
+			idpManager: idpManager,
+		}
+	})
+
+	It("should delete organization from IDP and remove finalizer", func() {
+		deletionTimestamp := timestamppb.New(time.Now())
+		organization := privatev1.Organization_builder{
+			Id: "org-123",
+			Metadata: privatev1.Metadata_builder{
+				Name:              "test-org",
+				Finalizers:        []string{finalizers.Controller},
+				DeletionTimestamp: deletionTimestamp,
+			}.Build(),
+			Status: privatev1.OrganizationStatus_builder{
+				State:               privatev1.OrganizationState_ORGANIZATION_STATE_SYNCED,
+				IdpOrganizationName: "test-org",
+				BreakGlassUserId:    "user-123",
+			}.Build(),
+		}.Build()
+
+		mockClient.EXPECT().
+			DeleteOrganization(gomock.Any(), "test-org").
+			Return(nil).
+			Times(1)
+
+		task := &task{
+			r:            reconciler,
+			organization: organization,
+		}
+
+		err := task.delete(ctx)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(organization.GetMetadata().GetFinalizers()).ToNot(ContainElement(finalizers.Controller))
+	})
+
+	It("should skip IDP deletion and remove finalizer when organization not synced", func() {
+		deletionTimestamp := timestamppb.New(time.Now())
+		organization := privatev1.Organization_builder{
+			Id: "org-123",
+			Metadata: privatev1.Metadata_builder{
+				Name:              "test-org",
+				Finalizers:        []string{finalizers.Controller},
+				DeletionTimestamp: deletionTimestamp,
+			}.Build(),
+			Status: privatev1.OrganizationStatus_builder{
+				State: privatev1.OrganizationState_ORGANIZATION_STATE_PENDING,
+			}.Build(),
+		}.Build()
+
+		task := &task{
+			r:            reconciler,
+			organization: organization,
+		}
+
+		err := task.delete(ctx)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(organization.GetMetadata().GetFinalizers()).ToNot(ContainElement(finalizers.Controller))
+	})
+
+	It("should skip IDP deletion and remove finalizer when idp_organization_name is empty", func() {
+		deletionTimestamp := timestamppb.New(time.Now())
+		organization := privatev1.Organization_builder{
+			Id: "org-123",
+			Metadata: privatev1.Metadata_builder{
+				Name:              "test-org",
+				Finalizers:        []string{finalizers.Controller},
+				DeletionTimestamp: deletionTimestamp,
+			}.Build(),
+			Status: privatev1.OrganizationStatus_builder{
+				State:               privatev1.OrganizationState_ORGANIZATION_STATE_SYNCED,
+				IdpOrganizationName: "",
+			}.Build(),
+		}.Build()
+
+		task := &task{
+			r:            reconciler,
+			organization: organization,
+		}
+
+		err := task.delete(ctx)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(organization.GetMetadata().GetFinalizers()).ToNot(ContainElement(finalizers.Controller))
+	})
+
+	It("should return error on IDP deletion failure and keep finalizer", func() {
+		deletionTimestamp := timestamppb.New(time.Now())
+		organization := privatev1.Organization_builder{
+			Id: "org-123",
+			Metadata: privatev1.Metadata_builder{
+				Name:              "test-org",
+				Finalizers:        []string{finalizers.Controller},
+				DeletionTimestamp: deletionTimestamp,
+			}.Build(),
+			Status: privatev1.OrganizationStatus_builder{
+				State:               privatev1.OrganizationState_ORGANIZATION_STATE_SYNCED,
+				IdpOrganizationName: "test-org",
+				BreakGlassUserId:    "user-123",
+			}.Build(),
+		}.Build()
+
+		mockClient.EXPECT().
+			DeleteOrganization(gomock.Any(), "test-org").
+			Return(fmt.Errorf("IDP connection timeout")).
+			Times(1)
+
+		task := &task{
+			r:            reconciler,
+			organization: organization,
+		}
+
+		err := task.delete(ctx)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("failed to delete IDP organization"))
+		Expect(err.Error()).To(ContainSubstring("IDP connection timeout"))
+		Expect(organization.GetMetadata().GetFinalizers()).To(ContainElement(finalizers.Controller))
+	})
+
+	It("should remove finalizer when called", func() {
+		organization := privatev1.Organization_builder{
+			Metadata: privatev1.Metadata_builder{
+				Finalizers: []string{finalizers.Controller, "other-finalizer"},
+			}.Build(),
+		}.Build()
+
+		task := &task{
+			organization: organization,
+		}
+
+		task.removeFinalizer()
+		Expect(organization.GetMetadata().GetFinalizers()).ToNot(ContainElement(finalizers.Controller))
+		Expect(organization.GetMetadata().GetFinalizers()).To(ContainElement("other-finalizer"))
+	})
+
+	It("should handle removal when finalizer not present", func() {
+		organization := privatev1.Organization_builder{
+			Metadata: privatev1.Metadata_builder{
+				Finalizers: []string{"other-finalizer"},
+			}.Build(),
+		}.Build()
+
+		task := &task{
+			organization: organization,
+		}
+
+		task.removeFinalizer()
+		Expect(organization.GetMetadata().GetFinalizers()).To(HaveLen(1))
+		Expect(organization.GetMetadata().GetFinalizers()).To(ContainElement("other-finalizer"))
 	})
 })
 
@@ -390,4 +565,5 @@ var _ = Describe("Skip Reconciliation", func() {
 		err := task.update(context.Background())
 		Expect(err).ToNot(HaveOccurred())
 	})
+
 })


### PR DESCRIPTION
# Description

Reconcile deleting an organization from the controller and in the identity provider.

# Testing

- [x] `go build ./...` compiles cleanly
- [x] All 520 unit test suites pass (`ginkgo run -r ./internal`)

Assisted-by: Claude

/cc @jhernand 