### PR TITLE
NO-ISSUE: Add CA bundle support to the Keycloak Helm chart

### DIFF
--- a/it/charts/keycloak/README.md
+++ b/it/charts/keycloak/README.md
@@ -19,6 +19,7 @@ The following table lists the configurable parameters of the Keycloak chart:
 | `hostname`                     | The hostname that Keycloak uses to refer to itself             | **Yes**  | None            |
 | `certs.issuerRef.kind`         | The kind of cert-manager issuer (`ClusterIssuer` or `Issuer`)  | No       | `ClusterIssuer` |
 | `certs.issuerRef.name`         | The name of the cert-manager issuer for TLS certificates       | **Yes**  | None            |
+| `certs.caBundle.configMap`     | ConfigMap with trusted CA certificates in PEM format           | No       | None            |
 | `admin.username`               | Bootstrap admin username for the initial Keycloak account      | No       | `admin`         |
 | `admin.password`               | Bootstrap admin password for the initial Keycloak account      | No       | `admin`         |
 | `images.keycloak`              | The Keycloak container image                                   | No       | `26.3`          |
@@ -58,6 +59,8 @@ certs:
   issuerRef:
     kind: ClusterIssuer
     name: default-ca
+  caBundle:
+    configMap: ca-bundle
 
 database:
   connection:

--- a/it/charts/keycloak/templates/_start.tpl
+++ b/it/charts/keycloak/templates/_start.tpl
@@ -100,6 +100,9 @@ https-enabled=true
 https-port=8000
 https-certificate-file=/opt/keycloak/tls/tls.crt
 https-certificate-key-file=/opt/keycloak/tls/tls.key
+{{ if .Values.certs.caBundle.configMap }}
+truststore-paths=/opt/keycloak/cas
+{{ end }}
 .
 chmod 600 "${conf_file}"
 

--- a/it/charts/keycloak/templates/pod.yaml
+++ b/it/charts/keycloak/templates/pod.yaml
@@ -26,6 +26,11 @@ spec:
   - name: tls
     secret:
       secretName: keycloak-tls
+  {{ if .Values.certs.caBundle.configMap }}
+  - name: cas
+    configMap:
+      name: {{ .Values.certs.caBundle.configMap }}
+  {{ end }}
   - name: db
     projected:
       sources:
@@ -64,6 +69,11 @@ spec:
     - name: tls
       mountPath: /opt/keycloak/tls
       readOnly: true
+    {{ if .Values.certs.caBundle.configMap }}
+    - name: cas
+      mountPath: /opt/keycloak/cas
+      readOnly: true
+    {{ end }}
     - name: db
       mountPath: /opt/keycloak/db
       readOnly: true

--- a/it/charts/keycloak/values.yaml
+++ b/it/charts/keycloak/values.yaml
@@ -25,6 +25,12 @@ certs:
     kind: ClusterIssuer
     name:
 
+  # This defines the trusted CA certificates bundle. It should be the name of a ConfigMap in the release namespace
+  # containing trusted CA certificates. All keys in the ConfigMap are picked up, so any key name is accepted as long
+  # as its value is valid PEM content. When set, Keycloak will trust connections signed by those CAs.
+  caBundle:
+    configMap:
+
 # Bootstrap admin credentials used for the initial Keycloak administrator account:
 admin:
   username: admin

--- a/it/it_tool.go
+++ b/it/it_tool.go
@@ -871,6 +871,9 @@ func (t *Tool) deployKeycloak(ctx context.Context) error {
 				"kind": "ClusterIssuer",
 				"name": "default-ca",
 			},
+			"caBundle": map[string]any{
+				"configMap": "ca-bundle",
+			},
 		},
 		"database": map[string]any{
 			"connection": []any{


### PR DESCRIPTION
## Summary

- Add a new `certs.caBundle.configMap` value to the Keycloak Helm chart that allows
  configuring a trusted CA certificates bundle. When set, the referenced ConfigMap is
  mounted into the pod and Keycloak's `truststore-paths` property is configured so that
  it trusts TLS connections signed by those CAs.
- Update the integration test tool to pass the `ca-bundle` ConfigMap so the test Keycloak
  instance trusts the cluster's internal CA.

## Test plan

- [x] Verify the Keycloak pod starts correctly when `certs.caBundle.configMap` is set
- [x] Verify the Keycloak pod starts correctly when `certs.caBundle.configMap` is not set (no regression)
- [x] Run integration tests with `ginkgo run it`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional certs.caBundle.configMap setting for Keycloak deployments. When set, the deployment mounts the CA bundle as a read-only volume and includes the corresponding truststore path in configuration.

* **Documentation**
  * Updated configuration docs and example values to document the new CA bundle setting and usage.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/osac-project/fulfillment-service/pull/530)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->