### PR TITLE
OSAC-505: Add migrate subcommand to fulfillment-service

### DIFF
--- a/internal/cmd/service/migrate/migrate_cmd.go
+++ b/internal/cmd/service/migrate/migrate_cmd.go
@@ -1,0 +1,75 @@
+/*
+Copyright (c) 2026 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package migrate
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/osac-project/fulfillment-service/internal/database"
+	"github.com/osac-project/fulfillment-service/internal/logging"
+)
+
+// Cmd creates and returns the `migrate` command.
+func Cmd() *cobra.Command {
+	runner := &runnerContext{}
+	command := &cobra.Command{
+		Use:   "migrate",
+		Short: "Run database migrations",
+		Args:  cobra.NoArgs,
+		RunE:  runner.run,
+	}
+	database.AddFlags(command.Flags())
+	return command
+}
+
+// runnerContext contains the data and logic needed to run the `migrate` command.
+type runnerContext struct {
+}
+
+// run executes the `migrate` command.
+func (c *runnerContext) run(cmd *cobra.Command, argv []string) error {
+	// Get the context:
+	ctx := cmd.Context()
+
+	// Get the logger:
+	logger := logging.LoggerFromContext(ctx)
+
+	// Create the database tool:
+	dbTool, err := database.NewTool().
+		SetLogger(logger).
+		SetFlags(cmd.Flags()).
+		Build()
+	if err != nil {
+		return fmt.Errorf("failed to create database tool: %w", err)
+	}
+
+	// Wait for the database to be available:
+	logger.InfoContext(ctx, "Waiting for database to be available")
+	err = dbTool.Wait(ctx)
+	if err != nil {
+		return fmt.Errorf("failed waiting for database: %w", err)
+	}
+
+	// Run the migrations:
+	logger.InfoContext(ctx, "Running database migrations")
+	err = dbTool.Migrate(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to run database migrations: %w", err)
+	}
+
+	logger.InfoContext(ctx, "Database migrations completed successfully")
+	return nil
+}

--- a/internal/cmd/service/root_cmd.go
+++ b/internal/cmd/service/root_cmd.go
@@ -19,6 +19,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/osac-project/fulfillment-service/internal/cmd/service/dev"
+	"github.com/osac-project/fulfillment-service/internal/cmd/service/migrate"
 	"github.com/osac-project/fulfillment-service/internal/cmd/service/probe"
 	"github.com/osac-project/fulfillment-service/internal/cmd/service/start"
 	"github.com/osac-project/fulfillment-service/internal/cmd/service/version"
@@ -41,6 +42,7 @@ func Root() *cobra.Command {
 
 	// Add commands:
 	result.AddCommand(dev.Cmd())
+	result.AddCommand(migrate.Cmd())
 	result.AddCommand(probe.Cmd())
 	result.AddCommand(start.Cmd())
 	result.AddCommand(version.Cmd())


### PR DESCRIPTION
## Motivation
OSAC is transitioning to Helm-based installation. The umbrella chart needs a pre-upgrade hook to run database migrations before deploying new code, which requires a CLI entrypoint for the existing migration framework.

## Summary
- Add `migrate` cobra subcommand exposing the existing database migration infrastructure as a standalone CLI command
- Uses the `database.Tool` interface with `Wait()` and `Migrate()` methods
- Follows the established command pattern (cobra command with `runnerContext` struct)
- Used by the Helm pre-upgrade hook to run database migrations before deployment

## Test plan
- [ ] `fulfillment-service migrate --help` shows the command with database connection flags
- [ ] Running against a database applies all pending migrations
- [ ] Running against an already-migrated database is a no-op (exits 0)
- [ ] Build succeeds with `go build ./...`