### PR TITLE
OSAC-745: Create Public IPs in Pending state, update state machine tr…

### DIFF
--- a/internal/servers/private_public_ips_server.go
+++ b/internal/servers/private_public_ips_server.go
@@ -34,11 +34,11 @@ import (
 // validPublicIPTransitions defines the allowed state transitions for PublicIP resources.
 // The key is the current state and the value is the list of valid target states.
 var validPublicIPTransitions = map[privatev1.PublicIPState][]privatev1.PublicIPState{
-	privatev1.PublicIPState_PUBLIC_IP_STATE_PENDING:   {privatev1.PublicIPState_PUBLIC_IP_STATE_ALLOCATED},
-	privatev1.PublicIPState_PUBLIC_IP_STATE_ALLOCATED: {privatev1.PublicIPState_PUBLIC_IP_STATE_ATTACHING, privatev1.PublicIPState_PUBLIC_IP_STATE_RELEASING},
-	privatev1.PublicIPState_PUBLIC_IP_STATE_ATTACHING: {privatev1.PublicIPState_PUBLIC_IP_STATE_ATTACHED},
-	privatev1.PublicIPState_PUBLIC_IP_STATE_ATTACHED:  {privatev1.PublicIPState_PUBLIC_IP_STATE_RELEASING},
-	privatev1.PublicIPState_PUBLIC_IP_STATE_RELEASING: {privatev1.PublicIPState_PUBLIC_IP_STATE_ALLOCATED},
+	privatev1.PublicIPState_PUBLIC_IP_STATE_PENDING:   {privatev1.PublicIPState_PUBLIC_IP_STATE_ALLOCATED, privatev1.PublicIPState_PUBLIC_IP_STATE_FAILED},
+	privatev1.PublicIPState_PUBLIC_IP_STATE_ALLOCATED: {privatev1.PublicIPState_PUBLIC_IP_STATE_ATTACHING, privatev1.PublicIPState_PUBLIC_IP_STATE_RELEASING, privatev1.PublicIPState_PUBLIC_IP_STATE_FAILED},
+	privatev1.PublicIPState_PUBLIC_IP_STATE_ATTACHING: {privatev1.PublicIPState_PUBLIC_IP_STATE_ATTACHED, privatev1.PublicIPState_PUBLIC_IP_STATE_FAILED},
+	privatev1.PublicIPState_PUBLIC_IP_STATE_ATTACHED:  {privatev1.PublicIPState_PUBLIC_IP_STATE_RELEASING, privatev1.PublicIPState_PUBLIC_IP_STATE_FAILED},
+	privatev1.PublicIPState_PUBLIC_IP_STATE_RELEASING: {privatev1.PublicIPState_PUBLIC_IP_STATE_ALLOCATED, privatev1.PublicIPState_PUBLIC_IP_STATE_FAILED},
 }
 
 // PrivatePublicIPsServerBuilder contains the data and logic needed to create a PrivatePublicIPsServer.
@@ -189,6 +189,15 @@ func (s *PrivatePublicIPsServer) Create(ctx context.Context,
 	err = s.validatePoolReference(ctx, poolID)
 	if err != nil {
 		return
+	}
+
+	// Set initial state to PENDING
+	if publicIP.GetStatus() == nil {
+		publicIP.SetStatus(privatev1.PublicIPStatus_builder{
+			State: privatev1.PublicIPState_PUBLIC_IP_STATE_PENDING,
+		}.Build())
+	} else {
+		publicIP.GetStatus().SetState(privatev1.PublicIPState_PUBLIC_IP_STATE_PENDING)
 	}
 
 	// Create the PublicIP:

--- a/internal/servers/private_public_ips_server.go
+++ b/internal/servers/private_public_ips_server.go
@@ -39,6 +39,7 @@ var validPublicIPTransitions = map[privatev1.PublicIPState][]privatev1.PublicIPS
 	privatev1.PublicIPState_PUBLIC_IP_STATE_ATTACHING: {privatev1.PublicIPState_PUBLIC_IP_STATE_ATTACHED, privatev1.PublicIPState_PUBLIC_IP_STATE_FAILED},
 	privatev1.PublicIPState_PUBLIC_IP_STATE_ATTACHED:  {privatev1.PublicIPState_PUBLIC_IP_STATE_RELEASING, privatev1.PublicIPState_PUBLIC_IP_STATE_FAILED},
 	privatev1.PublicIPState_PUBLIC_IP_STATE_RELEASING: {privatev1.PublicIPState_PUBLIC_IP_STATE_ALLOCATED, privatev1.PublicIPState_PUBLIC_IP_STATE_FAILED},
+	privatev1.PublicIPState_PUBLIC_IP_STATE_FAILED:    {privatev1.PublicIPState_PUBLIC_IP_STATE_ALLOCATED, privatev1.PublicIPState_PUBLIC_IP_STATE_ATTACHED},
 }
 
 // PrivatePublicIPsServerBuilder contains the data and logic needed to create a PrivatePublicIPsServer.

--- a/internal/servers/private_public_ips_server.go
+++ b/internal/servers/private_public_ips_server.go
@@ -35,7 +35,7 @@ import (
 // The key is the current state and the value is the list of valid target states.
 var validPublicIPTransitions = map[privatev1.PublicIPState][]privatev1.PublicIPState{
 	privatev1.PublicIPState_PUBLIC_IP_STATE_PENDING:   {privatev1.PublicIPState_PUBLIC_IP_STATE_ALLOCATED, privatev1.PublicIPState_PUBLIC_IP_STATE_FAILED},
-	privatev1.PublicIPState_PUBLIC_IP_STATE_ALLOCATED: {privatev1.PublicIPState_PUBLIC_IP_STATE_ATTACHING, privatev1.PublicIPState_PUBLIC_IP_STATE_RELEASING, privatev1.PublicIPState_PUBLIC_IP_STATE_FAILED},
+	privatev1.PublicIPState_PUBLIC_IP_STATE_ALLOCATED: {privatev1.PublicIPState_PUBLIC_IP_STATE_ATTACHING, privatev1.PublicIPState_PUBLIC_IP_STATE_FAILED},
 	privatev1.PublicIPState_PUBLIC_IP_STATE_ATTACHING: {privatev1.PublicIPState_PUBLIC_IP_STATE_ATTACHED, privatev1.PublicIPState_PUBLIC_IP_STATE_FAILED},
 	privatev1.PublicIPState_PUBLIC_IP_STATE_ATTACHED:  {privatev1.PublicIPState_PUBLIC_IP_STATE_RELEASING, privatev1.PublicIPState_PUBLIC_IP_STATE_FAILED},
 	privatev1.PublicIPState_PUBLIC_IP_STATE_RELEASING: {privatev1.PublicIPState_PUBLIC_IP_STATE_ALLOCATED, privatev1.PublicIPState_PUBLIC_IP_STATE_FAILED},

--- a/internal/servers/private_public_ips_server_test.go
+++ b/internal/servers/private_public_ips_server_test.go
@@ -275,6 +275,23 @@ var _ = Describe("Private public IPs server", func() {
 			Expect(err).ToNot(HaveOccurred())
 		})
 
+		It("creates PublicIP with PENDING initial state", func() {
+			response, err := publicIPsServer.Create(ctx, privatev1.PublicIPsCreateRequest_builder{
+				Object: privatev1.PublicIP_builder{
+					Metadata: privatev1.Metadata_builder{
+						Tenants: []string{"shared"},
+					}.Build(),
+					Spec: privatev1.PublicIPSpec_builder{
+						Pool: poolID,
+					}.Build(),
+				}.Build(),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+			Expect(response.GetObject().GetStatus()).ToNot(BeNil())
+			Expect(response.GetObject().GetStatus().GetState()).To(
+				Equal(privatev1.PublicIPState_PUBLIC_IP_STATE_PENDING))
+		})
+
 		It("creates PublicIP and generates ID", func() {
 			response, err := publicIPsServer.Create(ctx, privatev1.PublicIPsCreateRequest_builder{
 				Object: privatev1.PublicIP_builder{
@@ -672,6 +689,49 @@ var _ = Describe("Private public IPs server", func() {
 			Expect(updated.GetStatus().GetState()).To(Equal(privatev1.PublicIPState_PUBLIC_IP_STATE_ALLOCATED))
 		})
 
+		It("accepts PENDING to FAILED transition", func() {
+			object := createPublicIPInState(publicIPsServer, privatev1.PublicIPState_PUBLIC_IP_STATE_PENDING)
+			updated := transitionTo(object, privatev1.PublicIPState_PUBLIC_IP_STATE_FAILED)
+			Expect(updated.GetStatus().GetState()).To(Equal(privatev1.PublicIPState_PUBLIC_IP_STATE_FAILED))
+		})
+
+		It("accepts ATTACHING to FAILED transition", func() {
+			object := createPublicIPInState(publicIPsServer, privatev1.PublicIPState_PUBLIC_IP_STATE_ATTACHING)
+			updated := transitionTo(object, privatev1.PublicIPState_PUBLIC_IP_STATE_FAILED)
+			Expect(updated.GetStatus().GetState()).To(Equal(privatev1.PublicIPState_PUBLIC_IP_STATE_FAILED))
+		})
+
+		It("accepts RELEASING to FAILED transition", func() {
+			object := createPublicIPInState(publicIPsServer, privatev1.PublicIPState_PUBLIC_IP_STATE_RELEASING)
+			updated := transitionTo(object, privatev1.PublicIPState_PUBLIC_IP_STATE_FAILED)
+			Expect(updated.GetStatus().GetState()).To(Equal(privatev1.PublicIPState_PUBLIC_IP_STATE_FAILED))
+		})
+
+		It("rejects FAILED to PENDING transition", func() {
+			object := createPublicIPInState(publicIPsServer, privatev1.PublicIPState_PUBLIC_IP_STATE_FAILED)
+			setStateOnObject(object, privatev1.PublicIPState_PUBLIC_IP_STATE_PENDING)
+			_, err := publicIPsServer.Update(ctx, privatev1.PublicIPsUpdateRequest_builder{
+				Object: object,
+			}.Build())
+			Expect(err).To(HaveOccurred())
+			status, ok := grpcstatus.FromError(err)
+			Expect(ok).To(BeTrue())
+			Expect(status.Code()).To(Equal(grpccodes.FailedPrecondition))
+			Expect(err.Error()).To(ContainSubstring("invalid state transition"))
+		})
+
+		It("accepts ALLOCATED to FAILED transition", func() {
+			object := createPublicIPInState(publicIPsServer, privatev1.PublicIPState_PUBLIC_IP_STATE_ALLOCATED)
+			updated := transitionTo(object, privatev1.PublicIPState_PUBLIC_IP_STATE_FAILED)
+			Expect(updated.GetStatus().GetState()).To(Equal(privatev1.PublicIPState_PUBLIC_IP_STATE_FAILED))
+		})
+
+		It("accepts ATTACHED to FAILED transition", func() {
+			object := createPublicIPInState(publicIPsServer, privatev1.PublicIPState_PUBLIC_IP_STATE_ATTACHED)
+			updated := transitionTo(object, privatev1.PublicIPState_PUBLIC_IP_STATE_FAILED)
+			Expect(updated.GetStatus().GetState()).To(Equal(privatev1.PublicIPState_PUBLIC_IP_STATE_FAILED))
+		})
+
 		It("rejects PENDING to ATTACHED transition", func() {
 			object := createPublicIPInState(publicIPsServer, privatev1.PublicIPState_PUBLIC_IP_STATE_PENDING)
 			setStateOnObject(object, privatev1.PublicIPState_PUBLIC_IP_STATE_ATTACHED)
@@ -790,6 +850,15 @@ var _ = Describe("Private public IPs server", func() {
 
 		It("allows Delete when state is PENDING", func() {
 			object := createPublicIPInState(publicIPsServer, privatev1.PublicIPState_PUBLIC_IP_STATE_PENDING)
+
+			_, err := publicIPsServer.Delete(ctx, privatev1.PublicIPsDeleteRequest_builder{
+				Id: object.GetId(),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("allows Delete when state is FAILED", func() {
+			object := createPublicIPInState(publicIPsServer, privatev1.PublicIPState_PUBLIC_IP_STATE_FAILED)
 
 			_, err := publicIPsServer.Delete(ctx, privatev1.PublicIPsDeleteRequest_builder{
 				Id: object.GetId(),

--- a/internal/servers/private_public_ips_server_test.go
+++ b/internal/servers/private_public_ips_server_test.go
@@ -707,9 +707,47 @@ var _ = Describe("Private public IPs server", func() {
 			Expect(updated.GetStatus().GetState()).To(Equal(privatev1.PublicIPState_PUBLIC_IP_STATE_FAILED))
 		})
 
+		It("accepts FAILED to ALLOCATED transition", func() {
+			object := createPublicIPInState(publicIPsServer, privatev1.PublicIPState_PUBLIC_IP_STATE_FAILED)
+			updated := transitionTo(object, privatev1.PublicIPState_PUBLIC_IP_STATE_ALLOCATED)
+			Expect(updated.GetStatus().GetState()).To(Equal(privatev1.PublicIPState_PUBLIC_IP_STATE_ALLOCATED))
+		})
+
+		It("accepts FAILED to ATTACHED transition", func() {
+			object := createPublicIPInState(publicIPsServer, privatev1.PublicIPState_PUBLIC_IP_STATE_FAILED)
+			updated := transitionTo(object, privatev1.PublicIPState_PUBLIC_IP_STATE_ATTACHED)
+			Expect(updated.GetStatus().GetState()).To(Equal(privatev1.PublicIPState_PUBLIC_IP_STATE_ATTACHED))
+		})
+
 		It("rejects FAILED to PENDING transition", func() {
 			object := createPublicIPInState(publicIPsServer, privatev1.PublicIPState_PUBLIC_IP_STATE_FAILED)
 			setStateOnObject(object, privatev1.PublicIPState_PUBLIC_IP_STATE_PENDING)
+			_, err := publicIPsServer.Update(ctx, privatev1.PublicIPsUpdateRequest_builder{
+				Object: object,
+			}.Build())
+			Expect(err).To(HaveOccurred())
+			status, ok := grpcstatus.FromError(err)
+			Expect(ok).To(BeTrue())
+			Expect(status.Code()).To(Equal(grpccodes.FailedPrecondition))
+			Expect(err.Error()).To(ContainSubstring("invalid state transition"))
+		})
+
+		It("rejects FAILED to ATTACHING transition", func() {
+			object := createPublicIPInState(publicIPsServer, privatev1.PublicIPState_PUBLIC_IP_STATE_FAILED)
+			setStateOnObject(object, privatev1.PublicIPState_PUBLIC_IP_STATE_ATTACHING)
+			_, err := publicIPsServer.Update(ctx, privatev1.PublicIPsUpdateRequest_builder{
+				Object: object,
+			}.Build())
+			Expect(err).To(HaveOccurred())
+			status, ok := grpcstatus.FromError(err)
+			Expect(ok).To(BeTrue())
+			Expect(status.Code()).To(Equal(grpccodes.FailedPrecondition))
+			Expect(err.Error()).To(ContainSubstring("invalid state transition"))
+		})
+
+		It("rejects FAILED to RELEASING transition", func() {
+			object := createPublicIPInState(publicIPsServer, privatev1.PublicIPState_PUBLIC_IP_STATE_FAILED)
+			setStateOnObject(object, privatev1.PublicIPState_PUBLIC_IP_STATE_RELEASING)
 			_, err := publicIPsServer.Update(ctx, privatev1.PublicIPsUpdateRequest_builder{
 				Object: object,
 			}.Build())


### PR DESCRIPTION
[OSAC-745](https://redhat.atlassian.net/browse/OSAC-745)

1. Ensures Public IPs are created in PENDING state to align with state transitions allowed by the state machine rather than an UNSPECIFIED state.
2. Allow for other states to transition to FAILED.  The ticket specified PENDING, ATTACHING, RELEASING, however in practice the operator makes no distinction and I believe a more permissive approach allowing for states such as ATTACHED is prudent.

Verification done in MoC cloud osac-dakcrowder namespace - verified that a created public ip resource properly moves to 

```
# Create public ip - requires valid pool
osac create publicip --name test-osac745 --pool 019e0845-209a-7e3a-85f5-723af5a5e4e8

# Fetch using cli tooling until osac cli supports gets
  grpcurl -insecure -H "Authorization: Bearer $TOKEN" \                                                                                            
    -d '{"id": "019e0857-a58b-7b7b-8112-5dc40dda6959"}' \
    "$INTERNAL:443" osac.private.v1.PublicIPs/Get 
  {                                                                                                                                                
    "object": {                                                                                                                                    
      "id": "019e0857-a58b-7b7b-8112-5dc40dda6959",                                                                                                
      "metadata": {                                                                                                                                
        "creationTimestamp": "2026-05-08T16:07:02.283117Z",                                                                                        
        "finalizers": [                                                                                                                            
          "fulfillment-controller"                                                                                                                 
        ],                                                                                                                                         
        "creators": [                                                                                                                              
          "admin"                                                                                                                                  
        ],                                                  
        "tenants": [
          "shared"
        ],
        "name": "cli-test-osac745",
        "version": 2
      },
      "spec": {
        "pool": "019e0845-209a-7e3a-85f5-723af5a5e4e8"
      },                                                                                                                                           
      "status": {
        "state": "PUBLIC_IP_STATE_PENDING",                                                                                                        
        "hub": "hub"                                        
      }
    }                                                                                                                                              
  }
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Public IP state management now permits transitioning to FAILED from all lifecycle states and allows recovery transitions from FAILED to ALLOCATED or ATTACHED.
  * Public IPs in FAILED state can be deleted.

* **New Features**
  * Newly created Public IPs reliably initialize in PENDING state during creation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->