### PR TITLE
fix: add gofmt to pre-PR hook

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -17,7 +17,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "cmd=$(cat - | jq -r '.tool_input.command // empty') && case \"$cmd\" in *'git commit'*) cd \"$CLAUDE_PROJECT_DIR\" && buf lint ;; *'gh pr create'*) cd \"$CLAUDE_PROJECT_DIR\" && buf lint && ginkgo run -r internal ;; esac"
+            "command": "cmd=$(cat - | jq -r '.tool_input.command // empty') && case \"$cmd\" in *'git commit'*) cd \"$CLAUDE_PROJECT_DIR\" && buf lint ;; *'gh pr create'*) cd \"$CLAUDE_PROJECT_DIR\" && gofmt -s -w . && test -z \\\"$(git diff --name-only)\\\" && buf lint && ginkgo run -r internal ;; esac"
           }
         ]
       }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -138,7 +138,7 @@ Hooks are configured in `.claude/settings.json` and run automatically during Cla
 - **Proto changes** (`PostToolUse`): When a `.proto` file is edited, `buf lint && buf generate` runs automatically to keep generated Go code in sync.
 - **Go module changes** (`PostToolUse`): When `go.mod` is edited, `go mod tidy` runs automatically.
 - **Pre-commit** (`PreToolUse`): `buf lint` runs before every `git commit` to catch proto issues early.
-- **Pre-PR** (`PreToolUse`): `buf lint && ginkgo run -r internal` runs before `gh pr create` to ensure tests pass.
+- **Pre-PR** (`PreToolUse`): `gofmt -s -w .` (auto-formats, then fails if any files changed — commit the fixes first), `buf lint`, and `ginkgo run -r internal` run before `gh pr create`.
 
 To replicate this setup in another OSAC repo, copy `.claude/settings.json` and adjust the commands as needed.
 


### PR DESCRIPTION
## Summary

- Add `gofmt -s -w .` to the pre-PR Claude Code hook so formatting issues are caught before PR creation
- Update CLAUDE.md to document this step

Prevents CI format check failures like the one in #482.

## Test plan

- [ ] `gh pr create` triggers `gofmt -s -w .` before `buf lint` and `ginkgo`

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development workflow to enforce additional code formatting validation before pull request creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->