### PR TITLE
NO-ISSUE: add service-account-fulfillment-controller to admin service accounts

### DIFF
--- a/charts/service/templates/grpc-server/authconfig.yaml
+++ b/charts/service/templates/grpc-server/authconfig.yaml
@@ -83,6 +83,7 @@ spec:
           admin_service_accounts := {
             "service-account-osac-admin",
             "service-account-osac-controller",
+            "service-account-fulfillment-controller",
           }
 
           # Admin groups are groups that are allowed to act as administrators.

--- a/manifests/base/grpc-server/authconfig.yaml
+++ b/manifests/base/grpc-server/authconfig.yaml
@@ -51,6 +51,7 @@ spec:
           admin_service_accounts := {
             "service-account-osac-admin",
             "service-account-osac-controller",
+            "service-account-fulfillment-controller",
           }
 
           # Admin groups are groups that are allowed to act as administrators.


### PR DESCRIPTION
## Summary

The `fulfillment-controller` Keycloak client authenticates as `service-account-fulfillment-controller` via JWT. It needs admin access but was missing from `admin_service_accounts` in both the Helm chart and kustomize manifest. Every installer overlay had to add it independently, which is error-prone and was flagged during review of PR #99 (osac-installer).

Adding it to the base so the overlays don't need to override `admin_service_accounts` at all.

## Test plan

- [ ] Integration tests pass
- [ ] Prow E2E tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)