### PR TITLE
OSAC-360: migrate to Red Hat hardened images with Go 1.26

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -1,8 +1,5 @@
-# This is the base image, both for the builder and runtime containers.
-ARG BASE=registry.access.redhat.com/ubi10/ubi:10.1-1773895909
-
 # First stage is to build the image that contains the image with all the development tools needed to build the binary.
-FROM ${BASE} AS builder
+FROM registry.access.redhat.com/hi/go:1.26-builder AS builder
 
 # Set this to 'true' to build the binary with debugging symbols and disabling optimizations.
 ARG DEBUG=false
@@ -10,7 +7,7 @@ ARG DEBUG=false
 # Install packages:
 RUN \
   set -e; \
-  pkgs=(git golang); \
+  pkgs=(git); \
   dnf install -y "${pkgs[@]}"; \
   dnf clean all -y
 
@@ -42,22 +39,17 @@ RUN \
   fi; \
   go build -gcflags="${gcflags}" -ldflags="${ldflags}" ./cmd/fulfillment-service
 
-# Second stage is to build the image that contains the binary, without the development tools, except the debugger
-# if enabled.
-FROM ${BASE} AS runtime
+# dlv stage — only pulled into the build graph when targeting runtime-debug.
+FROM builder AS dlv-builder
+RUN go install github.com/go-delve/delve/cmd/dlv@latest
 
-# Set this to 'true' to include the 'dlv' debugger in the image.
-ARG DEBUG=false
-
-# Install packages:
-RUN \
-  set -e; \
-  pkgs=(openssl); \
-  if [[ "${DEBUG}" == "true" ]]; then \
-    pkgs+=(delve); \
-  fi; \
-  dnf install -y "${pkgs[@]}"; \
-  dnf clean all -y
-
-# Install the binary:
+# Common runtime base with the service binary.
+FROM registry.access.redhat.com/hi/core-runtime:latest-openssl AS runtime-base
 COPY --from=builder /source/fulfillment-service /usr/local/bin
+
+# Debug variant — adds dlv on top of the base; build with: podman build --target runtime-debug .
+FROM runtime-base AS runtime-debug
+COPY --from=dlv-builder /go/bin/dlv /usr/local/bin
+
+# Default (non-debug) runtime — must stay last so plain `podman build .` targets it.
+FROM runtime-base AS runtime

--- a/README.md
+++ b/README.md
@@ -161,6 +161,11 @@ command like this:
 
     $ podman build -t quay.io/myuser/fulfillment-service:latest .
 
+To build the debug variant (includes the `dlv` debugger and disables compiler optimisations), use the
+`runtime-debug` target:
+
+    $ podman build --build-arg DEBUG=true --target runtime-debug -t quay.io/myuser/fulfillment-service:latest .
+
 If you want to deploy to an OpenShift cluster then you will also need to push the image, so that the cluster can pull
 it:
 

--- a/it/it_tool.go
+++ b/it/it_tool.go
@@ -466,6 +466,10 @@ func (t *Tool) buildImage(ctx context.Context) (result string, err error) {
 		gitVersion = strings.TrimSpace(string(versionBytes))
 	}
 
+	buildTarget := "runtime"
+	if t.debug {
+		buildTarget = "runtime-debug"
+	}
 	buildCmd, err := testing.NewCommand().
 		SetLogger(t.logger).
 		SetHome(t.projectDir).
@@ -475,6 +479,7 @@ func (t *Tool) buildImage(ctx context.Context) (result string, err error) {
 			"build",
 			"--build-arg", fmt.Sprintf("DEBUG=%t", t.debug),
 			"--build-arg", fmt.Sprintf("VERSION=%s", gitVersion),
+			"--target", buildTarget,
 			"--tag", imageRef,
 			"--file", "Containerfile",
 			".",


### PR DESCRIPTION
## Summary

- Replace `ubi10/ubi:10.1` base image with Red Hat hardened images (`hi/go:1.26-builder` for builder, `hi/core-runtime:latest-openssl` for runtime), unblocking Go 1.26 which UBI10 dnf repos don't yet ship.
- Drop `golang` from dnf install — it's bundled in the builder image.
- Replace conditional dnf install of `delve` with dedicated `dlv-builder` stage and named build targets (`runtime` / `runtime-debug`) to avoid a conditional `COPY` that fails when the binary is absent.
- Fix `it/it_tool.go` to pass `--target runtime-debug` when `IT_DEBUG=true`.

## Build

```bash
# Non-debug (default)
podman build .

# Debug (includes dlv)
podman build --build-arg DEBUG=true --target runtime-debug .
```

## Test plan

- [x] `podman build --build-arg DEBUG=false .` completes successfully, `dlv-builder` stage not executed
- [ ] `podman build --target runtime-debug .` completes successfully, `dlv` present in image
- [ ] `IT_DEBUG=true ginkgo run it` builds and deploys the debug image with `dlv`

Closes [OSAC-360](https://redhat.atlassian.net/browse/OSAC-360)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Reorganized container image build stages for improved clarity and maintainability.

* **Documentation**
  * Added instructions for building a debug variant with debugging tools included.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/osac-project/fulfillment-service/pull/527)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->