### PR TITLE
OSAC-478: Fix deleting an Organization

### DIFF
--- a/internal/idp/keycloak/client.go
+++ b/internal/idp/keycloak/client.go
@@ -183,6 +183,12 @@ func (c *Client) GetOrganization(ctx context.Context, name string) (*idp.Organiz
 
 // DeleteOrganization deletes an organization (Keycloak organization in the configured realm) by name.
 func (c *Client) DeleteOrganization(ctx context.Context, organizationName string) error {
+	// Delete the break-glass account first (Keycloak-specific: it belongs to realm, not organization)
+	breakGlassUsername := fmt.Sprintf("%s-osac-break-glass", organizationName)
+	if err := c.deleteBreakGlassAccount(ctx, organizationName, breakGlassUsername); err != nil {
+		return fmt.Errorf("failed to delete break-glass account: %w", err)
+	}
+
 	org, err := c.GetOrganization(ctx, organizationName)
 	if err != nil {
 		return fmt.Errorf("failed to get organization: %w", err)
@@ -571,5 +577,57 @@ func (c *Client) AssignOrganizationAdminPermissions(ctx context.Context, organiz
 // organization settings, realm settings, or authorization policies.
 func (c *Client) AssignIdpManagerPermissions(ctx context.Context, organizationName, userID string) error {
 	// TODO: implement function
+	return nil
+}
+
+// getUserByUsername retrieves a user by username from the realm.
+// Returns nil if the user is not found.
+func (c *Client) getUserByUsername(ctx context.Context, username string) (*idp.User, error) {
+	query := url.Values{}
+	query.Add("username", username)
+	query.Add("exact", "true")
+	path := fmt.Sprintf("/admin/realms/%s/users?%s", c.realmName, query.Encode())
+
+	response, err := c.httpClient.DoRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query user by username: %w", err)
+	}
+	defer response.Body.Close()
+
+	var kcUsers []keycloakUser
+	if err = json.NewDecoder(response.Body).Decode(&kcUsers); err != nil {
+		return nil, fmt.Errorf("failed to decode user query response: %w", err)
+	}
+
+	if len(kcUsers) == 0 {
+		// User not found - return nil without error
+		return nil, nil
+	}
+
+	return fromKeycloakUser(&kcUsers[0]), nil
+}
+
+// deleteBreakGlassAccount is a Keycloak-specific helper that deletes the break-glass account.
+// In Keycloak, the break-glass account belongs to the realm (not the organization),
+// so it must be explicitly deleted and won't be cascade-deleted with the organization.
+func (c *Client) deleteBreakGlassAccount(ctx context.Context, organizationName, breakGlassUsername string) error {
+	// Query for the break-glass user by username
+	user, err := c.getUserByUsername(ctx, breakGlassUsername)
+	if err != nil {
+		return fmt.Errorf("failed to get user by username: %w", err)
+	}
+
+	if user == nil {
+		// Break-glass account not found - may have been already deleted
+		// This is not an error, just return success
+		return nil
+	}
+
+	// Delete the break-glass user
+	err = c.DeleteUser(ctx, organizationName, user.ID)
+	if err != nil {
+		return fmt.Errorf("failed to delete break-glass user: %w", err)
+	}
+
 	return nil
 }

--- a/internal/idp/keycloak/client_test.go
+++ b/internal/idp/keycloak/client_test.go
@@ -554,7 +554,27 @@ var _ = Describe("Keycloak Client", func() {
 	Describe("DeleteOrganization", func() {
 		It("deletes an organization from Keycloak", func() {
 			server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				// Second request: get organization by name
+				// First request: query user by username (for break-glass deletion)
+				if r.Method == http.MethodGet && r.URL.Path == "/admin/realms/osac/users" && r.URL.Query().Get("username") == "test-org-osac-break-glass" {
+					// Return break-glass user
+					response := []keycloakUser{{
+						ID:       "break-glass-id",
+						Username: "test-org-osac-break-glass",
+						Email:    "break-glass@test-org.osac.local",
+					}}
+					w.Header().Set("Content-Type", "application/json")
+					w.WriteHeader(http.StatusOK)
+					json.NewEncoder(w).Encode(response)
+					return
+				}
+
+				// Second request: delete break-glass user
+				if r.Method == http.MethodDelete && r.URL.Path == "/admin/realms/osac/users/break-glass-id" {
+					w.WriteHeader(http.StatusNoContent)
+					return
+				}
+
+				// Third request: get organization by name
 				if r.Method == http.MethodGet && r.URL.Path == "/admin/realms/osac/organizations" && r.URL.RawQuery == "exact=true&search=test-org" {
 					enabled := true
 					response := []keycloakOrganization{{
@@ -569,7 +589,7 @@ var _ = Describe("Keycloak Client", func() {
 					return
 				}
 
-				// Second request: delete organization
+				// Fourth request: delete organization
 				if r.Method == http.MethodDelete && r.URL.Path == "/admin/realms/osac/organizations/org-id" {
 					w.WriteHeader(http.StatusNoContent)
 					return

--- a/internal/idp/manager.go
+++ b/internal/idp/manager.go
@@ -283,7 +283,6 @@ func (m *OrganizationManager) createBreakGlassAccount(ctx context.Context, confi
 // assignIdpManagerPermissions assigns limited IdP manager permissions to a user.
 // This grants the user permissions to manage users and identity providers but not
 // critical realm settings.
-// The implementation is provider-specific (delegated to the IdP client).
 func (m *OrganizationManager) assignIdpManagerPermissions(ctx context.Context, organizationName, userID string) error {
 	m.logger.InfoContext(ctx, "Assigning IdP manager permissions to user",
 		slog.String("organization", organizationName),
@@ -303,6 +302,7 @@ func (m *OrganizationManager) assignIdpManagerPermissions(ctx context.Context, o
 }
 
 // DeleteOrganization deletes an IdP organization and all its resources.
+// The implementation handles provider-specific cleanup (e.g., Keycloak deletes break-glass account first).
 func (m *OrganizationManager) DeleteOrganization(ctx context.Context, organizationName string) error {
 	m.logger.InfoContext(ctx, "Deleting IdP organization",
 		slog.String("organization", organizationName),

--- a/internal/idp/manager_test.go
+++ b/internal/idp/manager_test.go
@@ -54,6 +54,16 @@ func (m *mockClient) DeleteOrganization(ctx context.Context, name string) error 
 	if m.failOrgDeletion {
 		return fmt.Errorf("simulated organization deletion failure")
 	}
+
+	// Simulate Keycloak behavior: delete break-glass account first
+	breakGlassUsername := fmt.Sprintf("%s-osac-break-glass", name)
+	for _, user := range m.createdUsers {
+		if user.Username == breakGlassUsername {
+			m.deletedUsers = append(m.deletedUsers, user.ID)
+			break
+		}
+	}
+
 	m.deletedRealm = name
 	return nil
 }


### PR DESCRIPTION
# Description 
Due to the move to Keycloak Organizations, users are not cascade deleted when an Organization is deleted, which includes the break-glass account.

When an Organization is deleted, we should also delete the break-glass account from the realm.

# Testing

1. Create an organization using OSAC CLI
2. Observe organization created successfully and break-glass account exists in Keycloak console
3. Delete organization via OSAC CLI
4. Observe organization is deleted in Keycloak console and break-glass account is deleted in realm

Assisted-by: Claude

/cc @jhernand 