### PR TITLE
NO-ISSUE: Skip cluster log dump when Kind cluster is preserved

### DIFF
--- a/it/it_suite_test.go
+++ b/it/it_suite_test.go
@@ -127,10 +127,6 @@ var _ = BeforeSuite(func() {
 		err := tool.Cleanup(ctx)
 		Expect(err).ToNot(HaveOccurred())
 	})
-	DeferCleanup(func() {
-		err := tool.Dump(ctx)
-		Expect(err).ToNot(HaveOccurred())
-	})
 })
 
 var _ = Describe("Integration", func() {

--- a/it/it_tool.go
+++ b/it/it_tool.go
@@ -1993,6 +1993,14 @@ func (t *Tool) Cleanup(ctx context.Context) error {
 		}
 	}
 
+	// Dump the logs:
+	if t.cluster != nil && !t.keepKind {
+		err := t.cluster.Dump(ctx, filepath.Join(t.projectDir, "logs"))
+		if err != nil {
+			errs = append(errs, fmt.Errorf("failed to dump cluster logs: %w", err))
+		}
+	}
+
 	// Undeploy the service:
 	if t.cluster != nil && t.keepKind && !t.keepService {
 		err := t.undeployService(ctx)


### PR DESCRIPTION
## Summary

When running integration tests with `IT_KEEP_KIND=true` the cluster state and
logs were always dumped, even though the cluster remains accessible for direct
inspection. This moves the dump into the `Cleanup` method, guarded by
`!t.keepKind`, so it only runs when the cluster is actually being torn down.
This reduces the time it takes to run integration tests during regular
development.

## Test plan

- Run integration tests with `IT_KEEP_KIND=true` and verify that the cluster
  logs are not dumped.
- Run integration tests without `IT_KEEP_KIND` and verify that the cluster
  logs are still dumped as before.