### PR TITLE
NO-ISSUE: Enable Keycloak organizations

### DIFF
--- a/charts/README.md
+++ b/charts/README.md
@@ -17,8 +17,15 @@ installed separately before deploying the service:
 - _Keycloak_ - The service requires a Keycloak issuer for authentication. The issuer URL is passed
   via `auth.issuerUrl`. You must create at least the `osac-admin` and `osac-controller` service
   account clients and pass the credentials via the `auth.controllerCredentials` value. The
-  `osac-controller` service account also needs the `manage-users` role from the `realm-management`
-  client. See the `charts/service/values.yaml` file for the expected format and the
+  `osac-controller` service account also needs the following roles from the `realm-management`
+  client:
+
+  - `manage-realm` - Manage the realm configuration, including organizations.
+  - `manage-users` - Create, update and delete users.
+  - `view-realm` - View the realm configuration.
+  - `view-users` - View users.
+
+  See the `charts/service/values.yaml` file for the expected format and the
   `charts/keycloak/README.md` file for details on the required Keycloak configuration.
 
 Note that the PostgreSQL and Keycloak Helm charts that are included in this project are intended
@@ -113,7 +120,12 @@ $ kubectl create secret generic fulfillment-database \
 
 Create the Kubernetes Secret containing the controller OAuth client credentials. The client
 identifier and secret must match the `osac-controller` service account created in Keycloak. That
-service account must also have the `manage-users` role from the `realm-management` client:
+service account must also have the following roles from the `realm-management` client:
+
+- `manage-realm` - Manage the realm configuration, including organizations.
+- `manage-users` - Create, update and delete users.
+- `view-realm` - View the realm configuration.
+- `view-users` - View users.
 
 ```shell
 $ kubectl create secret generic fulfillment-controller-credentials \
@@ -313,7 +325,12 @@ $ kubectl create secret generic fulfillment-database \
 
 Create the Kubernetes secret containing the controller OAuth client credentials. The client
 identifier and secret must match the `osac-controller` service account created in Keycloak. That
-service account must also have the `manage-users` role from the `realm-management` client:
+service account must also have the following roles from the `realm-management` client:
+
+- `manage-realm` - Manage the realm configuration, including organizations.
+- `manage-users` - Create, update and delete users.
+- `view-realm` - View the realm configuration.
+- `view-users` - View users.
 
 ```shell
 $ kubectl create secret generic fulfillment-controller-credentials \

--- a/charts/keycloak/README.md
+++ b/charts/keycloak/README.md
@@ -205,8 +205,13 @@ following two service account clients:
 - `osac-admin` - Used by the administrator tooling to manage the service.
 
 - `osac-controller` - Used by the controller to authenticate to the fulfillment API using the OAuth
-  client credentials flow. This service account requires the `manage-users` role from the
-  `realm-management` client so that the controller can manage Keycloak users.
+  client credentials flow. This service account requires the following roles from the
+  `realm-management` client:
+
+  - `manage-realm` - Manage the realm configuration, including organizations.
+  - `manage-users` - Create, update and delete users.
+  - `view-realm` - View the realm configuration.
+  - `view-users` - View users.
 
 For example:
 
@@ -252,7 +257,10 @@ users:
   serviceAccountClientId: osac-controller
   clientRoles:
     realm-management:
+    - manage-realm
     - manage-users
+    - view-realm
+    - view-users
 ```
 
 The `secret` values used here must match the credentials configured in the fulfillment service Helm

--- a/charts/keycloak/files/realm.json
+++ b/charts/keycloak/files/realm.json
@@ -2142,7 +2142,7 @@
   },
   "keycloakVersion" : "26.3.5",
   "userManagedAccessAllowed" : false,
-  "organizationsEnabled" : false,
+  "organizationsEnabled" : true,
   "verifiableCredentialsEnabled" : false,
   "adminPermissionsEnabled" : false,
   "clientProfiles" : {

--- a/it/it_tool.go
+++ b/it/it_tool.go
@@ -958,7 +958,10 @@ func (t *Tool) deployKeycloak(ctx context.Context) error {
 		ClientId:    controllerClientId,
 		ClientRoles: map[string][]string{
 			"realm-management": {
+				"manage-realm",
 				"manage-users",
+				"view-realm",
+				"view-users",
 			},
 		},
 	})

--- a/manifests/README.md
+++ b/manifests/README.md
@@ -16,7 +16,12 @@ patch in a custom overlay.
 Before deploying the service you need to create a Kubernetes secret containing the OAuth client
 credentials that the controller uses to authenticate to the API. The client identifier and secret
 must match the `osac-controller` service account configured in the identity provider. That service
-account must also have the `manage-users` role from the `realm-management` client.
+account must also have the following roles from the `realm-management` client:
+
+- `manage-realm` - Manage the realm configuration, including organizations.
+- `manage-users` - Create, update and delete users.
+- `view-realm` - View the realm configuration.
+- `view-users` - View users.
 
 The secret must be named `fulfillment-controller-credentials` and contain the keys `client-id` and
 `client-secret`:


### PR DESCRIPTION
## Summary

This enables the Keycloak organizations feature and grants the
`osac-controller` service account the permissions it needs to manage
them.

The realm configuration is updated to set `organizationsEnabled` to
`true`, and the `osac-controller` service account is granted the
following roles from the `realm-management` client:

- `manage-realm` - Manage the realm configuration, including organizations.
- `manage-users` - Create, update and delete users.
- `view-realm` - View the realm configuration.
- `view-users` - View users.

The documentation and integration test tooling are updated accordingly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Keycloak setup documentation across multiple deployment guides to reflect expanded service account authorization requirements for proper controller operation.

* **Configuration**
  * Enabled Keycloak organizations functionality in the realm configuration.
  * Updated controller service account role mappings to include additional realm management and viewing permissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->