### PR TITLE
MGMT-22992: Make Keycloak IDP configuration mandatory

### DIFF
--- a/charts/README.md
+++ b/charts/README.md
@@ -28,13 +28,13 @@ installed separately before deploying the service:
   See the `charts/service/values.yaml` file for the expected format and the
   `charts/keycloak/README.md` file for details on the required Keycloak configuration.
 
-- _IDP Credentials (Optional)_ - If you want to enable organization management via the IDP
-  integration, you must provide OAuth client credentials for authenticating with the identity
-  provider's admin API. For Keycloak, this uses the same `osac-controller` service account that
-  already has the required realm-management roles. You can reuse the same credentials as
-  `auth.controllerCredentials` or create separate credentials for separation of concerns. Configure
-  via the `idp.credentials` value. See the `charts/service/values.yaml` file for the expected
-  format.
+- _IDP Credentials_ - The controller manages organizations in the identity provider and requires
+  OAuth client credentials for authenticating with the identity provider's admin API. For Keycloak,
+  this uses the same `osac-controller` service account that already has the required
+  realm-management roles. You can reuse the same credentials as `auth.controllerCredentials` or
+  create separate credentials for separation of concerns. Configure the IDP URL via `idp.url` and
+  the credentials via `idp.credentials`. See the `charts/service/values.yaml` file for the
+  expected format.
 
 Note that the PostgreSQL and Keycloak Helm charts that are included in this project are intended
 only for development environments, and shouldn't be used in production.
@@ -142,7 +142,7 @@ $ kubectl create secret generic fulfillment-controller-credentials \
 --from-literal=client-secret=...
 ```
 
-Optional: Enable IDP integration for organization management. You can either reuse the same
+Create the Kubernetes Secret containing the IDP OAuth client credentials. You can reuse the same
 `fulfillment-controller-credentials` secret (simple approach) or create separate IDP credentials
 for separation of concerns:
 
@@ -200,12 +200,9 @@ database:
       - key: password
         param: password
 
-# Optional: Enable IDP integration for organization management
 idp:
-  enabled: true
   provider: keycloak
   url: https://keycloak.keycloak.svc.cluster.local:8000
-  # Reuse the same credentials as controllerCredentials
   credentials:
   - secret:
       name: fulfillment-controller-credentials
@@ -377,7 +374,7 @@ $ kubectl create secret generic fulfillment-controller-credentials \
 --from-literal=client-secret=...
 ```
 
-Optional: Enable IDP integration for organization management. You can either reuse the same
+Create the Kubernetes Secret containing the IDP OAuth client credentials. You can reuse the same
 `fulfillment-controller-credentials` secret (simple approach) or create separate IDP credentials
 for separation of concerns:
 
@@ -435,12 +432,9 @@ database:
       - key: password
         param: password
 
-# Optional: Enable IDP integration for organization management
 idp:
-  enabled: true
   provider: keycloak
   url: https://keycloak.keycloak.svc.cluster.local:8000
-  # Reuse the same credentials as controllerCredentials
   credentials:
   - secret:
       name: fulfillment-controller-credentials

--- a/charts/service/templates/controller/deployment.yaml
+++ b/charts/service/templates/controller/deployment.yaml
@@ -156,6 +156,7 @@ spec:
           hostPort: 30003
           protocol: TCP
         {{ end }}
+        {{ if not .Values.debug }}
         livenessProbe:
           exec:
             command:
@@ -178,3 +179,4 @@ spec:
             - --grpc-server-timeout=1s
           initialDelaySeconds: 5
           periodSeconds: 10
+        {{ end }}

--- a/charts/service/templates/controller/deployment.yaml
+++ b/charts/service/templates/controller/deployment.yaml
@@ -14,6 +14,8 @@ specific language governing permissions and limitations under the License.
 {{- $caBundleConfigMap := required "certs.caBundle.configMap is required" .Values.certs.caBundle.configMap }}
 {{- $authIssuerUrl := required "auth.issuerUrl is required" .Values.auth.issuerUrl }}
 {{- $authControllerCredentials := required "auth.controllerCredentials is required" .Values.auth.controllerCredentials }}
+{{- $idpUrl := required "idp.url is required" .Values.idp.url }}
+{{- $idpCredentials := required "idp.credentials is required" .Values.idp.credentials }}
 
 apiVersion: apps/v1
 kind: Deployment
@@ -63,12 +65,10 @@ spec:
               {{ end }}
           {{ end }}
           {{ end }}
-      {{- if .Values.idp.enabled }}
       - name: idp-credentials
         projected:
           sources:
-          {{- if .Values.idp.credentials }}
-          {{- range .Values.idp.credentials }}
+          {{- range $idpCredentials }}
           {{- if .configMap }}
           - configMap:
               name: {{ .configMap.name }}
@@ -88,10 +88,6 @@ spec:
               {{- end }}
           {{- end }}
           {{- end }}
-          {{- else }}
-          []
-          {{- end }}
-      {{- end }}
       containers:
       - name: controller
         image: {{ .Values.images.service }}
@@ -103,11 +99,9 @@ spec:
         - name: credentials
           mountPath: /etc/fulfillment-controller/credentials
           readOnly: true
-        {{- if .Values.idp.enabled }}
         - name: idp-credentials
           mountPath: /etc/fulfillment-controller/idp
           readOnly: true
-        {{- end }}
         command:
         {{ if .Values.debug }}
         - dlv
@@ -131,12 +125,10 @@ spec:
         - --auth-issuer-url={{ $authIssuerUrl }}
         - --auth-client-id-file=/etc/fulfillment-controller/credentials/client-id
         - --auth-client-secret-file=/etc/fulfillment-controller/credentials/client-secret
-        {{- if .Values.idp.enabled }}
         - --idp-provider={{ .Values.idp.provider }}
-        - --idp-url={{ required "idp.url is required when idp.enabled is true" .Values.idp.url }}
+        - --idp-url={{ $idpUrl }}
         - --idp-client-id-file=/etc/fulfillment-controller/idp/client-id
         - --idp-client-secret-file=/etc/fulfillment-controller/idp/client-secret
-        {{- end }}
         - --grpc-server-address=fulfillment-internal-api:8001
         - --grpc-keep-alive=5m
         - --grpc-listener-address=0.0.0.0:8000

--- a/charts/service/templates/grpc-server/deployment.yaml
+++ b/charts/service/templates/grpc-server/deployment.yaml
@@ -117,6 +117,7 @@ spec:
           hostPort: 30001
           protocol: TCP
         {{ end }}
+        {{ if not .Values.debug }}
         livenessProbe:
           exec:
             command:
@@ -139,3 +140,4 @@ spec:
             - --grpc-server-timeout=1s
           initialDelaySeconds: 5
           periodSeconds: 10
+        {{ end }}

--- a/charts/service/templates/rest-gateway/deployment.yaml
+++ b/charts/service/templates/rest-gateway/deployment.yaml
@@ -84,6 +84,7 @@ spec:
           hostPort: 30002
           protocol: TCP
         {{ end }}
+        {{ if not .Values.debug }}
         livenessProbe:
           httpGet:
             path: /healthz
@@ -98,3 +99,4 @@ spec:
             scheme: HTTPS
           initialDelaySeconds: 5
           periodSeconds: 10
+        {{ end }}

--- a/charts/service/values.yaml
+++ b/charts/service/values.yaml
@@ -146,19 +146,16 @@ database:
   # `uri` key but the connection parameter name is `url`.
   connection: []
 
-# Identity provider configuration (optional). When enabled, the controller will start the organization reconciler
-# to manage organizations in the identity provider.
+# Identity provider configuration. The controller uses this to manage organizations in the identity provider via the
+# organization reconciler. This parameter is mandatory.
 idp:
-
-  # Enable IDP integration for organization management. When disabled, the organization controller will not start.
-  # The default is false.
-  enabled: false
 
   # IDP provider type. Currently only 'keycloak' is supported.
   provider: keycloak
 
-  # Base URL of the identity provider (e.g., https://keycloak.keycloak.svc.cluster.local:8000)
-  url: ""
+  # Base URL of the identity provider (e.g., https://keycloak.keycloak.svc.cluster.local:8000). This parameter is
+  # mandatory.
+  url:
 
   # List of sources for the IDP OAuth client credentials. The controller uses the OAuth client credentials flow to
   # authenticate with the identity provider's admin API. The credentials must have sufficient privileges to manage
@@ -180,5 +177,5 @@ idp:
   # You can reuse the same credentials as auth.controllerCredentials if the osac-controller service account has both
   # API access and IDP management permissions, or use a separate secret for separation of concerns.
   #
-  # The default value is an empty list, meaning no credentials are configured.
-  credentials: []
+  # This parameter is mandatory.
+  credentials:

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -1034,7 +1034,6 @@ database:
         param: sslrootcert
 
 idp:
-  enabled: true
   provider: keycloak
   url: https://keycloak-keycloak.${DOMAIN}
   credentials:

--- a/internal/auth/auth_rules_test.go
+++ b/internal/auth/auth_rules_test.go
@@ -116,6 +116,26 @@ var _ = Describe("Authorization rules", Ordered, func() {
 					},
 				},
 			},
+			"idp": map[string]any{
+				"url": "https://keycloak.keycloak.svc.cluster.local:8000",
+				"credentials": []any{
+					map[string]any{
+						"secret": map[string]any{
+							"name": "fulfillment-controller-credentials",
+							"items": []any{
+								map[string]any{
+									"key":   "client-id",
+									"param": "client-id",
+								},
+								map[string]any{
+									"key":   "client-secret",
+									"param": "client-secret",
+								},
+							},
+						},
+					},
+				},
+			},
 		}
 		valuesBytes, err := yaml.Marshal(valuesData)
 		Expect(err).ToNot(HaveOccurred())

--- a/internal/cmd/service/start/controller/start_controller_cmd.go
+++ b/internal/cmd/service/start/controller/start_controller_cmd.go
@@ -354,7 +354,7 @@ func (r *runnerContext) run(cmd *cobra.Command, argv []string) error {
 		return fmt.Errorf("failed to create hub cache: %w", err)
 	}
 
-	// Create the IDP manager if configured:
+	// Create the IDP manager:
 	idpManager, err := r.createIDPManager(ctx, caPool)
 	if err != nil {
 		return err
@@ -691,44 +691,42 @@ func (r *runnerContext) run(cmd *cobra.Command, argv []string) error {
 		}
 	}()
 
-	// Create the organization reconciler if IDP is configured:
-	if idpManager != nil {
-		r.logger.InfoContext(ctx, "Creating organization reconciler")
-		organizationReconcilerFunction, err := organization.NewFunction().
-			SetLogger(r.logger).
-			SetConnection(r.client).
-			SetIdpManager(idpManager).
-			Build()
-		if err != nil {
-			return fmt.Errorf("failed to create organization reconciler function: %w", err)
-		}
-		organizationReconciler, err := controllers.NewReconciler[*privatev1.Organization]().
-			SetLogger(r.logger).
-			SetName("organization").
-			SetClient(r.client).
-			SetFunction(organizationReconcilerFunction.Run).
-			SetEventFilter("has(event.organization)").
-			SetHealthReporter(healthAggregator).
-			Build()
-		if err != nil {
-			return fmt.Errorf("failed to create organization reconciler: %w", err)
-		}
-
-		// Start the organization reconciler:
-		r.logger.InfoContext(ctx, "Starting organization reconciler")
-		go func() {
-			err := organizationReconciler.Start(ctx)
-			if err == nil || errors.Is(err, context.Canceled) {
-				r.logger.InfoContext(ctx, "Organization reconciler finished")
-			} else {
-				r.logger.InfoContext(
-					ctx,
-					"Organization reconciler failed",
-					slog.Any("error", err),
-				)
-			}
-		}()
+	// Create the organization reconciler:
+	r.logger.InfoContext(ctx, "Creating organization reconciler")
+	organizationReconcilerFunction, err := organization.NewFunction().
+		SetLogger(r.logger).
+		SetConnection(r.client).
+		SetIdpManager(idpManager).
+		Build()
+	if err != nil {
+		return fmt.Errorf("failed to create organization reconciler function: %w", err)
 	}
+	organizationReconciler, err := controllers.NewReconciler[*privatev1.Organization]().
+		SetLogger(r.logger).
+		SetName("organization").
+		SetClient(r.client).
+		SetFunction(organizationReconcilerFunction.Run).
+		SetEventFilter("has(event.organization)").
+		SetHealthReporter(healthAggregator).
+		Build()
+	if err != nil {
+		return fmt.Errorf("failed to create organization reconciler: %w", err)
+	}
+
+	// Start the organization reconciler:
+	r.logger.InfoContext(ctx, "Starting organization reconciler")
+	go func() {
+		err := organizationReconciler.Start(ctx)
+		if err == nil || errors.Is(err, context.Canceled) {
+			r.logger.InfoContext(ctx, "Organization reconciler finished")
+		} else {
+			r.logger.InfoContext(
+				ctx,
+				"Organization reconciler failed",
+				slog.Any("error", err),
+			)
+		}
+	}()
 
 	// Create the metrics listener:
 	r.logger.InfoContext(ctx, "Creating metrics listener")
@@ -867,15 +865,16 @@ func (r *runnerContext) createTokenSource(ctx context.Context, caPool *x509.Cert
 	return
 }
 
-// createIDPManager creates the IDP client and organization manager if IDP is configured.
-// Returns nil if IDP is not configured (not an error).
+// createIDPManager creates the IDP client and organization manager. The IDP URL and credentials are mandatory.
 func (r *runnerContext) createIDPManager(ctx context.Context, caPool *x509.CertPool) (*idp.OrganizationManager, error) {
-	// Check if IDP is configured (need URL and credentials)
-	hasClientId := r.args.idpClientId != "" || r.args.idpClientIdFile != ""
-	hasClientSecret := r.args.idpClientSecret != "" || r.args.idpClientSecretFile != ""
-	if r.args.idpURL == "" || !hasClientId || !hasClientSecret {
-		r.logger.InfoContext(ctx, "IDP not configured, organization controller will not be started")
-		return nil, nil
+	if r.args.idpURL == "" {
+		return nil, fmt.Errorf("flag '--idp-url' is required")
+	}
+	if r.args.idpClientId == "" && r.args.idpClientIdFile == "" {
+		return nil, fmt.Errorf("flag '--idp-client-id' or '--idp-client-id-file' is required")
+	}
+	if r.args.idpClientSecret == "" && r.args.idpClientSecretFile == "" {
+		return nil, fmt.Errorf("flag '--idp-client-secret' or '--idp-client-secret-file' is required")
 	}
 
 	// Get the client ID

--- a/internal/idp/keycloak/client.go
+++ b/internal/idp/keycloak/client.go
@@ -160,22 +160,34 @@ func (c *Client) CreateOrganization(ctx context.Context, org *idp.Organization) 
 
 // GetOrganization retrieves an organization (Keycloak organization in the configured realm) by name.
 func (c *Client) GetOrganization(ctx context.Context, name string) (*idp.Organization, error) {
-	response, err := c.httpClient.DoRequest(ctx, http.MethodGet, fmt.Sprintf("/admin/realms/%s/organizations/%s", c.realmName, url.PathEscape(name)), nil)
+	query := url.Values{}
+	query.Add("search", name)
+	query.Add("exact", "true")
+	path := fmt.Sprintf("/admin/realms/%s/organizations?%s", c.realmName, query.Encode())
+	response, err := c.httpClient.DoRequest(ctx, http.MethodGet, path, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get organization: %w", err)
 	}
 	defer response.Body.Close()
 
-	var kcOrg keycloakOrganization
-	if err = json.NewDecoder(response.Body).Decode(&kcOrg); err != nil {
+	var kcOrgs []keycloakOrganization
+	if err = json.NewDecoder(response.Body).Decode(&kcOrgs); err != nil {
 		return nil, fmt.Errorf("failed to decode organization response: %w", err)
 	}
+	if len(kcOrgs) == 0 {
+		return nil, fmt.Errorf("organization %q not found", name)
+	}
+	kcOrg := kcOrgs[0]
 	return fromKeycloakOrganization(&kcOrg), nil
 }
 
 // DeleteOrganization deletes an organization (Keycloak organization in the configured realm) by name.
 func (c *Client) DeleteOrganization(ctx context.Context, organizationName string) error {
-	response, err := c.httpClient.DoRequest(ctx, http.MethodDelete, fmt.Sprintf("/admin/realms/%s/organizations/%s", c.realmName, url.PathEscape(organizationName)), nil)
+	org, err := c.GetOrganization(ctx, organizationName)
+	if err != nil {
+		return fmt.Errorf("failed to get organization: %w", err)
+	}
+	response, err := c.httpClient.DoRequest(ctx, http.MethodDelete, fmt.Sprintf("/admin/realms/%s/organizations/%s", c.realmName, org.ID), nil)
 	if err != nil {
 		return fmt.Errorf("failed to delete organization: %w", err)
 	}
@@ -185,7 +197,12 @@ func (c *Client) DeleteOrganization(ctx context.Context, organizationName string
 }
 
 func (c *Client) AddUserToOrganization(ctx context.Context, organizationName string, userID string) error {
-	response, err := c.httpClient.DoRequest(ctx, http.MethodPost, fmt.Sprintf("/admin/realms/%s/organizations/%s/members", c.realmName, url.PathEscape(organizationName)), userID)
+	org, err := c.GetOrganization(ctx, organizationName)
+	if err != nil {
+		return fmt.Errorf("failed to get organization: %w", err)
+	}
+	path := fmt.Sprintf("/admin/realms/%s/organizations/%s/members", c.realmName, org.ID)
+	response, err := c.httpClient.DoRequest(ctx, http.MethodPost, path, userID)
 	if err != nil {
 		return fmt.Errorf("failed to add user to organization: %w", err)
 	}

--- a/internal/idp/keycloak/client_test.go
+++ b/internal/idp/keycloak/client_test.go
@@ -58,15 +58,15 @@ var _ = Describe("Keycloak Client", func() {
 					return
 				}
 
-				if r.Method == http.MethodGet && r.URL.Path == "/admin/realms/osac/organizations/test-org" {
+				if r.Method == http.MethodGet && r.URL.Path == "/admin/realms/osac/organizations" && r.URL.RawQuery == "exact=true&search=test-org" {
 					// Get request to verify creation
 					enabled := true
-					response := keycloakOrganization{
+					response := []keycloakOrganization{{
 						ID:      "org-uuid-123",
 						Name:    "test-org",
 						Alias:   "Test Organization",
 						Enabled: &enabled,
-					}
+					}}
 					w.Header().Set("Content-Type", "application/json")
 					w.WriteHeader(http.StatusOK)
 					json.NewEncoder(w).Encode(response)
@@ -130,20 +130,21 @@ var _ = Describe("Keycloak Client", func() {
 	Describe("GetOrganization", func() {
 		It("retrieves an organization from Keycloak", func() {
 			enabled := true
-			testOrg := &keycloakOrganization{
+			testOrgs := []keycloakOrganization{{
 				ID:      "org-id",
 				Name:    "test-org",
 				Alias:   "Test Organization",
 				Enabled: &enabled,
-			}
+			}}
 
 			server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				Expect(r.Method).To(Equal(http.MethodGet))
-				Expect(r.URL.Path).To(Equal("/admin/realms/osac/organizations/test-org"))
+				Expect(r.URL.Path).To(Equal("/admin/realms/osac/organizations"))
+				Expect(r.URL.RawQuery).To(Equal("exact=true&search=test-org"))
 
 				w.Header().Set("Content-Type", "application/json")
 				w.WriteHeader(http.StatusOK)
-				json.NewEncoder(w).Encode(testOrg)
+				json.NewEncoder(w).Encode(testOrgs)
 			}))
 
 			client = createTestClient(server.URL)
@@ -191,8 +192,23 @@ var _ = Describe("Keycloak Client", func() {
 					return
 				}
 
-				// Second request: add user to organization
-				if r.Method == http.MethodPost && r.URL.Path == "/admin/realms/osac/organizations/test-org/members" {
+				// Second request: get organization by name
+				if r.Method == http.MethodGet && r.URL.Path == "/admin/realms/osac/organizations" && r.URL.RawQuery == "exact=true&search=test-org" {
+					enabled := true
+					response := []keycloakOrganization{{
+						ID:      "org-id",
+						Name:    "test-org",
+						Alias:   "Test Organization",
+						Enabled: &enabled,
+					}}
+					w.Header().Set("Content-Type", "application/json")
+					w.WriteHeader(http.StatusOK)
+					json.NewEncoder(w).Encode(response)
+					return
+				}
+
+				// Third request: add user to organization
+				if r.Method == http.MethodPost && r.URL.Path == "/admin/realms/osac/organizations/org-id/members" {
 					json.NewDecoder(r.Body).Decode(&addedUserID)
 					w.WriteHeader(http.StatusNoContent)
 					return
@@ -538,9 +554,28 @@ var _ = Describe("Keycloak Client", func() {
 	Describe("DeleteOrganization", func() {
 		It("deletes an organization from Keycloak", func() {
 			server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				Expect(r.Method).To(Equal(http.MethodDelete))
-				Expect(r.URL.Path).To(Equal("/admin/realms/osac/organizations/test-org"))
-				w.WriteHeader(http.StatusNoContent)
+				// Second request: get organization by name
+				if r.Method == http.MethodGet && r.URL.Path == "/admin/realms/osac/organizations" && r.URL.RawQuery == "exact=true&search=test-org" {
+					enabled := true
+					response := []keycloakOrganization{{
+						ID:      "org-id",
+						Name:    "test-org",
+						Alias:   "Test Organization",
+						Enabled: &enabled,
+					}}
+					w.Header().Set("Content-Type", "application/json")
+					w.WriteHeader(http.StatusOK)
+					json.NewEncoder(w).Encode(response)
+					return
+				}
+
+				// Second request: delete organization
+				if r.Method == http.MethodDelete && r.URL.Path == "/admin/realms/osac/organizations/org-id" {
+					w.WriteHeader(http.StatusNoContent)
+					return
+				}
+
+				w.WriteHeader(http.StatusBadRequest)
 			}))
 
 			client = createTestClient(server.URL)

--- a/internal/idp/keycloak/types.go
+++ b/internal/idp/keycloak/types.go
@@ -57,11 +57,17 @@ type keycloakRole struct {
 }
 
 type keycloakOrganization struct {
-	ID         string              `json:"id,omitempty"`
-	Name       string              `json:"name,omitempty"`
-	Alias      string              `json:"alias,omitempty"`
-	Enabled    *bool               `json:"enabled,omitempty"`
-	Attributes map[string][]string `json:"attributes,omitempty"`
+	ID         string                        `json:"id,omitempty"`
+	Name       string                        `json:"name,omitempty"`
+	Alias      string                        `json:"alias,omitempty"`
+	Enabled    *bool                         `json:"enabled,omitempty"`
+	Attributes map[string][]string           `json:"attributes,omitempty"`
+	Domains    []*keycloakOrganizationDomain `json:"domains,omitempty"`
+}
+
+type keycloakOrganizationDomain struct {
+	Name     string `json:"name,omitempty"`
+	Verified bool   `json:"verified,omitempty"`
 }
 
 // Conversion functions from generic types to Keycloak types
@@ -176,6 +182,9 @@ func toKeycloakOrganization(org *idp.Organization) *keycloakOrganization {
 		Name:       org.Name,
 		Enabled:    &enabled,
 		Attributes: org.Attributes,
+		Domains: []*keycloakOrganizationDomain{{
+			Name: org.Name,
+		}},
 	}
 }
 

--- a/it/it_organization_reconciler_test.go
+++ b/it/it_organization_reconciler_test.go
@@ -1,0 +1,137 @@
+/*
+Copyright (c) 2026 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package it
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2/dsl/core"
+	. "github.com/onsi/gomega"
+	grpccodes "google.golang.org/grpc/codes"
+	grpcstatus "google.golang.org/grpc/status"
+
+	privatev1 "github.com/osac-project/fulfillment-service/internal/api/osac/private/v1"
+	"github.com/osac-project/fulfillment-service/internal/controllers/finalizers"
+	"github.com/osac-project/fulfillment-service/internal/uuid"
+)
+
+var _ = Describe("Organization reconciler", func() {
+	var (
+		ctx    context.Context
+		client privatev1.OrganizationsClient
+	)
+
+	BeforeEach(func() {
+		ctx = context.Background()
+		client = privatev1.NewOrganizationsClient(tool.InternalView().AdminConn())
+	})
+
+	It("Creates the Keycloak organization", func() {
+		// Create the organization and remember to delete it after the test:
+		name := fmt.Sprintf("my-%s", uuid.New())
+		createResponse, err := client.Create(ctx, privatev1.OrganizationsCreateRequest_builder{
+			Object: privatev1.Organization_builder{
+				Metadata: privatev1.Metadata_builder{
+					Name: name,
+				}.Build(),
+			}.Build(),
+		}.Build())
+		Expect(err).ToNot(HaveOccurred())
+		id := createResponse.GetObject().GetId()
+		DeferCleanup(func() {
+			_, _ = client.Delete(ctx, privatev1.OrganizationsDeleteRequest_builder{
+				Id: id,
+			}.Build())
+		})
+
+		// Verify that the reconciler eventually adds the finalizer, sets the state to 'SYNCED', and populates
+		// the Keycloak organization name:
+		Eventually(
+			func(g Gomega) {
+				getResponse, err := client.Get(ctx, privatev1.OrganizationsGetRequest_builder{
+					Id: id,
+				}.Build())
+				g.Expect(err).ToNot(HaveOccurred())
+				object := getResponse.GetObject()
+				metadata := object.GetMetadata()
+				g.Expect(metadata.GetFinalizers()).To(ContainElement(finalizers.Controller))
+				status := object.GetStatus()
+				g.Expect(status.GetState()).To(
+					Equal(privatev1.OrganizationState_ORGANIZATION_STATE_SYNCED),
+				)
+				g.Expect(status.GetIdpOrganizationName()).To(Equal(name))
+				g.Expect(status.GetBreakGlassUserId()).ToNot(BeEmpty())
+			},
+			time.Minute,
+			time.Second,
+		).Should(Succeed())
+	})
+
+	It("Deletes the Keycloak organization", func() {
+		// Create the organization:
+		name := fmt.Sprintf("my-%s", uuid.New())
+		createResponse, err := client.Create(ctx, privatev1.OrganizationsCreateRequest_builder{
+			Object: privatev1.Organization_builder{
+				Metadata: privatev1.Metadata_builder{
+					Name: name,
+				}.Build(),
+			}.Build(),
+		}.Build())
+		Expect(err).ToNot(HaveOccurred())
+		id := createResponse.GetObject().GetId()
+
+		// Wait for the reconciler to sync the organization to the IDP before deleting, as otherwise it would be
+		// deleted immediately by the server without going through the reconciler.
+		Eventually(
+			func(g Gomega) {
+				getResponse, err := client.Get(ctx, privatev1.OrganizationsGetRequest_builder{
+					Id: id,
+				}.Build())
+				g.Expect(err).ToNot(HaveOccurred())
+				object := getResponse.GetObject()
+				metadata := object.GetMetadata()
+				g.Expect(metadata.GetFinalizers()).To(ContainElement(finalizers.Controller))
+				status := object.GetStatus()
+				g.Expect(status.GetState()).To(
+					Equal(privatev1.OrganizationState_ORGANIZATION_STATE_SYNCED),
+				)
+			},
+			time.Minute,
+			time.Second,
+		).Should(Succeed())
+
+		// Delete the organization:
+		_, err = client.Delete(ctx, privatev1.OrganizationsDeleteRequest_builder{
+			Id: id,
+		}.Build())
+		Expect(err).ToNot(HaveOccurred())
+
+		// Verify the organization eventually disappears:
+		Eventually(
+			func(g Gomega) {
+				_, err := client.Get(ctx, privatev1.OrganizationsGetRequest_builder{
+					Id: id,
+				}.Build())
+				g.Expect(err).To(HaveOccurred())
+				status, ok := grpcstatus.FromError(err)
+				g.Expect(ok).To(BeTrue())
+				g.Expect(status.Code()).To(Equal(grpccodes.NotFound))
+			},
+			time.Minute,
+			time.Second,
+		).Should(Succeed())
+	})
+})

--- a/it/it_tool.go
+++ b/it/it_tool.go
@@ -1443,6 +1443,27 @@ func (t *Tool) deployServiceWithHelm(ctx context.Context, imageRef string) error
 				},
 			},
 		},
+		"idp": map[string]any{
+			"provider": "keycloak",
+			"url":      fmt.Sprintf("https://%s", keycloakAddr),
+			"credentials": []any{
+				map[string]any{
+					"secret": map[string]any{
+						"name": controllerCredentialsSecret,
+						"items": []any{
+							map[string]any{
+								"key":   "client-id",
+								"param": "client-id",
+							},
+							map[string]any{
+								"key":   "client-secret",
+								"param": "client-secret",
+							},
+						},
+					},
+				},
+			},
+		},
 	}
 	valuesBytes, err := yaml.Marshal(valuesData)
 	if err != nil {

--- a/manifests/README.md
+++ b/manifests/README.md
@@ -36,19 +36,16 @@ $ kubectl create secret generic fulfillment-controller-credentials \
 If you need to use a different secret name or different keys, you can override the volume definition
 in the controller deployment using a kustomize patch in your overlay.
 
-## Enabling IDP Integration (Optional)
+## IDP Integration
 
 The kustomize manifests include the IDP configuration flags by default, pointing to
 `https://keycloak.keycloak.svc.cluster.local:8000`. The controller uses OAuth client credentials
-flow to authenticate with the identity provider's admin API.
+flow to authenticate with the identity provider's admin API to manage organizations.
 
 By default, the IDP integration reuses the same `fulfillment-controller-credentials` secret (with
 keys `client-id` and `client-secret`) that is already configured for API authentication. The
 `osac-controller` service account has both API access permissions and the required IDP
 realm-management roles (manage-realm, manage-users, view-realm, view-users).
-
-**No additional setup is needed** - the organization controller will automatically start if the
-`fulfillment-controller-credentials` secret exists.
 
 If you want to use separate credentials for IDP (for better separation of concerns), you can create
 a kustomize patch to override the `idp-credentials` volume:
@@ -68,7 +65,6 @@ patches:
           - name: idp-credentials
             secret:
               secretName: fulfillment-idp-credentials
-              optional: true
 ```
 
 Then create the separate secret:
@@ -79,10 +75,6 @@ $ kubectl create secret generic fulfillment-idp-credentials \
 --from-literal=client-id=osac-idp-manager \
 --from-literal=client-secret=...
 ```
-
-If neither the reused credentials nor separate IDP credentials are available, the controller will
-log that IDP is not configured and will not start the organization controller. The volume is marked
-as optional, so the pod will start successfully.
 
 ## OpenShift
 

--- a/manifests/base/controller/deployment.yaml
+++ b/manifests/base/controller/deployment.yaml
@@ -39,7 +39,6 @@ spec:
       - name: idp-credentials
         secret:
           secretName: fulfillment-controller-credentials
-          optional: true
       containers:
       - name: controller
         image: fulfillment-service


### PR DESCRIPTION
## Summary

- Makes IDP configuration (URL and credentials) mandatory for the controller, removing the
  `idp.enabled` flag and conditional logic so the organization reconciler always starts.
- Fixes the Keycloak client to search organizations by name via the query API and use the
  returned identifier for delete, get, and add-member operations, since Keycloak requires the
  internal ID in the URL path rather than the name.
- Adds a domain entry to Keycloak organizations on creation, as Keycloak requires at least one
  domain per organization.
- Adds integration tests verifying the organization reconciler creates and deletes Keycloak
  organizations correctly.

## Test plan

- [x] Unit tests pass (`ginkgo run -r internal`)
- [x] Integration tests pass (`ginkgo run it`), including the new organization reconciler tests

Related: https://redhat.atlassian.net/browse/MGMT-22992

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated installation and configuration guides to reflect new IDP integration requirements.

* **Refactor**
  * IDP integration is now required for controller deployment (no longer optional).
  * Organization management automatically reconciles with identity provider.

* **New Features**
  * Enhanced organization handling with improved identity provider synchronization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->