### PR TITLE
MGMT-24034: Switch console backend to console.osac.openshift.io API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@
 /fulfillment-service
 /logs
 __debug_bin*
+.idea
+.vscode

--- a/internal/cmd/cli/console/computeinstance/console_computeinstance_cmd.go
+++ b/internal/cmd/cli/console/computeinstance/console_computeinstance_cmd.go
@@ -221,10 +221,19 @@ func (c *runnerContext) connectWithRetry(ctx context.Context, instanceID string)
 }
 
 func (c *runnerContext) connectOnce(ctx context.Context, instanceID string) error {
+	// Each attempt gets its own context so that when connectOnce returns
+	// (on error or clean disconnect), the gRPC stream is explicitly cancelled
+	// and its resources are released. For an active HTTP/2 gRPC stream, this
+	// normally aborts the stream on the wire, instead of leaving the server-side
+	// session alive until the parent context is cancelled — which would block
+	// reconnection because the server enforces one session per resource.
+	streamCtx, streamCancel := context.WithCancel(ctx)
+	defer streamCancel()
+
 	client := publicv1.NewConsoleClient(c.conn)
 
 	// Open bidirectional stream.
-	stream, err := client.Connect(ctx)
+	stream, err := client.Connect(streamCtx)
 	if err != nil {
 		return fmt.Errorf("failed to open console stream: %w", err)
 	}
@@ -242,7 +251,7 @@ func (c *runnerContext) connectOnce(ctx context.Context, instanceID string) erro
 	}
 
 	// Wait for connected status.
-	if err := c.waitForConnected(ctx, stream, instanceID); err != nil {
+	if err := c.waitForConnected(streamCtx, stream, instanceID); err != nil {
 		return err
 	}
 
@@ -256,7 +265,7 @@ func (c *runnerContext) connectOnce(ctx context.Context, instanceID string) erro
 		defer term.Restore(fd, oldState)
 	}
 
-	err = c.proxyIO(ctx, stream)
+	err = c.proxyIO(streamCtx, stream)
 	if err != nil {
 		// We were connected and then lost the connection.
 		return fmt.Errorf("%w: %v", errConnectionLost, err)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -233,6 +233,7 @@ func (c *Config) Connect(ctx context.Context, flags *pflag.FlagSet) (result *grp
 		SetCaPool(c.caPool).
 		SetTokenSource(tokenSource).
 		SetAddress(c.Address).
+		SetKeepAlive(10 * time.Second).
 		AddUnaryInterceptor(versionInterceptor.UnaryClient).
 		AddStreamInterceptor(versionInterceptor.StreamClient).
 		Build()

--- a/internal/console/backend.go
+++ b/internal/console/backend.go
@@ -46,5 +46,5 @@ type Target struct {
 	ResourceID   string
 	HubID        string
 	Namespace    string
-	VMName       string
+	CRName       string
 }

--- a/internal/console/kubevirt_backend.go
+++ b/internal/console/kubevirt_backend.go
@@ -39,7 +39,8 @@ type KubeVirtBackendBuilder struct {
 	hubConfigProvider HubConfigProvider
 }
 
-// kubeVirtBackend connects to KubeVirt VirtualMachineInstance console subresource.
+// kubeVirtBackend connects to compute instance serial consoles on hub clusters
+// via the console.osac.openshift.io aggregated API.
 type kubeVirtBackend struct {
 	logger            *slog.Logger
 	hubConfigProvider HubConfigProvider
@@ -73,12 +74,12 @@ func (b *KubeVirtBackendBuilder) Build() (Backend, error) {
 	}, nil
 }
 
-// Connect opens a WebSocket connection to the KubeVirt serial console subresource.
+// Connect opens a WebSocket to the compute instance console subresource on the target hub.
 func (b *kubeVirtBackend) Connect(ctx context.Context, target Target) (io.ReadWriteCloser, error) {
-	b.logger.InfoContext(ctx, "Connecting to KubeVirt console",
+	b.logger.InfoContext(ctx, "Connecting to console",
 		slog.String("hub", target.HubID),
 		slog.String("namespace", target.Namespace),
-		slog.String("vm", target.VMName),
+		slog.String("compute_instance", target.CRName),
 	)
 
 	config, err := b.hubConfigProvider(ctx, target.HubID)
@@ -86,7 +87,7 @@ func (b *kubeVirtBackend) Connect(ctx context.Context, target Target) (io.ReadWr
 		return nil, fmt.Errorf("failed to get hub config for %q: %w", target.HubID, err)
 	}
 
-	// Build the WebSocket URL for the KubeVirt console subresource.
+	// Build the WebSocket URL for the console subresource.
 	host := config.Host
 	if !strings.Contains(host, "://") {
 		host = "https://" + host
@@ -102,9 +103,9 @@ func (b *kubeVirtBackend) Connect(ctx context.Context, target Target) (io.ReadWr
 	}
 
 	consolePath := fmt.Sprintf(
-		"/apis/subresources.kubevirt.io/v1/namespaces/%s/virtualmachineinstances/%s/console",
+		"/apis/console.osac.openshift.io/v1alpha1/namespaces/%s/computeinstances/%s/console",
 		url.PathEscape(target.Namespace),
-		url.PathEscape(target.VMName),
+		url.PathEscape(target.CRName),
 	)
 
 	wsURL := fmt.Sprintf("%s://%s%s", scheme, parsed.Host, consolePath)
@@ -149,16 +150,16 @@ func (b *kubeVirtBackend) Connect(ctx context.Context, target Target) (io.ReadWr
 
 	conn, err := websocket.DialConfig(wsConfig)
 	if err != nil {
-		return nil, fmt.Errorf("failed to connect to KubeVirt console: %w", err)
+		return nil, fmt.Errorf("failed to connect to console: %w", err)
 	}
 
 	// Set binary mode for raw console I/O.
 	conn.PayloadType = websocket.BinaryFrame
 
-	b.logger.InfoContext(ctx, "Connected to KubeVirt console",
+	b.logger.InfoContext(ctx, "Connected to console",
 		slog.String("hub", target.HubID),
 		slog.String("namespace", target.Namespace),
-		slog.String("vm", target.VMName),
+		slog.String("compute_instance", target.CRName),
 	)
 
 	return conn, nil

--- a/internal/console/kubevirt_backend_integration_test.go
+++ b/internal/console/kubevirt_backend_integration_test.go
@@ -57,7 +57,7 @@ var _ = Describe("KubeVirt Backend Integration", func() {
 		conn, err := backend.Connect(ctx, Target{
 			HubID:     "hub-1",
 			Namespace: "test-ns",
-			VMName:    "test-vm",
+			CRName:    "test-vm",
 		})
 		Expect(err).NotTo(HaveOccurred())
 		defer conn.Close()
@@ -106,7 +106,7 @@ var _ = Describe("KubeVirt Backend Integration", func() {
 			ResourceID:   "ci-123",
 			HubID:        "hub-1",
 			Namespace:    "test-ns",
-			VMName:       "test-vm",
+			CRName:       "test-vm",
 		}, "testuser")
 		Expect(err).NotTo(HaveOccurred())
 		Expect(mgr.ActiveSessions()).To(Equal(1))
@@ -160,7 +160,7 @@ var _ = Describe("KubeVirt Backend Integration", func() {
 		conn, err := backend.Connect(ctx, Target{
 			HubID:     "hub-1",
 			Namespace: "test-ns",
-			VMName:    "test-vm",
+			CRName:    "test-vm",
 		})
 		Expect(err).NotTo(HaveOccurred())
 
@@ -203,7 +203,7 @@ var _ = Describe("KubeVirt Backend Integration", func() {
 			ResourceID:   "ci-same",
 			HubID:        "hub-1",
 			Namespace:    "test-ns",
-			VMName:       "test-vm",
+			CRName:       "test-vm",
 		}
 
 		conn1, err := mgr.Connect(ctx, target, "user1")
@@ -248,7 +248,7 @@ var _ = Describe("KubeVirt Backend Integration", func() {
 		defer cancel()
 
 		conn, err := backend.Connect(ctx, Target{
-			HubID: "hub-1", Namespace: "test-ns", VMName: "test-vm",
+			HubID: "hub-1", Namespace: "test-ns", CRName: "test-vm",
 		})
 		Expect(err).NotTo(HaveOccurred())
 		defer conn.Close()
@@ -291,7 +291,7 @@ var _ = Describe("KubeVirt Backend Integration", func() {
 		defer cancel()
 
 		conn, err := backend.Connect(ctx, Target{
-			HubID: "hub-1", Namespace: "test-ns", VMName: "test-vm",
+			HubID: "hub-1", Namespace: "test-ns", CRName: "test-vm",
 		})
 		Expect(err).NotTo(HaveOccurred())
 		defer conn.Close()

--- a/internal/console/kubevirt_backend_test.go
+++ b/internal/console/kubevirt_backend_test.go
@@ -70,7 +70,7 @@ var _ = Describe("KubeVirt Backend", func() {
 			_, err = backend.Connect(context.Background(), Target{
 				HubID:     "missing-hub",
 				Namespace: "test-ns",
-				VMName:    "test-vm",
+				CRName:    "test-cr",
 			})
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("missing-hub"))
@@ -94,7 +94,7 @@ var _ = Describe("KubeVirt Backend", func() {
 			_, err = backend.Connect(context.Background(), Target{
 				HubID:     "hub-1",
 				Namespace: "test-ns",
-				VMName:    "test-vm",
+				CRName:    "test-cr",
 			})
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("failed to connect"))

--- a/internal/console/manager_test.go
+++ b/internal/console/manager_test.go
@@ -146,7 +146,7 @@ var _ = Describe("Manager", func() {
 				ResourceID:   "test-123",
 				HubID:        "hub-1",
 				Namespace:    "ns",
-				VMName:       "vm-1",
+				CRName:       "vm-1",
 			}
 
 			conn, err := mgr.Connect(ctx, target, "testuser")

--- a/internal/console/mock_ws_server_test.go
+++ b/internal/console/mock_ws_server_test.go
@@ -21,7 +21,7 @@ import (
 	"golang.org/x/net/websocket"
 )
 
-// mockWSServer simulates a KubeVirt serial console subresource endpoint.
+// mockWSServer simulates the console subresource endpoint.
 // It accepts WebSocket connections and echoes data back with a configurable prefix.
 type mockWSServer struct {
 	listener   net.Listener
@@ -45,7 +45,7 @@ func newMockWSServer() (*mockWSServer, error) {
 	}
 
 	mux := http.NewServeMux()
-	mux.Handle("/apis/subresources.kubevirt.io/v1/namespaces/", websocket.Handler(m.handleConsole))
+	mux.Handle("/apis/console.osac.openshift.io/v1alpha1/namespaces/", websocket.Handler(m.handleConsole))
 
 	m.server = &http.Server{Handler: mux}
 	go m.server.Serve(listener)
@@ -63,7 +63,7 @@ func newMockWSServerWithHandler(handler func(ws *websocket.Conn)) (*mockWSServer
 	m := &mockWSServer{listener: listener}
 
 	mux := http.NewServeMux()
-	mux.Handle("/apis/subresources.kubevirt.io/v1/namespaces/", websocket.Handler(handler))
+	mux.Handle("/apis/console.osac.openshift.io/v1alpha1/namespaces/", websocket.Handler(handler))
 
 	m.server = &http.Server{Handler: mux}
 	go m.server.Serve(listener)

--- a/internal/servers/console_server.go
+++ b/internal/servers/console_server.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"net"
 
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -202,7 +203,7 @@ func (s *consoleServer) Connect(stream publicv1.Console_ConnectServer) error {
 			slog.String("resource_id", resourceID),
 			slog.String("hub", target.HubID),
 			slog.String("namespace", target.Namespace),
-			slog.String("vm", target.VMName),
+			slog.String("compute_instance", target.CRName),
 			slog.Any("error", err),
 		)
 		return status.Errorf(codes.Internal, "failed to connect: %v", err)
@@ -245,7 +246,7 @@ func (s *consoleServer) proxy(ctx context.Context, stream publicv1.Console_Conne
 				}
 			}
 			if err != nil {
-				if errors.Is(err, io.EOF) || errors.Is(err, context.Canceled) {
+				if errors.Is(err, io.EOF) || errors.Is(err, net.ErrClosed) || errors.Is(err, context.Canceled) {
 					errCh <- nil
 				} else {
 					errCh <- fmt.Errorf("read from backend: %w", err)
@@ -260,7 +261,7 @@ func (s *consoleServer) proxy(ctx context.Context, stream publicv1.Console_Conne
 		for {
 			req, err := stream.Recv()
 			if err != nil {
-				if errors.Is(err, io.EOF) || errors.Is(err, context.Canceled) {
+				if errors.Is(err, io.EOF) || errors.Is(err, net.ErrClosed) || errors.Is(err, context.Canceled) {
 					errCh <- nil
 				} else {
 					errCh <- fmt.Errorf("recv from client: %w", err)
@@ -273,7 +274,11 @@ func (s *consoleServer) proxy(ctx context.Context, stream publicv1.Console_Conne
 				if len(data) > 0 {
 					_, writeErr := conn.Write(data)
 					if writeErr != nil {
-						errCh <- fmt.Errorf("write to backend: %w", writeErr)
+						if errors.Is(writeErr, net.ErrClosed) {
+							errCh <- nil
+						} else {
+							errCh <- fmt.Errorf("write to backend: %w", writeErr)
+						}
 						return
 					}
 				}
@@ -299,7 +304,7 @@ func (s *consoleServer) proxy(ctx context.Context, stream publicv1.Console_Conne
 	select {
 	case err := <-errCh:
 		if err != nil && ctx.Err() == nil {
-			s.logger.InfoContext(ctx, "Console proxy ended with error",
+			s.logger.WarnContext(ctx, "Console proxy error",
 				slog.Any("error", err),
 			)
 			return err
@@ -368,8 +373,8 @@ func (s *consoleServer) resolveComputeInstance(ctx context.Context, id string) (
 			"compute instance %q has no hub assigned", id)
 	}
 
-	// Query the hub cluster for the VM reference.
-	namespace, vmName, err := s.getVMReferenceFromHub(txCtx, hubID, id)
+	// Query the hub cluster for the ComputeInstance CR.
+	namespace, crName, err := s.getComputeInstanceFromHub(txCtx, hubID, id)
 	if err != nil {
 		return nil, err
 	}
@@ -379,13 +384,13 @@ func (s *consoleServer) resolveComputeInstance(ctx context.Context, id string) (
 		ResourceID:   id,
 		HubID:        hubID,
 		Namespace:    namespace,
-		VMName:       vmName,
+		CRName:       crName,
 	}, nil
 }
 
-// getVMReferenceFromHub queries the hub cluster for the ComputeInstance CR
-// matching the given instance ID, and extracts the VM reference from its status.
-func (s *consoleServer) getVMReferenceFromHub(ctx context.Context, hubID, instanceID string) (namespace, vmName string, err error) {
+// getComputeInstanceFromHub queries the hub cluster for the ComputeInstance CR
+// matching the given instance ID, and returns its namespace and name.
+func (s *consoleServer) getComputeInstanceFromHub(ctx context.Context, hubID, instanceID string) (namespace, crName string, err error) {
 	// Get the hub's kubeconfig.
 	hubResp, err := s.hubServer.Get(ctx, privatev1.HubsGetRequest_builder{
 		Id: hubID,
@@ -433,30 +438,25 @@ func (s *consoleServer) getVMReferenceFromHub(ctx context.Context, hubID, instan
 		return
 	}
 
-	// Extract virtualMachineReference from the CR status.
 	obj := items[0]
-	vmRef := obj.Status.VirtualMachineReference
-	if vmRef == nil {
-		s.logger.WarnContext(ctx, "Running compute instance has no VM reference on hub",
+	if obj.Status.Phase != osacv1alpha1.ComputeInstancePhaseRunning {
+		phase := string(obj.Status.Phase)
+		s.logger.WarnContext(ctx, "Compute instance is not running on hub",
 			slog.String("instance_id", instanceID),
 			slog.String("hub_id", hubID),
 			slog.String("cr_name", obj.GetName()),
+			slog.String("phase", phase),
 		)
-		err = status.Errorf(codes.FailedPrecondition,
-			"compute instance %q has no VM reference on hub; it may still be provisioning", instanceID)
+		msg := fmt.Sprintf(
+			"compute instance %q is not running on hub %q (phase: %s)",
+			instanceID, hubID, phase)
+		if obj.Status.Phase == osacv1alpha1.ComputeInstancePhaseStarting {
+			msg += "; it may still be provisioning"
+		}
+		err = status.Errorf(codes.FailedPrecondition, "%s", msg)
 		return
 	}
-
-	namespace = vmRef.Namespace
-	vmName = vmRef.KubeVirtVirtualMachineName
-	if namespace == "" || vmName == "" {
-		err = status.Errorf(codes.FailedPrecondition,
-			"compute instance %q has incomplete VM reference on hub (namespace=%q, vmName=%q)",
-			instanceID, namespace, vmName)
-		return
-	}
-
-	return
+	return obj.GetNamespace(), obj.GetName(), nil
 }
 
 // GetAccess checks console availability for a resource.

--- a/internal/servers/console_server_test.go
+++ b/internal/servers/console_server_test.go
@@ -154,7 +154,7 @@ func newFakeHubClientFactory(client clnt.Client) HubClientFactory {
 }
 
 // newComputeInstanceCR creates a typed ComputeInstance CR for testing.
-func newComputeInstanceCR(id, namespace, vmNamespace, vmName string) *osacv1alpha1.ComputeInstance {
+func newComputeInstanceCR(id, namespace string, phase osacv1alpha1.ComputeInstancePhaseType) *osacv1alpha1.ComputeInstance {
 	obj := &osacv1alpha1.ComputeInstance{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "ci-" + id,
@@ -164,11 +164,8 @@ func newComputeInstanceCR(id, namespace, vmNamespace, vmName string) *osacv1alph
 			},
 		},
 	}
-	if vmNamespace != "" || vmName != "" {
-		obj.Status.VirtualMachineReference = &osacv1alpha1.VirtualMachineReferenceType{
-			Namespace:                  vmNamespace,
-			KubeVirtVirtualMachineName: vmName,
-		}
+	if phase != "" {
+		obj.Status.Phase = phase
 	}
 	return obj
 }
@@ -200,8 +197,8 @@ var _ = Describe("Console Server", func() {
 	})
 
 	// setupHubMock configures the hub server mock and creates a fake K8s client
-	// with a ComputeInstance CR that has a VM reference.
-	setupHubMock := func(instanceID, hubNamespace, vmNamespace, vmName string) clnt.Client {
+	// with a ComputeInstance CR in the given phase.
+	setupHubMock := func(instanceID, hubNamespace string, phase osacv1alpha1.ComputeInstancePhaseType) clnt.Client {
 		hubServer.getResponse = privatev1.HubsGetResponse_builder{
 			Object: privatev1.Hub_builder{
 				Id:         "hub-1",
@@ -209,7 +206,7 @@ var _ = Describe("Console Server", func() {
 				Namespace:  hubNamespace,
 			}.Build(),
 		}.Build()
-		cr := newComputeInstanceCR(instanceID, hubNamespace, vmNamespace, vmName)
+		cr := newComputeInstanceCR(instanceID, hubNamespace, phase)
 		return newFakeClient(cr)
 	}
 
@@ -327,7 +324,7 @@ var _ = Describe("Console Server", func() {
 				}.Build(),
 			}.Build()
 
-			fakeK8s = setupHubMock("ci-123", "test-ns", "vm-ns", "test-vm")
+			fakeK8s = setupHubMock("ci-123", "test-ns", osacv1alpha1.ComputeInstancePhaseRunning)
 			buildServer()
 
 			ctx := authpkg.ContextWithSubject(context.Background(), &authpkg.Subject{User: "testuser"})
@@ -395,7 +392,7 @@ var _ = Describe("Console Server", func() {
 			Expect(resp.GetReason()).To(ContainSubstring("not found on hub"))
 		})
 
-		It("should return unavailable when CR has no VM reference on hub", func() {
+		It("should return unavailable when CR is not running on hub", func() {
 			ciServer.getResponse = privatev1.ComputeInstancesGetResponse_builder{
 				Object: privatev1.ComputeInstance_builder{
 					Id: "ci-123",
@@ -406,8 +403,7 @@ var _ = Describe("Console Server", func() {
 				}.Build(),
 			}.Build()
 
-			// CR exists but without virtualMachineReference.
-			fakeK8s = setupHubMock("ci-123", "test-ns", "", "")
+			fakeK8s = setupHubMock("ci-123", "test-ns", osacv1alpha1.ComputeInstancePhaseStopped)
 			buildServer()
 
 			ctx := authpkg.ContextWithSubject(context.Background(), &authpkg.Subject{User: "testuser"})
@@ -417,7 +413,33 @@ var _ = Describe("Console Server", func() {
 			}.Build())
 			Expect(err).NotTo(HaveOccurred())
 			Expect(resp.GetAvailable()).To(BeFalse())
-			Expect(resp.GetReason()).To(ContainSubstring("no VM reference on hub"))
+			Expect(resp.GetReason()).To(ContainSubstring("not running on hub"))
+			Expect(resp.GetReason()).NotTo(ContainSubstring("provisioning"))
+		})
+
+		It("should include provisioning hint when CR is starting on hub", func() {
+			ciServer.getResponse = privatev1.ComputeInstancesGetResponse_builder{
+				Object: privatev1.ComputeInstance_builder{
+					Id: "ci-123",
+					Status: privatev1.ComputeInstanceStatus_builder{
+						State: privatev1.ComputeInstanceState_COMPUTE_INSTANCE_STATE_RUNNING,
+						Hub:   "hub-1",
+					}.Build(),
+				}.Build(),
+			}.Build()
+
+			fakeK8s = setupHubMock("ci-123", "test-ns", osacv1alpha1.ComputeInstancePhaseStarting)
+			buildServer()
+
+			ctx := authpkg.ContextWithSubject(context.Background(), &authpkg.Subject{User: "testuser"})
+			resp, err := server.GetAccess(ctx, publicv1.ConsoleGetAccessRequest_builder{
+				ResourceType: publicv1.ConsoleResourceType_CONSOLE_RESOURCE_TYPE_COMPUTE_INSTANCE,
+				ResourceId:   "ci-123",
+			}.Build())
+			Expect(err).NotTo(HaveOccurred())
+			Expect(resp.GetAvailable()).To(BeFalse())
+			Expect(resp.GetReason()).To(ContainSubstring("not running on hub"))
+			Expect(resp.GetReason()).To(ContainSubstring("provisioning"))
 		})
 
 		It("should return unavailable when compute instance not found", func() {
@@ -561,7 +583,7 @@ var _ = Describe("Console Server", func() {
 				}.Build(),
 			}.Build()
 
-			fakeK8s = setupHubMock("ci-123", "test-ns", "vm-ns", "test-vm")
+			fakeK8s = setupHubMock("ci-123", "test-ns", osacv1alpha1.ComputeInstancePhaseRunning)
 			buildServer()
 
 			ctx, cancel := context.WithCancel(
@@ -633,7 +655,7 @@ var _ = Describe("Console Server", func() {
 				}.Build(),
 			}.Build()
 
-			fakeK8s = setupHubMock("ci-123", "test-ns", "vm-ns", "test-vm")
+			fakeK8s = setupHubMock("ci-123", "test-ns", osacv1alpha1.ComputeInstancePhaseRunning)
 			buildServer()
 
 			stream := newMockStream(authpkg.ContextWithSubject(context.Background(), &authpkg.Subject{User: "testuser"}))

--- a/manifests/base/ingress-proxy/configmap.yaml
+++ b/manifests/base/ingress-proxy/configmap.yaml
@@ -90,6 +90,10 @@ data:
                   "@type": type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog
                   path: /dev/stdout
               stat_prefix: external-api
+              http2_protocol_options:
+                connection_keepalive:
+                  interval: 30s
+                  timeout: 30s
               route_config:
                 name: backend
                 virtual_hosts:
@@ -126,6 +130,18 @@ data:
                     match:
                       safe_regex:
                         regex: /osac\.public\..*/Watch
+                    route:
+                      cluster: grpc-server
+                      timeout: 0s
+                      idle_timeout: 0s
+
+                  # This route is for the Console.Connect bidirectional stream. Like Watch streams,
+                  # console sessions are long-lived and must not be subject to the default request
+                  # timeout. The CLI enforces its own 30-minute session timeout.
+                  - name: console
+                    match:
+                      safe_regex:
+                        regex: /osac\.public\..*Console/Connect
                     route:
                       cluster: grpc-server
                       timeout: 0s
@@ -180,6 +196,10 @@ data:
                   "@type": type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog
                   path: /dev/stdout
               stat_prefix: internal-api
+              http2_protocol_options:
+                connection_keepalive:
+                  interval: 30s
+                  timeout: 30s
               route_config:
                 name: backend
                 virtual_hosts:
@@ -214,6 +234,16 @@ data:
                     match:
                       safe_regex:
                         regex: .*/Watch
+                    route:
+                      cluster: grpc-server
+                      timeout: 0s
+                      idle_timeout: 0s
+
+                  # This route is for the Console.Connect bidirectional stream.
+                  - name: console
+                    match:
+                      safe_regex:
+                        regex: /osac\.public\..*Console/Connect
                     route:
                       cluster: grpc-server
                       timeout: 0s


### PR DESCRIPTION
\+ configure proxy for long-lived console sessions

To be merged AFTER:  https://github.com/osac-project/osac-operator/pull/213 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated console connection infrastructure to use OpenShift's aggregated console API.
  * Added connection keepalive intervals to improve stability and prevent timeout-related disconnects.
  * Enhanced stream retry logic with improved cancellation handling.
  * Strengthened error handling for connection failures and graceful shutdowns.
  * Updated Envoy routing configuration for console connections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->