### PR TITLE
MGMT-24184: Add `manage-users` role to controller service account

### DIFF
--- a/charts/README.md
+++ b/charts/README.md
@@ -14,10 +14,12 @@ installed separately before deploying the service:
   details are passed to the chart via the `database.connection` value. See the
   `charts/service/values.yaml` file for details.
 
-- _Keycloak_ - The service requires Keycloak issuer for authentication. The issuer URL is passed
+- _Keycloak_ - The service requires a Keycloak issuer for authentication. The issuer URL is passed
   via `auth.issuerUrl`. You must create at least the `osac-admin` and `osac-controller` service
-  account clients and pass the credentials via the `auth.controllerCredentials` value. See the
-  `charts/service/values.yaml` file for the expected format.
+  account clients and pass the credentials via the `auth.controllerCredentials` value. The
+  `osac-controller` service account also needs the `manage-users` role from the `realm-management`
+  client. See the `charts/service/values.yaml` file for the expected format and the
+  `charts/keycloak/README.md` file for details on the required Keycloak configuration.
 
 Note that the PostgreSQL and Keycloak Helm charts that are included in this project are intended
 only for development environments, and shouldn't be used in production.
@@ -110,7 +112,8 @@ $ kubectl create secret generic fulfillment-database \
 ```
 
 Create the Kubernetes Secret containing the controller OAuth client credentials. The client
-identifier and secret must match the `osac-controller` service account created in Keycloak:
+identifier and secret must match the `osac-controller` service account created in Keycloak. That
+service account must also have the `manage-users` role from the `realm-management` client:
 
 ```shell
 $ kubectl create secret generic fulfillment-controller-credentials \
@@ -309,7 +312,8 @@ $ kubectl create secret generic fulfillment-database \
 ```
 
 Create the Kubernetes secret containing the controller OAuth client credentials. The client
-identifier and secret must match the `osac-controller` service account created in Keycloak:
+identifier and secret must match the `osac-controller` service account created in Keycloak. That
+service account must also have the `manage-users` role from the `realm-management` client:
 
 ```shell
 $ kubectl create secret generic fulfillment-controller-credentials \

--- a/charts/keycloak/README.md
+++ b/charts/keycloak/README.md
@@ -202,9 +202,11 @@ details about the available fields for clients.
 When using this Keycloak chart together with the fulfillment service, you must create at least the
 following two service account clients:
 
-- `osac-admin` — Used by the administrator tooling to manage the service.
-- `osac-controller` — Used by the controller to authenticate to the fulfillment API using the OAuth
-  client credentials flow.
+- `osac-admin` - Used by the administrator tooling to manage the service.
+
+- `osac-controller` - Used by the controller to authenticate to the fulfillment API using the OAuth
+  client credentials flow. This service account requires the `manage-users` role from the
+  `realm-management` client so that the controller can manage Keycloak users.
 
 For example:
 
@@ -248,6 +250,9 @@ users:
 - username: service-account-osac-controller
   enabled: true
   serviceAccountClientId: osac-controller
+  clientRoles:
+    realm-management:
+    - manage-users
 ```
 
 The `secret` values used here must match the credentials configured in the fulfillment service Helm

--- a/charts/keycloak/README.md
+++ b/charts/keycloak/README.md
@@ -266,7 +266,7 @@ following steps:
     $ pod=$(kubectl get pods -n keycloak -l app=keycloak-service -o json | jq -r '.items[].metadata.name')
     ```
 
-2. Run the `export` command inside the pod to write the ream to a temporary file:
+2. Run the `export` command inside the pod to write the realm to a temporary file:
 
     ```bash
     $ kubectl exec -n keycloak "${pod}" -- /opt/keycloak/bin/kc.sh export --realm osac --file /tmp/realm.json
@@ -278,8 +278,7 @@ following steps:
     $ kubectl exec -n keycloak "${pod}" -- cat /tmp/realm.json > realm.json
     ```
 
-4. Optionally, if you want to replace the realm used by the chart, overwrite the
-   `realm.json` file:
+4. Optionally, if you want to replace the realm used by the chart, overwrite the `realm.json` file:
 
    ```bash
    $ cp realm.json charts/keycloak/files/realm.json

--- a/charts/keycloak/templates/_start.tpl
+++ b/charts/keycloak/templates/_start.tpl
@@ -1,3 +1,21 @@
+{{/*
+Copyright (c) 2025 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+the License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+*/}}
+
+{{/*
+Generates the shell script that writes the Keycloak configuration file and starts the server. This is used instead of
+environment variables so that tools like `kc.sh` work correctly when executed via `kubectl exec`.
+*/}}
+{{- define "keycloak.start" -}}
 #!/bin/bash
 
 # Directory containing the database connection parameters:
@@ -52,23 +70,39 @@ for param_path in "${param_dir}"/*; do
   esac
 done
 
-# Rebuild the URL without the user and password, as they are stored in separate environment variables:
-export KC_DB_URL="jdbc:postgresql://${db_host}:${db_port}/${db_name}"
+# Rebuild the URL without the user and password, as they are stored in separate properties:
+db_url="jdbc:postgresql://${db_host}:${db_port}/${db_name}"
 index="0"
 for param_name in "${!db_params[@]}"; do
   if [[ "${index}" == "0" ]]; then
-    KC_DB_URL+="?"
+    db_url+="?"
   else
-    KC_DB_URL+="&"
+    db_url+="&"
   fi
   param_value="${db_params[${param_name}]}"
-  KC_DB_URL+="${param_name}=${param_value}"
+  db_url+="${param_name}=${param_value}"
   ((index++))
 done
 
-# Set the user and password environment variables:
-export KC_DB_USERNAME="${db_user}"
-export KC_DB_PASSWORD="${db_password}"
+# Write the Keycloak configuration file:
+conf_file="/opt/keycloak/conf/keycloak.conf"
+cat > "${conf_file}" <<.
+db=postgres
+db-url=${db_url}
+db-username=${db_user}
+db-password=${db_password}
+hostname={{ include "keycloak.hostname" . }}
+hostname-port=8000
+hostname-strict=true
+hostname-strict-https=true
+http-enabled=false
+https-enabled=true
+https-port=8000
+https-certificate-file=/opt/keycloak/tls/tls.crt
+https-certificate-key-file=/opt/keycloak/tls/tls.key
+.
+chmod 600 "${conf_file}"
 
 # Start Keycloak:
 exec /opt/keycloak/bin/kc.sh start --import-realm
+{{- end -}}

--- a/charts/keycloak/templates/deployment.yaml
+++ b/charts/keycloak/templates/deployment.yaml
@@ -79,30 +79,10 @@ spec:
           value: admin
         - name: KC_BOOTSTRAP_ADMIN_PASSWORD
           value: admin
-        - name: KC_HOSTNAME_STRICT
-          value: "true"
-        - name: KC_HOSTNAME_STRICT_HTTPS
-          value: "true"
-        - name: KC_HTTP_ENABLED
-          value: "false"
-        - name: KC_HTTPS_ENABLED
-          value: "true"
-        - name: KC_HTTPS_PORT
-          value: "8000"
-        - name: KC_HTTPS_CERTIFICATE_FILE
-          value: "/opt/keycloak/tls/tls.crt"
-        - name: KC_HTTPS_CERTIFICATE_KEY_FILE
-          value: "/opt/keycloak/tls/tls.key"
-        - name: KC_HOSTNAME
-          value: "{{ include "keycloak.hostname" . }}"
-        - name: KC_HOSTNAME_PORT
-          value: "8000"
-        - name: KC_DB
-          value: "postgres"
         command:
         - /bin/bash
         - -c
-        - {{ .Files.Get "files/start.sh" | quote }}
+        - {{ include "keycloak.start" . | quote }}
         ports:
         - name: https
           containerPort: 8000

--- a/it/it_tool.go
+++ b/it/it_tool.go
@@ -917,6 +917,7 @@ func (t *Tool) deployKeycloak(ctx context.Context) error {
 		Name        string
 		Description string
 		ClientId    string
+		ClientRoles map[string][]string
 	}
 	addServiceAccount := func(data serviceAccountData) {
 		clients = append(
@@ -942,6 +943,7 @@ func (t *Tool) deployKeycloak(ctx context.Context) error {
 				"username":               fmt.Sprintf("service-account-%s", data.ClientId),
 				"enabled":                true,
 				"serviceAccountClientId": data.ClientId,
+				"clientRoles":            data.ClientRoles,
 			},
 		)
 	}
@@ -954,6 +956,11 @@ func (t *Tool) deployKeycloak(ctx context.Context) error {
 		Name:        "OSAC controller",
 		Description: "Service account for the OSAC controller",
 		ClientId:    controllerClientId,
+		ClientRoles: map[string][]string{
+			"realm-management": {
+				"manage-users",
+			},
+		},
 	})
 
 	// Add the prepared clients, groups and users to the values:

--- a/manifests/README.md
+++ b/manifests/README.md
@@ -15,7 +15,8 @@ patch in a custom overlay.
 
 Before deploying the service you need to create a Kubernetes secret containing the OAuth client
 credentials that the controller uses to authenticate to the API. The client identifier and secret
-must match the `osac-controller` service account configured in the identity provider.
+must match the `osac-controller` service account configured in the identity provider. That service
+account must also have the `manage-users` role from the `realm-management` client.
 
 The secret must be named `fulfillment-controller-credentials` and contain the keys `client-id` and
 `client-secret`:


### PR DESCRIPTION
## Summary

- Replaces the Keycloak startup shell script with a Helm named template that generates a
  `keycloak.conf` properties file instead of exporting environment variables. This allows tools
  like `kc.sh` to work when executed via `kubectl exec`, which was previously broken because the
  environment variables only existed in the startup process tree.

- Adds the `manage-users` role from the `realm-management` client to the `osac-controller` service
  account so that the controller can manage Keycloak users. Updates the integration test deployment
  and documents the requirement in the README files.

## Test plan

- [x] Integration tests pass (94/94).
- [x] Verified that `kc.sh export` works via `kubectl exec` against the running pod.

Related: https://redhat.atlassian.net/browse/MGMT-24184

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated Keycloak configuration and authorization documentation with enhanced setup prerequisites.
  * Revised deployment instructions for OpenShift and Kubernetes Kind environments.
  * Added guidance for service account role assignments.

* **Chores**
  * Enhanced deployment tooling to support flexible service account authorization configuration across environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->