### PR TITLE
MGMT-24156: Convert servers and integration tests to typed CRD objects

### DIFF
--- a/internal/cmd/service/start/controller/start_controller_cmd.go
+++ b/internal/cmd/service/start/controller/start_controller_cmd.go
@@ -34,12 +34,8 @@ import (
 	"google.golang.org/grpc/health"
 	healthv1 "google.golang.org/grpc/health/grpc_health_v1"
 	"google.golang.org/grpc/reflection"
-	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/klog/v2"
 	crlog "sigs.k8s.io/controller-runtime/pkg/log"
-
-	osacv1alpha1 "github.com/osac-project/osac-operator/api/v1alpha1"
 
 	privatev1 "github.com/osac-project/fulfillment-service/internal/api/osac/private/v1"
 	"github.com/osac-project/fulfillment-service/internal/auth"
@@ -55,6 +51,7 @@ import (
 	internalhealth "github.com/osac-project/fulfillment-service/internal/health"
 	"github.com/osac-project/fulfillment-service/internal/idp"
 	"github.com/osac-project/fulfillment-service/internal/idp/keycloak"
+	hubscheme "github.com/osac-project/fulfillment-service/internal/kubernetes/scheme"
 	"github.com/osac-project/fulfillment-service/internal/logging"
 	"github.com/osac-project/fulfillment-service/internal/network"
 	"github.com/osac-project/fulfillment-service/internal/oauth"
@@ -308,12 +305,9 @@ func (r *runnerContext) run(cmd *cobra.Command, argv []string) error {
 	}
 
 	// Create scheme for typed OSAC CRD access on hub clusters:
-	hubScheme := runtime.NewScheme()
-	if err = osacv1alpha1.AddToScheme(hubScheme); err != nil {
-		return fmt.Errorf("failed to register OSAC API types in hub scheme: %w", err)
-	}
-	if err = corev1.AddToScheme(hubScheme); err != nil {
-		return fmt.Errorf("failed to register core API types in hub scheme: %w", err)
+	hubScheme, err := hubscheme.NewHub()
+	if err != nil {
+		return fmt.Errorf("failed to create hub scheme: %w", err)
 	}
 
 	// Create the hub cache:

--- a/internal/cmd/service/start/grpcserver/start_grpc_server_cmd.go
+++ b/internal/cmd/service/start/grpcserver/start_grpc_server_cmd.go
@@ -31,8 +31,12 @@ import (
 	"google.golang.org/grpc/health"
 	healthv1 "google.golang.org/grpc/health/grpc_health_v1"
 	"google.golang.org/grpc/reflection"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/klog/v2"
 	crlog "sigs.k8s.io/controller-runtime/pkg/log"
+
+	osacv1alpha1 "github.com/osac-project/osac-operator/api/v1alpha1"
 
 	privatev1 "github.com/osac-project/fulfillment-service/internal/api/osac/private/v1"
 	publicv1 "github.com/osac-project/fulfillment-service/internal/api/osac/public/v1"
@@ -428,6 +432,15 @@ func (c *runnerContext) run(cmd *cobra.Command, argv []string) error {
 	}
 	privatev1.RegisterClusterTemplatesServer(grpcServer, privateClusterTemplatesServer)
 
+	// Create the runtime scheme for typed OSAC API objects:
+	hubScheme := runtime.NewScheme()
+	if err = osacv1alpha1.AddToScheme(hubScheme); err != nil {
+		return fmt.Errorf("failed to add OSAC scheme: %w", err)
+	}
+	if err = corev1.AddToScheme(hubScheme); err != nil {
+		return fmt.Errorf("failed to add core scheme: %w", err)
+	}
+
 	// Create the clusters server:
 	c.logger.InfoContext(ctx, "Creating clusters server")
 	clustersServer, err := servers.NewClustersServer().
@@ -436,6 +449,7 @@ func (c *runnerContext) run(cmd *cobra.Command, argv []string) error {
 		SetAttributionLogic(publicAttributionLogic).
 		SetTenancyLogic(tenancyLogic).
 		SetMetricsRegisterer(metricsRegisterer).
+		SetScheme(hubScheme).
 		Build()
 	if err != nil {
 		return fmt.Errorf("failed to create clusters server: %w", err)
@@ -817,6 +831,7 @@ func (c *runnerContext) run(cmd *cobra.Command, argv []string) error {
 		SetComputeInstancesServer(privateComputeInstancesServer).
 		SetHubServer(privateHubsServer).
 		SetTxManager(txManager).
+		SetScheme(hubScheme).
 		Build()
 	if err != nil {
 		return fmt.Errorf("failed to create console server: %w", err)

--- a/internal/cmd/service/start/grpcserver/start_grpc_server_cmd.go
+++ b/internal/cmd/service/start/grpcserver/start_grpc_server_cmd.go
@@ -31,18 +31,15 @@ import (
 	"google.golang.org/grpc/health"
 	healthv1 "google.golang.org/grpc/health/grpc_health_v1"
 	"google.golang.org/grpc/reflection"
-	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/klog/v2"
 	crlog "sigs.k8s.io/controller-runtime/pkg/log"
-
-	osacv1alpha1 "github.com/osac-project/osac-operator/api/v1alpha1"
 
 	privatev1 "github.com/osac-project/fulfillment-service/internal/api/osac/private/v1"
 	publicv1 "github.com/osac-project/fulfillment-service/internal/api/osac/public/v1"
 	"github.com/osac-project/fulfillment-service/internal/auth"
 	"github.com/osac-project/fulfillment-service/internal/console"
 	"github.com/osac-project/fulfillment-service/internal/database"
+	hubscheme "github.com/osac-project/fulfillment-service/internal/kubernetes/scheme"
 	"github.com/osac-project/fulfillment-service/internal/logging"
 	"github.com/osac-project/fulfillment-service/internal/metrics"
 	"github.com/osac-project/fulfillment-service/internal/network"
@@ -433,12 +430,9 @@ func (c *runnerContext) run(cmd *cobra.Command, argv []string) error {
 	privatev1.RegisterClusterTemplatesServer(grpcServer, privateClusterTemplatesServer)
 
 	// Create the runtime scheme for typed OSAC API objects:
-	hubScheme := runtime.NewScheme()
-	if err = osacv1alpha1.AddToScheme(hubScheme); err != nil {
-		return fmt.Errorf("failed to add OSAC scheme: %w", err)
-	}
-	if err = corev1.AddToScheme(hubScheme); err != nil {
-		return fmt.Errorf("failed to add core scheme: %w", err)
+	hubScheme, err := hubscheme.NewHub()
+	if err != nil {
+		return fmt.Errorf("failed to create hub scheme: %w", err)
 	}
 
 	// Create the clusters server:

--- a/internal/controllers/computeinstance/computeinstance_reconciler_function_test.go
+++ b/internal/controllers/computeinstance/computeinstance_reconciler_function_test.go
@@ -736,7 +736,7 @@ var _ = Describe("ensureUserDataSecret", func() {
 		Expect(ownerRefs).To(HaveLen(1))
 		Expect(ownerRefs[0].Name).To(Equal(crName))
 		Expect(ownerRefs[0].UID).To(Equal(owner.GetUID()))
-		Expect(ownerRefs[0].Kind).To(Equal(gvks.ComputeInstance.Kind))
+		Expect(ownerRefs[0].Kind).To(Equal("ComputeInstance"))
 	})
 
 	It("should be idempotent when Secret already exists", func() {

--- a/internal/kubernetes/gvks/kubernetes_gkvs.go
+++ b/internal/kubernetes/gvks/kubernetes_gkvs.go
@@ -15,14 +15,6 @@ package gvks
 
 import "k8s.io/apimachinery/pkg/runtime/schema"
 
-var ClusterOrder = schema.GroupVersionKind{
-	Group:   "osac.openshift.io",
-	Version: "v1alpha1",
-	Kind:    "ClusterOrder",
-}
-
-var ClusterOrderList = listGVK(ClusterOrder)
-
 var HostedCluster = schema.GroupVersionKind{
 	Group:   "hypershift.openshift.io",
 	Version: "v1beta1",
@@ -31,66 +23,10 @@ var HostedCluster = schema.GroupVersionKind{
 
 var HostedClusterList = listGVK(HostedCluster)
 
-var ComputeInstance = schema.GroupVersionKind{
-	Group:   "osac.openshift.io",
-	Version: "v1alpha1",
-	Kind:    "ComputeInstance",
-}
-
-var ComputeInstanceList = listGVK(ComputeInstance)
-
 var Secret = schema.GroupVersionKind{
 	Version: "v1",
 	Kind:    "Secret",
 }
-
-var Subnet = schema.GroupVersionKind{
-	Group:   "osac.openshift.io",
-	Version: "v1alpha1",
-	Kind:    "Subnet",
-}
-
-var SubnetList = listGVK(Subnet)
-
-var VirtualNetwork = schema.GroupVersionKind{
-	Group:   "osac.openshift.io",
-	Version: "v1alpha1",
-	Kind:    "VirtualNetwork",
-}
-
-var VirtualNetworkList = listGVK(VirtualNetwork)
-
-var NetworkClass = schema.GroupVersionKind{
-	Group:   "osac.openshift.io",
-	Version: "v1alpha1",
-	Kind:    "NetworkClass",
-}
-
-var NetworkClassList = listGVK(NetworkClass)
-
-var PublicIPPool = schema.GroupVersionKind{
-	Group:   "osac.openshift.io",
-	Version: "v1alpha1",
-	Kind:    "PublicIPPool",
-}
-
-var PublicIPPoolList = listGVK(PublicIPPool)
-
-var SecurityGroup = schema.GroupVersionKind{
-	Group:   "osac.openshift.io",
-	Version: "v1alpha1",
-	Kind:    "SecurityGroup",
-}
-
-var SecurityGroupList = listGVK(SecurityGroup)
-
-var PublicIP = schema.GroupVersionKind{
-	Group:   "osac.openshift.io",
-	Version: "v1alpha1",
-	Kind:    "PublicIP",
-}
-
-var PublicIPList = listGVK(PublicIP)
 
 func listGVK(gvk schema.GroupVersionKind) schema.GroupVersionKind {
 	gvk.Kind = gvk.Kind + "List"

--- a/internal/kubernetes/scheme/scheme.go
+++ b/internal/kubernetes/scheme/scheme.go
@@ -1,0 +1,34 @@
+/*
+Copyright (c) 2025 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package scheme
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	osacv1alpha1 "github.com/osac-project/osac-operator/api/v1alpha1"
+)
+
+// NewHub creates a runtime.Scheme with OSAC CRD types and core Kubernetes types
+// registered. Use this for any Kubernetes client that interacts with hub clusters.
+func NewHub() (*runtime.Scheme, error) {
+	s := runtime.NewScheme()
+	if err := osacv1alpha1.AddToScheme(s); err != nil {
+		return nil, err
+	}
+	if err := corev1.AddToScheme(s); err != nil {
+		return nil, err
+	}
+	return s, nil
+}

--- a/internal/servers/clusters_server.go
+++ b/internal/servers/clusters_server.go
@@ -27,8 +27,11 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/clientcmd"
 	clnt "sigs.k8s.io/controller-runtime/pkg/client"
+
+	osacv1alpha1 "github.com/osac-project/osac-operator/api/v1alpha1"
 
 	privatev1 "github.com/osac-project/fulfillment-service/internal/api/osac/private/v1"
 	publicv1 "github.com/osac-project/fulfillment-service/internal/api/osac/public/v1"
@@ -46,6 +49,7 @@ type ClustersServerBuilder struct {
 	attributionLogic  auth.AttributionLogic
 	tenancyLogic      auth.TenancyLogic
 	metricsRegisterer prometheus.Registerer
+	scheme            *runtime.Scheme
 }
 
 var _ publicv1.ClustersServer = (*ClustersServer)(nil)
@@ -62,6 +66,7 @@ type ClustersServer struct {
 	hubsDao         *dao.GenericDAO[*privatev1.Hub]
 	kubeClients     map[string]clnt.Client
 	kubeClientsLock *sync.Mutex
+	scheme          *runtime.Scheme
 }
 
 func NewClustersServer() *ClustersServerBuilder {
@@ -99,6 +104,13 @@ func (b *ClustersServerBuilder) SetMetricsRegisterer(value prometheus.Registerer
 	return b
 }
 
+// SetScheme sets the Kubernetes runtime scheme used for typed API objects.
+// This is mandatory.
+func (b *ClustersServerBuilder) SetScheme(value *runtime.Scheme) *ClustersServerBuilder {
+	b.scheme = value
+	return b
+}
+
 func (b *ClustersServerBuilder) Build() (result *ClustersServer, err error) {
 	// Check parameters:
 	if b.logger == nil {
@@ -107,6 +119,10 @@ func (b *ClustersServerBuilder) Build() (result *ClustersServer, err error) {
 	}
 	if b.tenancyLogic == nil {
 		err = errors.New("tenancy logic is mandatory")
+		return
+	}
+	if b.scheme == nil {
+		err = errors.New("scheme is mandatory")
 		return
 	}
 
@@ -179,6 +195,7 @@ func (b *ClustersServerBuilder) Build() (result *ClustersServer, err error) {
 		private:         delegate,
 		inMapper:        inMapper,
 		outMapper:       outMapper,
+		scheme:          b.scheme,
 	}
 	return
 }
@@ -626,16 +643,14 @@ func (s *ClustersServer) getHostedClusterSecret(ctx context.Context, clusterId s
 	}
 
 	// Extract the location of the hosted cluster:
-	hcKey := clnt.ObjectKey{}
-	err = s.jqTool.Evaluate(
-		`.status.clusterReference | {
-			Namespace: .namespace,
-			Name: .hostedClusterName
-		}`,
-		order.Object, &hcKey,
-	)
-	if err != nil {
+	clusterRef := order.Status.ClusterReference
+	if clusterRef == nil {
+		err = fmt.Errorf("cluster order for '%s' has no cluster reference", cluster.GetId())
 		return
+	}
+	hcKey := clnt.ObjectKey{
+		Namespace: clusterRef.Namespace,
+		Name:      clusterRef.HostedClusterName,
 	}
 
 	// Get the hosted cluster from the hub:
@@ -678,14 +693,13 @@ func (s *ClustersServer) createKubeClient(ctx context.Context, hub *privatev1.Hu
 	if err != nil {
 		return
 	}
-	result, err = clnt.New(config, clnt.Options{})
+	result, err = clnt.New(config, clnt.Options{Scheme: s.scheme})
 	return
 }
 
 func (s *ClustersServer) getKubeClusterOrder(ctx context.Context, client clnt.Client,
-	namespace string, id string) (result *unstructured.Unstructured, err error) {
-	list := &unstructured.UnstructuredList{}
-	list.SetGroupVersionKind(gvks.ClusterOrderList)
+	namespace string, id string) (result *osacv1alpha1.ClusterOrder, err error) {
+	list := &osacv1alpha1.ClusterOrderList{}
 	err = client.List(
 		ctx, list,
 		clnt.InNamespace(namespace),

--- a/internal/servers/clusters_server_test.go
+++ b/internal/servers/clusters_server_test.go
@@ -92,6 +92,7 @@ var _ = Describe("Clusters server", func() {
 				SetLogger(logger).
 				SetAttributionLogic(attribution).
 				SetTenancyLogic(tenancy).
+				SetScheme(testScheme).
 				Build()
 			Expect(err).ToNot(HaveOccurred())
 			Expect(server).ToNot(BeNil())
@@ -101,6 +102,7 @@ var _ = Describe("Clusters server", func() {
 			server, err := NewClustersServer().
 				SetAttributionLogic(attribution).
 				SetTenancyLogic(tenancy).
+				SetScheme(testScheme).
 				Build()
 			Expect(err).To(MatchError("logger is mandatory"))
 			Expect(server).To(BeNil())
@@ -110,6 +112,7 @@ var _ = Describe("Clusters server", func() {
 			server, err := NewClustersServer().
 				SetLogger(logger).
 				SetTenancyLogic(tenancy).
+				SetScheme(testScheme).
 				Build()
 			Expect(err).To(MatchError("attribution logic is mandatory"))
 			Expect(server).To(BeNil())
@@ -119,6 +122,7 @@ var _ = Describe("Clusters server", func() {
 			server, err := NewClustersServer().
 				SetLogger(logger).
 				SetAttributionLogic(attribution).
+				SetScheme(testScheme).
 				Build()
 			Expect(err).To(MatchError("tenancy logic is mandatory"))
 			Expect(server).To(BeNil())
@@ -142,6 +146,7 @@ var _ = Describe("Clusters server", func() {
 				SetLogger(logger).
 				SetAttributionLogic(attribution).
 				SetTenancyLogic(tenancy).
+				SetScheme(testScheme).
 				Build()
 			Expect(err).ToNot(HaveOccurred())
 
@@ -1599,6 +1604,7 @@ var _ = Describe("Clusters server", func() {
 				SetLogger(logger).
 				SetAttributionLogic(attribution).
 				SetTenancyLogic(tenancy).
+				SetScheme(testScheme).
 				Build()
 			Expect(err).ToNot(HaveOccurred())
 

--- a/internal/servers/clusters_server_test.go
+++ b/internal/servers/clusters_server_test.go
@@ -127,6 +127,16 @@ var _ = Describe("Clusters server", func() {
 			Expect(err).To(MatchError("tenancy logic is mandatory"))
 			Expect(server).To(BeNil())
 		})
+
+		It("Fails if scheme is not set", func() {
+			server, err := NewClustersServer().
+				SetLogger(logger).
+				SetAttributionLogic(attribution).
+				SetTenancyLogic(tenancy).
+				Build()
+			Expect(err).To(MatchError("scheme is mandatory"))
+			Expect(server).To(BeNil())
+		})
 	})
 
 	Describe("Behaviour", func() {

--- a/internal/servers/console_server.go
+++ b/internal/servers/console_server.go
@@ -22,29 +22,33 @@ import (
 
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/clientcmd"
 	clnt "sigs.k8s.io/controller-runtime/pkg/client"
+
+	osacv1alpha1 "github.com/osac-project/osac-operator/api/v1alpha1"
 
 	privatev1 "github.com/osac-project/fulfillment-service/internal/api/osac/private/v1"
 	publicv1 "github.com/osac-project/fulfillment-service/internal/api/osac/public/v1"
 	"github.com/osac-project/fulfillment-service/internal/auth"
 	"github.com/osac-project/fulfillment-service/internal/console"
 	"github.com/osac-project/fulfillment-service/internal/database"
-	"github.com/osac-project/fulfillment-service/internal/kubernetes/gvks"
 	"github.com/osac-project/fulfillment-service/internal/kubernetes/labels"
 )
 
 // HubClientFactory creates a Kubernetes client from raw kubeconfig bytes.
 type HubClientFactory func(kubeconfig []byte) (clnt.Client, error)
 
-// DefaultHubClientFactory creates a real Kubernetes client from kubeconfig bytes.
-func DefaultHubClientFactory(kubeconfig []byte) (clnt.Client, error) {
-	config, err := clientcmd.RESTConfigFromKubeConfig(kubeconfig)
-	if err != nil {
-		return nil, fmt.Errorf("failed to parse kubeconfig: %w", err)
+// NewDefaultHubClientFactory creates a HubClientFactory that uses the given scheme
+// to create real Kubernetes clients from kubeconfig bytes.
+func NewDefaultHubClientFactory(scheme *runtime.Scheme) HubClientFactory {
+	return func(kubeconfig []byte) (clnt.Client, error) {
+		config, err := clientcmd.RESTConfigFromKubeConfig(kubeconfig)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse kubeconfig: %w", err)
+		}
+		return clnt.New(config, clnt.Options{Scheme: scheme})
 	}
-	return clnt.New(config, clnt.Options{})
 }
 
 // ConsoleServerBuilder builds a ConsoleServer.
@@ -55,6 +59,7 @@ type ConsoleServerBuilder struct {
 	hubServer        privatev1.HubsServer
 	txManager        database.TxManager
 	hubClientFactory HubClientFactory
+	scheme           *runtime.Scheme
 }
 
 // consoleServer implements the Console gRPC service.
@@ -103,6 +108,11 @@ func (b *ConsoleServerBuilder) SetTxManager(value database.TxManager) *ConsoleSe
 	return b
 }
 
+func (b *ConsoleServerBuilder) SetScheme(value *runtime.Scheme) *ConsoleServerBuilder {
+	b.scheme = value
+	return b
+}
+
 func (b *ConsoleServerBuilder) Build() (publicv1.ConsoleServer, error) {
 	if b.logger == nil {
 		return nil, errors.New("logger is mandatory")
@@ -119,9 +129,12 @@ func (b *ConsoleServerBuilder) Build() (publicv1.ConsoleServer, error) {
 	if b.txManager == nil {
 		return nil, errors.New("transaction manager is mandatory")
 	}
+	if b.scheme == nil {
+		return nil, errors.New("scheme is mandatory")
+	}
 	hubClientFactory := b.hubClientFactory
 	if hubClientFactory == nil {
-		hubClientFactory = DefaultHubClientFactory
+		hubClientFactory = NewDefaultHubClientFactory(b.scheme)
 	}
 	return &consoleServer{
 		logger:           b.logger,
@@ -391,8 +404,7 @@ func (s *consoleServer) getVMReferenceFromHub(ctx context.Context, hubID, instan
 	}
 
 	// Query for the ComputeInstance CR by UUID label.
-	list := &unstructured.UnstructuredList{}
-	list.SetGroupVersionKind(gvks.ComputeInstanceList)
+	list := &osacv1alpha1.ComputeInstanceList{}
 	err = hubClient.List(
 		ctx, list,
 		clnt.InNamespace(hub.GetNamespace()),
@@ -423,8 +435,8 @@ func (s *consoleServer) getVMReferenceFromHub(ctx context.Context, hubID, instan
 
 	// Extract virtualMachineReference from the CR status.
 	obj := items[0]
-	statusMap, ok, _ := unstructured.NestedMap(obj.Object, "status", "virtualMachineReference")
-	if !ok || statusMap == nil {
+	vmRef := obj.Status.VirtualMachineReference
+	if vmRef == nil {
 		s.logger.WarnContext(ctx, "Running compute instance has no VM reference on hub",
 			slog.String("instance_id", instanceID),
 			slog.String("hub_id", hubID),
@@ -435,8 +447,8 @@ func (s *consoleServer) getVMReferenceFromHub(ctx context.Context, hubID, instan
 		return
 	}
 
-	namespace, _ = statusMap["namespace"].(string)
-	vmName, _ = statusMap["kubeVirtVirtualMachineName"].(string)
+	namespace = vmRef.Namespace
+	vmName = vmRef.KubeVirtVirtualMachineName
 	if namespace == "" || vmName == "" {
 		err = status.Errorf(codes.FailedPrecondition,
 			"compute instance %q has incomplete VM reference on hub (namespace=%q, vmName=%q)",

--- a/internal/servers/console_server_test.go
+++ b/internal/servers/console_server_test.go
@@ -28,17 +28,18 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	clnt "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	osacv1alpha1 "github.com/osac-project/osac-operator/api/v1alpha1"
 
 	privatev1 "github.com/osac-project/fulfillment-service/internal/api/osac/private/v1"
 	publicv1 "github.com/osac-project/fulfillment-service/internal/api/osac/public/v1"
 	authpkg "github.com/osac-project/fulfillment-service/internal/auth"
 	"github.com/osac-project/fulfillment-service/internal/console"
 	"github.com/osac-project/fulfillment-service/internal/database"
-	"github.com/osac-project/fulfillment-service/internal/kubernetes/gvks"
 	"github.com/osac-project/fulfillment-service/internal/kubernetes/labels"
 )
 
@@ -152,29 +153,37 @@ func newFakeHubClientFactory(client clnt.Client) HubClientFactory {
 	}
 }
 
-// newComputeInstanceCR creates an unstructured ComputeInstance CR for testing.
-func newComputeInstanceCR(id, namespace, vmNamespace, vmName string) *unstructured.Unstructured {
-	obj := &unstructured.Unstructured{}
-	obj.SetGroupVersionKind(gvks.ComputeInstance)
-	obj.SetName("ci-" + id)
-	obj.SetNamespace(namespace)
-	obj.SetLabels(map[string]string{
-		labels.ComputeInstanceUuid: id,
-	})
+// newComputeInstanceCR creates a typed ComputeInstance CR for testing.
+func newComputeInstanceCR(id, namespace, vmNamespace, vmName string) *osacv1alpha1.ComputeInstance {
+	obj := &osacv1alpha1.ComputeInstance{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "ci-" + id,
+			Namespace: namespace,
+			Labels: map[string]string{
+				labels.ComputeInstanceUuid: id,
+			},
+		},
+	}
 	if vmNamespace != "" || vmName != "" {
-		_ = unstructured.SetNestedMap(obj.Object, map[string]interface{}{
-			"namespace":                  vmNamespace,
-			"kubeVirtVirtualMachineName": vmName,
-		}, "status", "virtualMachineReference")
+		obj.Status.VirtualMachineReference = &osacv1alpha1.VirtualMachineReferenceType{
+			Namespace:                  vmNamespace,
+			KubeVirtVirtualMachineName: vmName,
+		}
 	}
 	return obj
 }
 
+// testScheme is a shared scheme for test fake clients with OSAC types registered.
+var testScheme = func() *runtime.Scheme {
+	s := runtime.NewScheme()
+	_ = osacv1alpha1.AddToScheme(s)
+	return s
+}()
+
 // newFakeClient creates a fake K8s client with the given objects.
 func newFakeClient(objects ...clnt.Object) clnt.Client {
-	scheme := runtime.NewScheme()
 	return fake.NewClientBuilder().
-		WithScheme(scheme).
+		WithScheme(testScheme).
 		WithObjects(objects...).
 		Build()
 }
@@ -274,6 +283,7 @@ var _ = Describe("Console Server", func() {
 				SetComputeInstancesServer(ciServer).
 				SetHubServer(hubServer).
 				SetTxManager(&mockTxManager{}).
+				SetScheme(testScheme).
 				Build()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(server).NotTo(BeNil())
@@ -301,6 +311,7 @@ var _ = Describe("Console Server", func() {
 				SetHubServer(hubServer).
 				SetHubClientFactory(newFakeHubClientFactory(fakeK8s)).
 				SetTxManager(&mockTxManager{}).
+				SetScheme(testScheme).
 				Build()
 			Expect(err).NotTo(HaveOccurred())
 		}
@@ -465,6 +476,7 @@ var _ = Describe("Console Server", func() {
 				SetHubServer(hubServer).
 				SetHubClientFactory(newFakeHubClientFactory(fakeK8s)).
 				SetTxManager(&mockTxManager{}).
+				SetScheme(testScheme).
 				Build()
 			Expect(err).NotTo(HaveOccurred())
 		}

--- a/internal/servers/servers_tenancy_test.go
+++ b/internal/servers/servers_tenancy_test.go
@@ -132,6 +132,7 @@ var _ = Describe("Tenancy logic", func() {
 			SetLogger(logger).
 			SetAttributionLogic(attribution).
 			SetTenancyLogic(tenancy).
+			SetScheme(testScheme).
 			Build()
 		Expect(err).ToNot(HaveOccurred())
 
@@ -198,6 +199,7 @@ var _ = Describe("Tenancy logic", func() {
 			SetLogger(logger).
 			SetAttributionLogic(attribution).
 			SetTenancyLogic(tenancy).
+			SetScheme(testScheme).
 			Build()
 		Expect(err).ToNot(HaveOccurred())
 
@@ -256,6 +258,7 @@ var _ = Describe("Tenancy logic", func() {
 			SetLogger(logger).
 			SetAttributionLogic(attribution).
 			SetTenancyLogic(tenancy).
+			SetScheme(testScheme).
 			Build()
 		Expect(err).ToNot(HaveOccurred())
 

--- a/internal/testing/kind.go
+++ b/internal/testing/kind.go
@@ -32,12 +32,14 @@ import (
 	"strings"
 	"time"
 
+	osacv1alpha1 "github.com/osac-project/osac-operator/api/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/runtime/serializer/yaml"
 	"k8s.io/client-go/kubernetes"
+	kubescheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/tools/clientcmd"
 	crclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -635,7 +637,13 @@ func (k *Kind) createKubeClient(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("failed to create REST config for kind cluster '%s': %w", k.name, err)
 	}
-	k.kubeClient, err = crclient.NewWithWatch(restConfig, crclient.Options{})
+	scheme := kubescheme.Scheme
+	if err = osacv1alpha1.AddToScheme(scheme); err != nil {
+		return fmt.Errorf("failed to add osac/v1alpha1 to scheme: %w", err)
+	}
+	k.kubeClient, err = crclient.NewWithWatch(restConfig, crclient.Options{
+		Scheme: scheme,
+	})
 	if err != nil {
 		return fmt.Errorf("failed to create client for kind cluster '%s': %w", k.name, err)
 	}

--- a/it/it_cluster_reconciler_test.go
+++ b/it/it_cluster_reconciler_test.go
@@ -24,14 +24,13 @@ import (
 	"google.golang.org/protobuf/types/known/anypb"
 	"google.golang.org/protobuf/types/known/wrapperspb"
 	kubeerrors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	crclient "sigs.k8s.io/controller-runtime/pkg/client"
 
 	privatev1 "github.com/osac-project/fulfillment-service/internal/api/osac/private/v1"
 	publicv1 "github.com/osac-project/fulfillment-service/internal/api/osac/public/v1"
-	"github.com/osac-project/fulfillment-service/internal/kubernetes/gvks"
 	"github.com/osac-project/fulfillment-service/internal/kubernetes/labels"
 	"github.com/osac-project/fulfillment-service/internal/uuid"
+	osacv1alpha1 "github.com/osac-project/osac-operator/api/v1alpha1"
 )
 
 var _ = Describe("Cluster reconciler", func() {
@@ -132,9 +131,8 @@ var _ = Describe("Cluster reconciler", func() {
 
 		// Check that the Kubernetes object is eventually created:
 		kubeClient := tool.KubeClient()
-		clusterOrderList := &unstructured.UnstructuredList{}
-		clusterOrderList.SetGroupVersionKind(gvks.ClusterOrderList)
-		var kubeObject *unstructured.Unstructured
+		clusterOrderList := &osacv1alpha1.ClusterOrderList{}
+		var kubeObject *osacv1alpha1.ClusterOrder
 		Eventually(
 			func(g Gomega) {
 				err := kubeClient.List(ctx, clusterOrderList, crclient.MatchingLabels{
@@ -152,19 +150,12 @@ var _ = Describe("Cluster reconciler", func() {
 		Expect(kubeObject.GetNamespace()).To(Equal(hubNamespace))
 
 		// Verify that the node sets from the template are reflected in the Kubernetes object:
-		nodeRequests, ok, err := unstructured.NestedSlice(kubeObject.Object, "spec", "nodeRequests")
-		Expect(err).ToNot(HaveOccurred())
-		Expect(ok).To(BeTrue())
-		Expect(nodeRequests).To(HaveLen(1))
-		nodeRequest := nodeRequests[0].(map[string]any)
-		Expect(nodeRequest["resourceClass"]).To(Equal(hostTypeId))
-		Expect(nodeRequest["numberOfNodes"]).To(BeNumerically("==", 3))
+		Expect(kubeObject.Spec.NodeRequests).To(HaveLen(1))
+		Expect(kubeObject.Spec.NodeRequests[0].ResourceClass).To(Equal(hostTypeId))
+		Expect(kubeObject.Spec.NodeRequests[0].NumberOfNodes).To(BeNumerically("==", 3))
 
 		// Verify that the template parameters are reflected in the Kubernetes object:
-		templateParameters, ok, err := unstructured.NestedString(kubeObject.Object, "spec", "templateParameters")
-		Expect(err).ToNot(HaveOccurred())
-		Expect(ok).To(BeTrue())
-		Expect(templateParameters).To(MatchJSON(`{
+		Expect(kubeObject.Spec.TemplateParameters).To(MatchJSON(`{
 			"my": "my_value",
 			"your": "your_default"
 		}`))
@@ -187,9 +178,8 @@ var _ = Describe("Cluster reconciler", func() {
 
 		// Wait for the corresponding Kubernetes object to be created:
 		kubeClient := tool.KubeClient()
-		clusterOrderList := &unstructured.UnstructuredList{}
-		clusterOrderList.SetGroupVersionKind(gvks.ClusterOrderList)
-		var clusterOrderObj *unstructured.Unstructured
+		clusterOrderList := &osacv1alpha1.ClusterOrderList{}
+		var clusterOrderObj *osacv1alpha1.ClusterOrder
 		Eventually(
 			func(g Gomega) {
 				err := kubeClient.List(ctx, clusterOrderList, crclient.MatchingLabels{
@@ -257,9 +247,8 @@ var _ = Describe("Cluster reconciler", func() {
 
 		// Wait for the corresponding Kubernetes object to be created:
 		kubeClient := tool.KubeClient()
-		clusterOrderList := &unstructured.UnstructuredList{}
-		clusterOrderList.SetGroupVersionKind(gvks.ClusterOrderList)
-		var clusterOrderObj *unstructured.Unstructured
+		clusterOrderList := &osacv1alpha1.ClusterOrderList{}
+		var clusterOrderObj *osacv1alpha1.ClusterOrder
 		Eventually(
 			func(g Gomega) {
 				err := kubeClient.List(ctx, clusterOrderList, crclient.MatchingLabels{
@@ -274,13 +263,9 @@ var _ = Describe("Cluster reconciler", func() {
 		).Should(Succeed())
 
 		// Verify the initial node set size in the Kubernetes object:
-		nodeRequests, found, err := unstructured.NestedSlice(clusterOrderObj.Object, "spec", "nodeRequests")
-		Expect(err).ToNot(HaveOccurred())
-		Expect(found).To(BeTrue())
-		Expect(nodeRequests).To(HaveLen(1))
-		nodeRequest := nodeRequests[0].(map[string]any)
-		Expect(nodeRequest["resourceClass"]).To(Equal(hostTypeId))
-		Expect(nodeRequest["numberOfNodes"]).To(BeNumerically("==", 3))
+		Expect(clusterOrderObj.Spec.NodeRequests).To(HaveLen(1))
+		Expect(clusterOrderObj.Spec.NodeRequests[0].ResourceClass).To(Equal(hostTypeId))
+		Expect(clusterOrderObj.Spec.NodeRequests[0].NumberOfNodes).To(BeNumerically("==", 3))
 
 		// Update the cluster to change the node set size
 		_, err = clustersClient.Update(ctx, publicv1.ClustersUpdateRequest_builder{
@@ -311,13 +296,9 @@ var _ = Describe("Cluster reconciler", func() {
 			func(g Gomega) {
 				err := kubeClient.Get(ctx, clusterOrderKey, clusterOrderObj)
 				g.Expect(err).ToNot(HaveOccurred())
-				nodeRequests, found, err := unstructured.NestedSlice(clusterOrderObj.Object, "spec", "nodeRequests")
-				g.Expect(err).ToNot(HaveOccurred())
-				g.Expect(found).To(BeTrue())
-				g.Expect(nodeRequests).To(HaveLen(1))
-				nodeRequest := nodeRequests[0].(map[string]any)
-				g.Expect(nodeRequest["resourceClass"]).To(Equal(hostTypeId))
-				g.Expect(nodeRequest["numberOfNodes"]).To(BeNumerically("==", 5))
+				g.Expect(clusterOrderObj.Spec.NodeRequests).To(HaveLen(1))
+				g.Expect(clusterOrderObj.Spec.NodeRequests[0].ResourceClass).To(Equal(hostTypeId))
+				g.Expect(clusterOrderObj.Spec.NodeRequests[0].NumberOfNodes).To(BeNumerically("==", 5))
 			},
 			time.Minute,
 			time.Second,

--- a/it/it_public_clusters_test.go
+++ b/it/it_public_clusters_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/osac-project/fulfillment-service/internal/kubernetes/gvks"
 	"github.com/osac-project/fulfillment-service/internal/kubernetes/labels"
 	"github.com/osac-project/fulfillment-service/internal/uuid"
+	osacv1alpha1 "github.com/osac-project/osac-operator/api/v1alpha1"
 )
 
 var _ = Describe("Public clusters", func() {
@@ -320,9 +321,8 @@ var _ = Describe("Public clusters", func() {
 
 		// Wait till the Kubernetes object has been created:
 		kubeClient := tool.KubeClient()
-		clusterOrderList := &unstructured.UnstructuredList{}
-		clusterOrderList.SetGroupVersionKind(gvks.ClusterOrderList)
-		var clusterOrderObj *unstructured.Unstructured
+		clusterOrderList := &osacv1alpha1.ClusterOrderList{}
+		var clusterOrderObj *osacv1alpha1.ClusterOrder
 		Eventually(
 			func(g Gomega) {
 				err := kubeClient.List(ctx, clusterOrderList, crclient.MatchingLabels{
@@ -382,13 +382,10 @@ var _ = Describe("Public clusters", func() {
 
 		// Save the reference to the hosted cluster in the cluster order:
 		clusterOrderUpdate := clusterOrderObj.DeepCopy()
-		clusterOrderUpdate.Object["status"] = map[string]any{
-			"clusterReference": map[string]any{
-				"namespace":         hostedClusterObj.GetNamespace(),
-				"hostedClusterName": hostedClusterObj.GetName(),
-			},
+		clusterOrderUpdate.Status.ClusterReference = &osacv1alpha1.ClusterOrderClusterReferenceType{
+			Namespace:         hostedClusterObj.GetNamespace(),
+			HostedClusterName: hostedClusterObj.GetName(),
 		}
-		Expect(err).ToNot(HaveOccurred())
 		clusterOrderPatch := crclient.MergeFrom(clusterOrderObj)
 		err = kubeClient.Status().Patch(ctx, clusterOrderUpdate, clusterOrderPatch)
 		Expect(err).ToNot(HaveOccurred())
@@ -432,9 +429,8 @@ var _ = Describe("Public clusters", func() {
 
 		// Wait till the Kubernetes object has been created:
 		kubeClient := tool.KubeClient()
-		clusterOrderList := &unstructured.UnstructuredList{}
-		clusterOrderList.SetGroupVersionKind(gvks.ClusterOrderList)
-		var clusterOrderObj *unstructured.Unstructured
+		clusterOrderList := &osacv1alpha1.ClusterOrderList{}
+		var clusterOrderObj *osacv1alpha1.ClusterOrder
 		Eventually(
 			func(g Gomega) {
 				err := kubeClient.List(ctx, clusterOrderList, crclient.MatchingLabels{
@@ -494,13 +490,10 @@ var _ = Describe("Public clusters", func() {
 
 		// Save the reference to the hosted cluster in the cluster order:
 		clusterOrderUpdate := clusterOrderObj.DeepCopy()
-		clusterOrderUpdate.Object["status"] = map[string]any{
-			"clusterReference": map[string]any{
-				"namespace":         hostedClusterObj.GetNamespace(),
-				"hostedClusterName": hostedClusterObj.GetName(),
-			},
+		clusterOrderUpdate.Status.ClusterReference = &osacv1alpha1.ClusterOrderClusterReferenceType{
+			Namespace:         hostedClusterObj.GetNamespace(),
+			HostedClusterName: hostedClusterObj.GetName(),
 		}
-		Expect(err).ToNot(HaveOccurred())
 		clusterOrderPatch := crclient.MergeFrom(clusterOrderObj)
 		err = kubeClient.Status().Patch(ctx, clusterOrderUpdate, clusterOrderPatch)
 		Expect(err).ToNot(HaveOccurred())
@@ -543,9 +536,8 @@ var _ = Describe("Public clusters", func() {
 
 		// Wait till the Kubernetes object has been created:
 		kubeClient := tool.KubeClient()
-		clusterOrderList := &unstructured.UnstructuredList{}
-		clusterOrderList.SetGroupVersionKind(gvks.ClusterOrderList)
-		var clusterOrderObj *unstructured.Unstructured
+		clusterOrderList := &osacv1alpha1.ClusterOrderList{}
+		var clusterOrderObj *osacv1alpha1.ClusterOrder
 		Eventually(
 			func(g Gomega) {
 				err := kubeClient.List(ctx, clusterOrderList, crclient.MatchingLabels{
@@ -605,13 +597,10 @@ var _ = Describe("Public clusters", func() {
 
 		// Save the reference to the hosted cluster in the cluster order:
 		clusterOrderUpdate := clusterOrderObj.DeepCopy()
-		clusterOrderUpdate.Object["status"] = map[string]any{
-			"clusterReference": map[string]any{
-				"namespace":         hostedClusterObj.GetNamespace(),
-				"hostedClusterName": hostedClusterObj.GetName(),
-			},
+		clusterOrderUpdate.Status.ClusterReference = &osacv1alpha1.ClusterOrderClusterReferenceType{
+			Namespace:         hostedClusterObj.GetNamespace(),
+			HostedClusterName: hostedClusterObj.GetName(),
 		}
-		Expect(err).ToNot(HaveOccurred())
 		clusterOrderPatch := crclient.MergeFrom(clusterOrderObj)
 		err = kubeClient.Status().Patch(ctx, clusterOrderUpdate, clusterOrderPatch)
 		Expect(err).ToNot(HaveOccurred())
@@ -652,9 +641,8 @@ var _ = Describe("Public clusters", func() {
 
 		// Wait till the Kubernetes object has been created:
 		kubeClient := tool.KubeClient()
-		clusterOrderList := &unstructured.UnstructuredList{}
-		clusterOrderList.SetGroupVersionKind(gvks.ClusterOrderList)
-		var clusterOrderObj *unstructured.Unstructured
+		clusterOrderList := &osacv1alpha1.ClusterOrderList{}
+		var clusterOrderObj *osacv1alpha1.ClusterOrder
 		Eventually(
 			func(g Gomega) {
 				err := kubeClient.List(ctx, clusterOrderList, crclient.MatchingLabels{
@@ -714,13 +702,10 @@ var _ = Describe("Public clusters", func() {
 
 		// Save the reference to the hosted cluster in the cluster order:
 		clusterOrderUpdate := clusterOrderObj.DeepCopy()
-		clusterOrderUpdate.Object["status"] = map[string]any{
-			"clusterReference": map[string]any{
-				"namespace":         hostedClusterObj.GetNamespace(),
-				"hostedClusterName": hostedClusterObj.GetName(),
-			},
+		clusterOrderUpdate.Status.ClusterReference = &osacv1alpha1.ClusterOrderClusterReferenceType{
+			Namespace:         hostedClusterObj.GetNamespace(),
+			HostedClusterName: hostedClusterObj.GetName(),
 		}
-		Expect(err).ToNot(HaveOccurred())
 		clusterOrderPatch := crclient.MergeFrom(clusterOrderObj)
 		err = kubeClient.Status().Patch(ctx, clusterOrderUpdate, clusterOrderPatch)
 		Expect(err).ToNot(HaveOccurred())


### PR DESCRIPTION
## Summary

PR 3 of 3 for [MGMT-24156](https://redhat.atlassian.net/browse/MGMT-24156). Converts server files and integration tests from `unstructured.Unstructured` to typed `osacv1alpha1` objects, and removes all OSAC GVK entries from the GVK file.

Depends on: #467 (reconcilers PR)

## Changes

**Server files:**
- **`clusters_server.go`** — `getKubeClusterOrder` returns typed `*osacv1alpha1.ClusterOrder`; `createKubeClient` passes scheme; status reads use typed field access. `getKubeHostedCluster` stays unstructured (external type).
- **`console_server.go`** — `getVMReferenceFromHub` uses typed `ComputeInstanceList` and typed `VirtualMachineReference` field access instead of `unstructured.NestedMap`. `DefaultHubClientFactory` refactored to `NewDefaultHubClientFactory(scheme)`.
- Both servers get `SetScheme` builder method, wired at startup in `start_grpc_server_cmd.go`.

**GVK cleanup:**
- Removed all OSAC GVK entries (ClusterOrder, ComputeInstance, Subnet, VirtualNetwork, SecurityGroup, PublicIP, PublicIPPool, NetworkClass). Only HostedCluster and Secret remain.

**Integration tests:**
- `it_cluster_reconciler_test.go` — typed `ClusterOrderList` and `ClusterOrder`, struct field assertions
- `it_public_clusters_test.go` — typed ClusterOrder, HostedCluster stays unstructured
- `internal/testing/kind.go` — registers OSAC scheme on kind cluster client

**Test fixes:**
- All server test builders updated with `.SetScheme(testScheme)`

Net -28 lines.

## Test plan

- [x] `go vet ./...` — no issues
- [x] `gofmt -s -l .` — no formatting issues
- [x] `ginkgo run -r internal` — all 51 test suites pass
- [ ] Integration tests require kind cluster (not run locally)

Generated with [Claude Code](https://claude.com/claude-code)