### PR TITLE
NO-ISSUE: Add JSON schema for the service Helm chart

### DIFF
--- a/.github/actions/setup-helm/action.yaml
+++ b/.github/actions/setup-helm/action.yaml
@@ -1,0 +1,22 @@
+#
+# Copyright (c) 2025 Red Hat Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License. You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License
+# is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+# or implied. See the License for the specific language governing permissions and limitations under
+# the License.
+#
+
+name: Setup Helm
+description: Install Helm
+runs:
+  using: composite
+  steps:
+  - uses: azure/setup-helm@v5
+    with:
+      version: 'v4.1.4'

--- a/.github/workflows/check-pull-request.yaml
+++ b/.github/workflows/check-pull-request.yaml
@@ -58,6 +58,7 @@ jobs:
     steps:
     - uses: actions/checkout@v6
     - uses: ./.github/actions/setup-go
+    - uses: ./.github/actions/setup-helm
     - run: |
         ginkgo run -r internal
 
@@ -77,6 +78,7 @@ jobs:
     steps:
     - uses: actions/checkout@v6
     - uses: ./.github/actions/setup-go
+    - uses: ./.github/actions/setup-helm
     - run: |
         echo '127.0.0.1 fulfillment-api.osac.svc.cluster.local' | sudo tee -a /etc/hosts
         echo '127.0.0.1 fulfillment-internal-api.osac.svc.cluster.local' | sudo tee -a /etc/hosts
@@ -95,6 +97,7 @@ jobs:
     steps:
     - uses: actions/checkout@v6
     - uses: ./.github/actions/setup-go
+    - uses: ./.github/actions/setup-helm
     - run: |
         echo '127.0.0.1 fulfillment-api.osac.svc.cluster.local' | sudo tee -a /etc/hosts
         echo '127.0.0.1 fulfillment-internal-api.osac.svc.cluster.local' | sudo tee -a /etc/hosts

--- a/charts/service/templates/controller/deployment.yaml
+++ b/charts/service/templates/controller/deployment.yaml
@@ -45,6 +45,7 @@ spec:
       - name: credentials
         projected:
           sources:
+          {{ if $authControllerCredentials }}
           {{ range $authControllerCredentials }}
           {{ if .configMap }}
           - configMap:
@@ -65,20 +66,24 @@ spec:
               {{ end }}
           {{ end }}
           {{ end }}
+          {{ else }}
+          []
+          {{ end }}
       - name: idp-credentials
         projected:
           sources:
-          {{- range $idpCredentials }}
-          {{- if .configMap }}
+          {{ if $idpCredentials }}
+          {{ range $idpCredentials }}
+          {{ if .configMap }}
           - configMap:
               name: {{ .configMap.name }}
               items:
-              {{- range .configMap.items }}
+              {{ range .configMap.items }}
               - key: {{ .key }}
                 path: {{ .param }}
-              {{- end }}
-          {{- end }}
-          {{- if .secret }}
+              {{ end }}
+          {{ end }}
+          {{ if .secret }}
           - secret:
               name: {{ .secret.name }}
               items:
@@ -86,8 +91,11 @@ spec:
               - key: {{ .key }}
                 path: {{ .param }}
               {{- end }}
-          {{- end }}
-          {{- end }}
+          {{ end }}
+          {{ end }}
+          {{ else }}
+          []
+          {{ end }}
       containers:
       - name: controller
         image: {{ .Values.images.service }}

--- a/charts/service/values.schema.json
+++ b/charts/service/values.schema.json
@@ -1,0 +1,282 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/osac-project/fulfillment-service/charts/service/values.schema.json",
+  "title": "Fulfillment Service Helm Values",
+  "description": "Schema for the fulfillment-service Helm chart values.",
+  "type": "object",
+  "$defs": {
+    "paramMapping": {
+      "type": "object",
+      "description": "Maps a key in a ConfigMap or Secret to a named parameter.",
+      "properties": {
+        "key": {
+          "type": "string",
+          "description": "The key in the ConfigMap or Secret."
+        },
+        "param": {
+          "type": "string",
+          "description": "The target parameter name."
+        }
+      },
+      "required": [
+        "key",
+        "param"
+      ],
+      "additionalProperties": false
+    },
+    "configMapSource": {
+      "type": "object",
+      "description": "A ConfigMap reference with parameter mappings.",
+      "properties": {
+        "configMap": {
+          "type": "object",
+          "properties": {
+            "name": {
+              "type": "string",
+              "description": "Name of the ConfigMap."
+            },
+            "items": {
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/paramMapping"
+              },
+              "minItems": 1
+            }
+          },
+          "required": [
+            "name",
+            "items"
+          ],
+          "additionalProperties": false
+        }
+      },
+      "required": [
+        "configMap"
+      ],
+      "additionalProperties": false
+    },
+    "secretSource": {
+      "type": "object",
+      "description": "A Secret reference with parameter mappings.",
+      "properties": {
+        "secret": {
+          "type": "object",
+          "properties": {
+            "name": {
+              "type": "string",
+              "description": "Name of the Secret."
+            },
+            "items": {
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/paramMapping"
+              },
+              "minItems": 1
+            }
+          },
+          "required": [
+            "name",
+            "items"
+          ],
+          "additionalProperties": false
+        }
+      },
+      "required": [
+        "secret"
+      ],
+      "additionalProperties": false
+    },
+    "credentialSources": {
+      "type": "array",
+      "description": "List of ConfigMap or Secret sources that supply credential parameters.",
+      "items": {
+        "oneOf": [
+          {
+            "$ref": "#/$defs/configMapSource"
+          },
+          {
+            "$ref": "#/$defs/secretSource"
+          }
+        ]
+      }
+    }
+  },
+  "properties": {
+    "variant": {
+      "type": "string",
+      "description": "Target cluster variant. Use 'openshift' for OpenShift clusters or 'kind' for Kind clusters.",
+      "enum": [
+        "openshift",
+        "kind"
+      ],
+      "default": "kind"
+    },
+    "debug": {
+      "type": "boolean",
+      "description": "Enable debug mode. Runs services under the 'dlv' debugger; intended only for development environments.",
+      "default": false
+    },
+    "certs": {
+      "type": "object",
+      "description": "Certificate configuration.",
+      "properties": {
+        "issuerRef": {
+          "type": "object",
+          "description": "The cert-manager issuer reference used for service certificates.",
+          "properties": {
+            "kind": {
+              "type": "string",
+              "description": "Kind of the cert-manager issuer.",
+              "enum": [
+                "ClusterIssuer",
+                "Issuer"
+              ],
+              "default": "ClusterIssuer"
+            },
+            "name": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "description": "Name of the cert-manager issuer."
+            }
+          },
+          "additionalProperties": false
+        },
+        "caBundle": {
+          "type": "object",
+          "description": "Trusted CA certificates bundle.",
+          "properties": {
+            "configMap": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "description": "Name of a ConfigMap containing trusted CA certificates in PEM format."
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
+    "externalHostname": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "description": "Hostname for accessing the public API from outside the cluster. Defaults to 'fulfillment-api.<namespace>.svc.cluster.local'."
+    },
+    "internalHostname": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "description": "Hostname for accessing both the public and private APIs from the administrator's internal network. Defaults to 'fulfillment-internal-api.<namespace>.svc.cluster.local'."
+    },
+    "auth": {
+      "type": "object",
+      "description": "Authentication and authorization configuration.",
+      "properties": {
+        "issuerUrl": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "URL of the OAuth issuer used for authentication. This parameter is mandatory.",
+          "format": "uri"
+        },
+        "controllerCredentials": {
+          "$ref": "#/$defs/credentialSources",
+          "description": "Sources for the OAuth client credentials used by the controller. Supported parameter names are 'client-id' and 'client-secret'."
+        }
+      },
+      "additionalProperties": false
+    },
+    "log": {
+      "type": "object",
+      "description": "Logging configuration.",
+      "properties": {
+        "level": {
+          "type": "string",
+          "description": "Log level for all components.",
+          "enum": [
+            "debug",
+            "info",
+            "warn",
+            "error"
+          ],
+          "default": "info"
+        },
+        "headers": {
+          "type": "boolean",
+          "description": "Log HTTP/gRPC headers. May expose sensitive information; avoid in production.",
+          "default": false
+        },
+        "bodies": {
+          "type": "boolean",
+          "description": "Log HTTP/gRPC request and response bodies. May expose sensitive information; avoid in production.",
+          "default": false
+        }
+      },
+      "additionalProperties": false
+    },
+    "images": {
+      "type": "object",
+      "description": "Container image references.",
+      "properties": {
+        "service": {
+          "type": "string",
+          "description": "Image for the fulfillment service.",
+          "default": "ghcr.io/osac/fulfillment-service:main"
+        },
+        "envoy": {
+          "type": "string",
+          "description": "Image for the Envoy proxy.",
+          "default": "docker.io/envoyproxy/envoy:v1.37.1"
+        }
+      },
+      "additionalProperties": false
+    },
+    "database": {
+      "type": "object",
+      "description": "Database connection configuration. Expects an external PostgreSQL database.",
+      "properties": {
+        "connection": {
+          "$ref": "#/$defs/credentialSources",
+          "description": "Sources for database connection parameters. Supported parameter names are 'url', 'host', 'port', 'user', 'password', and 'dbname', in addition to standard PostgreSQL connection parameters.",
+          "default": []
+        }
+      },
+      "additionalProperties": false
+    },
+    "idp": {
+      "type": "object",
+      "description": "Identity provider configuration used by the controller to manage organizations.",
+      "properties": {
+        "provider": {
+          "type": "string",
+          "description": "IDP provider type.",
+          "enum": [
+            "keycloak"
+          ],
+          "default": "keycloak"
+        },
+        "url": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Base URL of the identity provider. This parameter is mandatory.",
+          "format": "uri"
+        },
+        "credentials": {
+          "$ref": "#/$defs/credentialSources",
+          "description": "Sources for IDP OAuth client credentials. The controller uses these to authenticate with the IDP admin API. Supported parameter names are 'client-id' and 'client-secret'."
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  "additionalProperties": false
+}

--- a/charts/service/values.yaml
+++ b/charts/service/values.yaml
@@ -80,7 +80,7 @@ auth:
   #
   # The keys of the ConfigMap and Secret don't need to match the parameter names. In the above example the client
   # identifier is in an `id` key but the credential parameter name is `client-id`.
-  controllerCredentials:
+  controllerCredentials: []
 
 # Logging configuration:
 log:
@@ -178,4 +178,4 @@ idp:
   # API access and IDP management permissions, or use a separate secret for separation of concerns.
   #
   # This parameter is mandatory.
-  credentials:
+  credentials: []

--- a/internal/auth/auth_rules_test.go
+++ b/internal/auth/auth_rules_test.go
@@ -73,17 +73,19 @@ var _ = Describe("Authorization rules", Ordered, func() {
 			},
 			"auth": map[string]any{
 				"issuerUrl": "https://my-issuer.com",
-				"controllerCredentials": map[string]any{
-					"secret": map[string]any{
-						"name": "fulfillment-controller-credentials",
-						"items": []any{
-							map[string]any{
-								"key":   "client-id",
-								"param": "client-id",
-							},
-							map[string]any{
-								"key":   "client-secret",
-								"param": "client-secret",
+				"controllerCredentials": []any{
+					map[string]any{
+						"secret": map[string]any{
+							"name": "fulfillment-controller-credentials",
+							"items": []any{
+								map[string]any{
+									"key":   "client-id",
+									"param": "client-id",
+								},
+								map[string]any{
+									"key":   "client-secret",
+									"param": "client-secret",
+								},
 							},
 						},
 					},

--- a/internal/chart/chart_lint_test.go
+++ b/internal/chart/chart_lint_test.go
@@ -1,0 +1,133 @@
+/*
+Copyright (c) 2025 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package chart
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+
+	. "github.com/onsi/ginkgo/v2/dsl/core"
+	. "github.com/onsi/gomega"
+	"go.yaml.in/yaml/v2"
+)
+
+var _ = Describe("Service chart", func() {
+	var (
+		tempDir string
+	)
+
+	BeforeEach(func() {
+		var err error
+
+		// Create a temporary directory:
+		tempDir, err = os.MkdirTemp("", "*.test")
+		Expect(err).ToNot(HaveOccurred())
+		DeferCleanup(func() {
+			err := os.RemoveAll(tempDir)
+			Expect(err).ToNot(HaveOccurred())
+		})
+	})
+
+	It("Passes lint", func() {
+		// Create a values file with all the required values:
+		valuesFile := filepath.Join(tempDir, "values.yaml")
+		valuesData := map[string]any{
+			"certs": map[string]any{
+				"caBundle": map[string]any{
+					"configMap": "my-bundle",
+				},
+				"issuerRef": map[string]any{
+					"kind": "ClusterIssuer",
+					"name": "my-ca",
+				},
+			},
+			"auth": map[string]any{
+				"issuerUrl": "https://keycloak.example.com/realms/osac",
+				"controllerCredentials": []any{
+					map[string]any{
+						"secret": map[string]any{
+							"name": "my-secret",
+							"items": []any{
+								map[string]any{
+									"key":   "id",
+									"param": "client-id",
+								},
+								map[string]any{
+									"key":   "secret",
+									"param": "client-secret",
+								},
+							},
+						},
+					},
+				},
+			},
+			"database": map[string]any{
+				"connection": []any{
+					map[string]any{
+						"secret": map[string]any{
+							"name": "db-creds",
+							"items": []any{
+								map[string]any{
+									"key":   "uri",
+									"param": "url",
+								},
+							},
+						},
+					},
+				},
+			},
+			"idp": map[string]any{
+				"url": "https://keycloak.example.com",
+				"credentials": []any{
+					map[string]any{
+						"secret": map[string]any{
+							"name": "my-secret",
+							"items": []any{
+								map[string]any{
+									"key":   "id",
+									"param": "client-id",
+								},
+								map[string]any{
+									"key":   "secret",
+									"param": "client-secret",
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+		valuesBytes, err := yaml.Marshal(valuesData)
+		Expect(err).ToNot(HaveOccurred())
+		err = os.WriteFile(valuesFile, valuesBytes, 0600)
+		Expect(err).ToNot(HaveOccurred())
+
+		// Run the 'helm lint' command:
+		listCmd := exec.Cmd{
+			Dir:  projectDir,
+			Path: helmPath,
+			Args: []string{
+				"helm",
+				"lint",
+				chartDir,
+				"--values", valuesFile,
+			},
+			Stdout: GinkgoWriter,
+			Stderr: GinkgoWriter,
+		}
+		err = listCmd.Run()
+		Expect(err).ToNot(HaveOccurred())
+	})
+})

--- a/internal/chart/chart_suite_test.go
+++ b/internal/chart/chart_suite_test.go
@@ -1,0 +1,104 @@
+/*
+Copyright (c) 2026 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package chart
+
+import (
+	"bytes"
+	"io"
+	"log/slog"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2/dsl/core"
+	. "github.com/onsi/gomega"
+
+	"github.com/osac-project/fulfillment-service/internal/logging"
+)
+
+func TestChart(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Helm chart")
+}
+
+// Logger used for tests:
+var logger *slog.Logger
+
+// Location of the 'helm' command:
+var helmPath string
+
+// Chart files:
+var (
+	projectDir string
+	chartDir   string
+	chartFile  string
+)
+
+var _ = BeforeSuite(func() {
+	var err error
+
+	// Create the logger:
+	logger, err = logging.NewLogger().
+		SetLevel(slog.LevelDebug.String()).
+		SetWriter(GinkgoWriter).
+		Build()
+	Expect(err).ToNot(HaveOccurred())
+
+	// Check that the 'helm' command is available:
+	helmPath, err = exec.LookPath("helm")
+	Expect(err).ToNot(
+		HaveOccurred(),
+		"The 'helm' command isn't available",
+	)
+
+	// Check that the 'helm' command is at least version 4:
+	helmOut := &bytes.Buffer{}
+	helmCmd := exec.Cmd{
+		Path: helmPath,
+		Args: []string{
+			"helm",
+			"version",
+			"--template", "{{ .Version }}",
+		},
+		Stdout: io.MultiWriter(helmOut, GinkgoWriter),
+		Stderr: GinkgoWriter,
+	}
+	err = helmCmd.Run()
+	Expect(err).ToNot(HaveOccurred())
+	helmVersion := strings.TrimSpace(helmOut.String())
+	Expect(helmVersion).To(
+		MatchRegexp("^v4\\."),
+		"Helm version is '%s' but must be at least version 4",
+		helmVersion,
+	)
+
+	// Find the chart directory:
+	currentDir, err := os.Getwd()
+	Expect(err).ToNot(HaveOccurred())
+	projectDir = filepath.Join(currentDir, "..", "..")
+	chartDir = filepath.Join(projectDir, "charts", "service")
+	chartDir, err = filepath.Abs(chartDir)
+	Expect(err).ToNot(HaveOccurred())
+
+	// Check that it is indeed the chart directory:
+	chartFile = filepath.Join(chartDir, "Chart.yaml")
+	_, err = os.Stat(chartFile)
+	Expect(err).ToNot(
+		HaveOccurred(),
+		"Chart file '%s' doesn't exist",
+		chartFile,
+	)
+})


### PR DESCRIPTION
## Summary

- Add a `values.schema.json` file to validate the service chart's `values.yaml` at lint and
  install time, enforcing types, enums, and structure for all values including the reusable
  ConfigMap/Secret credential source pattern.
- Default `auth.controllerCredentials` and `idp.credentials` to empty arrays instead of null,
  and guard the controller deployment template's `range` blocks with `if` checks so empty
  credential lists render valid YAML.
- Add a Ginkgo test in `internal/chart` that runs `helm lint` against the service chart with
  all required values populated, catching schema and template regressions automatically.

## Test plan

- [x] `ginkgo run -v internal/chart` passes (helm lint succeeds with valid values).
- [x] Verify `helm lint charts/service/` with real deployment values still works.
- [x] Verify `helm install --dry-run` renders correct manifests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added JSON Schema validation for Helm chart values to enforce configuration structure.

* **Improvements**
  * Safer conditional rendering for credential volumes in deployment templates.
  * Default credential lists set to empty arrays.

* **Tests**
  * Added automated Helm lint/validation tests for the chart.

* **Chores**
  * CI updated to install a pinned Helm tool before relevant jobs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->