### PR TITLE
NO-ISSUE: fix flaky version lock integration test

### DIFF
--- a/it/it_version_test.go
+++ b/it/it_version_test.go
@@ -199,9 +199,16 @@ var _ = Describe("Version", func() {
 			version := object.GetMetadata().GetVersion()
 
 			// Try repeatedly till the update succeeds. It may initially fail because the controller may
-			// update the object before us.
+			// update the object before us. Re-read the current version before each attempt to avoid
+			// sending a stale version that will never match.
 			Eventually(
 				func(g Gomega) {
+					getResponse, err := clustersClient.Get(ctx, publicv1.ClustersGetRequest_builder{
+						Id: id,
+					}.Build())
+					g.Expect(err).ToNot(HaveOccurred())
+					version = getResponse.GetObject().GetMetadata().GetVersion()
+
 					updateResponse, err := clustersClient.Update(ctx, publicv1.ClustersUpdateRequest_builder{
 						Object: publicv1.Cluster_builder{
 							Id: id,
@@ -216,7 +223,6 @@ var _ = Describe("Version", func() {
 					}.Build())
 					g.Expect(err).ToNot(HaveOccurred())
 					object = updateResponse.GetObject()
-					version = object.GetMetadata().GetVersion()
 				},
 				10*time.Second,
 				100*time.Millisecond,


### PR DESCRIPTION
## Summary

- Fix flaky `Version Lock: Succeeds when version matches` integration test that times out in CI
- Root cause: the `Eventually` loop sent a stale version from the initial create on each retry, while the controller concurrently bumped the version — the stale version would never match
- Fix: re-read the current version via Get before each update attempt so the version always reflects the latest state

## Test plan

- [x] `go build ./...` — compiles clean
- [ ] CI integration tests pass (this is the test being fixed)

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test reliability for cluster metadata version handling during locked updates.

---

**Note:** This release contains no user-facing changes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/osac-project/fulfillment-service/pull/524)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->