### PR TITLE
MGMT-23732/MGMT-24180: use pool status.allocated for delete check

### DIFF
--- a/internal/servers/private_public_ip_pools_server.go
+++ b/internal/servers/private_public_ip_pools_server.go
@@ -16,7 +16,6 @@ package servers
 import (
 	"context"
 	"errors"
-	"fmt"
 	"log/slog"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -26,7 +25,6 @@ import (
 	privatev1 "github.com/osac-project/fulfillment-service/internal/api/osac/private/v1"
 	"github.com/osac-project/fulfillment-service/internal/auth"
 	"github.com/osac-project/fulfillment-service/internal/database"
-	"github.com/osac-project/fulfillment-service/internal/database/dao"
 )
 
 // PrivatePublicIPPoolsServerBuilder contains the data and logic needed to create a new private public IP pools server.
@@ -44,9 +42,8 @@ var _ privatev1.PublicIPPoolsServer = (*PrivatePublicIPPoolsServer)(nil)
 type PrivatePublicIPPoolsServer struct {
 	privatev1.UnimplementedPublicIPPoolsServer
 
-	logger      *slog.Logger
-	generic     *GenericServer[*privatev1.PublicIPPool]
-	publicIPDAO *dao.GenericDAO[*privatev1.PublicIP]
+	logger  *slog.Logger
+	generic *GenericServer[*privatev1.PublicIPPool]
 }
 
 // NewPrivatePublicIPPoolsServer creates a builder that can then be used to configure and create a new private public
@@ -97,17 +94,6 @@ func (b *PrivatePublicIPPoolsServerBuilder) Build() (result *PrivatePublicIPPool
 		return
 	}
 
-	// Create the PublicIP DAO used to check for allocated IPs on pool deletion:
-	publicIPDAO, err := dao.NewGenericDAO[*privatev1.PublicIP]().
-		SetLogger(b.logger).
-		SetTenancyLogic(b.tenancyLogic).
-		SetMetricsRegisterer(b.metricsRegisterer).
-		Build()
-	if err != nil {
-		err = fmt.Errorf("failed to create public IP DAO: %w", err)
-		return
-	}
-
 	generic, err := NewGenericServer[*privatev1.PublicIPPool]().
 		SetLogger(b.logger).
 		SetService(privatev1.PublicIPPools_ServiceDesc.ServiceName).
@@ -121,9 +107,8 @@ func (b *PrivatePublicIPPoolsServerBuilder) Build() (result *PrivatePublicIPPool
 	}
 
 	result = &PrivatePublicIPPoolsServer{
-		logger:      b.logger,
-		generic:     generic,
-		publicIPDAO: publicIPDAO,
+		logger:  b.logger,
+		generic: generic,
 	}
 	return
 }
@@ -154,46 +139,23 @@ func (s *PrivatePublicIPPoolsServer) Update(ctx context.Context,
 
 func (s *PrivatePublicIPPoolsServer) Delete(ctx context.Context,
 	request *privatev1.PublicIPPoolsDeleteRequest) (response *privatev1.PublicIPPoolsDeleteResponse, err error) {
-	if s.publicIPDAO != nil {
-		err = s.checkNoAllocatedIPs(ctx, request.GetId())
-		if err != nil {
-			return
-		}
+	var getResponse *privatev1.PublicIPPoolsGetResponse
+	err = s.generic.Get(ctx, privatev1.PublicIPPoolsGetRequest_builder{
+		Id: request.GetId(),
+	}.Build(), &getResponse)
+	if err != nil {
+		return
+	}
+	if allocated := getResponse.GetObject().GetStatus().GetAllocated(); allocated > 0 {
+		err = grpcstatus.Errorf(
+			grpccodes.FailedPrecondition,
+			"cannot delete public IP pool '%s': %d public IP(s) are still allocated from it",
+			request.GetId(), allocated,
+		)
+		return
 	}
 	err = s.generic.Delete(ctx, request, &response)
 	return
-}
-
-// checkNoAllocatedIPs returns a FailedPrecondition error when at least one PublicIP still
-// references this pool. Any database error is treated as a hard failure so that a transient
-// connectivity issue cannot silently bypass the referential-integrity check and orphan IPs.
-func (s *PrivatePublicIPPoolsServer) checkNoAllocatedIPs(ctx context.Context, poolID string) error {
-	filter := fmt.Sprintf("this.spec.pool == %q", poolID)
-	listResponse, err := s.publicIPDAO.List().
-		SetFilter(filter).
-		SetLimit(1).
-		Do(ctx)
-	if err != nil {
-		s.logger.ErrorContext(
-			ctx,
-			"Failed to verify allocated public IPs for pool",
-			slog.String("pool_id", poolID),
-			slog.Any("error", err),
-		)
-		return grpcstatus.Errorf(
-			grpccodes.Internal,
-			"failed to verify allocated public IPs for pool '%s'",
-			poolID,
-		)
-	}
-	if total := listResponse.GetTotal(); total > 0 {
-		return grpcstatus.Errorf(
-			grpccodes.FailedPrecondition,
-			"cannot delete public IP pool '%s': %d public IP(s) are still allocated from it",
-			poolID, total,
-		)
-	}
-	return nil
 }
 
 func (s *PrivatePublicIPPoolsServer) Signal(ctx context.Context,


### PR DESCRIPTION
## Summary

[MGMT-24180](https://redhat.atlassian.net/browse/MGMT-24180): Optimizes the pool delete referential integrity check to use the pool's
`status.allocated` counter instead of querying the PublicIP table. Now that [MGMT-23900](https://redhat.atlassian.net/browse/MGMT-23900)
has implemented capacity tracking, the allocated counter is maintained atomically on
every PublicIP create/delete, making the cross-table query redundant.

This removes the `publicIPDAO` dependency from `PrivatePublicIPPoolsServer` and replaces
a filtered List call with a single pool Get.

## Testing

```bash
$ go build ./...
# clean

$ go run github.com/onsi/ginkgo/v2/ginkgo run -r internal
Ginkgo ran 51 suites in 1m43s
Test Suite Passed
```

Both deletion-specific tests pass unchanged:
- "Rejects deletion when allocated PublicIPs reference the pool"
- "Allows deletion when no PublicIPs reference the pool"

## Ticket

[MGMT-24180](https://redhat.atlassian.net/browse/MGMT-24180)

<br>

<small>Assisted-by: Cursor/Claude</small>