### PR TITLE
OSAC-474: remove --include-deleted flag, always show deleting objects

### DIFF
--- a/internal/cmd/cli/annotate/annotate_cmd.go
+++ b/internal/cmd/cli/annotate/annotate_cmd.go
@@ -129,7 +129,7 @@ func (c *runnerContext) run(cmd *cobra.Command, args []string) error {
 	}
 
 	// Find the object by identifier or name:
-	object, err := c.helper.FindObject(ctx, ref, false, c.console)
+	object, err := c.helper.FindObject(ctx, ref, c.console)
 	if err != nil {
 		return err
 	}

--- a/internal/cmd/cli/console/connect/resolve.go
+++ b/internal/cmd/cli/console/connect/resolve.go
@@ -27,7 +27,7 @@ import (
 // ResolveInstance resolves a name or ID to a compute instance ID.
 func ResolveInstance(ctx context.Context, conn *grpc.ClientConn, key string) (string, error) {
 	client := publicv1.NewComputeInstancesClient(conn)
-	ci, err := lookup.Find(key, "compute instance", lookup.FindOptions{}, func(filter string, limit int32) ([]*publicv1.ComputeInstance, error) {
+	ci, err := lookup.Find(key, "compute instance", func(filter string, limit int32) ([]*publicv1.ComputeInstance, error) {
 		resp, err := client.List(ctx, publicv1.ComputeInstancesListRequest_builder{
 			Filter: proto.String(filter),
 			Limit:  proto.Int32(limit),

--- a/internal/cmd/cli/create/publicip/create_publicip_cmd.go
+++ b/internal/cmd/cli/create/publicip/create_publicip_cmd.go
@@ -85,7 +85,7 @@ func (c *runnerContext) run(cmd *cobra.Command, args []string) error {
 	defer conn.Close()
 
 	poolClient := publicv1.NewPublicIPPoolsClient(conn)
-	pool, err := lookup.Find(c.args.pool, "public IP pool", lookup.FindOptions{}, func(filter string, limit int32) ([]*publicv1.PublicIPPool, error) {
+	pool, err := lookup.Find(c.args.pool, "public IP pool", func(filter string, limit int32) ([]*publicv1.PublicIPPool, error) {
 		resp, err := poolClient.List(ctx, publicv1.PublicIPPoolsListRequest_builder{
 			Filter: proto.String(filter),
 			Limit:  proto.Int32(limit),

--- a/internal/cmd/cli/create/publicipattachment/create_publicipattachment_cmd.go
+++ b/internal/cmd/cli/create/publicipattachment/create_publicipattachment_cmd.go
@@ -85,7 +85,7 @@ func (c *runnerContext) run(cmd *cobra.Command, args []string) error {
 	ciClient := publicv1.NewComputeInstancesClient(conn)
 	attachClient := publicv1.NewPublicIPAttachmentsClient(conn)
 
-	pip, err := lookup.Find(c.args.publicIP, "public IP", lookup.FindOptions{}, func(filter string, limit int32) ([]*publicv1.PublicIP, error) {
+	pip, err := lookup.Find(c.args.publicIP, "public IP", func(filter string, limit int32) ([]*publicv1.PublicIP, error) {
 		resp, err := pipClient.List(ctx, publicv1.PublicIPsListRequest_builder{
 			Filter: proto.String(filter),
 			Limit:  proto.Int32(limit),
@@ -99,7 +99,7 @@ func (c *runnerContext) run(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	ci, err := lookup.Find(c.args.computeInstance, "compute instance", lookup.FindOptions{}, func(filter string, limit int32) ([]*publicv1.ComputeInstance, error) {
+	ci, err := lookup.Find(c.args.computeInstance, "compute instance", func(filter string, limit int32) ([]*publicv1.ComputeInstance, error) {
 		resp, err := ciClient.List(ctx, publicv1.ComputeInstancesListRequest_builder{
 			Filter: proto.String(filter),
 			Limit:  proto.Int32(limit),

--- a/internal/cmd/cli/create/securitygroup/create_securitygroup_cmd.go
+++ b/internal/cmd/cli/create/securitygroup/create_securitygroup_cmd.go
@@ -113,7 +113,7 @@ func (c *runnerContext) run(cmd *cobra.Command, args []string) error {
 	defer conn.Close()
 
 	vnClient := publicv1.NewVirtualNetworksClient(conn)
-	vn, err := lookup.Find(c.args.virtualNetwork, "virtual network", lookup.FindOptions{}, func(filter string, limit int32) ([]*publicv1.VirtualNetwork, error) {
+	vn, err := lookup.Find(c.args.virtualNetwork, "virtual network", func(filter string, limit int32) ([]*publicv1.VirtualNetwork, error) {
 		resp, err := vnClient.List(ctx, publicv1.VirtualNetworksListRequest_builder{
 			Filter: proto.String(filter),
 			Limit:  proto.Int32(limit),

--- a/internal/cmd/cli/create/subnet/create_subnet_cmd.go
+++ b/internal/cmd/cli/create/subnet/create_subnet_cmd.go
@@ -104,7 +104,7 @@ func (c *runnerContext) run(cmd *cobra.Command, args []string) error {
 	defer conn.Close()
 
 	vnClient := publicv1.NewVirtualNetworksClient(conn)
-	vn, err := lookup.Find(c.args.virtualNetwork, "virtual network", lookup.FindOptions{}, func(filter string, limit int32) ([]*publicv1.VirtualNetwork, error) {
+	vn, err := lookup.Find(c.args.virtualNetwork, "virtual network", func(filter string, limit int32) ([]*publicv1.VirtualNetwork, error) {
 		resp, err := vnClient.List(ctx, publicv1.VirtualNetworksListRequest_builder{
 			Filter: proto.String(filter),
 			Limit:  proto.Int32(limit),

--- a/internal/cmd/cli/describe/cluster/describe_cluster.go
+++ b/internal/cmd/cli/describe/cluster/describe_cluster.go
@@ -40,18 +40,11 @@ func Cmd() *cobra.Command {
 		Args:                  cobra.ExactArgs(1),
 		RunE:                  runner.run,
 	}
-	result.Flags().BoolVar(
-		&runner.includeDeleted,
-		"include-deleted",
-		false,
-		"Include soft-deleted objects in resolution.",
-	)
 	return result
 }
 
 type runnerContext struct {
-	console        *terminal.Console
-	includeDeleted bool
+	console *terminal.Console
 }
 
 func (c *runnerContext) run(cmd *cobra.Command, args []string) error {
@@ -74,7 +67,7 @@ func (c *runnerContext) run(cmd *cobra.Command, args []string) error {
 
 	client := publicv1.NewClustersClient(conn)
 
-	matched, err := lookup.Find(ref, "cluster", lookup.FindOptions{IncludeDeleted: c.includeDeleted}, func(filter string, limit int32) ([]*publicv1.Cluster, error) {
+	matched, err := lookup.Find(ref, "cluster", func(filter string, limit int32) ([]*publicv1.Cluster, error) {
 		resp, err := client.List(ctx, publicv1.ClustersListRequest_builder{
 			Filter: proto.String(filter),
 			Limit:  proto.Int32(limit),

--- a/internal/cmd/cli/describe/computeinstance/describe_computeinstance_cmd.go
+++ b/internal/cmd/cli/describe/computeinstance/describe_computeinstance_cmd.go
@@ -41,18 +41,11 @@ func Cmd() *cobra.Command {
 		Args:                  cobra.ExactArgs(1),
 		RunE:                  runner.run,
 	}
-	result.Flags().BoolVar(
-		&runner.includeDeleted,
-		"include-deleted",
-		false,
-		"Include soft-deleted objects in resolution.",
-	)
 	return result
 }
 
 type runnerContext struct {
-	console        *terminal.Console
-	includeDeleted bool
+	console *terminal.Console
 }
 
 func (c *runnerContext) run(cmd *cobra.Command, args []string) error {
@@ -75,7 +68,7 @@ func (c *runnerContext) run(cmd *cobra.Command, args []string) error {
 
 	client := publicv1.NewComputeInstancesClient(conn)
 
-	matched, err := lookup.Find(ref, "compute instance", lookup.FindOptions{IncludeDeleted: c.includeDeleted}, func(filter string, limit int32) ([]*publicv1.ComputeInstance, error) {
+	matched, err := lookup.Find(ref, "compute instance", func(filter string, limit int32) ([]*publicv1.ComputeInstance, error) {
 		resp, err := client.List(ctx, publicv1.ComputeInstancesListRequest_builder{
 			Filter: proto.String(filter),
 			Limit:  proto.Int32(limit),

--- a/internal/cmd/cli/describe/publicip/describe_publicip_cmd.go
+++ b/internal/cmd/cli/describe/publicip/describe_publicip_cmd.go
@@ -41,19 +41,12 @@ func Cmd() *cobra.Command {
 		Args:                  cobra.ExactArgs(1),
 		RunE:                  runner.run,
 	}
-	result.Flags().BoolVar(
-		&runner.includeDeleted,
-		"include-deleted",
-		false,
-		"Include soft-deleted objects in resolution.",
-	)
 	return result
 }
 
 type runnerContext struct {
-	logger         *slog.Logger
-	console        *terminal.Console
-	includeDeleted bool
+	logger  *slog.Logger
+	console *terminal.Console
 }
 
 func (c *runnerContext) run(cmd *cobra.Command, args []string) error {
@@ -77,7 +70,7 @@ func (c *runnerContext) run(cmd *cobra.Command, args []string) error {
 
 	client := publicv1.NewPublicIPsClient(conn)
 
-	matched, err := lookup.Find(ref, "public IP", lookup.FindOptions{IncludeDeleted: c.includeDeleted}, func(filter string, limit int32) ([]*publicv1.PublicIP, error) {
+	matched, err := lookup.Find(ref, "public IP", func(filter string, limit int32) ([]*publicv1.PublicIP, error) {
 		resp, err := client.List(ctx, publicv1.PublicIPsListRequest_builder{
 			Filter: proto.String(filter),
 			Limit:  proto.Int32(limit),

--- a/internal/cmd/cli/describe/publicipattachment/describe_publicipattachment_cmd.go
+++ b/internal/cmd/cli/describe/publicipattachment/describe_publicipattachment_cmd.go
@@ -41,19 +41,12 @@ func Cmd() *cobra.Command {
 		Args:                  cobra.ExactArgs(1),
 		RunE:                  runner.run,
 	}
-	result.Flags().BoolVar(
-		&runner.includeDeleted,
-		"include-deleted",
-		false,
-		"Include soft-deleted objects in resolution.",
-	)
 	return result
 }
 
 type runnerContext struct {
-	logger         *slog.Logger
-	console        *terminal.Console
-	includeDeleted bool
+	logger  *slog.Logger
+	console *terminal.Console
 }
 
 func (c *runnerContext) run(cmd *cobra.Command, args []string) error {
@@ -77,7 +70,7 @@ func (c *runnerContext) run(cmd *cobra.Command, args []string) error {
 
 	client := publicv1.NewPublicIPAttachmentsClient(conn)
 
-	matched, err := lookup.Find(ref, "public IP attachment", lookup.FindOptions{IncludeDeleted: c.includeDeleted}, func(filter string, limit int32) ([]*publicv1.PublicIPAttachment, error) {
+	matched, err := lookup.Find(ref, "public IP attachment", func(filter string, limit int32) ([]*publicv1.PublicIPAttachment, error) {
 		resp, err := client.List(ctx, publicv1.PublicIPAttachmentsListRequest_builder{
 			Filter: proto.String(filter),
 			Limit:  proto.Int32(limit),

--- a/internal/cmd/cli/describe/securitygroup/describe_securitygroup_cmd.go
+++ b/internal/cmd/cli/describe/securitygroup/describe_securitygroup_cmd.go
@@ -42,19 +42,12 @@ func Cmd() *cobra.Command {
 		Args:                  cobra.ExactArgs(1),
 		RunE:                  runner.run,
 	}
-	result.Flags().BoolVar(
-		&runner.includeDeleted,
-		"include-deleted",
-		false,
-		"Include soft-deleted objects in resolution.",
-	)
 	return result
 }
 
 type runnerContext struct {
-	logger         *slog.Logger
-	console        *terminal.Console
-	includeDeleted bool
+	logger  *slog.Logger
+	console *terminal.Console
 }
 
 func (c *runnerContext) run(cmd *cobra.Command, args []string) error {
@@ -78,7 +71,7 @@ func (c *runnerContext) run(cmd *cobra.Command, args []string) error {
 
 	client := publicv1.NewSecurityGroupsClient(conn)
 
-	matched, err := lookup.Find(ref, "security group", lookup.FindOptions{IncludeDeleted: c.includeDeleted}, func(filter string, limit int32) ([]*publicv1.SecurityGroup, error) {
+	matched, err := lookup.Find(ref, "security group", func(filter string, limit int32) ([]*publicv1.SecurityGroup, error) {
 		resp, err := client.List(ctx, publicv1.SecurityGroupsListRequest_builder{
 			Filter: proto.String(filter),
 			Limit:  proto.Int32(limit),

--- a/internal/cmd/cli/describe/subnet/describe_subnet_cmd.go
+++ b/internal/cmd/cli/describe/subnet/describe_subnet_cmd.go
@@ -42,19 +42,12 @@ func Cmd() *cobra.Command {
 		Args:                  cobra.ExactArgs(1),
 		RunE:                  runner.run,
 	}
-	result.Flags().BoolVar(
-		&runner.includeDeleted,
-		"include-deleted",
-		false,
-		"Include soft-deleted objects in resolution.",
-	)
 	return result
 }
 
 type runnerContext struct {
-	logger         *slog.Logger
-	console        *terminal.Console
-	includeDeleted bool
+	logger  *slog.Logger
+	console *terminal.Console
 }
 
 func (c *runnerContext) run(cmd *cobra.Command, args []string) error {
@@ -78,7 +71,7 @@ func (c *runnerContext) run(cmd *cobra.Command, args []string) error {
 
 	client := publicv1.NewSubnetsClient(conn)
 
-	matched, err := lookup.Find(ref, "subnet", lookup.FindOptions{IncludeDeleted: c.includeDeleted}, func(filter string, limit int32) ([]*publicv1.Subnet, error) {
+	matched, err := lookup.Find(ref, "subnet", func(filter string, limit int32) ([]*publicv1.Subnet, error) {
 		resp, err := client.List(ctx, publicv1.SubnetsListRequest_builder{
 			Filter: proto.String(filter),
 			Limit:  proto.Int32(limit),

--- a/internal/cmd/cli/describe/virtualnetwork/describe_virtualnetwork_cmd.go
+++ b/internal/cmd/cli/describe/virtualnetwork/describe_virtualnetwork_cmd.go
@@ -42,19 +42,12 @@ func Cmd() *cobra.Command {
 		Args:                  cobra.ExactArgs(1),
 		RunE:                  runner.run,
 	}
-	result.Flags().BoolVar(
-		&runner.includeDeleted,
-		"include-deleted",
-		false,
-		"Include soft-deleted objects in resolution.",
-	)
 	return result
 }
 
 type runnerContext struct {
-	logger         *slog.Logger
-	console        *terminal.Console
-	includeDeleted bool
+	logger  *slog.Logger
+	console *terminal.Console
 }
 
 func (c *runnerContext) run(cmd *cobra.Command, args []string) error {
@@ -78,7 +71,7 @@ func (c *runnerContext) run(cmd *cobra.Command, args []string) error {
 
 	client := publicv1.NewVirtualNetworksClient(conn)
 
-	matched, err := lookup.Find(ref, "virtual network", lookup.FindOptions{IncludeDeleted: c.includeDeleted}, func(filter string, limit int32) ([]*publicv1.VirtualNetwork, error) {
+	matched, err := lookup.Find(ref, "virtual network", func(filter string, limit int32) ([]*publicv1.VirtualNetwork, error) {
 		resp, err := client.List(ctx, publicv1.VirtualNetworksListRequest_builder{
 			Filter: proto.String(filter),
 			Limit:  proto.Int32(limit),

--- a/internal/cmd/cli/edit/edit_cmd.go
+++ b/internal/cmd/cli/edit/edit_cmd.go
@@ -66,12 +66,6 @@ func Cmd() *cobra.Command {
 		outputFormatYaml,
 		outputFlagHelp,
 	)
-	flags.BoolVar(
-		&runner.includeDeleted,
-		"include-deleted",
-		false,
-		"Include soft-deleted objects in resolution.",
-	)
 	return result
 }
 
@@ -79,7 +73,6 @@ type runnerContext struct {
 	logger         *slog.Logger
 	console        *terminal.Console
 	format         string
-	includeDeleted bool
 	conn           *grpc.ClientConn
 	marshalOptions protojson.MarshalOptions
 	helper         *reflection.ObjectHelper
@@ -159,7 +152,7 @@ func (c *runnerContext) run(cmd *cobra.Command, args []string) error {
 	key := args[1]
 
 	// Find the object by identifier or name:
-	object, err := c.helper.FindObject(ctx, key, c.includeDeleted, c.console)
+	object, err := c.helper.FindObject(ctx, key, c.console)
 	if err != nil {
 		return err
 	}

--- a/internal/cmd/cli/get/get_cmd.go
+++ b/internal/cmd/cli/get/get_cmd.go
@@ -80,12 +80,6 @@ func Cmd() *cobra.Command {
 		"",
 		filterFlagHelp,
 	)
-	flags.BoolVar(
-		&runner.args.includeDeleted,
-		"include-deleted",
-		false,
-		includeDeletedFlagHelp,
-	)
 	flags.BoolVarP(
 		&runner.args.watch,
 		"watch",
@@ -98,10 +92,9 @@ func Cmd() *cobra.Command {
 
 type runnerContext struct {
 	args struct {
-		format         string
-		filter         string
-		includeDeleted bool
-		watch          bool
+		format string
+		filter string
+		watch  bool
 	}
 	ctx            context.Context
 	logger         *slog.Logger
@@ -230,8 +223,6 @@ func (c *runnerContext) list(ctx context.Context, keys []string) (results []prot
 		}
 	}
 
-	options.IncludeDeleted = c.args.includeDeleted
-
 	listResult, err := c.objectHelper.List(ctx, options)
 	if err != nil {
 		return
@@ -252,7 +243,6 @@ func (c *runnerContext) renderTable(ctx context.Context, objects []proto.Message
 		SetLogger(c.logger).
 		SetHelper(c.globalHelper).
 		SetWriter(c.console).
-		SetIncludeDeleted(c.args.includeDeleted).
 		Build()
 	if err != nil {
 		return fmt.Errorf("failed to create table renderer: %w", err)
@@ -375,10 +365,6 @@ _FORMAT_ - Output format. Must be one of {{ bt }}table{{ bt }}, {{ bt }}json{{ b
 const filterFlagHelp = `
 _EXPRESSION_ - CEL expression used for filtering results. The expression is evaluated against each object and only those
 for which it returns true are included in the output.
-`
-
-const includeDeletedFlagHelp = `
-_[BOOLEAN]_ - Include objects that have been marked for deletion but have not yet been fully removed.
 `
 
 const watchFlagHelp = `

--- a/internal/cmd/cli/get/get_cmd_watch_e2e_test.go
+++ b/internal/cmd/cli/get/get_cmd_watch_e2e_test.go
@@ -132,10 +132,9 @@ var _ = Describe("Watch e2e", func() {
 			objectHelper: helper,
 			console:      console,
 			args: struct {
-				format         string
-				filter         string
-				includeDeleted bool
-				watch          bool
+				format string
+				filter string
+				watch  bool
 			}{
 				format: outputFormatTable,
 				watch:  true,

--- a/internal/cmd/cli/get/publicippool/get_publicippool_cmd.go
+++ b/internal/cmd/cli/get/publicippool/get_publicippool_cmd.go
@@ -85,7 +85,7 @@ func (c *runnerContext) run(cmd *cobra.Command, args []string) error {
 	}
 
 	ref := args[0]
-	pool, err := lookup.Find(ref, "public IP pool", lookup.FindOptions{}, func(filter string, limit int32) ([]*publicv1.PublicIPPool, error) {
+	pool, err := lookup.Find(ref, "public IP pool", func(filter string, limit int32) ([]*publicv1.PublicIPPool, error) {
 		resp, err := client.List(ctx, publicv1.PublicIPPoolsListRequest_builder{
 			Filter: proto.String(filter),
 			Limit:  proto.Int32(limit),

--- a/internal/cmd/cli/label/label_cmd.go
+++ b/internal/cmd/cli/label/label_cmd.go
@@ -128,7 +128,7 @@ func (c *runnerContext) run(cmd *cobra.Command, args []string) error {
 	}
 
 	// Find the object by identifier or name:
-	object, err := c.helper.FindObject(ctx, ref, false, c.console)
+	object, err := c.helper.FindObject(ctx, ref, c.console)
 	if err != nil {
 		return err
 	}

--- a/internal/cmd/cli/lookup/lookup.go
+++ b/internal/cmd/cli/lookup/lookup.go
@@ -42,31 +42,14 @@ func (e *ErrAmbiguous) Error() string {
 	return fmt.Sprintf("multiple %ss match %q, use the ID instead", e.Kind, e.Ref)
 }
 
-// NotDeletedFilter is the CEL expression that excludes soft-deleted objects.
-const NotDeletedFilter = "!has(this.metadata.deletion_timestamp)"
-
-// FindOptions configures the behavior of Find.
-type FindOptions struct {
-	IncludeDeleted bool
-}
-
 // Find resolves a name-or-ID reference to exactly one object.
 // It builds the CEL filter "this.id == ref || this.metadata.name == ref", calls list, and returns matching object.
-// When opts.IncludeDeleted is false the filter also excludes soft-deleted objects.
-func Find[T any](ref, kind string, opts FindOptions, list ListFunc[T]) (result T, err error) {
+func Find[T any](ref, kind string, list ListFunc[T]) (result T, err error) {
 	if ref == "" {
 		err = fmt.Errorf("%s name or ID must not be empty", kind)
 		return
 	}
-	var filter string
-	if opts.IncludeDeleted {
-		filter = fmt.Sprintf(`this.id == %[1]q || this.metadata.name == %[1]q`, ref)
-	} else {
-		filter = fmt.Sprintf(
-			`%[1]s && (this.id == %[2]q || this.metadata.name == %[2]q)`,
-			NotDeletedFilter, ref,
-		)
-	}
+	filter := fmt.Sprintf(`this.id == %[1]q || this.metadata.name == %[1]q`, ref)
 	items, err := list(filter, 2)
 	if err != nil {
 		return

--- a/internal/cmd/cli/lookup/lookup_test.go
+++ b/internal/cmd/cli/lookup/lookup_test.go
@@ -51,33 +51,10 @@ func captureListFn(captured *string) ListFunc[*fakeItem] {
 }
 
 var _ = Describe("Find", func() {
-	table.DescribeTable("CEL filter construction (exclude deleted)",
+	table.DescribeTable("CEL filter construction",
 		func(ref, expectedFilter string) {
 			var got string
-			_, _ = Find(ref, "compute instance", FindOptions{}, captureListFn(&got))
-			Expect(got).To(Equal(expectedFilter))
-		},
-		table.Entry("plain name",
-			"my-vm",
-			`!has(this.metadata.deletion_timestamp) && (this.id == "my-vm" || this.metadata.name == "my-vm")`),
-		table.Entry("UUID-style ID",
-			"550e8400-e29b-41d4-a716-446655440000",
-			`!has(this.metadata.deletion_timestamp) && (this.id == "550e8400-e29b-41d4-a716-446655440000" || this.metadata.name == "550e8400-e29b-41d4-a716-446655440000")`),
-		table.Entry("double quotes are escaped",
-			`my"vm`,
-			`!has(this.metadata.deletion_timestamp) && (this.id == "my\"vm" || this.metadata.name == "my\"vm")`),
-		table.Entry("backslashes are escaped",
-			`my\vm`,
-			`!has(this.metadata.deletion_timestamp) && (this.id == "my\\vm" || this.metadata.name == "my\\vm")`),
-		table.Entry("single quotes pass through unescaped",
-			"my'vm",
-			`!has(this.metadata.deletion_timestamp) && (this.id == "my'vm" || this.metadata.name == "my'vm")`),
-	)
-
-	table.DescribeTable("CEL filter construction (include deleted)",
-		func(ref, expectedFilter string) {
-			var got string
-			_, _ = Find(ref, "compute instance", FindOptions{IncludeDeleted: true}, captureListFn(&got))
+			_, _ = Find(ref, "compute instance", captureListFn(&got))
 			Expect(got).To(Equal(expectedFilter))
 		},
 		table.Entry("plain name",
@@ -86,18 +63,27 @@ var _ = Describe("Find", func() {
 		table.Entry("UUID-style ID",
 			"550e8400-e29b-41d4-a716-446655440000",
 			`this.id == "550e8400-e29b-41d4-a716-446655440000" || this.metadata.name == "550e8400-e29b-41d4-a716-446655440000"`),
+		table.Entry("double quotes are escaped",
+			`my"vm`,
+			`this.id == "my\"vm" || this.metadata.name == "my\"vm"`),
+		table.Entry("backslashes are escaped",
+			`my\vm`,
+			`this.id == "my\\vm" || this.metadata.name == "my\\vm"`),
+		table.Entry("single quotes pass through unescaped",
+			"my'vm",
+			`this.id == "my'vm" || this.metadata.name == "my'vm"`),
 	)
 
 	Describe("match count handling", func() {
 		It("should return the single item on exactly one match", func() {
 			item := &fakeItem{id: "abc"}
-			result, err := Find("abc", "compute instance", FindOptions{}, makeListFn([]*fakeItem{item}))
+			result, err := Find("abc", "compute instance", makeListFn([]*fakeItem{item}))
 			Expect(err).NotTo(HaveOccurred())
 			Expect(result).To(Equal(item))
 		})
 
 		It("should return ErrNotFound on zero matches", func() {
-			_, err := Find("missing", "virtual network", FindOptions{}, makeListFn(nil))
+			_, err := Find("missing", "virtual network", makeListFn(nil))
 			Expect(err).To(HaveOccurred())
 			var notFound *ErrNotFound
 			Expect(errors.As(err, &notFound)).To(BeTrue())
@@ -110,7 +96,7 @@ var _ = Describe("Find", func() {
 
 		It("should return ErrAmbiguous on two or more matches", func() {
 			items := []*fakeItem{{id: "a"}, {id: "b"}}
-			_, err := Find("shared-name", "subnet", FindOptions{}, makeListFn(items))
+			_, err := Find("shared-name", "subnet", makeListFn(items))
 			Expect(err).To(HaveOccurred())
 			var ambiguous *ErrAmbiguous
 			Expect(errors.As(err, &ambiguous)).To(BeTrue())
@@ -129,7 +115,7 @@ var _ = Describe("Find", func() {
 				called = true
 				return nil, nil
 			}
-			_, err := Find("", "compute instance", FindOptions{}, listFn)
+			_, err := Find("", "compute instance", listFn)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("compute instance"))
 			Expect(err.Error()).To(ContainSubstring("must not be empty"))
@@ -139,7 +125,7 @@ var _ = Describe("Find", func() {
 
 	Describe("list function error propagation", func() {
 		It("should propagate errors returned by the list function", func() {
-			_, err := Find("ref", "cluster", FindOptions{}, errorListFn("connection refused"))
+			_, err := Find("ref", "cluster", errorListFn("connection refused"))
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("connection refused"))
 			var notFound *ErrNotFound

--- a/internal/reflection/find_object.go
+++ b/internal/reflection/find_object.go
@@ -35,12 +35,11 @@ type Renderer interface {
 // Expected templates (looked up in the console's registered template set):
 //   - "no_matches.txt"       vars: Object (string), Ref (string)
 //   - "multiple_matches.txt" vars: Matches ([]proto.Message), Object (string), Ref (string), Total (int32)
-func (h *ObjectHelper) FindObject(ctx context.Context, ref string, includeDeleted bool, console Renderer) (result proto.Message, err error) {
+func (h *ObjectHelper) FindObject(ctx context.Context, ref string, console Renderer) (result proto.Message, err error) {
 	filter := fmt.Sprintf(`this.id == %[1]q || this.metadata.name == %[1]q`, ref)
 	response, err := h.List(ctx, ListOptions{
-		Filter:         filter,
-		Limit:          2,
-		IncludeDeleted: includeDeleted,
+		Filter: filter,
+		Limit:  2,
 	})
 	if err != nil {
 		err = fmt.Errorf(

--- a/internal/reflection/reflection_helper.go
+++ b/internal/reflection/reflection_helper.go
@@ -33,7 +33,6 @@ import (
 	// they will be visible only if they are explicitly used in some part of the code.
 	_ "github.com/osac-project/fulfillment-service/internal/api/osac/private/v1"
 	_ "github.com/osac-project/fulfillment-service/internal/api/osac/public/v1"
-	"github.com/osac-project/fulfillment-service/internal/cmd/cli/lookup"
 )
 
 // Frequently used names:
@@ -602,9 +601,8 @@ func (h *ObjectHelper) Plural() string {
 }
 
 type ListOptions struct {
-	Filter         string
-	Limit          int32
-	IncludeDeleted bool
+	Filter string
+	Limit  int32
 }
 
 type ListResult struct {
@@ -614,13 +612,6 @@ type ListResult struct {
 
 func (h *ObjectHelper) List(ctx context.Context, options ListOptions) (result ListResult, err error) {
 	filter := options.Filter
-	if !options.IncludeDeleted {
-		if filter != "" {
-			filter = fmt.Sprintf("%s && (%s)", lookup.NotDeletedFilter, filter)
-		} else {
-			filter = lookup.NotDeletedFilter
-		}
-	}
 	request := proto.Clone(h.list.request)
 	if filter != "" {
 		request.ProtoReflect().Set(h.list.filter, protoreflect.ValueOfString(filter))

--- a/internal/rendering/table_renderer.go
+++ b/internal/rendering/table_renderer.go
@@ -79,20 +79,18 @@ type columnLayout struct {
 // TableRendererBuilder is used to create table renderers. Don't create instances of this type directly, use the
 // NewTableRenderer function instead.
 type TableRendererBuilder struct {
-	logger         *slog.Logger
-	helper         *reflection.Helper
-	writer         io.Writer
-	includeDeleted bool
+	logger *slog.Logger
+	helper *reflection.Helper
+	writer io.Writer
 }
 
 // TableRenderer is responsible for rendering protocol buffer messages as tables. Don't create instances of this type
 // directly, use the NewTableRenderer function instead.
 type TableRenderer struct {
-	logger         *slog.Logger
-	helper         *reflection.Helper
-	writer         *tabwriter.Writer
-	cache          map[protoreflect.FullName]map[string]string
-	includeDeleted bool
+	logger *slog.Logger
+	helper *reflection.Helper
+	writer *tabwriter.Writer
+	cache  map[protoreflect.FullName]map[string]string
 }
 
 // NewTableRenderer creates a new builder for table renderers.
@@ -115,12 +113,6 @@ func (b *TableRendererBuilder) SetHelper(value *reflection.Helper) *TableRendere
 // SetWriter sets the writer that the renderer will use to write messages to the console. This is mandatory.
 func (b *TableRendererBuilder) SetWriter(value io.Writer) *TableRendererBuilder {
 	b.writer = value
-	return b
-}
-
-// SetIncludeDeleted sets whether to include the DELETED column in the output.
-func (b *TableRendererBuilder) SetIncludeDeleted(value bool) *TableRendererBuilder {
-	b.includeDeleted = value
 	return b
 }
 
@@ -148,11 +140,10 @@ func (b *TableRendererBuilder) Build() (result *TableRenderer, err error) {
 
 	// Create and populate the object:
 	result = &TableRenderer{
-		logger:         b.logger,
-		helper:         b.helper,
-		writer:         writer,
-		cache:          cache,
-		includeDeleted: b.includeDeleted,
+		logger: b.logger,
+		helper: b.helper,
+		writer: writer,
+		cache:  cache,
 	}
 	return
 }
@@ -194,14 +185,13 @@ func (r *TableRenderer) Render(ctx context.Context, objects any) error {
 		table = r.defaultTable()
 	}
 
-	// If the user has asked to include deleted objects then add the deletion timestamp column:
-	if r.includeDeleted {
-		deletedCol := &columnLayout{
-			Header: "DELETED",
-			Value:  "has(this.metadata.deletion_timestamp)? string(this.metadata.deletion_timestamp): '-'",
-		}
-		table.Columns = slices.Insert(table.Columns, 1, deletedCol)
+	// Always show a DELETING column so users can see objects being torn down.
+	// TODO: remove this column once all resource types have DELETING in their state enum.
+	deletingCol := &columnLayout{
+		Header: "DELETING",
+		Value:  "has(this.metadata.deletion_timestamp)? 'Yes': '-'",
 	}
+	table.Columns = slices.Insert(table.Columns, 1, deletingCol)
 
 	// Get the descriptor for the object type:
 	thisDesc := helper.Descriptor()

--- a/internal/rendering/table_renderer_test.go
+++ b/internal/rendering/table_renderer_test.go
@@ -22,6 +22,7 @@ import (
 	. "github.com/onsi/gomega"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/protobuf/types/known/timestamppb"
 
 	publicv1 "github.com/osac-project/fulfillment-service/internal/api/osac/public/v1"
 	"github.com/osac-project/fulfillment-service/internal/packages"
@@ -123,5 +124,58 @@ var _ = Describe("Table renderer", func() {
 				"OpenShift Virt VM",
 			),
 		)
+	})
+
+	Describe("DELETING column", func() {
+		renderSubnets := func(items []*publicv1.Subnet) string {
+			server.Start()
+
+			var buf bytes.Buffer
+			renderer, err := NewTableRenderer().
+				SetLogger(logger).
+				SetHelper(helper).
+				SetWriter(&buf).
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+
+			err = renderer.Render(ctx, items)
+			Expect(err).ToNot(HaveOccurred())
+			return buf.String()
+		}
+
+		It("always includes the DELETING header", func() {
+			output := renderSubnets([]*publicv1.Subnet{
+				publicv1.Subnet_builder{
+					Id:       "subnet-1",
+					Metadata: publicv1.Metadata_builder{Name: "active-subnet"}.Build(),
+				}.Build(),
+			})
+			Expect(output).To(ContainSubstring("DELETING"))
+		})
+
+		It("shows dash for non-deleting objects", func() {
+			output := renderSubnets([]*publicv1.Subnet{
+				publicv1.Subnet_builder{
+					Id:       "subnet-1",
+					Metadata: publicv1.Metadata_builder{Name: "active-subnet"}.Build(),
+				}.Build(),
+			})
+			Expect(output).To(MatchRegexp(`DELETING.*\n.*-`))
+		})
+
+		It("shows Yes for deleting objects", func() {
+			ts := timestamppb.Now()
+			output := renderSubnets([]*publicv1.Subnet{
+				publicv1.Subnet_builder{
+					Id: "subnet-2",
+					Metadata: publicv1.Metadata_builder{
+						Name:              "deleting-subnet",
+						DeletionTimestamp: ts,
+					}.Build(),
+				}.Build(),
+			})
+			Expect(output).To(ContainSubstring("DELETING"))
+			Expect(output).To(MatchRegexp(`subnet-2\s+Yes\s`))
+		})
 	})
 })


### PR DESCRIPTION
## Summary

- Remove the `--include-deleted` flag entirely from `get`, `describe`, and `edit` commands — it was a temporary workaround from before archive tables existed
- Always show all non-archived objects in CLI output (no more filtering by `deletion_timestamp`)
- Always display a `DELETING` column in table output so users can see objects being torn down
- Keep the "Deleted" message in the delete command (consistent with `oc delete` convention)

## Jira

[OSAC-474](https://redhat.atlassian.net/browse/OSAC-474)

## Context

The `--include-deleted` flag and `!has(this.metadata.deletion_timestamp)` filter were introduced as a temporary workaround before archive tables existed (see fulfillment-cli PR #17). Now that fully-deleted objects go to `archived_*` tables, the workaround is obsolete — if an object is in the main table, it's still active and should be visible.

This caused user confusion: `osac delete subnet` said "Deleted" and `osac get subnet` showed nothing, but creating a new subnet with the same CIDR failed because the old one was still being torn down.

The agreed approach (from [Jira discussion](https://redhat.atlassian.net/browse/OSAC-474)):
1. Remove the flag entirely — archive tables handle truly-deleted objects now
2. Keep the "Deleted" message as-is (consistent with `oc delete namespace`)
3. Show deletion state visually in table output (DELETING column)
4. Don't change CIDR overlap validation (it's correct)

## Test plan

- [x] `gofmt -s -w .` — no changes
- [x] `go build ./...` — compiles
- [x] `ginkgo run -r internal` — passes (pre-existing auth test env issue excluded)
- [x] New unit tests for DELETING column: header always present, dash for active objects, timestamp for deleting objects
- [ ] `osac get subnet` shows subnets in DELETING state with DELETING column
- [ ] `osac delete subnet <id>` prints "Deleted subnet '...'"

🤖 Generated with [Claude Code](https://claude.com/claude-code)