### PR TITLE
MGMT-24156: Add osac-operator API module and register scheme on hub clients

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,7 @@ require (
 	github.com/mattn/go-isatty v0.0.21
 	github.com/neilotoole/jsoncolor v0.7.2
 	github.com/open-policy-agent/opa v1.15.2
+	github.com/osac-project/osac-operator/api v0.0.1
 	github.com/prometheus/client_golang v1.23.2
 	github.com/skratchdot/open-golang v0.0.0-20200116055534-eef842397966
 	go.uber.org/mock v0.6.0

--- a/go.sum
+++ b/go.sum
@@ -235,6 +235,8 @@ github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/opencontainers/image-spec v1.1.1 h1:y0fUlFfIZhPF1W537XOLg0/fcx6zcHCJwooC2xJA040=
 github.com/opencontainers/image-spec v1.1.1/go.mod h1:qpqAh3Dmcf36wStyyWU+kCeDgrGnAve2nCC8+7h8Q0M=
+github.com/osac-project/osac-operator/api v0.0.1 h1:+E9YF7SMgxLlxxYv3NFvTtfmJQLX6HeFMn0fOzUZY0c=
+github.com/osac-project/osac-operator/api v0.0.1/go.mod h1:JBz/wSWPT4NhksjXZs2QUjulga+KTUdW5UJX0kB22aA=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10 h1:GFCKgmp0tecUJ0sJuv4pzYCqS9+RGSn52M3FUwPs+uo=

--- a/internal/cmd/service/start/controller/start_controller_cmd.go
+++ b/internal/cmd/service/start/controller/start_controller_cmd.go
@@ -309,8 +309,12 @@ func (r *runnerContext) run(cmd *cobra.Command, argv []string) error {
 
 	// Create scheme for typed OSAC CRD access on hub clusters:
 	hubScheme := runtime.NewScheme()
-	_ = osacv1alpha1.AddToScheme(hubScheme)
-	_ = corev1.AddToScheme(hubScheme)
+	if err = osacv1alpha1.AddToScheme(hubScheme); err != nil {
+		return fmt.Errorf("failed to register OSAC API types in hub scheme: %w", err)
+	}
+	if err = corev1.AddToScheme(hubScheme); err != nil {
+		return fmt.Errorf("failed to register core API types in hub scheme: %w", err)
+	}
 
 	// Create the hub cache:
 	r.logger.InfoContext(ctx, "Creating hub cache")

--- a/internal/cmd/service/start/controller/start_controller_cmd.go
+++ b/internal/cmd/service/start/controller/start_controller_cmd.go
@@ -34,8 +34,12 @@ import (
 	"google.golang.org/grpc/health"
 	healthv1 "google.golang.org/grpc/health/grpc_health_v1"
 	"google.golang.org/grpc/reflection"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/klog/v2"
 	crlog "sigs.k8s.io/controller-runtime/pkg/log"
+
+	osacv1alpha1 "github.com/osac-project/osac-operator/api/v1alpha1"
 
 	privatev1 "github.com/osac-project/fulfillment-service/internal/api/osac/private/v1"
 	"github.com/osac-project/fulfillment-service/internal/auth"
@@ -303,11 +307,17 @@ func (r *runnerContext) run(cmd *cobra.Command, argv []string) error {
 		return fmt.Errorf("failed to wait for server to be ready: %w", err)
 	}
 
+	// Create scheme for typed OSAC CRD access on hub clusters:
+	hubScheme := runtime.NewScheme()
+	_ = osacv1alpha1.AddToScheme(hubScheme)
+	_ = corev1.AddToScheme(hubScheme)
+
 	// Create the hub cache:
 	r.logger.InfoContext(ctx, "Creating hub cache")
 	hubCache, err := controllers.NewHubCache().
 		SetLogger(r.logger).
 		SetConnection(r.client).
+		SetScheme(hubScheme).
 		Build()
 	if err != nil {
 		return fmt.Errorf("failed to create hub cache: %w", err)

--- a/internal/controllers/hub_cache.go
+++ b/internal/controllers/hub_cache.go
@@ -20,6 +20,7 @@ import (
 	"sync"
 
 	"google.golang.org/grpc"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/clientcmd"
 	clnt "sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -38,12 +39,14 @@ type HubCache interface {
 type HubCacheBuilder struct {
 	logger     *slog.Logger
 	connection *grpc.ClientConn
+	scheme     *runtime.Scheme
 }
 
 // hubCache caches the information and connections to the hubs.
 type hubCache struct {
 	logger      *slog.Logger
 	client      privatev1.HubsClient
+	scheme      *runtime.Scheme
 	entries     map[string]*HubEntry
 	entriesLock *sync.Mutex
 }
@@ -70,6 +73,12 @@ func (b *HubCacheBuilder) SetConnection(value *grpc.ClientConn) *HubCacheBuilder
 	return b
 }
 
+// SetScheme sets the Kubernetes scheme used for typed object support. This is mandatory.
+func (b *HubCacheBuilder) SetScheme(value *runtime.Scheme) *HubCacheBuilder {
+	b.scheme = value
+	return b
+}
+
 // Build uses the information stored in the buidler to create a new hub client cache.
 func (b *HubCacheBuilder) Build() (result HubCache, err error) {
 	// Check parameters:
@@ -81,11 +90,16 @@ func (b *HubCacheBuilder) Build() (result HubCache, err error) {
 		err = errors.New("gRPC connection is mandatory")
 		return
 	}
+	if b.scheme == nil {
+		err = errors.New("scheme is mandatory")
+		return
+	}
 
 	// Create and populate the object:
 	result = &hubCache{
 		logger:      b.logger,
 		client:      privatev1.NewHubsClient(b.connection),
+		scheme:      b.scheme,
 		entries:     map[string]*HubEntry{},
 		entriesLock: &sync.Mutex{},
 	}
@@ -119,7 +133,7 @@ func (r *hubCache) create(ctx context.Context, id string) (result *HubEntry, err
 	if err != nil {
 		return
 	}
-	client, err := clnt.New(config, clnt.Options{})
+	client, err := clnt.New(config, clnt.Options{Scheme: r.scheme})
 	if err != nil {
 		return
 	}

--- a/internal/kubernetes/labels/kubernetes_labels.go
+++ b/internal/kubernetes/labels/kubernetes_labels.go
@@ -16,29 +16,31 @@ package labels
 import (
 	"fmt"
 
-	"github.com/osac-project/fulfillment-service/internal/kubernetes/gvks"
+	osacv1alpha1 "github.com/osac-project/osac-operator/api/v1alpha1"
 )
 
+var group = osacv1alpha1.GroupVersion.Group
+
 // ClusterOrderUuid is the label where the fulfillment API will write the identifier of the order.
-var ClusterOrderUuid = fmt.Sprintf("%s/%s", gvks.ClusterOrder.Group, "clusterorder-uuid")
+var ClusterOrderUuid = fmt.Sprintf("%s/%s", group, "clusterorder-uuid")
 
 // ComputeInstanceUuid is the label where the fulfillment API will write the identifier of the compute instance.
-var ComputeInstanceUuid = fmt.Sprintf("%s/%s", gvks.ComputeInstance.Group, "computeinstance-uuid")
+var ComputeInstanceUuid = fmt.Sprintf("%s/%s", group, "computeinstance-uuid")
 
 // SubnetUuid is the label where the fulfillment API will write the identifier of the subnet.
-var SubnetUuid = fmt.Sprintf("%s/%s", gvks.Subnet.Group, "subnet-uuid")
+var SubnetUuid = fmt.Sprintf("%s/%s", group, "subnet-uuid")
 
 // VirtualNetworkUuid is the label where the fulfillment API will write the identifier of the virtual network.
-var VirtualNetworkUuid = fmt.Sprintf("%s/%s", gvks.VirtualNetwork.Group, "virtualnetwork-uuid")
+var VirtualNetworkUuid = fmt.Sprintf("%s/%s", group, "virtualnetwork-uuid")
 
 // NetworkClassUuid is the label where the fulfillment API will write the identifier of the network class.
-var NetworkClassUuid = fmt.Sprintf("%s/%s", gvks.NetworkClass.Group, "networkclass-uuid")
+var NetworkClassUuid = fmt.Sprintf("%s/%s", group, "networkclass-uuid")
 
 // PublicIPPoolUuid is the label where the fulfillment API will write the identifier of the public IP pool.
-var PublicIPPoolUuid = fmt.Sprintf("%s/%s", gvks.PublicIPPool.Group, "publicippool-uuid")
+var PublicIPPoolUuid = fmt.Sprintf("%s/%s", group, "publicippool-uuid")
 
 // SecurityGroupUuid is the label where the fulfillment API will write the identifier of the security group.
-var SecurityGroupUuid = fmt.Sprintf("%s/%s", gvks.SecurityGroup.Group, "securitygroup-uuid")
+var SecurityGroupUuid = fmt.Sprintf("%s/%s", group, "securitygroup-uuid")
 
 // PublicIPUuid is the label where the fulfillment API will write the identifier of the public IP.
-var PublicIPUuid = fmt.Sprintf("%s/%s", gvks.PublicIP.Group, "publicip-uuid")
+var PublicIPUuid = fmt.Sprintf("%s/%s", group, "publicip-uuid")


### PR DESCRIPTION
## Summary

Foundation PR for replacing unstructured CRD access with typed osac-operator API objects (1 of 3 PRs).

- Import `github.com/osac-project/osac-operator/api` v0.0.1 — the lightweight API module with zero controller-runtime dependency
- Register OSAC and core v1 schemes on hub K8s clients via new `SetScheme` builder method
- Update labels package to use `osacv1alpha1.GroupVersion.Group` instead of GVK struct group fields

## Why

[MGMT-24140](https://redhat.atlassian.net/browse/MGMT-24140) extracted the osac-operator API types into a separate Go module. This PR wires it into the fulfillment-service as the foundation for replacing `unstructured.Unstructured` objects with typed structs (compile-time safety, IDE autocomplete, no more string-to-struct drift).

## Changes

- **`go.mod`** — added `github.com/osac-project/osac-operator/api v0.0.1`
- **`internal/controllers/hub_cache.go`** — added `scheme` field to builder, pass to `clnt.New(config, clnt.Options{Scheme: scheme})`
- **`internal/cmd/service/start/controller/start_controller_cmd.go`** — create scheme with `osacv1alpha1.AddToScheme` + `corev1.AddToScheme`, pass to hub cache
- **`internal/kubernetes/labels/kubernetes_labels.go`** — use `osacv1alpha1.GroupVersion.Group` constant instead of `gvks.X.Group`

## What's next (follow-up PRs)

- PR 2: Convert all 7 reconcilers from unstructured to typed objects
- PR 3: Convert server files and integration tests

## Test plan

- [x] `go build ./cmd/fulfillment-service ./cmd/osac` — builds
- [x] `go vet ./...` — no issues
- [x] `ginkgo run -r internal` — all 51 test suites pass (zero behavioral change)

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added an OSAC operator API dependency to the module.
  * Enabled registration of a typed Kubernetes scheme for hub cluster operations, improving typed resource handling.
  * Standardized OSAC resource label keys system-wide by using a centralized group identifier for UUID labels.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->