### PR TITLE
MGMT-22988: Add identity provider flags to deployment manifests

### DIFF
--- a/charts/README.md
+++ b/charts/README.md
@@ -28,6 +28,14 @@ installed separately before deploying the service:
   See the `charts/service/values.yaml` file for the expected format and the
   `charts/keycloak/README.md` file for details on the required Keycloak configuration.
 
+- _IDP Credentials (Optional)_ - If you want to enable organization management via the IDP
+  integration, you must provide OAuth client credentials for authenticating with the identity
+  provider's admin API. For Keycloak, this uses the same `osac-controller` service account that
+  already has the required realm-management roles. You can reuse the same credentials as
+  `auth.controllerCredentials` or create separate credentials for separation of concerns. Configure
+  via the `idp.credentials` value. See the `charts/service/values.yaml` file for the expected
+  format.
+
 Note that the PostgreSQL and Keycloak Helm charts that are included in this project are intended
 only for development environments, and shouldn't be used in production.
 
@@ -134,6 +142,21 @@ $ kubectl create secret generic fulfillment-controller-credentials \
 --from-literal=client-secret=...
 ```
 
+Optional: Enable IDP integration for organization management. You can either reuse the same
+`fulfillment-controller-credentials` secret (simple approach) or create separate IDP credentials
+for separation of concerns:
+
+```shell
+# Option 1: Reuse the same credentials (recommended for simple deployments)
+# No additional secret needed - use the existing fulfillment-controller-credentials
+
+# Option 2: Create separate IDP credentials (for better separation of concerns)
+$ kubectl create secret generic fulfillment-idp-credentials \
+--namespace osac \
+--from-literal=client-id=osac-controller \
+--from-literal=client-secret=...
+```
+
 Deploy the application:
 
 ```shell
@@ -176,6 +199,21 @@ database:
         param: user
       - key: password
         param: password
+
+# Optional: Enable IDP integration for organization management
+idp:
+  enabled: true
+  provider: keycloak
+  url: https://keycloak.keycloak.svc.cluster.local:8000
+  # Reuse the same credentials as controllerCredentials
+  credentials:
+  - secret:
+      name: fulfillment-controller-credentials
+      items:
+      - key: client-id
+        param: client-id
+      - key: client-secret
+        param: client-secret
 ```
 
 ## Kind
@@ -339,6 +377,21 @@ $ kubectl create secret generic fulfillment-controller-credentials \
 --from-literal=client-secret=...
 ```
 
+Optional: Enable IDP integration for organization management. You can either reuse the same
+`fulfillment-controller-credentials` secret (simple approach) or create separate IDP credentials
+for separation of concerns:
+
+```shell
+# Option 1: Reuse the same credentials (recommended for simple deployments)
+# No additional secret needed - use the existing fulfillment-controller-credentials
+
+# Option 2: Create separate IDP credentials (for better separation of concerns)
+$ kubectl create secret generic fulfillment-idp-credentials \
+--namespace osac \
+--from-literal=client-id=osac-controller \
+--from-literal=client-secret=...
+```
+
 Deploy the application:
 
 ```shell
@@ -381,4 +434,19 @@ database:
         param: user
       - key: password
         param: password
+
+# Optional: Enable IDP integration for organization management
+idp:
+  enabled: true
+  provider: keycloak
+  url: https://keycloak.keycloak.svc.cluster.local:8000
+  # Reuse the same credentials as controllerCredentials
+  credentials:
+  - secret:
+      name: fulfillment-controller-credentials
+      items:
+      - key: client-id
+        param: client-id
+      - key: client-secret
+        param: client-secret
 ```

--- a/charts/service/templates/controller/deployment.yaml
+++ b/charts/service/templates/controller/deployment.yaml
@@ -63,6 +63,35 @@ spec:
               {{ end }}
           {{ end }}
           {{ end }}
+      {{- if .Values.idp.enabled }}
+      - name: idp-credentials
+        projected:
+          sources:
+          {{- if .Values.idp.credentials }}
+          {{- range .Values.idp.credentials }}
+          {{- if .configMap }}
+          - configMap:
+              name: {{ .configMap.name }}
+              items:
+              {{- range .configMap.items }}
+              - key: {{ .key }}
+                path: {{ .param }}
+              {{- end }}
+          {{- end }}
+          {{- if .secret }}
+          - secret:
+              name: {{ .secret.name }}
+              items:
+              {{- range .secret.items }}
+              - key: {{ .key }}
+                path: {{ .param }}
+              {{- end }}
+          {{- end }}
+          {{- end }}
+          {{- else }}
+          []
+          {{- end }}
+      {{- end }}
       containers:
       - name: controller
         image: {{ .Values.images.service }}
@@ -74,6 +103,11 @@ spec:
         - name: credentials
           mountPath: /etc/fulfillment-controller/credentials
           readOnly: true
+        {{- if .Values.idp.enabled }}
+        - name: idp-credentials
+          mountPath: /etc/fulfillment-controller/idp
+          readOnly: true
+        {{- end }}
         command:
         {{ if .Values.debug }}
         - dlv
@@ -97,6 +131,12 @@ spec:
         - --auth-issuer-url={{ $authIssuerUrl }}
         - --auth-client-id-file=/etc/fulfillment-controller/credentials/client-id
         - --auth-client-secret-file=/etc/fulfillment-controller/credentials/client-secret
+        {{- if .Values.idp.enabled }}
+        - --idp-provider={{ .Values.idp.provider }}
+        - --idp-url={{ required "idp.url is required when idp.enabled is true" .Values.idp.url }}
+        - --idp-client-id-file=/etc/fulfillment-controller/idp/client-id
+        - --idp-client-secret-file=/etc/fulfillment-controller/idp/client-secret
+        {{- end }}
         - --grpc-server-address=fulfillment-internal-api:8001
         - --grpc-keep-alive=5m
         - --grpc-listener-address=0.0.0.0:8000

--- a/charts/service/values.yaml
+++ b/charts/service/values.yaml
@@ -145,3 +145,40 @@ database:
   # The keys of the ConfigMap and secret don't need to match the parameter names. In the above example the URL is in a
   # `uri` key but the connection parameter name is `url`.
   connection: []
+
+# Identity provider configuration (optional). When enabled, the controller will start the organization reconciler
+# to manage organizations in the identity provider.
+idp:
+
+  # Enable IDP integration for organization management. When disabled, the organization controller will not start.
+  # The default is false.
+  enabled: false
+
+  # IDP provider type. Currently only 'keycloak' is supported.
+  provider: keycloak
+
+  # Base URL of the identity provider (e.g., https://keycloak.keycloak.svc.cluster.local:8000)
+  url: ""
+
+  # List of sources for the IDP OAuth client credentials. The controller uses the OAuth client credentials flow to
+  # authenticate with the identity provider's admin API. The credentials must have sufficient privileges to manage
+  # organizations and users (for Keycloak, this means the realm-management client roles: manage-realm, manage-users,
+  # view-realm, view-users).
+  #
+  # The format follows the same pattern as auth.controllerCredentials:
+  #
+  # idp:
+  #   credentials:
+  #   - secret:
+  #       name: fulfillment-controller-credentials
+  #       items:
+  #       - key: client-id
+  #         param: client-id
+  #       - key: client-secret
+  #         param: client-secret
+  #
+  # You can reuse the same credentials as auth.controllerCredentials if the osac-controller service account has both
+  # API access and IDP management permissions, or use a separate secret for separation of concerns.
+  #
+  # The default value is an empty list, meaning no credentials are configured.
+  credentials: []

--- a/manifests/README.md
+++ b/manifests/README.md
@@ -36,6 +36,54 @@ $ kubectl create secret generic fulfillment-controller-credentials \
 If you need to use a different secret name or different keys, you can override the volume definition
 in the controller deployment using a kustomize patch in your overlay.
 
+## Enabling IDP Integration (Optional)
+
+The kustomize manifests include the IDP configuration flags by default, pointing to
+`https://keycloak.keycloak.svc.cluster.local:8000`. The controller uses OAuth client credentials
+flow to authenticate with the identity provider's admin API.
+
+By default, the IDP integration reuses the same `fulfillment-controller-credentials` secret (with
+keys `client-id` and `client-secret`) that is already configured for API authentication. The
+`osac-controller` service account has both API access permissions and the required IDP
+realm-management roles (manage-realm, manage-users, view-realm, view-users).
+
+**No additional setup is needed** - the organization controller will automatically start if the
+`fulfillment-controller-credentials` secret exists.
+
+If you want to use separate credentials for IDP (for better separation of concerns), you can create
+a kustomize patch to override the `idp-credentials` volume:
+
+```yaml
+# kustomization.yaml
+patches:
+- patch: |-
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      name: fulfillment-controller
+    spec:
+      template:
+        spec:
+          volumes:
+          - name: idp-credentials
+            secret:
+              secretName: fulfillment-idp-credentials
+              optional: true
+```
+
+Then create the separate secret:
+
+```shell
+$ kubectl create secret generic fulfillment-idp-credentials \
+--namespace osac \
+--from-literal=client-id=osac-idp-manager \
+--from-literal=client-secret=...
+```
+
+If neither the reused credentials nor separate IDP credentials are available, the controller will
+log that IDP is not configured and will not start the organization controller. The volume is marked
+as optional, so the pod will start successfully.
+
 ## OpenShift
 
 The gRPC protocol is based on HTTP2, which isn't enabled by default in OpenShift. To enable it run

--- a/manifests/base/controller/deployment.yaml
+++ b/manifests/base/controller/deployment.yaml
@@ -36,6 +36,10 @@ spec:
       - name: credentials
         secret:
           secretName: fulfillment-controller-credentials
+      - name: idp-credentials
+        secret:
+          secretName: fulfillment-controller-credentials
+          optional: true
       containers:
       - name: controller
         image: fulfillment-service
@@ -48,6 +52,9 @@ spec:
         - name: credentials
           mountPath: /etc/fulfillment-controller/credentials
           readOnly: true
+        - name: idp-credentials
+          mountPath: /etc/fulfillment-controller/idp
+          readOnly: true
         command:
         - /usr/local/bin/fulfillment-service
         - start
@@ -59,6 +66,10 @@ spec:
         - --auth-issuer-url=https://keycloak.keycloak.svc.cluster.local:8000/realms/osac
         - --auth-client-id-file=/etc/fulfillment-controller/credentials/client-id
         - --auth-client-secret-file=/etc/fulfillment-controller/credentials/client-secret
+        - --idp-provider=keycloak
+        - --idp-url=https://keycloak.keycloak.svc.cluster.local:8000
+        - --idp-client-id-file=/etc/fulfillment-controller/idp/client-id
+        - --idp-client-secret-file=/etc/fulfillment-controller/idp/client-secret
         - --grpc-server-address=fulfillment-internal-api:8001
         - --grpc-keep-alive=5m
         - --grpc-listener-address=0.0.0.0:8000


### PR DESCRIPTION
# Description
Enables keycloak by adding the necessary and missing flags required to deploy it to the fulfillment-service manifests

# Testing

Deployed fulfillment-service on OpenShift cluster using new manifests.

```sh
CLIENT_SECRET=$(openssl rand -base64 32) 

oc create secret generic fulfillment-controller-credentials --namespace osac --from-literal=client-id=osac-controller --from-literal=client-secret=${CLIENT_SECRET}
```

Added to keycloak values.yaml
```yaml
clients:
- clientId: osac-controller                        
  name: OSAC controller                            
  description: Service account for the OSAC controller                                         
  enabled: true                                  
  clientAuthenticatorType: client-secret           
  secret: ${CLIENT_SECRET}                                  
  serviceAccountsEnabled: true                   
  publicClient: false                              
  standardFlowEnabled: false                     
  implicitFlowEnabled: false                       
  directAccessGrantsEnabled: false               
  protocol: openid-connect
  fullScopeAllowed: true                           

users:                                             
- username: service-account-osac-controller      
  enabled: true                                    
  serviceAccountClientId: osac-controller
  clientRoles:                                     
    realm-management:                              
    - manage-realm
    - manage-users                                 
    - view-realm                                 
    - view-users 
```

```sh
kubectl create configmap keycloak-database-config --namespace keycloak --from-literal=url='postgres://postgres.postgres.svc.cluster.local:5432/keycloak' --from-literal=user='keycloak' --from-literal=password='' --from-literal=sslmode='require' 

kubectl apply -f - <<EOF
apiVersion: cert-manager.io/v1                     
kind: Certificate
metadata:
  name: keycloak-database-client                 
  namespace: keycloak                              
spec:
  issuerRef:                                       
    kind: ClusterIssuer                          
    name: default-ca
  usages:                                          
  - client auth
  commonName: keycloak                             
  secretName: keycloak-database-client-cert        
  privateKey:
    encoding: PKCS8                                
    rotationPolicy: Always                       
  additionalOutputFormats:
  - type: DER
EOF

helm install postgres charts/postgres --namespace postgres --create-namespace 

helm install keycloak charts/keycloak -n keycloak

oc apply -k manifests/overlays/openshift
```

Verified all services running
```sh
# oc get po -n keycloak
NAME                               READY   STATUS    RESTARTS   AGE
keycloak-service-f48cfb496-pslcv   1/1     Running   0          86m

# oc get po -n osac 
NAME                                        READY   STATUS    RESTARTS   AGE
authorino-65878c4c6f-f7brn                  1/1     Running   0          5m56s
fulfillment-controller-68dc97d8b-c7vdg      1/1     Running   0          5m59s
fulfillment-database-0                      1/1     Running   0          5m59s
fulfillment-grpc-server-57b757c7f4-cjlsf    1/1     Running   0          5m59s
fulfillment-ingress-proxy-c5cc79d87-kwr9j   1/1     Running   0          5m59s
fulfillment-rest-gateway-6d94dcd9f7-trdgk   1/1     Running   0          5m59s
[root@rdu-infra-edge-01 ~]# 
```

Assisted-by: Claude

/cc @jhernand 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional Identity Provider (IDP) integration for organization management, with support for Keycloak.
  * IDP can be enabled and configured through Helm values or kustomize manifests.

* **Documentation**
  * Updated setup guides for both Helm and kustomize deployments with IDP configuration instructions.
  * Added examples and guidance for supplying OAuth credentials and managing organization permissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->