### PR TITLE
MGMT-23734/MGMT-23900: PublicIP pool validation, state machine and capacity tracking

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -67,6 +67,24 @@
                         ]
                 },
                 {
+                        "name": "start grpc-server (serviceaccount tenancy)",
+                        "type": "go",
+                        "request": "launch",
+                        "mode": "auto",
+                        "program": "${workspaceFolder}",
+                        "args": [
+                                "start",
+                                "grpc-server",
+                                "--log-level=debug",
+                                "--log-headers=true",
+                                "--log-bodies=true",
+                                "--grpc-authn-trusted-token-issuers=https://keycloak.keycloak.svc.cluster.local:8000/realms/osac",
+                                "--grpc-listener-address=localhost:8000",
+                                "--db-url=postgres://service:service123@localhost:5432/service",
+                                "--tenancy-logic=serviceaccount"
+                        ]
+                },
+                {
                         "name": "start rest-gateway",
                         "type": "go",
                         "request": "launch",

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -67,24 +67,6 @@
                         ]
                 },
                 {
-                        "name": "start grpc-server (serviceaccount tenancy)",
-                        "type": "go",
-                        "request": "launch",
-                        "mode": "auto",
-                        "program": "${workspaceFolder}",
-                        "args": [
-                                "start",
-                                "grpc-server",
-                                "--log-level=debug",
-                                "--log-headers=true",
-                                "--log-bodies=true",
-                                "--grpc-authn-trusted-token-issuers=https://keycloak.keycloak.svc.cluster.local:8000/realms/osac",
-                                "--grpc-listener-address=localhost:8000",
-                                "--db-url=postgres://service:service123@localhost:5432/service",
-                                "--tenancy-logic=serviceaccount"
-                        ]
-                },
-                {
                         "name": "start rest-gateway",
                         "type": "go",
                         "request": "launch",

--- a/internal/servers/field_mask.go
+++ b/internal/servers/field_mask.go
@@ -1,0 +1,42 @@
+/*
+Copyright (c) 2026 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package servers
+
+import (
+	"strings"
+
+	"google.golang.org/protobuf/types/known/fieldmaskpb"
+)
+
+// updateIncludesField reports whether a field (or any of its children) is being
+// updated. When mask is nil or empty the caller is doing a full object
+// replacement, so every field is considered updated and the function returns
+// true. This matches GenericServer.Update semantics: a nil mask replaces the
+// entire object, while a non-nil mask applies only the listed fields.
+//
+// Use this to guard field-specific validation in Update hooks so that
+// validation only runs when the field is actually part of the update.
+func updateIncludesField(mask *fieldmaskpb.FieldMask, prefixes ...string) bool {
+	if mask == nil || len(mask.GetPaths()) == 0 {
+		return true
+	}
+	for _, path := range mask.GetPaths() {
+		for _, prefix := range prefixes {
+			if path == prefix || strings.HasPrefix(path, prefix+".") {
+				return true
+			}
+		}
+	}
+	return false
+}

--- a/internal/servers/field_mask.go
+++ b/internal/servers/field_mask.go
@@ -33,7 +33,9 @@ func updateIncludesField(mask *fieldmaskpb.FieldMask, prefixes ...string) bool {
 	}
 	for _, path := range mask.GetPaths() {
 		for _, prefix := range prefixes {
-			if path == prefix || strings.HasPrefix(path, prefix+".") {
+			if path == prefix ||
+				strings.HasPrefix(path, prefix+".") ||
+				strings.HasPrefix(prefix, path+".") {
 				return true
 			}
 		}

--- a/internal/servers/private_public_ip_pools_server_test.go
+++ b/internal/servers/private_public_ip_pools_server_test.go
@@ -301,6 +301,23 @@ var _ = Describe("Private public IP pools server", func() {
 			Expect(err).ToNot(HaveOccurred())
 			poolID := createPoolResponse.GetObject().GetId()
 
+			// Set pool to READY with capacity (required by PublicIP Create validation):
+			_, err = poolsServer.Update(ctx, privatev1.PublicIPPoolsUpdateRequest_builder{
+				Object: privatev1.PublicIPPool_builder{
+					Id: poolID,
+					Status: privatev1.PublicIPPoolStatus_builder{
+						State:     privatev1.PublicIPPoolState_PUBLIC_IP_POOL_STATE_READY,
+						Total:     10,
+						Allocated: 0,
+						Available: 10,
+					}.Build(),
+				}.Build(),
+				UpdateMask: &fieldmaskpb.FieldMask{
+					Paths: []string{"status"},
+				},
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+
 			// Allocate a PublicIP from the pool:
 			_, err = ipsServer.Create(ctx, privatev1.PublicIPsCreateRequest_builder{
 				Object: privatev1.PublicIP_builder{

--- a/internal/servers/private_public_ips_server.go
+++ b/internal/servers/private_public_ips_server.go
@@ -156,6 +156,9 @@ func (s *PrivatePublicIPsServer) Get(ctx context.Context,
 	return
 }
 
+// Create validates the pool reference, creates the PublicIP, and updates pool capacity counters.
+// All operations share the gRPC interceptor's database transaction: if any step fails, the
+// entire transaction rolls back (pool capacity, PublicIP creation, and validation are atomic).
 func (s *PrivatePublicIPsServer) Create(ctx context.Context,
 	request *privatev1.PublicIPsCreateRequest) (response *privatev1.PublicIPsCreateResponse, err error) {
 	publicIP := request.GetObject()
@@ -179,7 +182,9 @@ func (s *PrivatePublicIPsServer) Create(ctx context.Context,
 		return
 	}
 
-	// Update pool capacity: decrement available, increment allocated:
+	// Update pool capacity: decrement available, increment allocated.
+	// Concurrent allocations are serialized by the pool's resource_version
+	// (optimistic locking). A version conflict returns Aborted for client retry.
 	err = s.updatePoolCapacity(ctx, poolID, 1)
 	if err != nil {
 		return
@@ -188,9 +193,12 @@ func (s *PrivatePublicIPsServer) Create(ctx context.Context,
 	return
 }
 
+// Update validates pool immutability and state machine transitions before persisting.
+// The Get and Update share the gRPC interceptor's transaction. GenericServer.Update uses
+// optimistic locking (resource_version), so a concurrent state change between Get and
+// Update causes a version conflict rather than a silent overwrite.
 func (s *PrivatePublicIPsServer) Update(ctx context.Context,
 	request *privatev1.PublicIPsUpdateRequest) (response *privatev1.PublicIPsUpdateResponse, err error) {
-	// Get existing object for immutability and state machine validation:
 	id := request.GetObject().GetId()
 	if id == "" {
 		err = grpcstatus.Errorf(grpccodes.InvalidArgument, "object identifier is mandatory")
@@ -225,6 +233,8 @@ func (s *PrivatePublicIPsServer) Update(ctx context.Context,
 	return
 }
 
+// Delete rejects deletion of ATTACHED PublicIPs and restores pool capacity on success.
+// All operations share the gRPC interceptor's transaction for atomicity.
 func (s *PrivatePublicIPsServer) Delete(ctx context.Context,
 	request *privatev1.PublicIPsDeleteRequest) (response *privatev1.PublicIPsDeleteResponse, err error) {
 	// Fetch the existing PublicIP to check state and get pool ID:

--- a/internal/servers/private_public_ips_server.go
+++ b/internal/servers/private_public_ips_server.go
@@ -55,9 +55,9 @@ var _ privatev1.PublicIPsServer = (*PrivatePublicIPsServer)(nil)
 type PrivatePublicIPsServer struct {
 	privatev1.UnimplementedPublicIPsServer
 
-	logger           *slog.Logger
-	generic          *GenericServer[*privatev1.PublicIP]
-	publicIPPoolDao  *dao.GenericDAO[*privatev1.PublicIPPool]
+	logger          *slog.Logger
+	generic         *GenericServer[*privatev1.PublicIP]
+	publicIPPoolDao *dao.GenericDAO[*privatev1.PublicIPPool]
 }
 
 // NewPrivatePublicIPsServer creates a builder that can then be used to configure and create a PrivatePublicIPsServer.

--- a/internal/servers/private_public_ips_server.go
+++ b/internal/servers/private_public_ips_server.go
@@ -25,7 +25,17 @@ import (
 	privatev1 "github.com/osac-project/fulfillment-service/internal/api/osac/private/v1"
 	"github.com/osac-project/fulfillment-service/internal/auth"
 	"github.com/osac-project/fulfillment-service/internal/database"
+	"github.com/osac-project/fulfillment-service/internal/database/dao"
 )
+
+// validPublicIPTransitions defines the allowed state transitions for PublicIP resources.
+// The key is the current state and the value is the list of valid target states.
+var validPublicIPTransitions = map[privatev1.PublicIPState][]privatev1.PublicIPState{
+	privatev1.PublicIPState_PUBLIC_IP_STATE_PENDING:   {privatev1.PublicIPState_PUBLIC_IP_STATE_ALLOCATED},
+	privatev1.PublicIPState_PUBLIC_IP_STATE_ALLOCATED: {privatev1.PublicIPState_PUBLIC_IP_STATE_ATTACHED},
+	privatev1.PublicIPState_PUBLIC_IP_STATE_ATTACHED:  {privatev1.PublicIPState_PUBLIC_IP_STATE_RELEASING},
+	privatev1.PublicIPState_PUBLIC_IP_STATE_RELEASING: {privatev1.PublicIPState_PUBLIC_IP_STATE_ALLOCATED},
+}
 
 // PrivatePublicIPsServerBuilder contains the data and logic needed to create a PrivatePublicIPsServer.
 type PrivatePublicIPsServerBuilder struct {
@@ -39,12 +49,14 @@ type PrivatePublicIPsServerBuilder struct {
 var _ privatev1.PublicIPsServer = (*PrivatePublicIPsServer)(nil)
 
 // PrivatePublicIPsServer implements the private PublicIPs gRPC service. It delegates most operations to a
-// GenericServer and adds pool-required validation on Create.
+// GenericServer and adds pool validation on Create, state machine enforcement on Update, and delete
+// constraints.
 type PrivatePublicIPsServer struct {
 	privatev1.UnimplementedPublicIPsServer
 
-	logger  *slog.Logger
-	generic *GenericServer[*privatev1.PublicIP]
+	logger           *slog.Logger
+	generic          *GenericServer[*privatev1.PublicIP]
+	publicIPPoolDao  *dao.GenericDAO[*privatev1.PublicIPPool]
 }
 
 // NewPrivatePublicIPsServer creates a builder that can then be used to configure and create a PrivatePublicIPsServer.
@@ -99,6 +111,16 @@ func (b *PrivatePublicIPsServerBuilder) Build() (result *PrivatePublicIPsServer,
 		return
 	}
 
+	// Create the PublicIPPool DAO for pool validation and capacity tracking:
+	publicIPPoolDao, err := dao.NewGenericDAO[*privatev1.PublicIPPool]().
+		SetLogger(b.logger).
+		SetTenancyLogic(b.tenancyLogic).
+		SetMetricsRegisterer(b.metricsRegisterer).
+		Build()
+	if err != nil {
+		return
+	}
+
 	// Create the generic server:
 	generic, err := NewGenericServer[*privatev1.PublicIP]().
 		SetLogger(b.logger).
@@ -114,8 +136,9 @@ func (b *PrivatePublicIPsServerBuilder) Build() (result *PrivatePublicIPsServer,
 
 	// Create and populate the object:
 	result = &PrivatePublicIPsServer{
-		logger:  b.logger,
-		generic: generic,
+		logger:          b.logger,
+		generic:         generic,
+		publicIPPoolDao: publicIPPoolDao,
 	}
 	return
 }
@@ -142,19 +165,106 @@ func (s *PrivatePublicIPsServer) Create(ctx context.Context,
 		return
 	}
 
+	// Validate pool reference (existence, READY state, capacity):
+	poolID := publicIP.GetSpec().GetPool()
+	err = s.validatePoolReference(ctx, poolID)
+	if err != nil {
+		return
+	}
+
+	// Create the PublicIP:
 	err = s.generic.Create(ctx, request, &response)
+	if err != nil {
+		return
+	}
+
+	// Update pool capacity: decrement available, increment allocated:
+	err = s.updatePoolCapacity(ctx, poolID, 1)
+	if err != nil {
+		return
+	}
+
 	return
 }
 
 func (s *PrivatePublicIPsServer) Update(ctx context.Context,
 	request *privatev1.PublicIPsUpdateRequest) (response *privatev1.PublicIPsUpdateResponse, err error) {
+	// Get existing object for immutability and state machine validation:
+	id := request.GetObject().GetId()
+	if id == "" {
+		err = grpcstatus.Errorf(grpccodes.InvalidArgument, "object identifier is mandatory")
+		return
+	}
+
+	getRequest := &privatev1.PublicIPsGetRequest{}
+	getRequest.SetId(id)
+	var getResponse *privatev1.PublicIPsGetResponse
+	err = s.generic.Get(ctx, getRequest, &getResponse)
+	if err != nil {
+		return
+	}
+
+	existingPublicIP := getResponse.GetObject()
+
+	// Check pool immutability:
+	if err = validateImmutableFieldsPublicIP(request.GetObject(), existingPublicIP); err != nil {
+		return
+	}
+
+	// Check state machine transitions:
+	newState := request.GetObject().GetStatus().GetState()
+	existingState := existingPublicIP.GetStatus().GetState()
+	if newState != privatev1.PublicIPState_PUBLIC_IP_STATE_UNSPECIFIED && newState != existingState {
+		if err = validatePublicIPStateTransition(existingState, newState); err != nil {
+			return
+		}
+	}
+
 	err = s.generic.Update(ctx, request, &response)
 	return
 }
 
 func (s *PrivatePublicIPsServer) Delete(ctx context.Context,
 	request *privatev1.PublicIPsDeleteRequest) (response *privatev1.PublicIPsDeleteResponse, err error) {
+	// Fetch the existing PublicIP to check state and get pool ID:
+	id := request.GetId()
+	if id == "" {
+		err = grpcstatus.Errorf(grpccodes.InvalidArgument, "object identifier is mandatory")
+		return
+	}
+
+	getRequest := &privatev1.PublicIPsGetRequest{}
+	getRequest.SetId(id)
+	var getResponse *privatev1.PublicIPsGetResponse
+	err = s.generic.Get(ctx, getRequest, &getResponse)
+	if err != nil {
+		return
+	}
+
+	existingPublicIP := getResponse.GetObject()
+
+	// Reject delete when in ATTACHED state:
+	if existingPublicIP.GetStatus().GetState() == privatev1.PublicIPState_PUBLIC_IP_STATE_ATTACHED {
+		err = grpcstatus.Errorf(grpccodes.FailedPrecondition,
+			"cannot delete PublicIP: detach from ComputeInstance first")
+		return
+	}
+
+	// Delete the PublicIP:
 	err = s.generic.Delete(ctx, request, &response)
+	if err != nil {
+		return
+	}
+
+	// Update pool capacity: increment available, decrement allocated:
+	poolID := existingPublicIP.GetSpec().GetPool()
+	if poolID != "" {
+		err = s.updatePoolCapacity(ctx, poolID, -1)
+		if err != nil {
+			return
+		}
+	}
+
 	return
 }
 
@@ -179,4 +289,109 @@ func (s *PrivatePublicIPsServer) validatePublicIP(ctx context.Context,
 			"field 'spec.pool' is required")
 	}
 	return nil
+}
+
+// validatePoolReference validates that the referenced PublicIPPool exists, is in READY state,
+// and has available capacity.
+func (s *PrivatePublicIPsServer) validatePoolReference(ctx context.Context, poolID string) error {
+	getResponse, err := s.publicIPPoolDao.Get().
+		SetId(poolID).
+		Do(ctx)
+	if err != nil {
+		var notFoundErr *dao.ErrNotFound
+		if errors.As(err, &notFoundErr) {
+			return grpcstatus.Errorf(grpccodes.InvalidArgument,
+				"pool '%s' does not exist", poolID)
+		}
+		s.logger.ErrorContext(ctx, "Failed to query PublicIPPool",
+			slog.String("pool_id", poolID),
+			slog.Any("error", err))
+		return grpcstatus.Errorf(grpccodes.Internal, "failed to validate pool")
+	}
+
+	pool := getResponse.GetObject()
+
+	// Check pool is in READY state:
+	if pool.GetStatus().GetState() != privatev1.PublicIPPoolState_PUBLIC_IP_POOL_STATE_READY {
+		return grpcstatus.Errorf(grpccodes.FailedPrecondition,
+			"pool '%s' is not in READY state (current state: %s)",
+			poolID, pool.GetStatus().GetState().String())
+	}
+
+	// Check pool has available capacity:
+	if pool.GetStatus().GetAvailable() <= 0 {
+		return grpcstatus.Errorf(grpccodes.FailedPrecondition,
+			"pool '%s' has no available capacity", poolID)
+	}
+
+	return nil
+}
+
+// updatePoolCapacity atomically updates the PublicIPPool capacity counters.
+// A positive delta means allocation (increment allocated, decrement available).
+// A negative delta means release (decrement allocated, increment available).
+func (s *PrivatePublicIPsServer) updatePoolCapacity(ctx context.Context, poolID string, delta int64) error {
+	poolResponse, err := s.publicIPPoolDao.Get().
+		SetId(poolID).
+		Do(ctx)
+	if err != nil {
+		s.logger.ErrorContext(ctx, "Failed to get pool for capacity update",
+			slog.String("pool_id", poolID),
+			slog.Any("error", err))
+		return grpcstatus.Errorf(grpccodes.Internal, "failed to update pool capacity")
+	}
+
+	pool := poolResponse.GetObject()
+	pool.GetStatus().SetAllocated(pool.GetStatus().GetAllocated() + delta)
+	pool.GetStatus().SetAvailable(pool.GetStatus().GetAvailable() - delta)
+
+	_, err = s.publicIPPoolDao.Update().
+		SetObject(pool).
+		Do(ctx)
+	if err != nil {
+		s.logger.ErrorContext(ctx, "Failed to update pool capacity",
+			slog.String("pool_id", poolID),
+			slog.Any("error", err))
+		return grpcstatus.Errorf(grpccodes.Aborted, "pool capacity update conflict, retry")
+	}
+
+	return nil
+}
+
+// validateImmutableFieldsPublicIP validates that immutable fields have not been changed on Update.
+func validateImmutableFieldsPublicIP(newPublicIP, existingPublicIP *privatev1.PublicIP) error {
+	if existingPublicIP == nil {
+		return nil // Create operation, no immutability checks
+	}
+
+	newPool := newPublicIP.GetSpec().GetPool()
+	existingPool := existingPublicIP.GetSpec().GetPool()
+
+	// Only check if the request explicitly sets a pool value that differs from the existing one:
+	if newPool != "" && newPool != existingPool {
+		return grpcstatus.Errorf(grpccodes.InvalidArgument,
+			"field 'spec.pool' is immutable and cannot be changed from '%s' to '%s'",
+			existingPool, newPool)
+	}
+
+	return nil
+}
+
+// validatePublicIPStateTransition checks whether a state transition is valid according to the
+// PublicIP lifecycle state machine.
+func validatePublicIPStateTransition(from, to privatev1.PublicIPState) error {
+	allowed, exists := validPublicIPTransitions[from]
+	if !exists {
+		return grpcstatus.Errorf(grpccodes.FailedPrecondition,
+			"invalid state transition from %s to %s", from.String(), to.String())
+	}
+
+	for _, valid := range allowed {
+		if to == valid {
+			return nil
+		}
+	}
+
+	return grpcstatus.Errorf(grpccodes.FailedPrecondition,
+		"invalid state transition from %s to %s", from.String(), to.String())
 }

--- a/internal/servers/private_public_ips_server.go
+++ b/internal/servers/private_public_ips_server.go
@@ -214,18 +214,21 @@ func (s *PrivatePublicIPsServer) Update(ctx context.Context,
 	}
 
 	existingPublicIP := getResponse.GetObject()
+	mask := request.GetUpdateMask()
 
-	// Check pool immutability:
-	if err = validateImmutableFieldsPublicIP(request.GetObject(), existingPublicIP); err != nil {
-		return
+	if updateIncludesField(mask, "spec.pool") {
+		if err = validateImmutableFieldsPublicIP(request.GetObject(), existingPublicIP); err != nil {
+			return
+		}
 	}
 
-	// Check state machine transitions:
-	newState := request.GetObject().GetStatus().GetState()
-	existingState := existingPublicIP.GetStatus().GetState()
-	if newState != privatev1.PublicIPState_PUBLIC_IP_STATE_UNSPECIFIED && newState != existingState {
-		if err = validatePublicIPStateTransition(existingState, newState); err != nil {
-			return
+	if updateIncludesField(mask, "status.state") {
+		newState := request.GetObject().GetStatus().GetState()
+		existingState := existingPublicIP.GetStatus().GetState()
+		if newState != privatev1.PublicIPState_PUBLIC_IP_STATE_UNSPECIFIED && newState != existingState {
+			if err = validatePublicIPStateTransition(existingState, newState); err != nil {
+				return
+			}
 		}
 	}
 
@@ -330,7 +333,9 @@ func (s *PrivatePublicIPsServer) validatePoolReference(ctx context.Context, pool
 			poolID, pool.GetStatus().GetState().String())
 	}
 
-	// Check pool has available capacity:
+	// Best-effort check for user-facing error quality. The real serialization
+	// point is updatePoolCapacity, which uses the pool's resource_version for
+	// optimistic locking to prevent concurrent over-allocation.
 	if pool.GetStatus().GetAvailable() <= 0 {
 		return grpcstatus.Errorf(grpccodes.FailedPrecondition,
 			"pool '%s' has no available capacity", poolID)
@@ -356,9 +361,14 @@ func (s *PrivatePublicIPsServer) updatePoolCapacity(ctx context.Context, poolID 
 	pool := poolResponse.GetObject()
 	newAllocated := pool.GetStatus().GetAllocated() + delta
 	newAvailable := pool.GetStatus().GetAvailable() - delta
-	if newAllocated < 0 || newAvailable < 0 {
+	if newAvailable < 0 {
 		return grpcstatus.Errorf(grpccodes.FailedPrecondition,
 			"pool '%s' has no available capacity", poolID)
+	}
+	if newAllocated < 0 {
+		return grpcstatus.Errorf(grpccodes.FailedPrecondition,
+			"pool '%s' capacity inconsistency: allocated would become %d (available: %d)",
+			poolID, newAllocated, newAvailable)
 	}
 	pool.GetStatus().SetAllocated(newAllocated)
 	pool.GetStatus().SetAvailable(newAvailable)

--- a/internal/servers/private_public_ips_server.go
+++ b/internal/servers/private_public_ips_server.go
@@ -254,8 +254,9 @@ func (s *PrivatePublicIPsServer) Delete(ctx context.Context,
 
 	existingPublicIP := getResponse.GetObject()
 
-	// Reject delete when in ATTACHED state:
-	if existingPublicIP.GetStatus().GetState() == privatev1.PublicIPState_PUBLIC_IP_STATE_ATTACHED {
+	state := existingPublicIP.GetStatus().GetState()
+	if state == privatev1.PublicIPState_PUBLIC_IP_STATE_ATTACHED ||
+		state == privatev1.PublicIPState_PUBLIC_IP_STATE_RELEASING {
 		err = grpcstatus.Errorf(grpccodes.FailedPrecondition,
 			"cannot delete PublicIP: detach from ComputeInstance first")
 		return

--- a/internal/servers/private_public_ips_server.go
+++ b/internal/servers/private_public_ips_server.go
@@ -17,6 +17,7 @@ import (
 	"context"
 	"errors"
 	"log/slog"
+	"slices"
 
 	"github.com/prometheus/client_golang/prometheus"
 	grpccodes "google.golang.org/grpc/codes"
@@ -381,17 +382,10 @@ func validateImmutableFieldsPublicIP(newPublicIP, existingPublicIP *privatev1.Pu
 // PublicIP lifecycle state machine.
 func validatePublicIPStateTransition(from, to privatev1.PublicIPState) error {
 	allowed, exists := validPublicIPTransitions[from]
-	if !exists {
+	if !exists || !slices.Contains(allowed, to) {
 		return grpcstatus.Errorf(grpccodes.FailedPrecondition,
 			"invalid state transition from %s to %s", from.String(), to.String())
 	}
 
-	for _, valid := range allowed {
-		if to == valid {
-			return nil
-		}
-	}
-
-	return grpcstatus.Errorf(grpccodes.FailedPrecondition,
-		"invalid state transition from %s to %s", from.String(), to.String())
+	return nil
 }

--- a/internal/servers/private_public_ips_server.go
+++ b/internal/servers/private_public_ips_server.go
@@ -225,7 +225,7 @@ func (s *PrivatePublicIPsServer) Update(ctx context.Context,
 	if updateIncludesField(mask, "status.state") {
 		newState := request.GetObject().GetStatus().GetState()
 		existingState := existingPublicIP.GetStatus().GetState()
-		if newState != privatev1.PublicIPState_PUBLIC_IP_STATE_UNSPECIFIED && newState != existingState {
+		if newState != existingState {
 			if err = validatePublicIPStateTransition(existingState, newState); err != nil {
 				return
 			}
@@ -399,8 +399,7 @@ func validateImmutableFieldsPublicIP(newPublicIP, existingPublicIP *privatev1.Pu
 	newPool := newPublicIP.GetSpec().GetPool()
 	existingPool := existingPublicIP.GetSpec().GetPool()
 
-	// Only check if the request explicitly sets a pool value that differs from the existing one:
-	if newPool != "" && newPool != existingPool {
+	if newPool != existingPool {
 		return grpcstatus.Errorf(grpccodes.InvalidArgument,
 			"field 'spec.pool' is immutable and cannot be changed from '%s' to '%s'",
 			existingPool, newPool)

--- a/internal/servers/private_public_ips_server.go
+++ b/internal/servers/private_public_ips_server.go
@@ -353,8 +353,14 @@ func (s *PrivatePublicIPsServer) updatePoolCapacity(ctx context.Context, poolID 
 	}
 
 	pool := poolResponse.GetObject()
-	pool.GetStatus().SetAllocated(pool.GetStatus().GetAllocated() + delta)
-	pool.GetStatus().SetAvailable(pool.GetStatus().GetAvailable() - delta)
+	newAllocated := pool.GetStatus().GetAllocated() + delta
+	newAvailable := pool.GetStatus().GetAvailable() - delta
+	if newAllocated < 0 || newAvailable < 0 {
+		return grpcstatus.Errorf(grpccodes.FailedPrecondition,
+			"pool '%s' has no available capacity", poolID)
+	}
+	pool.GetStatus().SetAllocated(newAllocated)
+	pool.GetStatus().SetAvailable(newAvailable)
 
 	_, err = s.publicIPPoolDao.Update().
 		SetObject(pool).
@@ -363,7 +369,11 @@ func (s *PrivatePublicIPsServer) updatePoolCapacity(ctx context.Context, poolID 
 		s.logger.ErrorContext(ctx, "Failed to update pool capacity",
 			slog.String("pool_id", poolID),
 			slog.Any("error", err))
-		return grpcstatus.Errorf(grpccodes.Aborted, "pool capacity update conflict, retry")
+		var conflictErr *dao.ErrConflict
+		if errors.As(err, &conflictErr) {
+			return grpcstatus.Errorf(grpccodes.Aborted, "%s", conflictErr.Error())
+		}
+		return grpcstatus.Errorf(grpccodes.Internal, "failed to update pool capacity")
 	}
 
 	return nil

--- a/internal/servers/private_public_ips_server_test.go
+++ b/internal/servers/private_public_ips_server_test.go
@@ -30,9 +30,9 @@ import (
 
 var _ = Describe("Private public IPs server", func() {
 	var (
-		ctx              context.Context
-		publicIPPoolDao  *dao.GenericDAO[*privatev1.PublicIPPool]
-		publicIPDao      *dao.GenericDAO[*privatev1.PublicIP]
+		ctx             context.Context
+		publicIPPoolDao *dao.GenericDAO[*privatev1.PublicIPPool]
+		publicIPDao     *dao.GenericDAO[*privatev1.PublicIP]
 	)
 
 	BeforeEach(func() {

--- a/internal/servers/private_public_ips_server_test.go
+++ b/internal/servers/private_public_ips_server_test.go
@@ -108,6 +108,35 @@ var _ = Describe("Private public IPs server", func() {
 		return resp.GetObject().GetId()
 	}
 
+	// createPublicIPInState creates a PublicIP via the server (triggers pool validation and
+	// capacity tracking), then sets its state via the DAO (bypasses state machine validation
+	// since the controller, not the server, sets the initial state in production).
+	createPublicIPInState := func(
+		server *PrivatePublicIPsServer,
+		state privatev1.PublicIPState,
+	) *privatev1.PublicIP {
+		poolID := createReadyPool(ctx, 100, 0)
+		resp, err := server.Create(ctx, privatev1.PublicIPsCreateRequest_builder{
+			Object: privatev1.PublicIP_builder{
+				Metadata: privatev1.Metadata_builder{
+					Tenants: []string{"shared"},
+				}.Build(),
+				Spec: privatev1.PublicIPSpec_builder{
+					Pool: poolID,
+				}.Build(),
+			}.Build(),
+		}.Build())
+		Expect(err).ToNot(HaveOccurred())
+		object := resp.GetObject()
+
+		object.SetStatus(privatev1.PublicIPStatus_builder{
+			State: state,
+		}.Build())
+		daoResp, err := publicIPDao.Update().SetObject(object).Do(ctx)
+		Expect(err).ToNot(HaveOccurred())
+		return daoResp.GetObject()
+	}
+
 	Describe("Creation", func() {
 		It("Can be built if all the required parameters are set", func() {
 			server, err := NewPrivatePublicIPsServer().
@@ -579,33 +608,6 @@ var _ = Describe("Private public IPs server", func() {
 			Expect(err).ToNot(HaveOccurred())
 		})
 
-		// createPublicIPInState creates a PublicIP via the server (triggers pool validation and capacity
-		// tracking), then sets its initial state via the DAO (bypasses state machine validation since
-		// the controller, not the server, sets the initial PENDING state in production).
-		createPublicIPInState := func(initialState privatev1.PublicIPState) *privatev1.PublicIP {
-			poolID := createReadyPool(ctx, 100, 0)
-			resp, err := publicIPsServer.Create(ctx, privatev1.PublicIPsCreateRequest_builder{
-				Object: privatev1.PublicIP_builder{
-					Metadata: privatev1.Metadata_builder{
-						Tenants: []string{"shared"},
-					}.Build(),
-					Spec: privatev1.PublicIPSpec_builder{
-						Pool: poolID,
-					}.Build(),
-				}.Build(),
-			}.Build())
-			Expect(err).ToNot(HaveOccurred())
-			object := resp.GetObject()
-
-			// Set the initial state via DAO (production path: controller sets PENDING via Signal):
-			object.SetStatus(privatev1.PublicIPStatus_builder{
-				State: initialState,
-			}.Build())
-			daoResp, err := publicIPDao.Update().SetObject(object).Do(ctx)
-			Expect(err).ToNot(HaveOccurred())
-			return daoResp.GetObject()
-		}
-
 		// setStateOnObject sets the state on a PublicIP, handling the case where Status is nil.
 		setStateOnObject := func(object *privatev1.PublicIP, state privatev1.PublicIPState) {
 			if object.GetStatus() == nil {
@@ -628,20 +630,20 @@ var _ = Describe("Private public IPs server", func() {
 		}
 
 		It("accepts PENDING to ALLOCATED transition", func() {
-			object := createPublicIPInState(privatev1.PublicIPState_PUBLIC_IP_STATE_PENDING)
+			object := createPublicIPInState(publicIPsServer, privatev1.PublicIPState_PUBLIC_IP_STATE_PENDING)
 			updated := transitionTo(object, privatev1.PublicIPState_PUBLIC_IP_STATE_ALLOCATED)
 			Expect(updated.GetStatus().GetState()).To(Equal(privatev1.PublicIPState_PUBLIC_IP_STATE_ALLOCATED))
 		})
 
 		It("accepts ALLOCATED to ATTACHED transition", func() {
-			object := createPublicIPInState(privatev1.PublicIPState_PUBLIC_IP_STATE_PENDING)
+			object := createPublicIPInState(publicIPsServer, privatev1.PublicIPState_PUBLIC_IP_STATE_PENDING)
 			object = transitionTo(object, privatev1.PublicIPState_PUBLIC_IP_STATE_ALLOCATED)
 			updated := transitionTo(object, privatev1.PublicIPState_PUBLIC_IP_STATE_ATTACHED)
 			Expect(updated.GetStatus().GetState()).To(Equal(privatev1.PublicIPState_PUBLIC_IP_STATE_ATTACHED))
 		})
 
 		It("accepts ATTACHED to RELEASING transition", func() {
-			object := createPublicIPInState(privatev1.PublicIPState_PUBLIC_IP_STATE_PENDING)
+			object := createPublicIPInState(publicIPsServer, privatev1.PublicIPState_PUBLIC_IP_STATE_PENDING)
 			object = transitionTo(object, privatev1.PublicIPState_PUBLIC_IP_STATE_ALLOCATED)
 			object = transitionTo(object, privatev1.PublicIPState_PUBLIC_IP_STATE_ATTACHED)
 			updated := transitionTo(object, privatev1.PublicIPState_PUBLIC_IP_STATE_RELEASING)
@@ -649,7 +651,7 @@ var _ = Describe("Private public IPs server", func() {
 		})
 
 		It("accepts RELEASING to ALLOCATED transition", func() {
-			object := createPublicIPInState(privatev1.PublicIPState_PUBLIC_IP_STATE_PENDING)
+			object := createPublicIPInState(publicIPsServer, privatev1.PublicIPState_PUBLIC_IP_STATE_PENDING)
 			object = transitionTo(object, privatev1.PublicIPState_PUBLIC_IP_STATE_ALLOCATED)
 			object = transitionTo(object, privatev1.PublicIPState_PUBLIC_IP_STATE_ATTACHED)
 			object = transitionTo(object, privatev1.PublicIPState_PUBLIC_IP_STATE_RELEASING)
@@ -658,7 +660,7 @@ var _ = Describe("Private public IPs server", func() {
 		})
 
 		It("rejects PENDING to ATTACHED transition", func() {
-			object := createPublicIPInState(privatev1.PublicIPState_PUBLIC_IP_STATE_PENDING)
+			object := createPublicIPInState(publicIPsServer, privatev1.PublicIPState_PUBLIC_IP_STATE_PENDING)
 			setStateOnObject(object, privatev1.PublicIPState_PUBLIC_IP_STATE_ATTACHED)
 			_, err := publicIPsServer.Update(ctx, privatev1.PublicIPsUpdateRequest_builder{
 				Object: object,
@@ -671,7 +673,7 @@ var _ = Describe("Private public IPs server", func() {
 		})
 
 		It("rejects ALLOCATED to RELEASING transition", func() {
-			object := createPublicIPInState(privatev1.PublicIPState_PUBLIC_IP_STATE_ALLOCATED)
+			object := createPublicIPInState(publicIPsServer, privatev1.PublicIPState_PUBLIC_IP_STATE_ALLOCATED)
 			setStateOnObject(object, privatev1.PublicIPState_PUBLIC_IP_STATE_RELEASING)
 			_, err := publicIPsServer.Update(ctx, privatev1.PublicIPsUpdateRequest_builder{
 				Object: object,
@@ -684,7 +686,7 @@ var _ = Describe("Private public IPs server", func() {
 		})
 
 		It("rejects ATTACHED to ALLOCATED transition", func() {
-			object := createPublicIPInState(privatev1.PublicIPState_PUBLIC_IP_STATE_ATTACHED)
+			object := createPublicIPInState(publicIPsServer, privatev1.PublicIPState_PUBLIC_IP_STATE_ATTACHED)
 			setStateOnObject(object, privatev1.PublicIPState_PUBLIC_IP_STATE_ALLOCATED)
 			_, err := publicIPsServer.Update(ctx, privatev1.PublicIPsUpdateRequest_builder{
 				Object: object,
@@ -697,7 +699,7 @@ var _ = Describe("Private public IPs server", func() {
 		})
 
 		It("skips state validation when new state is UNSPECIFIED", func() {
-			object := createPublicIPInState(privatev1.PublicIPState_PUBLIC_IP_STATE_ALLOCATED)
+			object := createPublicIPInState(publicIPsServer, privatev1.PublicIPState_PUBLIC_IP_STATE_ALLOCATED)
 
 			// Update without setting state (UNSPECIFIED is the zero value):
 			object.GetMetadata().Name = "updated-name"
@@ -723,33 +725,8 @@ var _ = Describe("Private public IPs server", func() {
 			Expect(err).ToNot(HaveOccurred())
 		})
 
-		// createPublicIPWithState creates a PublicIP via the server, then sets its state via DAO.
-		createPublicIPWithState := func(state privatev1.PublicIPState) *privatev1.PublicIP {
-			poolID := createReadyPool(ctx, 100, 0)
-			resp, err := publicIPsServer.Create(ctx, privatev1.PublicIPsCreateRequest_builder{
-				Object: privatev1.PublicIP_builder{
-					Metadata: privatev1.Metadata_builder{
-						Tenants: []string{"shared"},
-					}.Build(),
-					Spec: privatev1.PublicIPSpec_builder{
-						Pool: poolID,
-					}.Build(),
-				}.Build(),
-			}.Build())
-			Expect(err).ToNot(HaveOccurred())
-			object := resp.GetObject()
-
-			// Set the state via DAO to bypass state machine validation in test setup:
-			object.SetStatus(privatev1.PublicIPStatus_builder{
-				State: state,
-			}.Build())
-			daoResp, err := publicIPDao.Update().SetObject(object).Do(ctx)
-			Expect(err).ToNot(HaveOccurred())
-			return daoResp.GetObject()
-		}
-
 		It("rejects Delete when state is ATTACHED", func() {
-			object := createPublicIPWithState(privatev1.PublicIPState_PUBLIC_IP_STATE_ATTACHED)
+			object := createPublicIPInState(publicIPsServer, privatev1.PublicIPState_PUBLIC_IP_STATE_ATTACHED)
 
 			_, err := publicIPsServer.Delete(ctx, privatev1.PublicIPsDeleteRequest_builder{
 				Id: object.GetId(),
@@ -762,7 +739,7 @@ var _ = Describe("Private public IPs server", func() {
 		})
 
 		It("rejects Delete when state is RELEASING", func() {
-			object := createPublicIPWithState(privatev1.PublicIPState_PUBLIC_IP_STATE_RELEASING)
+			object := createPublicIPInState(publicIPsServer, privatev1.PublicIPState_PUBLIC_IP_STATE_RELEASING)
 
 			_, err := publicIPsServer.Delete(ctx, privatev1.PublicIPsDeleteRequest_builder{
 				Id: object.GetId(),
@@ -775,7 +752,7 @@ var _ = Describe("Private public IPs server", func() {
 		})
 
 		It("allows Delete when state is ALLOCATED", func() {
-			object := createPublicIPWithState(privatev1.PublicIPState_PUBLIC_IP_STATE_ALLOCATED)
+			object := createPublicIPInState(publicIPsServer, privatev1.PublicIPState_PUBLIC_IP_STATE_ALLOCATED)
 
 			_, err := publicIPsServer.Delete(ctx, privatev1.PublicIPsDeleteRequest_builder{
 				Id: object.GetId(),
@@ -784,7 +761,7 @@ var _ = Describe("Private public IPs server", func() {
 		})
 
 		It("allows Delete when state is PENDING", func() {
-			object := createPublicIPWithState(privatev1.PublicIPState_PUBLIC_IP_STATE_PENDING)
+			object := createPublicIPInState(publicIPsServer, privatev1.PublicIPState_PUBLIC_IP_STATE_PENDING)
 
 			_, err := publicIPsServer.Delete(ctx, privatev1.PublicIPsDeleteRequest_builder{
 				Id: object.GetId(),

--- a/internal/servers/private_public_ips_server_test.go
+++ b/internal/servers/private_public_ips_server_test.go
@@ -15,7 +15,6 @@ package servers
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/jackc/pgx/v5/pgxpool"
 	. "github.com/onsi/ginkgo/v2"
@@ -31,7 +30,9 @@ import (
 
 var _ = Describe("Private public IPs server", func() {
 	var (
-		ctx context.Context
+		ctx              context.Context
+		publicIPPoolDao  *dao.GenericDAO[*privatev1.PublicIPPool]
+		publicIPDao      *dao.GenericDAO[*privatev1.PublicIP]
 	)
 
 	BeforeEach(func() {
@@ -66,7 +67,46 @@ var _ = Describe("Private public IPs server", func() {
 		// Create the tables:
 		err = dao.CreateTables[*privatev1.PublicIP](ctx)
 		Expect(err).ToNot(HaveOccurred())
+		err = dao.CreateTables[*privatev1.PublicIPPool](ctx)
+		Expect(err).ToNot(HaveOccurred())
+
+		// Create the PublicIPPool DAO for test data setup:
+		publicIPPoolDao, err = dao.NewGenericDAO[*privatev1.PublicIPPool]().
+			SetLogger(logger).
+			SetTenancyLogic(tenancy).
+			Build()
+		Expect(err).ToNot(HaveOccurred())
+
+		// Create the PublicIP DAO for setting initial state in state machine tests:
+		publicIPDao, err = dao.NewGenericDAO[*privatev1.PublicIP]().
+			SetLogger(logger).
+			SetTenancyLogic(tenancy).
+			Build()
+		Expect(err).ToNot(HaveOccurred())
 	})
+
+	// createReadyPool creates a PublicIPPool in READY state with the given capacity.
+	// Returns the pool ID for use in PublicIP creation.
+	createReadyPool := func(ctx context.Context, total int64, allocated int64) string {
+		resp, err := publicIPPoolDao.Create().SetObject(
+			privatev1.PublicIPPool_builder{
+				Metadata: privatev1.Metadata_builder{
+					Tenants: []string{"shared"},
+				}.Build(),
+				Spec: privatev1.PublicIPPoolSpec_builder{
+					Cidrs: []string{"10.0.0.0/24"},
+				}.Build(),
+				Status: privatev1.PublicIPPoolStatus_builder{
+					State:     privatev1.PublicIPPoolState_PUBLIC_IP_POOL_STATE_READY,
+					Total:     total,
+					Allocated: allocated,
+					Available: total - allocated,
+				}.Build(),
+			}.Build(),
+		).Do(ctx)
+		Expect(err).ToNot(HaveOccurred())
+		return resp.GetObject().GetId()
+	}
 
 	Describe("Creation", func() {
 		It("Can be built if all the required parameters are set", func() {
@@ -164,13 +204,14 @@ var _ = Describe("Private public IPs server", func() {
 			})
 
 			It("accepts valid pool on Create", func() {
+				poolID := createReadyPool(ctx, 10, 0)
 				response, err := publicIPsServer.Create(ctx, privatev1.PublicIPsCreateRequest_builder{
 					Object: privatev1.PublicIP_builder{
 						Metadata: privatev1.Metadata_builder{
 							Tenants: []string{"shared"},
 						}.Build(),
 						Spec: privatev1.PublicIPSpec_builder{
-							Pool: "test-pool",
+							Pool: poolID,
 						}.Build(),
 					}.Build(),
 				}.Build())
@@ -182,10 +223,16 @@ var _ = Describe("Private public IPs server", func() {
 	})
 
 	Describe("CRUD operations", func() {
-		var publicIPsServer *PrivatePublicIPsServer
+		var (
+			publicIPsServer *PrivatePublicIPsServer
+			poolID          string
+		)
 
 		BeforeEach(func() {
 			var err error
+
+			// Create a READY pool for all CRUD tests:
+			poolID = createReadyPool(ctx, 100, 0)
 
 			// Create the server:
 			publicIPsServer, err = NewPrivatePublicIPsServer().
@@ -203,7 +250,7 @@ var _ = Describe("Private public IPs server", func() {
 						Tenants: []string{"shared"},
 					}.Build(),
 					Spec: privatev1.PublicIPSpec_builder{
-						Pool: "my-pool",
+						Pool: poolID,
 					}.Build(),
 				}.Build(),
 			}.Build())
@@ -222,7 +269,7 @@ var _ = Describe("Private public IPs server", func() {
 						Tenants: []string{"shared"},
 					}.Build(),
 					Spec: privatev1.PublicIPSpec_builder{
-						Pool: "my-pool",
+						Pool: poolID,
 					}.Build(),
 				}.Build(),
 			}.Build())
@@ -239,14 +286,14 @@ var _ = Describe("Private public IPs server", func() {
 
 		It("lists PublicIPs", func() {
 			const count = 3
-			for i := range count {
+			for range count {
 				_, err := publicIPsServer.Create(ctx, privatev1.PublicIPsCreateRequest_builder{
 					Object: privatev1.PublicIP_builder{
 						Metadata: privatev1.Metadata_builder{
 							Tenants: []string{"shared"},
 						}.Build(),
 						Spec: privatev1.PublicIPSpec_builder{
-							Pool: fmt.Sprintf("pool-%d", i),
+							Pool: poolID,
 						}.Build(),
 					}.Build(),
 				}.Build())
@@ -266,7 +313,7 @@ var _ = Describe("Private public IPs server", func() {
 						Tenants: []string{"shared"},
 					}.Build(),
 					Spec: privatev1.PublicIPSpec_builder{
-						Pool: "my-pool",
+						Pool: poolID,
 					}.Build(),
 				}.Build(),
 			}.Build())
@@ -296,7 +343,7 @@ var _ = Describe("Private public IPs server", func() {
 						Tenants:    []string{"shared"},
 					}.Build(),
 					Spec: privatev1.PublicIPSpec_builder{
-						Pool: "my-pool",
+						Pool: poolID,
 					}.Build(),
 				}.Build(),
 			}.Build())
@@ -324,7 +371,7 @@ var _ = Describe("Private public IPs server", func() {
 						Tenants: []string{"shared"},
 					}.Build(),
 					Spec: privatev1.PublicIPSpec_builder{
-						Pool: "my-pool",
+						Pool: poolID,
 					}.Build(),
 				}.Build(),
 			}.Build())
@@ -334,6 +381,471 @@ var _ = Describe("Private public IPs server", func() {
 				Id: createResponse.GetObject().GetId(),
 			}.Build())
 			Expect(err).ToNot(HaveOccurred())
+		})
+	})
+
+	Describe("Pool validation on Create", func() {
+		var publicIPsServer *PrivatePublicIPsServer
+
+		BeforeEach(func() {
+			var err error
+			publicIPsServer, err = NewPrivatePublicIPsServer().
+				SetLogger(logger).
+				SetAttributionLogic(attribution).
+				SetTenancyLogic(tenancy).
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("rejects Create when pool does not exist", func() {
+			_, err := publicIPsServer.Create(ctx, privatev1.PublicIPsCreateRequest_builder{
+				Object: privatev1.PublicIP_builder{
+					Metadata: privatev1.Metadata_builder{
+						Tenants: []string{"shared"},
+					}.Build(),
+					Spec: privatev1.PublicIPSpec_builder{
+						Pool: "nonexistent-pool-id",
+					}.Build(),
+				}.Build(),
+			}.Build())
+			Expect(err).To(HaveOccurred())
+			status, ok := grpcstatus.FromError(err)
+			Expect(ok).To(BeTrue())
+			Expect(status.Code()).To(Equal(grpccodes.InvalidArgument))
+			Expect(err.Error()).To(ContainSubstring("does not exist"))
+		})
+
+		It("rejects Create when pool is not READY", func() {
+			// Create a pool in PENDING state:
+			resp, err := publicIPPoolDao.Create().SetObject(
+				privatev1.PublicIPPool_builder{
+					Metadata: privatev1.Metadata_builder{
+						Tenants: []string{"shared"},
+					}.Build(),
+					Spec: privatev1.PublicIPPoolSpec_builder{
+						Cidrs: []string{"10.0.0.0/24"},
+					}.Build(),
+					Status: privatev1.PublicIPPoolStatus_builder{
+						State:     privatev1.PublicIPPoolState_PUBLIC_IP_POOL_STATE_PENDING,
+						Total:     10,
+						Allocated: 0,
+						Available: 10,
+					}.Build(),
+				}.Build(),
+			).Do(ctx)
+			Expect(err).ToNot(HaveOccurred())
+			pendingPoolID := resp.GetObject().GetId()
+
+			_, err = publicIPsServer.Create(ctx, privatev1.PublicIPsCreateRequest_builder{
+				Object: privatev1.PublicIP_builder{
+					Metadata: privatev1.Metadata_builder{
+						Tenants: []string{"shared"},
+					}.Build(),
+					Spec: privatev1.PublicIPSpec_builder{
+						Pool: pendingPoolID,
+					}.Build(),
+				}.Build(),
+			}.Build())
+			Expect(err).To(HaveOccurred())
+			status, ok := grpcstatus.FromError(err)
+			Expect(ok).To(BeTrue())
+			Expect(status.Code()).To(Equal(grpccodes.FailedPrecondition))
+			Expect(err.Error()).To(ContainSubstring("not in READY state"))
+		})
+
+		It("rejects Create when pool has no available capacity", func() {
+			exhaustedPoolID := createReadyPool(ctx, 10, 10)
+
+			_, err := publicIPsServer.Create(ctx, privatev1.PublicIPsCreateRequest_builder{
+				Object: privatev1.PublicIP_builder{
+					Metadata: privatev1.Metadata_builder{
+						Tenants: []string{"shared"},
+					}.Build(),
+					Spec: privatev1.PublicIPSpec_builder{
+						Pool: exhaustedPoolID,
+					}.Build(),
+				}.Build(),
+			}.Build())
+			Expect(err).To(HaveOccurred())
+			status, ok := grpcstatus.FromError(err)
+			Expect(ok).To(BeTrue())
+			Expect(status.Code()).To(Equal(grpccodes.FailedPrecondition))
+			Expect(err.Error()).To(ContainSubstring("no available capacity"))
+		})
+
+		It("accepts Create when pool is READY with available capacity", func() {
+			readyPoolID := createReadyPool(ctx, 10, 0)
+
+			response, err := publicIPsServer.Create(ctx, privatev1.PublicIPsCreateRequest_builder{
+				Object: privatev1.PublicIP_builder{
+					Metadata: privatev1.Metadata_builder{
+						Tenants: []string{"shared"},
+					}.Build(),
+					Spec: privatev1.PublicIPSpec_builder{
+						Pool: readyPoolID,
+					}.Build(),
+				}.Build(),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+			Expect(response).ToNot(BeNil())
+			Expect(response.GetObject().GetId()).ToNot(BeEmpty())
+		})
+	})
+
+	Describe("Capacity tracking", func() {
+		var publicIPsServer *PrivatePublicIPsServer
+
+		BeforeEach(func() {
+			var err error
+			publicIPsServer, err = NewPrivatePublicIPsServer().
+				SetLogger(logger).
+				SetAttributionLogic(attribution).
+				SetTenancyLogic(tenancy).
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("decrements pool available and increments allocated on Create", func() {
+			poolID := createReadyPool(ctx, 10, 2)
+
+			_, err := publicIPsServer.Create(ctx, privatev1.PublicIPsCreateRequest_builder{
+				Object: privatev1.PublicIP_builder{
+					Metadata: privatev1.Metadata_builder{
+						Tenants: []string{"shared"},
+					}.Build(),
+					Spec: privatev1.PublicIPSpec_builder{
+						Pool: poolID,
+					}.Build(),
+				}.Build(),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+
+			// Read the pool and verify capacity was updated:
+			poolResp, err := publicIPPoolDao.Get().SetId(poolID).Do(ctx)
+			Expect(err).ToNot(HaveOccurred())
+			pool := poolResp.GetObject()
+			Expect(pool.GetStatus().GetAllocated()).To(Equal(int64(3)))
+			Expect(pool.GetStatus().GetAvailable()).To(Equal(int64(7)))
+		})
+
+		It("increments pool available and decrements allocated on Delete", func() {
+			poolID := createReadyPool(ctx, 10, 0)
+
+			// Create a PublicIP (no finalizers, so delete is immediate):
+			createResponse, err := publicIPsServer.Create(ctx, privatev1.PublicIPsCreateRequest_builder{
+				Object: privatev1.PublicIP_builder{
+					Metadata: privatev1.Metadata_builder{
+						Tenants: []string{"shared"},
+					}.Build(),
+					Spec: privatev1.PublicIPSpec_builder{
+						Pool: poolID,
+					}.Build(),
+				}.Build(),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+			publicIPID := createResponse.GetObject().GetId()
+
+			// Verify pool after Create: allocated=1, available=9
+			poolResp, err := publicIPPoolDao.Get().SetId(poolID).Do(ctx)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(poolResp.GetObject().GetStatus().GetAllocated()).To(Equal(int64(1)))
+			Expect(poolResp.GetObject().GetStatus().GetAvailable()).To(Equal(int64(9)))
+
+			// Delete the PublicIP:
+			_, err = publicIPsServer.Delete(ctx, privatev1.PublicIPsDeleteRequest_builder{
+				Id: publicIPID,
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+
+			// Verify pool capacity was restored:
+			poolResp, err = publicIPPoolDao.Get().SetId(poolID).Do(ctx)
+			Expect(err).ToNot(HaveOccurred())
+			pool := poolResp.GetObject()
+			Expect(pool.GetStatus().GetAllocated()).To(Equal(int64(0)))
+			Expect(pool.GetStatus().GetAvailable()).To(Equal(int64(10)))
+		})
+	})
+
+	Describe("State machine enforcement", func() {
+		var publicIPsServer *PrivatePublicIPsServer
+
+		BeforeEach(func() {
+			var err error
+			publicIPsServer, err = NewPrivatePublicIPsServer().
+				SetLogger(logger).
+				SetAttributionLogic(attribution).
+				SetTenancyLogic(tenancy).
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		// createPublicIPInState creates a PublicIP via the server (triggers pool validation and capacity
+		// tracking), then sets its initial state via the DAO (bypasses state machine validation since
+		// the controller, not the server, sets the initial PENDING state in production).
+		createPublicIPInState := func(initialState privatev1.PublicIPState) *privatev1.PublicIP {
+			poolID := createReadyPool(ctx, 100, 0)
+			resp, err := publicIPsServer.Create(ctx, privatev1.PublicIPsCreateRequest_builder{
+				Object: privatev1.PublicIP_builder{
+					Metadata: privatev1.Metadata_builder{
+						Tenants: []string{"shared"},
+					}.Build(),
+					Spec: privatev1.PublicIPSpec_builder{
+						Pool: poolID,
+					}.Build(),
+				}.Build(),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+			object := resp.GetObject()
+
+			// Set the initial state via DAO (production path: controller sets PENDING via Signal):
+			object.SetStatus(privatev1.PublicIPStatus_builder{
+				State: initialState,
+			}.Build())
+			daoResp, err := publicIPDao.Update().SetObject(object).Do(ctx)
+			Expect(err).ToNot(HaveOccurred())
+			return daoResp.GetObject()
+		}
+
+		// setStateOnObject sets the state on a PublicIP, handling the case where Status is nil.
+		setStateOnObject := func(object *privatev1.PublicIP, state privatev1.PublicIPState) {
+			if object.GetStatus() == nil {
+				object.SetStatus(privatev1.PublicIPStatus_builder{
+					State: state,
+				}.Build())
+			} else {
+				object.GetStatus().SetState(state)
+			}
+		}
+
+		// transitionTo updates the PublicIP to the given state via the server's Update method.
+		transitionTo := func(object *privatev1.PublicIP, state privatev1.PublicIPState) *privatev1.PublicIP {
+			setStateOnObject(object, state)
+			resp, err := publicIPsServer.Update(ctx, privatev1.PublicIPsUpdateRequest_builder{
+				Object: object,
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+			return resp.GetObject()
+		}
+
+		It("accepts PENDING to ALLOCATED transition", func() {
+			object := createPublicIPInState(privatev1.PublicIPState_PUBLIC_IP_STATE_PENDING)
+			updated := transitionTo(object, privatev1.PublicIPState_PUBLIC_IP_STATE_ALLOCATED)
+			Expect(updated.GetStatus().GetState()).To(Equal(privatev1.PublicIPState_PUBLIC_IP_STATE_ALLOCATED))
+		})
+
+		It("accepts ALLOCATED to ATTACHED transition", func() {
+			object := createPublicIPInState(privatev1.PublicIPState_PUBLIC_IP_STATE_PENDING)
+			object = transitionTo(object, privatev1.PublicIPState_PUBLIC_IP_STATE_ALLOCATED)
+			updated := transitionTo(object, privatev1.PublicIPState_PUBLIC_IP_STATE_ATTACHED)
+			Expect(updated.GetStatus().GetState()).To(Equal(privatev1.PublicIPState_PUBLIC_IP_STATE_ATTACHED))
+		})
+
+		It("accepts ATTACHED to RELEASING transition", func() {
+			object := createPublicIPInState(privatev1.PublicIPState_PUBLIC_IP_STATE_PENDING)
+			object = transitionTo(object, privatev1.PublicIPState_PUBLIC_IP_STATE_ALLOCATED)
+			object = transitionTo(object, privatev1.PublicIPState_PUBLIC_IP_STATE_ATTACHED)
+			updated := transitionTo(object, privatev1.PublicIPState_PUBLIC_IP_STATE_RELEASING)
+			Expect(updated.GetStatus().GetState()).To(Equal(privatev1.PublicIPState_PUBLIC_IP_STATE_RELEASING))
+		})
+
+		It("accepts RELEASING to ALLOCATED transition", func() {
+			object := createPublicIPInState(privatev1.PublicIPState_PUBLIC_IP_STATE_PENDING)
+			object = transitionTo(object, privatev1.PublicIPState_PUBLIC_IP_STATE_ALLOCATED)
+			object = transitionTo(object, privatev1.PublicIPState_PUBLIC_IP_STATE_ATTACHED)
+			object = transitionTo(object, privatev1.PublicIPState_PUBLIC_IP_STATE_RELEASING)
+			updated := transitionTo(object, privatev1.PublicIPState_PUBLIC_IP_STATE_ALLOCATED)
+			Expect(updated.GetStatus().GetState()).To(Equal(privatev1.PublicIPState_PUBLIC_IP_STATE_ALLOCATED))
+		})
+
+		It("rejects PENDING to ATTACHED transition", func() {
+			object := createPublicIPInState(privatev1.PublicIPState_PUBLIC_IP_STATE_PENDING)
+			setStateOnObject(object, privatev1.PublicIPState_PUBLIC_IP_STATE_ATTACHED)
+			_, err := publicIPsServer.Update(ctx, privatev1.PublicIPsUpdateRequest_builder{
+				Object: object,
+			}.Build())
+			Expect(err).To(HaveOccurred())
+			status, ok := grpcstatus.FromError(err)
+			Expect(ok).To(BeTrue())
+			Expect(status.Code()).To(Equal(grpccodes.FailedPrecondition))
+			Expect(err.Error()).To(ContainSubstring("invalid state transition"))
+		})
+
+		It("rejects ALLOCATED to RELEASING transition", func() {
+			object := createPublicIPInState(privatev1.PublicIPState_PUBLIC_IP_STATE_ALLOCATED)
+			setStateOnObject(object, privatev1.PublicIPState_PUBLIC_IP_STATE_RELEASING)
+			_, err := publicIPsServer.Update(ctx, privatev1.PublicIPsUpdateRequest_builder{
+				Object: object,
+			}.Build())
+			Expect(err).To(HaveOccurred())
+			status, ok := grpcstatus.FromError(err)
+			Expect(ok).To(BeTrue())
+			Expect(status.Code()).To(Equal(grpccodes.FailedPrecondition))
+			Expect(err.Error()).To(ContainSubstring("invalid state transition"))
+		})
+
+		It("rejects ATTACHED to ALLOCATED transition", func() {
+			object := createPublicIPInState(privatev1.PublicIPState_PUBLIC_IP_STATE_ATTACHED)
+			setStateOnObject(object, privatev1.PublicIPState_PUBLIC_IP_STATE_ALLOCATED)
+			_, err := publicIPsServer.Update(ctx, privatev1.PublicIPsUpdateRequest_builder{
+				Object: object,
+			}.Build())
+			Expect(err).To(HaveOccurred())
+			status, ok := grpcstatus.FromError(err)
+			Expect(ok).To(BeTrue())
+			Expect(status.Code()).To(Equal(grpccodes.FailedPrecondition))
+			Expect(err.Error()).To(ContainSubstring("invalid state transition"))
+		})
+	})
+
+	Describe("Delete constraint", func() {
+		var publicIPsServer *PrivatePublicIPsServer
+
+		BeforeEach(func() {
+			var err error
+			publicIPsServer, err = NewPrivatePublicIPsServer().
+				SetLogger(logger).
+				SetAttributionLogic(attribution).
+				SetTenancyLogic(tenancy).
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		// createPublicIPWithState creates a PublicIP via the server, then sets its state via DAO.
+		createPublicIPWithState := func(state privatev1.PublicIPState) *privatev1.PublicIP {
+			poolID := createReadyPool(ctx, 100, 0)
+			resp, err := publicIPsServer.Create(ctx, privatev1.PublicIPsCreateRequest_builder{
+				Object: privatev1.PublicIP_builder{
+					Metadata: privatev1.Metadata_builder{
+						Tenants: []string{"shared"},
+					}.Build(),
+					Spec: privatev1.PublicIPSpec_builder{
+						Pool: poolID,
+					}.Build(),
+				}.Build(),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+			object := resp.GetObject()
+
+			// Set the state via DAO to bypass state machine validation in test setup:
+			object.SetStatus(privatev1.PublicIPStatus_builder{
+				State: state,
+			}.Build())
+			daoResp, err := publicIPDao.Update().SetObject(object).Do(ctx)
+			Expect(err).ToNot(HaveOccurred())
+			return daoResp.GetObject()
+		}
+
+		It("rejects Delete when state is ATTACHED", func() {
+			object := createPublicIPWithState(privatev1.PublicIPState_PUBLIC_IP_STATE_ATTACHED)
+
+			_, err := publicIPsServer.Delete(ctx, privatev1.PublicIPsDeleteRequest_builder{
+				Id: object.GetId(),
+			}.Build())
+			Expect(err).To(HaveOccurred())
+			status, ok := grpcstatus.FromError(err)
+			Expect(ok).To(BeTrue())
+			Expect(status.Code()).To(Equal(grpccodes.FailedPrecondition))
+			Expect(err.Error()).To(ContainSubstring("detach from ComputeInstance first"))
+		})
+
+		It("allows Delete when state is ALLOCATED", func() {
+			object := createPublicIPWithState(privatev1.PublicIPState_PUBLIC_IP_STATE_ALLOCATED)
+
+			_, err := publicIPsServer.Delete(ctx, privatev1.PublicIPsDeleteRequest_builder{
+				Id: object.GetId(),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("allows Delete when state is PENDING", func() {
+			// Default state after Create is PENDING/UNSPECIFIED:
+			poolID := createReadyPool(ctx, 100, 0)
+			createResp, err := publicIPsServer.Create(ctx, privatev1.PublicIPsCreateRequest_builder{
+				Object: privatev1.PublicIP_builder{
+					Metadata: privatev1.Metadata_builder{
+						Tenants: []string{"shared"},
+					}.Build(),
+					Spec: privatev1.PublicIPSpec_builder{
+						Pool: poolID,
+					}.Build(),
+				}.Build(),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+
+			_, err = publicIPsServer.Delete(ctx, privatev1.PublicIPsDeleteRequest_builder{
+				Id: createResp.GetObject().GetId(),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+		})
+	})
+
+	Describe("Pool immutability on Update", func() {
+		var publicIPsServer *PrivatePublicIPsServer
+
+		BeforeEach(func() {
+			var err error
+			publicIPsServer, err = NewPrivatePublicIPsServer().
+				SetLogger(logger).
+				SetAttributionLogic(attribution).
+				SetTenancyLogic(tenancy).
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("rejects Update that changes pool", func() {
+			poolA := createReadyPool(ctx, 100, 0)
+			poolB := createReadyPool(ctx, 100, 0)
+
+			// Create PublicIP with pool A:
+			createResp, err := publicIPsServer.Create(ctx, privatev1.PublicIPsCreateRequest_builder{
+				Object: privatev1.PublicIP_builder{
+					Metadata: privatev1.Metadata_builder{
+						Tenants: []string{"shared"},
+					}.Build(),
+					Spec: privatev1.PublicIPSpec_builder{
+						Pool: poolA,
+					}.Build(),
+				}.Build(),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+			object := createResp.GetObject()
+
+			// Try to change pool to B:
+			object.GetSpec().SetPool(poolB)
+			_, err = publicIPsServer.Update(ctx, privatev1.PublicIPsUpdateRequest_builder{
+				Object: object,
+			}.Build())
+			Expect(err).To(HaveOccurred())
+			status, ok := grpcstatus.FromError(err)
+			Expect(ok).To(BeTrue())
+			Expect(status.Code()).To(Equal(grpccodes.InvalidArgument))
+			Expect(err.Error()).To(ContainSubstring("spec.pool' is immutable"))
+		})
+
+		It("allows Update that keeps same pool", func() {
+			poolID := createReadyPool(ctx, 100, 0)
+
+			// Create PublicIP:
+			createResp, err := publicIPsServer.Create(ctx, privatev1.PublicIPsCreateRequest_builder{
+				Object: privatev1.PublicIP_builder{
+					Metadata: privatev1.Metadata_builder{
+						Tenants: []string{"shared"},
+					}.Build(),
+					Spec: privatev1.PublicIPSpec_builder{
+						Pool: poolID,
+					}.Build(),
+				}.Build(),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+			object := createResp.GetObject()
+
+			// Update with same pool (change name instead):
+			object.GetMetadata().Name = "updated-name"
+			updateResp, err := publicIPsServer.Update(ctx, privatev1.PublicIPsUpdateRequest_builder{
+				Object: object,
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+			Expect(updateResp.GetObject().GetMetadata().GetName()).To(Equal("updated-name"))
 		})
 	})
 })

--- a/internal/servers/private_public_ips_server_test.go
+++ b/internal/servers/private_public_ips_server_test.go
@@ -22,6 +22,7 @@ import (
 	grpccodes "google.golang.org/grpc/codes"
 	grpcstatus "google.golang.org/grpc/status"
 	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/fieldmaskpb"
 
 	privatev1 "github.com/osac-project/fulfillment-service/internal/api/osac/private/v1"
 	"github.com/osac-project/fulfillment-service/internal/database"
@@ -698,14 +699,29 @@ var _ = Describe("Private public IPs server", func() {
 			Expect(err.Error()).To(ContainSubstring("invalid state transition"))
 		})
 
-		It("skips state validation when new state is UNSPECIFIED", func() {
+		It("rejects UNSPECIFIED state on full replacement (nil mask)", func() {
 			object := createPublicIPInState(publicIPsServer, privatev1.PublicIPState_PUBLIC_IP_STATE_ALLOCATED)
 
-			// Update without setting state (UNSPECIFIED is the zero value):
-			object.GetMetadata().Name = "updated-name"
 			object.GetStatus().SetState(privatev1.PublicIPState_PUBLIC_IP_STATE_UNSPECIFIED)
+			_, err := publicIPsServer.Update(ctx, privatev1.PublicIPsUpdateRequest_builder{
+				Object: object,
+			}.Build())
+			Expect(err).To(HaveOccurred())
+			status, ok := grpcstatus.FromError(err)
+			Expect(ok).To(BeTrue())
+			Expect(status.Code()).To(Equal(grpccodes.FailedPrecondition))
+			Expect(err.Error()).To(ContainSubstring("invalid state transition"))
+		})
+
+		It("skips state validation when UpdateMask excludes status.state", func() {
+			object := createPublicIPInState(publicIPsServer, privatev1.PublicIPState_PUBLIC_IP_STATE_ALLOCATED)
+
+			object.GetMetadata().Name = "updated-name"
 			resp, err := publicIPsServer.Update(ctx, privatev1.PublicIPsUpdateRequest_builder{
 				Object: object,
+				UpdateMask: &fieldmaskpb.FieldMask{
+					Paths: []string{"metadata.name"},
+				},
 			}.Build())
 			Expect(err).ToNot(HaveOccurred())
 			Expect(resp.GetObject().GetMetadata().GetName()).To(Equal("updated-name"))

--- a/internal/servers/private_public_ips_server_test.go
+++ b/internal/servers/private_public_ips_server_test.go
@@ -771,22 +771,10 @@ var _ = Describe("Private public IPs server", func() {
 		})
 
 		It("allows Delete when state is PENDING", func() {
-			// Default state after Create is PENDING/UNSPECIFIED:
-			poolID := createReadyPool(ctx, 100, 0)
-			createResp, err := publicIPsServer.Create(ctx, privatev1.PublicIPsCreateRequest_builder{
-				Object: privatev1.PublicIP_builder{
-					Metadata: privatev1.Metadata_builder{
-						Tenants: []string{"shared"},
-					}.Build(),
-					Spec: privatev1.PublicIPSpec_builder{
-						Pool: poolID,
-					}.Build(),
-				}.Build(),
-			}.Build())
-			Expect(err).ToNot(HaveOccurred())
+			object := createPublicIPWithState(privatev1.PublicIPState_PUBLIC_IP_STATE_PENDING)
 
-			_, err = publicIPsServer.Delete(ctx, privatev1.PublicIPsDeleteRequest_builder{
-				Id: createResp.GetObject().GetId(),
+			_, err := publicIPsServer.Delete(ctx, privatev1.PublicIPsDeleteRequest_builder{
+				Id: object.GetId(),
 			}.Build())
 			Expect(err).ToNot(HaveOccurred())
 		})

--- a/internal/servers/private_public_ips_server_test.go
+++ b/internal/servers/private_public_ips_server_test.go
@@ -761,6 +761,19 @@ var _ = Describe("Private public IPs server", func() {
 			Expect(err.Error()).To(ContainSubstring("detach from ComputeInstance first"))
 		})
 
+		It("rejects Delete when state is RELEASING", func() {
+			object := createPublicIPWithState(privatev1.PublicIPState_PUBLIC_IP_STATE_RELEASING)
+
+			_, err := publicIPsServer.Delete(ctx, privatev1.PublicIPsDeleteRequest_builder{
+				Id: object.GetId(),
+			}.Build())
+			Expect(err).To(HaveOccurred())
+			status, ok := grpcstatus.FromError(err)
+			Expect(ok).To(BeTrue())
+			Expect(status.Code()).To(Equal(grpccodes.FailedPrecondition))
+			Expect(err.Error()).To(ContainSubstring("detach from ComputeInstance first"))
+		})
+
 		It("allows Delete when state is ALLOCATED", func() {
 			object := createPublicIPWithState(privatev1.PublicIPState_PUBLIC_IP_STATE_ALLOCATED)
 

--- a/internal/servers/private_public_ips_server_test.go
+++ b/internal/servers/private_public_ips_server_test.go
@@ -695,6 +695,19 @@ var _ = Describe("Private public IPs server", func() {
 			Expect(status.Code()).To(Equal(grpccodes.FailedPrecondition))
 			Expect(err.Error()).To(ContainSubstring("invalid state transition"))
 		})
+
+		It("skips state validation when new state is UNSPECIFIED", func() {
+			object := createPublicIPInState(privatev1.PublicIPState_PUBLIC_IP_STATE_ALLOCATED)
+
+			// Update without setting state (UNSPECIFIED is the zero value):
+			object.GetMetadata().Name = "updated-name"
+			object.GetStatus().SetState(privatev1.PublicIPState_PUBLIC_IP_STATE_UNSPECIFIED)
+			resp, err := publicIPsServer.Update(ctx, privatev1.PublicIPsUpdateRequest_builder{
+				Object: object,
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+			Expect(resp.GetObject().GetMetadata().GetName()).To(Equal("updated-name"))
+		})
 	})
 
 	Describe("Delete constraint", func() {

--- a/internal/servers/public_ips_server_test.go
+++ b/internal/servers/public_ips_server_test.go
@@ -30,8 +30,9 @@ import (
 
 var _ = Describe("Public IPs server", func() {
 	var (
-		ctx context.Context
-		tx  database.Tx
+		ctx             context.Context
+		tx              database.Tx
+		publicIPPoolDao *dao.GenericDAO[*privatev1.PublicIPPool]
 	)
 
 	BeforeEach(func() {
@@ -66,7 +67,38 @@ var _ = Describe("Public IPs server", func() {
 		// Create the tables:
 		err = dao.CreateTables[*privatev1.PublicIP](ctx)
 		Expect(err).ToNot(HaveOccurred())
+		err = dao.CreateTables[*privatev1.PublicIPPool](ctx)
+		Expect(err).ToNot(HaveOccurred())
+
+		// Create the PublicIPPool DAO:
+		publicIPPoolDao, err = dao.NewGenericDAO[*privatev1.PublicIPPool]().
+			SetLogger(logger).
+			SetTenancyLogic(tenancy).
+			Build()
+		Expect(err).ToNot(HaveOccurred())
 	})
+
+	// createReadyPool creates a READY pool with available capacity.
+	createReadyPool := func(ctx context.Context) string {
+		resp, err := publicIPPoolDao.Create().SetObject(
+			privatev1.PublicIPPool_builder{
+				Metadata: privatev1.Metadata_builder{
+					Tenants: []string{"shared"},
+				}.Build(),
+				Spec: privatev1.PublicIPPoolSpec_builder{
+					Cidrs: []string{"10.0.0.0/24"},
+				}.Build(),
+				Status: privatev1.PublicIPPoolStatus_builder{
+					State:     privatev1.PublicIPPoolState_PUBLIC_IP_POOL_STATE_READY,
+					Total:     254,
+					Allocated: 0,
+					Available: 254,
+				}.Build(),
+			}.Build(),
+		).Do(ctx)
+		Expect(err).ToNot(HaveOccurred())
+		return resp.GetObject().GetId()
+	}
 
 	Describe("Creation", func() {
 		It("Can be built if all the required parameters are set", func() {
@@ -108,10 +140,16 @@ var _ = Describe("Public IPs server", func() {
 	})
 
 	Describe("Behaviour", func() {
-		var publicIPsServer *PublicIPsServer
+		var (
+			publicIPsServer *PublicIPsServer
+			poolID          string
+		)
 
 		BeforeEach(func() {
 			var err error
+
+			// Create a READY pool for all behaviour tests:
+			poolID = createReadyPool(ctx)
 
 			// Create the server:
 			publicIPsServer, err = NewPublicIPsServer().
@@ -126,7 +164,7 @@ var _ = Describe("Public IPs server", func() {
 			response, err := publicIPsServer.Create(ctx, publicv1.PublicIPsCreateRequest_builder{
 				Object: publicv1.PublicIP_builder{
 					Spec: publicv1.PublicIPSpec_builder{
-						Pool: "my-pool",
+						Pool: poolID,
 					}.Build(),
 				}.Build(),
 			}.Build())
@@ -140,11 +178,11 @@ var _ = Describe("Public IPs server", func() {
 		It("List objects", func() {
 			// Create a few objects:
 			const count = 10
-			for i := range count {
+			for range count {
 				_, err := publicIPsServer.Create(ctx, publicv1.PublicIPsCreateRequest_builder{
 					Object: publicv1.PublicIP_builder{
 						Spec: publicv1.PublicIPSpec_builder{
-							Pool: fmt.Sprintf("pool-%d", i),
+							Pool: poolID,
 						}.Build(),
 					}.Build(),
 				}.Build())
@@ -162,11 +200,11 @@ var _ = Describe("Public IPs server", func() {
 		It("List objects with limit", func() {
 			// Create a few objects:
 			const count = 10
-			for i := range count {
+			for range count {
 				_, err := publicIPsServer.Create(ctx, publicv1.PublicIPsCreateRequest_builder{
 					Object: publicv1.PublicIP_builder{
 						Spec: publicv1.PublicIPSpec_builder{
-							Pool: fmt.Sprintf("pool-%d", i),
+							Pool: poolID,
 						}.Build(),
 					}.Build(),
 				}.Build())
@@ -184,11 +222,11 @@ var _ = Describe("Public IPs server", func() {
 		It("List objects with offset", func() {
 			// Create a few objects:
 			const count = 10
-			for i := range count {
+			for range count {
 				_, err := publicIPsServer.Create(ctx, publicv1.PublicIPsCreateRequest_builder{
 					Object: publicv1.PublicIP_builder{
 						Spec: publicv1.PublicIPSpec_builder{
-							Pool: fmt.Sprintf("pool-%d", i),
+							Pool: poolID,
 						}.Build(),
 					}.Build(),
 				}.Build())
@@ -207,11 +245,11 @@ var _ = Describe("Public IPs server", func() {
 			// Create a few objects:
 			const count = 10
 			var objects []*publicv1.PublicIP
-			for i := range count {
+			for range count {
 				response, err := publicIPsServer.Create(ctx, publicv1.PublicIPsCreateRequest_builder{
 					Object: publicv1.PublicIP_builder{
 						Spec: publicv1.PublicIPSpec_builder{
-							Pool: fmt.Sprintf("pool-%d", i),
+							Pool: poolID,
 						}.Build(),
 					}.Build(),
 				}.Build())
@@ -235,7 +273,7 @@ var _ = Describe("Public IPs server", func() {
 			createResponse, err := publicIPsServer.Create(ctx, publicv1.PublicIPsCreateRequest_builder{
 				Object: publicv1.PublicIP_builder{
 					Spec: publicv1.PublicIPSpec_builder{
-						Pool: "my-pool",
+						Pool: poolID,
 					}.Build(),
 				}.Build(),
 			}.Build())
@@ -254,7 +292,7 @@ var _ = Describe("Public IPs server", func() {
 			createResponse, err := publicIPsServer.Create(ctx, publicv1.PublicIPsCreateRequest_builder{
 				Object: publicv1.PublicIP_builder{
 					Spec: publicv1.PublicIPSpec_builder{
-						Pool: "my-pool",
+						Pool: poolID,
 					}.Build(),
 				}.Build(),
 			}.Build())


### PR DESCRIPTION
## Summary

Add business logic validation to the PublicIP server for [MGMT-23734](https://redhat.atlassian.net/browse/MGMT-23734)/[MGMT-23900](https://redhat.atlassian.net/browse/MGMT-23900):

- **Pool validation on Create**: reject nonexistent pool, non-READY pool, exhausted pool (available == 0)
- **State machine enforcement on Update**: only valid transitions accepted (PENDING->ALLOCATED, ALLOCATED->ATTACHED, ATTACHED->RELEASING, RELEASING->ALLOCATED)
- **Atomic capacity tracking**: Create decrements pool.status.available and increments pool.status.allocated in the same DB transaction; Delete reverses
- **Delete constraint**: reject deletion when state is ATTACHED ("detach from ComputeInstance first")
- **Pool immutability on Update**: reject changes to spec.pool after creation

All validation and capacity updates run within the request's existing database transaction.

## Testing

### Unit Tests

```bash
# Build
go build ./...

# Run all server tests (577 specs)
go run github.com/onsi/ginkgo/v2/ginkgo run internal/servers
# Ran 577 of 577 Specs in 31s
# SUCCESS\! -- 577 Passed | 0 Failed | 0 Pending | 0 Skipped

# Full internal test suite (no regressions)
go run github.com/onsi/ginkgo/v2/ginkgo run -r internal
# SUCCESS\! -- 577 Passed | 0 Failed | 0 Pending | 0 Skipped
```

33 new test cases covering:
- Pool validation: nonexistent pool, non-READY pool, exhausted pool, valid pool (4 tests)
- Capacity tracking: decrement on Create, increment on Delete (2 tests)
- State machine: 4 valid transitions + 3 invalid transitions + UNSPECIFIED no-op (8 tests)
- Delete constraint: reject ATTACHED, allow ALLOCATED, allow PENDING (3 tests)
- Pool immutability: reject change, allow same value (2 tests)
- Existing tests updated to create pools before PublicIP creation (14 tests fixed)

### E2E Tests (edge-22, osac-devel namespace)

Tested against the cluster with all components running the PR branch image
(`mgmt-23734-e2e`). API calls via `curl` to the REST gateway.

| # | Test | Requirement | Result |
|---|------|-------------|--------|
| 1 | Create PublicIP from nonexistent pool | VAL-01 | PASS: `pool 'nonexistent-pool-id-12345' does not exist` (code 3) |
| 2 | Create PublicIP from READY pool + verify capacity | VAL-01, VAL-03 | PASS: PublicIP created, pool allocated 1->2, available 5->4 |
| 3 | Invalid state transition (PENDING -> ATTACHED) | VAL-02 | PASS: `invalid state transition from PUBLIC_IP_STATE_PENDING to PUBLIC_IP_STATE_ATTACHED` (code 9) |
| 4 | Valid state transition (PENDING -> ALLOCATED) | VAL-02 | PASS: state changed to ALLOCATED |
| 5 | Delete PublicIP in ATTACHED state | VAL-04 | PASS: `cannot delete PublicIP: detach from ComputeInstance first` (code 9) |
| 6 | Pool immutability on Update | D-09 | PASS: `field 'spec.pool' is immutable and cannot be changed from '019dc144...' to 'some-other-pool-id'` (code 3) |
| 7 | Delete in non-ATTACHED state + capacity restore | VAL-03, VAL-04 | PASS: deleted, pool allocated 2->1, available 4->5 |

**7/7 E2E tests passed.**

E2E environment: fulfillment-service `mgmt-23734-e2e`, osac-operator `mgmt-23734-e2e`,
OCP 4.20.0, Keycloak OAuth for controller auth, Authorino+OPA for API authorization.

## Related PRs

- [PR #456](https://github.com/osac-project/fulfillment-service/pull/456): Pool-side referential integrity (blocks pool deletion when allocated PublicIPs exist, Siddarth). Complementary, no merge dependency.

## Ticket

- [MGMT-23734](https://redhat.atlassian.net/browse/MGMT-23734): PublicIP Backend (parent story)
- [MGMT-23900](https://redhat.atlassian.net/browse/MGMT-23900): Add pool validation, state machine, capacity tracking, and unit tests (subtask)

<br>

<small>Assisted-by: Cursor/Claude</small>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enforces pool existence, READY state, and available capacity on PublicIP create; updates pool capacity counters atomically
  * Validates allowed PublicIP state transitions and enforces immutability of a PublicIP's pool

* **Bug Fixes**
  * Blocks deletion of PublicIPs in ATTACHED or RELEASING states
  * Maps concurrent capacity update conflicts to an abort error

* **Tests**
  * Expanded tests using real pool fixtures covering capacity, transitions, immutability, and error cases
<!-- end of auto-generated comment: release notes by coderabbit.ai -->