### PR TITLE
OSAC-478: Fix assigning IDP Manager role to break-glass account

### DIFF
--- a/internal/controllers/organization/organization_reconciler_function_test.go
+++ b/internal/controllers/organization/organization_reconciler_function_test.go
@@ -242,7 +242,7 @@ var _ = Describe("IDP Sync", func() {
 			Times(1)
 
 		mockClient.EXPECT().
-			AssignIdpManagerPermissions(gomock.Any(), "test-org", "user-123").
+			AssignIdpManagerPermissions(gomock.Any(), "user-123").
 			Return(nil).
 			Times(1)
 
@@ -284,7 +284,7 @@ var _ = Describe("IDP Sync", func() {
 			Times(1)
 
 		mockClient.EXPECT().
-			AssignIdpManagerPermissions(gomock.Any(), "test-org", "user-123").
+			AssignIdpManagerPermissions(gomock.Any(), "user-123").
 			Return(nil).
 			Times(1)
 

--- a/internal/idp/client.go
+++ b/internal/idp/client.go
@@ -49,19 +49,19 @@ type Client interface {
 	// Admin permissions
 	// AssignOrganizationAdminPermissions grants full administrative access to an organization for the specified user.
 	// The implementation is provider-specific:
-	// - Keycloak: Assigns realm-management client roles (manage-realm, manage-users, etc.)
+	// - Keycloak: Assigns tenant-admin role
 	// - Auth0: Assigns organization Admin role
 	// - Okta: Assigns Organizational Administrator role
 	// - Azure AD: Assigns Global Administrator or Organizational Administrator role
 	AssignOrganizationAdminPermissions(ctx context.Context, organizationName, userID string) error
 
 	// AssignIdpManagerPermissions grants limited IdP management permissions to the specified user.
-	// This is used for the break-glass account which can manage users and identity providers
+	// This is used for the break-glass account which can manage user roles and identity providers
 	// but cannot modify critical organization settings.
 	// The implementation is provider-specific:
-	// - Keycloak: Assigns limited realm-management client roles (manage-users, view-users, etc.)
+	// - Keycloak: Assigns limited tenant-idp-manager role
 	// - Auth0: Assigns organization Member Manager role
 	// - Okta: Assigns User Administrator role
 	// - Azure AD: Assigns User Administrator role
-	AssignIdpManagerPermissions(ctx context.Context, organizationName, userID string) error
+	AssignIdpManagerPermissions(ctx context.Context, userID string) error
 }

--- a/internal/idp/client_mock.go
+++ b/internal/idp/client_mock.go
@@ -55,17 +55,17 @@ func (mr *MockClientMockRecorder) AssignClientRolesToUser(ctx, organizationName,
 }
 
 // AssignIdpManagerPermissions mocks base method.
-func (m *MockClient) AssignIdpManagerPermissions(ctx context.Context, organizationName, userID string) error {
+func (m *MockClient) AssignIdpManagerPermissions(ctx context.Context, userID string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "AssignIdpManagerPermissions", ctx, organizationName, userID)
+	ret := m.ctrl.Call(m, "AssignIdpManagerPermissions", ctx, userID)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // AssignIdpManagerPermissions indicates an expected call of AssignIdpManagerPermissions.
-func (mr *MockClientMockRecorder) AssignIdpManagerPermissions(ctx, organizationName, userID any) *gomock.Call {
+func (mr *MockClientMockRecorder) AssignIdpManagerPermissions(ctx, userID any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AssignIdpManagerPermissions", reflect.TypeOf((*MockClient)(nil).AssignIdpManagerPermissions), ctx, organizationName, userID)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AssignIdpManagerPermissions", reflect.TypeOf((*MockClient)(nil).AssignIdpManagerPermissions), ctx, userID)
 }
 
 // AssignOrganizationAdminPermissions mocks base method.

--- a/internal/idp/keycloak/client.go
+++ b/internal/idp/keycloak/client.go
@@ -570,13 +570,35 @@ func (c *Client) AssignOrganizationAdminPermissions(ctx context.Context, organiz
 	return nil
 }
 
+func (c *Client) GetRealmRole(ctx context.Context, roleName string) (keycloakRole, error) {
+	response, err := c.httpClient.DoRequest(ctx, http.MethodGet, fmt.Sprintf("/admin/realms/%s/roles/%s", c.realmName, url.PathEscape(roleName)), nil)
+	if err != nil {
+		return keycloakRole{}, fmt.Errorf("failed to get role: %w", err)
+	}
+	defer response.Body.Close()
+	var kcRole keycloakRole
+	if err = json.NewDecoder(response.Body).Decode(&kcRole); err != nil {
+		return keycloakRole{}, fmt.Errorf("failed to decode role response: %w", err)
+	}
+	return kcRole, nil
+}
+
 // AssignIdpManagerPermissions grants limited IdP management permissions to the specified user.
 //
-// For Keycloak, this assigns a limited set of organization-level admin roles to the user.
-// Intended for the break-glass account which can manage users and identity providers but cannot modify critical
+// For Keycloak, this assigns a tenant-idp-manager role to the user.
+// Intended for the break-glass account which can manage user roles and identity providers but cannot modify critical
 // organization settings, realm settings, or authorization policies.
-func (c *Client) AssignIdpManagerPermissions(ctx context.Context, organizationName, userID string) error {
-	// TODO: implement function
+func (c *Client) AssignIdpManagerPermissions(ctx context.Context, userID string) error {
+	role, err := c.GetRealmRole(ctx, "tenant-idp-manager")
+	if err != nil {
+		return fmt.Errorf("failed to get tenant-idp-manager role from Keycloak: %w", err)
+	}
+	// Keycloak role assignment API expects an array of roles
+	response, err := c.httpClient.DoRequest(ctx, http.MethodPost, fmt.Sprintf("/admin/realms/%s/users/%s/role-mappings/realm", c.realmName, url.PathEscape(userID)), []keycloakRole{role})
+	if err != nil {
+		return fmt.Errorf("failed to assign role to user: %w", err)
+	}
+	defer response.Body.Close()
 	return nil
 }
 

--- a/internal/idp/keycloak/client_test.go
+++ b/internal/idp/keycloak/client_test.go
@@ -895,10 +895,32 @@ var _ = Describe("Keycloak Client", func() {
 	})
 
 	Describe("AssignIdpManagerPermissions", func() {
-		It("is not yet implemented (returns nil)", func() {
+		It("assigns tenant-idp-manager role to user", func() {
+			clientRole := false
+			role := keycloakRole{
+				ID:         "role-idp-manager",
+				Name:       "tenant-idp-manager",
+				ClientRole: &clientRole,
+			}
+
+			server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+
+				if r.Method == http.MethodGet && r.URL.Path == "/admin/realms/osac/roles/tenant-idp-manager" {
+					// Return the tenant-idp-manager role
+					w.WriteHeader(http.StatusOK)
+					json.NewEncoder(w).Encode(role)
+				} else if r.Method == http.MethodPost && r.URL.Path == "/admin/realms/osac/users/user-123/role-mappings/realm" {
+					// Assignment endpoint
+					w.WriteHeader(http.StatusNoContent)
+				} else {
+					w.WriteHeader(http.StatusNotFound)
+				}
+			}))
+
 			client = createTestClient(server.URL)
-			err := client.AssignIdpManagerPermissions(ctx, "test-org", "user-123")
-			Expect(err).ToNot(HaveOccurred()) // TODO returns nil until implemented
+			err := client.AssignIdpManagerPermissions(ctx, "user-123")
+			Expect(err).ToNot(HaveOccurred())
 		})
 	})
 

--- a/internal/idp/manager.go
+++ b/internal/idp/manager.go
@@ -168,7 +168,7 @@ func (m *OrganizationManager) CreateOrganization(ctx context.Context, config *Or
 	}
 
 	// Step 3: Assign IdP manager permissions to break-glass account
-	err = m.assignIdpManagerPermissions(ctx, createdOrg.Name, credentials.UserID)
+	err = m.assignIdpManagerPermissions(ctx, credentials.UserID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to assign IdP manager permissions: %w", err)
 	}
@@ -281,21 +281,20 @@ func (m *OrganizationManager) createBreakGlassAccount(ctx context.Context, confi
 }
 
 // assignIdpManagerPermissions assigns limited IdP manager permissions to a user.
-// This grants the user permissions to manage users and identity providers but not
+// This grants the user permissions to manage user roles and identity providers but not
 // critical realm settings.
-func (m *OrganizationManager) assignIdpManagerPermissions(ctx context.Context, organizationName, userID string) error {
+// The implementation is provider-specific (delegated to the IdP client).
+func (m *OrganizationManager) assignIdpManagerPermissions(ctx context.Context, userID string) error {
 	m.logger.InfoContext(ctx, "Assigning IdP manager permissions to user",
-		slog.String("organization", organizationName),
 		slog.String("user_id", userID),
 	)
 
-	err := m.client.AssignIdpManagerPermissions(ctx, organizationName, userID)
+	err := m.client.AssignIdpManagerPermissions(ctx, userID)
 	if err != nil {
 		return fmt.Errorf("failed to assign IdP manager permissions: %w", err)
 	}
 
 	m.logger.InfoContext(ctx, "IdP manager permissions assigned",
-		slog.String("organization", organizationName),
 		slog.String("user_id", userID),
 	)
 	return nil

--- a/internal/idp/manager_test.go
+++ b/internal/idp/manager_test.go
@@ -200,7 +200,7 @@ func (m *mockClient) AssignOrganizationAdminPermissions(ctx context.Context, org
 	return m.AssignClientRolesToUser(ctx, organization, userID, "realm-management", roles)
 }
 
-func (m *mockClient) AssignIdpManagerPermissions(ctx context.Context, organization, userID string) error {
+func (m *mockClient) AssignIdpManagerPermissions(ctx context.Context, userID string) error {
 	if m.failRoleAssignment {
 		return fmt.Errorf("simulated role assignment failure")
 	}
@@ -212,7 +212,8 @@ func (m *mockClient) AssignIdpManagerPermissions(ctx context.Context, organizati
 		{ID: "10", Name: "view-identity-providers", ClientRole: true},
 		{ID: "7", Name: "view-realm", ClientRole: true},
 	}
-	return m.AssignClientRolesToUser(ctx, organization, userID, "realm-management", roles)
+	// Use empty organization name since it's no longer a parameter
+	return m.AssignClientRolesToUser(ctx, "", userID, "realm-management", roles)
 }
 
 var _ = Describe("OrganizationManager", func() {

--- a/it/charts/keycloak/files/realm.json
+++ b/it/charts/keycloak/files/realm.json
@@ -76,6 +76,30 @@
       "clientRole" : false,
       "containerId" : "01e6c34f-6906-4907-9cbd-2dec7a6a0e1d",
       "attributes" : { }
+    }, {
+      "id" : "a1b2c3d4-5678-9012-3456-789012345678",
+      "name" : "tenant-admin",
+      "description" : "Tenant administrator with full user and IdP management permissions",
+      "composite" : false,
+      "clientRole" : false,
+      "containerId" : "01e6c34f-6906-4907-9cbd-2dec7a6a0e1d",
+      "attributes" : { }
+    }, {
+      "id" : "b2c3d4e5-6789-0123-4567-890123456789",
+      "name" : "tenant-user-manager",
+      "description" : "Tenant user manager with user management permissions",
+      "composite" : false,
+      "clientRole" : false,
+      "containerId" : "01e6c34f-6906-4907-9cbd-2dec7a6a0e1d",
+      "attributes" : { }
+    }, {
+      "id" : "c3d4e5f6-7890-1234-5678-901234567890",
+      "name" : "tenant-idp-manager",
+      "description" : "Tenant IdP manager with IdP configuration and role assignment permissions",
+      "composite" : false,
+      "clientRole" : false,
+      "containerId" : "01e6c34f-6906-4907-9cbd-2dec7a6a0e1d",
+      "attributes" : { }
     } ],
     "client" : {
       "osac-cli" : [ ],


### PR DESCRIPTION
# Description
After moving to using Keycloak Organizations, the role assignment moved from keycloak client roles such as `manage-users` (which are realm-wide) to custom roles we define at the realm-level. The custom roles are read during the request and authorization is determined based off of these roles.

This particular change updates the IDP manager permissions for the break-glass account by calling the correct Keycloak admin endpoint to assign the `tenant-idp-manager` role.

Also includes a few wording changes to match the current situation.

Assisted-by: Claude

# Testing

1. Log in as osac admin using osac CLI and create organization `osac-demo` 
2. Observe organization get created successfully and break-glass account credentials in status `./osac get organization -oyaml`
3. Login with break-glass account and change password `./osac login --ca-file bundle.pem \
--oauth-flow device https://fulfillment-internal-api.osac.svc.cluster.local:8000`
4. Login with break-glass account using osac CLI 
```sh
./osac login \                     
--ca-file bundle.pem \
--oauth-flow password \
--oauth-user osac-demo-3-osac-break-glass \
--oauth-password testpass https://fulfillment-internal-api.osac.svc.cluster.local:8000
```
5. Get resource `./osac get clustertemplates` and check authorino logs for role `tenant-idp-manager`
```
$ echo '{"level":"debug","ts":"2026-05-08T19:33:39Z","logger":"authorino.service.auth.authpipeline.identity","msg":"identity validated","request id":"a86aa7d3-cfd7-409f-84d3-0282f71621c5","config":{"Name":"keycloak-jwt","Priority":0,"Conditions":{"Left":null,"Right":null},"Metrics":false,"Cache":null,"OAuth2":null,"JWTAuthentication":{"AuthCredentials":{"KeySelector":"Bearer","In":"authorization_header"}},"MTLS":null,"HMAC":null,"APIKey":null,"KubernetesAuth":null,"Plain":null,"Noop":null,"ExtendedProperties":[{"Name":"authnMethod","Value":{"Static":"jwt","Pattern":""},"Overwrite":true}]},"object":{"aud":"account","authnMethod":"jwt","azp":"osac-cli","exp":1778269069,"iat":1778268769,"iss":"https://keycloak.keycloak.svc.cluster.local:8000/realms/osac","jti":"onrtro:afddb746-a562-be75-dc98-94cb7c3f6e6d","organization":["osac-demo-3"],"realm_access":{"roles":["tenant-idp-manager","offline_access","uma_authorization","default-roles-my realm"]},"resource_access":{"account":{"roles":["manage-account","manage-account-links","view-profile"]}},"scope":"openid organization","sid":"1325c20a-50ed-4bbb-91ab-89645ef7f244","sub":"faa2cc8b-079f-4a44-bf8e-ba87efc91f81","typ":"Bearer","username":"osac-demo-3-osac-break-glass"}}' | jq '.object.realm_access'
{
  "roles": [
    "tenant-idp-manager",
    "offline_access",
    "uma_authorization",
    "default-roles-my realm"
  ]
}
```

/cc @jhernand 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added new Keycloak realm roles for tenant admin, user manager, and IdP manager.

* **Bug Fixes**
  * Fixed IdP manager permission assignment so break-glass accounts receive the proper role during organization creation.

* **Tests**
  * Updated tests to validate IdP manager role resolution and assignment behavior.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/osac-project/fulfillment-service/pull/513)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->