### PR TITLE
NO-ISSUE: Disable probes when debug is enabled

### DIFF
--- a/charts/service/templates/controller/deployment.yaml
+++ b/charts/service/templates/controller/deployment.yaml
@@ -156,6 +156,7 @@ spec:
           hostPort: 30003
           protocol: TCP
         {{ end }}
+        {{ if not .Values.debug }}
         livenessProbe:
           exec:
             command:
@@ -178,3 +179,4 @@ spec:
             - --grpc-server-timeout=1s
           initialDelaySeconds: 5
           periodSeconds: 10
+        {{ end }}

--- a/charts/service/templates/grpc-server/deployment.yaml
+++ b/charts/service/templates/grpc-server/deployment.yaml
@@ -117,6 +117,7 @@ spec:
           hostPort: 30001
           protocol: TCP
         {{ end }}
+        {{ if not .Values.debug }}
         livenessProbe:
           exec:
             command:
@@ -139,3 +140,4 @@ spec:
             - --grpc-server-timeout=1s
           initialDelaySeconds: 5
           periodSeconds: 10
+        {{ end }}

--- a/charts/service/templates/rest-gateway/deployment.yaml
+++ b/charts/service/templates/rest-gateway/deployment.yaml
@@ -84,6 +84,7 @@ spec:
           hostPort: 30002
           protocol: TCP
         {{ end }}
+        {{ if not .Values.debug }}
         livenessProbe:
           httpGet:
             path: /healthz
@@ -98,3 +99,4 @@ spec:
             scheme: HTTPS
           initialDelaySeconds: 5
           periodSeconds: 10
+        {{ end }}


### PR DESCRIPTION
## Summary

- Wraps the liveness and readiness probes of the gRPC server, REST gateway, and controller
  deployments in a `{{ if not .Values.debug }}` condition so that they are excluded when debugging
  is enabled. This prevents the probes from interfering with debug sessions or killing the process
  when stopped at a breakpoint.

## Test plan

- Deploy with `debug: false` (default) and verify that the liveness and readiness probes are
  present in all three deployments.
- Deploy with `debug: true` and verify that the probes are omitted.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment configurations for all services to conditionally disable health check probes (liveness and readiness) when debug mode is enabled. Health checks remain fully operational in production mode, ensuring reliable monitoring while improving development iteration efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->