### PR TITLE
OSAC-748: Add Console methods to OPA client allowlist

### DIFF
--- a/charts/service/templates/grpc-server/authconfig.yaml
+++ b/charts/service/templates/grpc-server/authconfig.yaml
@@ -233,6 +233,8 @@ spec:
               "/osac.public.v1.ComputeInstances/Get",
               "/osac.public.v1.ComputeInstances/List",
               "/osac.public.v1.ComputeInstances/Update",
+              "/osac.public.v1.Console/Connect",
+              "/osac.public.v1.Console/GetAccess",
               "/osac.public.v1.Events/Watch",
               "/osac.public.v1.HostTypes/Get",
               "/osac.public.v1.HostTypes/List",

--- a/manifests/base/grpc-server/authconfig.yaml
+++ b/manifests/base/grpc-server/authconfig.yaml
@@ -160,6 +160,8 @@ spec:
               "/osac.public.v1.ComputeInstances/Get",
               "/osac.public.v1.ComputeInstances/List",
               "/osac.public.v1.ComputeInstances/Update",
+              "/osac.public.v1.Console/Connect",
+              "/osac.public.v1.Console/GetAccess",
               "/osac.public.v1.Events/Watch",
               "/osac.public.v1.HostTypes/Get",
               "/osac.public.v1.HostTypes/List",


### PR DESCRIPTION
## Summary
- Add `Console/Connect` and `Console/GetAccess` to the Authorino OPA client allowlist in both Kustomize and Helm authconfig files
- Fixes `permission denied` for non-admin users running `osac console computeinstance`
- Root cause: when the console feature was added (PR #325), the new gRPC methods were not added to the client allowlist — admin SAs bypass the list, so this was not caught during testing

## Test plan
- [ ] Verify non-admin user can call `osac console computeinstance <name>` without permission denied
- [ ] Verify admin users still have full access (no regression)

Fixes: https://issues.redhat.com/browse/OSAC-748

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Client users can now access the Console Connect and GetAccess endpoints, enabling additional console functionality and streamlined access for client accounts. No other authorization behavior or response handling was changed.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/osac-project/fulfillment-service/pull/505)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->