### PR TITLE
NO-ISSUE: Sort node requests deterministically

### DIFF
--- a/internal/controllers/cluster/cluster_reconciler_function.go
+++ b/internal/controllers/cluster/cluster_reconciler_function.go
@@ -334,10 +334,16 @@ func (t *task) addExplicitFields(spec *osacv1alpha1.ClusterOrderSpec) {
 }
 
 func (t *task) prepareNodeRequests() []osacv1alpha1.NodeRequest {
-	var nodeRequests []osacv1alpha1.NodeRequest
-	for _, nodeSet := range t.cluster.GetSpec().GetNodeSets() {
-		nodeRequest := t.prepareNodeRequest(nodeSet)
-		nodeRequests = append(nodeRequests, nodeRequest)
+	nodeSets := t.cluster.GetSpec().GetNodeSets()
+	keys := make([]string, 0, len(nodeSets))
+	for key := range nodeSets {
+		keys = append(keys, key)
+	}
+	slices.Sort(keys)
+
+	nodeRequests := make([]osacv1alpha1.NodeRequest, 0, len(keys))
+	for _, key := range keys {
+		nodeRequests = append(nodeRequests, t.prepareNodeRequest(nodeSets[key]))
 	}
 	return nodeRequests
 }


### PR DESCRIPTION
## Summary

- Sort NodeRequest slice by map key before building ClusterOrder spec
- `GetNodeSets()` returns a map — iterating it produces non-deterministic order
- Without sorting, identical cluster configurations generate different patches when multiple node sets exist, causing unnecessary hub writes

Follow-up from CodeRabbit review on #467.

## Test plan

- [x] `ginkgo run internal/controllers/cluster/` — 9/9 pass

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved consistency in cluster node processing by ensuring deterministic ordering of node requests during reconciliation operations.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/osac-project/fulfillment-service/pull/470)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->