### PR TITLE
NO_ISSUE: fix event dispatch race in processEvent

### DIFF
--- a/internal/servers/events_server.go
+++ b/internal/servers/events_server.go
@@ -247,7 +247,7 @@ func (s *EventsServer) Watch(request *publicv1.EventsWatchRequest,
 		subject:    subject,
 		filterSrc:  filterSrc,
 		filterPrg:  filterPrg,
-		eventsChan: make(chan *publicv1.Event),
+		eventsChan: make(chan *publicv1.Event, eventsChanBufferSize),
 	}
 	s.subsLock.Lock()
 	s.subs[subId] = subInfo
@@ -463,8 +463,12 @@ func (s *EventsServer) processEvent(ctx context.Context, public *publicv1.Event,
 
 		// Forward the event to the subscription:
 		if accepted {
-			logger.DebugContext(ctx, "Event accepted by filter")
-			sub.eventsChan <- public
+			select {
+			case sub.eventsChan <- public:
+				logger.DebugContext(ctx, "Event accepted by filter")
+			default:
+				logger.WarnContext(ctx, "Subscriber channel full, event dropped")
+			}
 		} else {
 			logger.DebugContext(ctx, "Event rejected by filter")
 		}

--- a/internal/servers/private_events_server.go
+++ b/internal/servers/private_events_server.go
@@ -62,6 +62,8 @@ type privateEventsServerSubInfo struct {
 	eventsChan chan *privatev1.Event
 }
 
+const eventsChanBufferSize = 64
+
 func NewPrivateEventsServer() *PrivateEventsServerBuilder {
 	return &PrivateEventsServerBuilder{}
 }
@@ -208,7 +210,7 @@ func (s *PrivateEventsServer) Watch(request *privatev1.EventsWatchRequest,
 		stream:     stream,
 		filterSrc:  filterSrc,
 		filterPrg:  filterPrg,
-		eventsChan: make(chan *privatev1.Event),
+		eventsChan: make(chan *privatev1.Event, eventsChanBufferSize),
 	}
 	s.subsLock.Lock()
 	s.subs[subId] = subInfo
@@ -310,8 +312,12 @@ func (s *PrivateEventsServer) processEvent(ctx context.Context, event *privatev1
 			}
 		}
 		if accepted {
-			logger.DebugContext(ctx, "Event accepted by filter")
-			sub.eventsChan <- event
+			select {
+			case sub.eventsChan <- event:
+				logger.DebugContext(ctx, "Event accepted by filter")
+			default:
+				logger.WarnContext(ctx, "Subscriber channel full, event dropped")
+			}
 		} else {
 			logger.DebugContext(ctx, "Event rejected by filter")
 		}

--- a/internal/servers/private_events_server_test.go
+++ b/internal/servers/private_events_server_test.go
@@ -1,0 +1,107 @@
+/*
+Copyright (c) 2025 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package servers
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2/dsl/core"
+	. "github.com/onsi/gomega"
+
+	privatev1 "github.com/osac-project/fulfillment-service/internal/api/osac/private/v1"
+)
+
+var _ = Describe("PrivateEventsServer processEvent", func() {
+	It("Does not block when one subscriber is slow", func() {
+		server := &PrivateEventsServer{
+			logger:   logger,
+			subs:     map[string]privateEventsServerSubInfo{},
+			subsLock: &sync.RWMutex{},
+		}
+
+		slowChan := make(chan *privatev1.Event, eventsChanBufferSize)
+		fastChan := make(chan *privatev1.Event, eventsChanBufferSize)
+
+		server.subs["slow"] = privateEventsServerSubInfo{
+			eventsChan: slowChan,
+		}
+		server.subs["fast"] = privateEventsServerSubInfo{
+			eventsChan: fastChan,
+		}
+
+		event := &privatev1.Event{}
+		event.SetId("test-event")
+		event.SetType(privatev1.EventType_EVENT_TYPE_OBJECT_UPDATED)
+
+		// Call processEvent — it should return quickly even though nobody is reading from
+		// either channel, because channels are buffered and sends are non-blocking.
+		done := make(chan struct{})
+		go func() {
+			defer GinkgoRecover()
+			_ = server.processEvent(context.Background(), event)
+			close(done)
+		}()
+
+		Eventually(done, 2*time.Second).Should(BeClosed())
+
+		// Both subscribers should have the event in their channel.
+		Eventually(fastChan).Should(Receive())
+		Eventually(slowChan).Should(Receive())
+	})
+
+	It("Drops events for a subscriber whose buffer is full", func() {
+		server := &PrivateEventsServer{
+			logger:   logger,
+			subs:     map[string]privateEventsServerSubInfo{},
+			subsLock: &sync.RWMutex{},
+		}
+
+		fullChan := make(chan *privatev1.Event, eventsChanBufferSize)
+		healthyChan := make(chan *privatev1.Event, eventsChanBufferSize)
+
+		// Fill the slow subscriber's buffer completely.
+		for range eventsChanBufferSize {
+			fullChan <- &privatev1.Event{}
+		}
+
+		server.subs["full"] = privateEventsServerSubInfo{
+			eventsChan: fullChan,
+		}
+		server.subs["healthy"] = privateEventsServerSubInfo{
+			eventsChan: healthyChan,
+		}
+
+		event := &privatev1.Event{}
+		event.SetId("overflow-event")
+		event.SetType(privatev1.EventType_EVENT_TYPE_OBJECT_UPDATED)
+
+		// processEvent should still return quickly — the full subscriber's event is dropped.
+		done := make(chan struct{})
+		go func() {
+			defer GinkgoRecover()
+			_ = server.processEvent(context.Background(), event)
+			close(done)
+		}()
+
+		Eventually(done, 2*time.Second).Should(BeClosed())
+
+		// The healthy subscriber should have the event.
+		Eventually(healthyChan).Should(Receive())
+
+		// The full subscriber's channel should still be at capacity (overflow event was dropped).
+		Expect(fullChan).To(HaveLen(eventsChanBufferSize))
+	})
+})


### PR DESCRIPTION
## Problem

`processEvent()` in both `PrivateEventsServer` and `EventsServer` holds `subsLock.RLock()` while sequentially sending to **unbuffered** `eventsChan` channels for each subscriber. If any single subscriber is slow to drain its channel (e.g., its reconciler is busy making gRPC/k8s/AAP calls), `processEvent` blocks indefinitely — preventing **all** other subscribers from receiving events too.

This was observed during E2E testing: the fulfillment-controller pod was running, healthy, 0 restarts, 21Mi memory, reporting ready — but silently stopped processing events for 35+ minutes. Deletions accepted by the gRPC server never propagated to Kubernetes CRs. New compute instances created via CLI never appeared as CRs.

### The deadlock chain

```
PostgreSQL NOTIFY
  → database.Listener (synchronous callback)
  → processEvent() [holds subsLock.RLock, iterates ALL subs sequentially]
  → sub.eventsChan <- event  [UNBUFFERED — blocks if subscriber is slow]
  → entire notification pipeline frozen
```

## Fix

Two changes applied to **both** `private_events_server.go` and `events_server.go`:

1. **Buffer `eventsChan`** (64 slots) — gives subscribers slack to absorb event bursts without blocking the dispatcher
2. **Non-blocking send** via `select/default` — if a subscriber's buffer is full, log a warning and drop the event for that subscriber instead of blocking all subscribers

The periodic `syncObjects` loop (runs every hour) acts as a safety net to reconcile any dropped events.

### Known downstream limitation

The reconciler's `objectChannel` (`reconciler.go:218`) is also unbuffered. A slow reconciler will eventually fill the 64-slot `eventsChan` buffer and start dropping events. This is a separate issue not addressed in this PR — the `syncObjects` safety net covers it, but reducing the sync interval or buffering `objectChannel` would further reduce the risk.

## Test

Added `private_events_server_test.go` with two test cases:

- **"Does not block when one subscriber is slow"** — creates two subscribers, neither draining, verifies `processEvent` returns quickly and both receive the event via the buffer
- **"Drops events for a subscriber whose buffer is full"** — fills one subscriber's buffer completely, verifies `processEvent` still returns quickly and the healthy subscriber receives the event while the full subscriber's event is dropped