### PR TITLE
OSAC-743: Add CLI table definitions for PublicIP and PublicIPPool listing

### DIFF
--- a/internal/rendering/tables/osac.private.v1.PublicIP.yaml
+++ b/internal/rendering/tables/osac.private.v1.PublicIP.yaml
@@ -1,0 +1,38 @@
+#
+# Copyright (c) 2026 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+# the License. You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+columns:
+
+- header: ID
+  value: this.id
+
+- header: NAME
+  value: "has(this.metadata.name)? this.metadata.name: '-'"
+
+- header: POOL
+  value: this.spec.pool
+
+- header: STATE
+  value: this.status.state
+  type: osac.private.v1.PublicIPState
+
+- header: ADDRESS
+  value: "this.status.address != ''? this.status.address: '-'"
+
+- header: HUB
+  value: this.status.hub
+  type: osac.private.v1.Hub
+  lookup: true
+
+- header: COMPUTE-INSTANCE
+  value: "has(this.spec.compute_instance)? this.spec.compute_instance: '-'"

--- a/internal/rendering/tables/osac.private.v1.PublicIPPool.yaml
+++ b/internal/rendering/tables/osac.private.v1.PublicIPPool.yaml
@@ -1,0 +1,39 @@
+#
+# Copyright (c) 2026 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+# the License. You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+columns:
+
+- header: ID
+  value: this.id
+
+- header: NAME
+  value: "has(this.metadata.name)? this.metadata.name: '-'"
+
+- header: CIDRS
+  value: "size(this.spec.cidrs) > 0? this.spec.cidrs.join(', '): '-'"
+
+- header: IP-FAMILY
+  value: this.spec.ip_family
+  type: osac.private.v1.IPFamily
+
+- header: STRATEGY
+  value: this.spec.implementation_strategy
+
+- header: STATE
+  value: this.status.state
+  type: osac.private.v1.PublicIPPoolState
+
+- header: HUB
+  value: this.status.hub
+  type: osac.private.v1.Hub
+  lookup: true

--- a/internal/rendering/tables/osac.private.v1.PublicIPPool.yaml
+++ b/internal/rendering/tables/osac.private.v1.PublicIPPool.yaml
@@ -33,6 +33,15 @@ columns:
   value: this.status.state
   type: osac.private.v1.PublicIPPoolState
 
+- header: TOTAL
+  value: '"%d".format([this.status.total])'
+
+- header: ALLOCATED
+  value: '"%d".format([this.status.allocated])'
+
+- header: FREE
+  value: '"%d".format([this.status.available])'
+
 - header: HUB
   value: this.status.hub
   type: osac.private.v1.Hub

--- a/internal/rendering/tables/osac.public.v1.PublicIP.yaml
+++ b/internal/rendering/tables/osac.public.v1.PublicIP.yaml
@@ -1,0 +1,33 @@
+#
+# Copyright (c) 2026 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+# the License. You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+columns:
+
+- header: ID
+  value: this.id
+
+- header: NAME
+  value: "has(this.metadata.name)? this.metadata.name: '-'"
+
+- header: POOL
+  value: this.spec.pool
+
+- header: STATE
+  value: this.status.state
+  type: osac.public.v1.PublicIPState
+
+- header: ADDRESS
+  value: "this.status.address != ''? this.status.address: '-'"
+
+- header: COMPUTE-INSTANCE
+  value: "has(this.spec.compute_instance)? this.spec.compute_instance: '-'"


### PR DESCRIPTION
### Problem
osac get publicips and osac get publicippools produced broken/empty table output. The CLI renders resource tables using YAML definitions. PublicIP and PublicIPPool proto types were added, but the corresponding table YAML files were never included.

### Changes
Add three table definition YAML files under internal/rendering/tables/:
File	                                                                Columns
osac.public.v1.PublicIP.yaml	ID, NAME, POOL, STATE, ADDRESS, COMPUTE-INSTANCE
osac.private.v1.PublicIP.yaml	ID, NAME, POOL, STATE, ADDRESS, HUB, COMPUTE-INSTANCE
osac.private.v1.PublicIPPool.yaml	ID, NAME, CIDRS, IP-FAMILY, STRATEGY, STATE, HUB

### Testing
osac get publicips
ID                                    NAME     POOL                                  STATE      ADDRESS  HUB  COMPUTE-INSTANCE
019dfd74-29c5-7305-b163-5853bbb03e5c  my-ip    019dfd63-044e-7400-b353-541a809fa401  ATTACHING  -        hub  019dfe1f-45de-7450-858f-5f9292521db4
019e080e-6cf5-7751-99e9-20f13111950b  demo-ip  019dfd63-044e-7400-b353-541a809fa401  ALLOCATED  -        hub  -

osac get publicippools:
ID                                    NAME     CIDRS            IP-FAMILY  STRATEGY    STATE  TOTAL  ALLOCATED  FREE  HUB
019dfd63-044e-7400-b353-541a809fa401  my-pool  192.168.99.0/24  IPV4       metallb-l2  READY  254    2          252   hub

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added table display for Public IP resources, showing ID, name, associated pool, state, address, hub, and compute instance information.
  * Added table display for Public IP Pool resources, including ID, name, CIDRs, IP family, strategy, state, hub, and capacity metrics (total, allocated, free).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->