### PR TITLE
NO-ISSUE: Fix flaky ScriptTokenSource test

### DIFF
--- a/internal/auth/auth_script_token_source_test.go
+++ b/internal/auth/auth_script_token_source_test.go
@@ -194,18 +194,16 @@ var _ = Describe("Script token source", func() {
 			Expect(token).To(BeNil())
 		})
 
-		It("Returns the loaded token if it is a JWT that hasn't expired", func() {
+		It("Returns the stored token if it is a JWT that hasn't expired", func() {
 			// Prepare a store that returns a token that is a JWT and hasn't expired:
-			loaded := &Token{
+			stored := &Token{
 				Access: MakeTokenString("Bearer", 5*time.Minute),
 			}
 			store, err := NewMemoryTokenStore().
 				SetLogger(logger).
 				Build()
 			Expect(err).ToNot(HaveOccurred())
-			err = store.Save(ctx, &Token{
-				Access: MakeTokenString("Bearer", 5*time.Minute),
-			})
+			err = store.Save(ctx, stored)
 			Expect(err).ToNot(HaveOccurred())
 
 			// Create the source:
@@ -215,12 +213,12 @@ var _ = Describe("Script token source", func() {
 				SetStore(store).
 				Build()
 			Expect(err).ToNot(HaveOccurred())
-			token, err := source.Token(ctx)
 
 			// Verify that the returned token is the one from the store:
+			token, err := source.Token(ctx)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(token).ToNot(BeNil())
-			Expect(token.Access).To(Equal(loaded.Access))
+			Expect(token.Access).To(Equal(stored.Access))
 		})
 
 		It("Saves the generated token if it is a JWT that hasn't expired", func() {


### PR DESCRIPTION
## Summary

- Fix an intermittent test failure in `"Returns the stored token if it is a JWT that hasn't expired"` caused by calling `MakeTokenString` twice independently. Since each call embeds the current timestamp, two calls straddling a second boundary produced different JWT strings, making the equality assertion fail non-deterministically. The fix saves the same token object into the store and asserts against it.

## Test plan

- [x] `ginkgo run internal/auth` passes (106 specs, 0 failures)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Internal test suite refinements made to enhance authentication verification reliability and code quality.

**Note:** This release contains no user-facing changes. Updates are limited to internal test infrastructure improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->