### PR TITLE
OSAC-703: add public CRUD servers for catalog items

### DIFF
--- a/internal/cmd/service/start/grpcserver/start_grpc_server_cmd.go
+++ b/internal/cmd/service/start/grpcserver/start_grpc_server_cmd.go
@@ -425,6 +425,34 @@ func (c *runnerContext) run(cmd *cobra.Command, argv []string) error {
 	}
 	publicv1.RegisterClusterTemplatesServer(grpcServer, clusterTemplatesServer)
 
+	// Create the cluster catalog items server:
+	c.logger.InfoContext(ctx, "Creating cluster catalog items server")
+	clusterCatalogItemsServer, err := servers.NewClusterCatalogItemsServer().
+		SetLogger(c.logger).
+		SetNotifier(notifier).
+		SetAttributionLogic(publicAttributionLogic).
+		SetTenancyLogic(tenancyLogic).
+		SetMetricsRegisterer(metricsRegisterer).
+		Build()
+	if err != nil {
+		return fmt.Errorf("failed to create cluster catalog items server: %w", err)
+	}
+	publicv1.RegisterClusterCatalogItemsServer(grpcServer, clusterCatalogItemsServer)
+
+	// Create the compute instance catalog items server:
+	c.logger.InfoContext(ctx, "Creating compute instance catalog items server")
+	computeInstanceCatalogItemsServer, err := servers.NewComputeInstanceCatalogItemsServer().
+		SetLogger(c.logger).
+		SetNotifier(notifier).
+		SetAttributionLogic(publicAttributionLogic).
+		SetTenancyLogic(tenancyLogic).
+		SetMetricsRegisterer(metricsRegisterer).
+		Build()
+	if err != nil {
+		return fmt.Errorf("failed to create compute instance catalog items server: %w", err)
+	}
+	publicv1.RegisterComputeInstanceCatalogItemsServer(grpcServer, computeInstanceCatalogItemsServer)
+
 	// Create the private cluster templates server:
 	c.logger.InfoContext(ctx, "Creating private cluster templates server")
 	privateClusterTemplatesServer, err := servers.NewPrivateClusterTemplatesServer().

--- a/internal/cmd/service/start/restgateway/start_rest_gateway_cmd.go
+++ b/internal/cmd/service/start/restgateway/start_rest_gateway_cmd.go
@@ -157,6 +157,10 @@ func (c *runnerContext) run(cmd *cobra.Command, argv []string) error {
 	if err != nil {
 		return err
 	}
+	err = publicv1.RegisterClusterCatalogItemsHandler(ctx, gatewayMux, c.grpcClient)
+	if err != nil {
+		return err
+	}
 	err = publicv1.RegisterClustersHandler(ctx, gatewayMux, c.grpcClient)
 	if err != nil {
 		return err
@@ -166,6 +170,10 @@ func (c *runnerContext) run(cmd *cobra.Command, argv []string) error {
 		return err
 	}
 	err = publicv1.RegisterComputeInstanceTemplatesHandler(ctx, gatewayMux, c.grpcClient)
+	if err != nil {
+		return err
+	}
+	err = publicv1.RegisterComputeInstanceCatalogItemsHandler(ctx, gatewayMux, c.grpcClient)
 	if err != nil {
 		return err
 	}

--- a/internal/servers/cluster_catalog_items_server.go
+++ b/internal/servers/cluster_catalog_items_server.go
@@ -1,0 +1,274 @@
+/*
+Copyright (c) 2025 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package servers
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+
+	"github.com/prometheus/client_golang/prometheus"
+	grpccodes "google.golang.org/grpc/codes"
+	grpcstatus "google.golang.org/grpc/status"
+
+	privatev1 "github.com/osac-project/fulfillment-service/internal/api/osac/private/v1"
+	publicv1 "github.com/osac-project/fulfillment-service/internal/api/osac/public/v1"
+	"github.com/osac-project/fulfillment-service/internal/auth"
+	"github.com/osac-project/fulfillment-service/internal/database"
+)
+
+type ClusterCatalogItemsServerBuilder struct {
+	logger            *slog.Logger
+	notifier          *database.Notifier
+	attributionLogic  auth.AttributionLogic
+	tenancyLogic      auth.TenancyLogic
+	metricsRegisterer prometheus.Registerer
+}
+
+var _ publicv1.ClusterCatalogItemsServer = (*ClusterCatalogItemsServer)(nil)
+
+type ClusterCatalogItemsServer struct {
+	publicv1.UnimplementedClusterCatalogItemsServer
+
+	logger    *slog.Logger
+	delegate  privatev1.ClusterCatalogItemsServer
+	inMapper  *GenericMapper[*publicv1.ClusterCatalogItem, *privatev1.ClusterCatalogItem]
+	outMapper *GenericMapper[*privatev1.ClusterCatalogItem, *publicv1.ClusterCatalogItem]
+}
+
+func NewClusterCatalogItemsServer() *ClusterCatalogItemsServerBuilder {
+	return &ClusterCatalogItemsServerBuilder{}
+}
+
+func (b *ClusterCatalogItemsServerBuilder) SetLogger(value *slog.Logger) *ClusterCatalogItemsServerBuilder {
+	b.logger = value
+	return b
+}
+
+func (b *ClusterCatalogItemsServerBuilder) SetNotifier(value *database.Notifier) *ClusterCatalogItemsServerBuilder {
+	b.notifier = value
+	return b
+}
+
+func (b *ClusterCatalogItemsServerBuilder) SetAttributionLogic(value auth.AttributionLogic) *ClusterCatalogItemsServerBuilder {
+	b.attributionLogic = value
+	return b
+}
+
+func (b *ClusterCatalogItemsServerBuilder) SetTenancyLogic(value auth.TenancyLogic) *ClusterCatalogItemsServerBuilder {
+	b.tenancyLogic = value
+	return b
+}
+
+func (b *ClusterCatalogItemsServerBuilder) SetMetricsRegisterer(value prometheus.Registerer) *ClusterCatalogItemsServerBuilder {
+	b.metricsRegisterer = value
+	return b
+}
+
+func (b *ClusterCatalogItemsServerBuilder) Build() (result *ClusterCatalogItemsServer, err error) {
+	if b.logger == nil {
+		err = errors.New("logger is mandatory")
+		return
+	}
+	if b.tenancyLogic == nil {
+		err = errors.New("tenancy logic is mandatory")
+		return
+	}
+
+	inMapper, err := NewGenericMapper[*publicv1.ClusterCatalogItem, *privatev1.ClusterCatalogItem]().
+		SetLogger(b.logger).
+		SetStrict(true).
+		Build()
+	if err != nil {
+		return
+	}
+	outMapper, err := NewGenericMapper[*privatev1.ClusterCatalogItem, *publicv1.ClusterCatalogItem]().
+		SetLogger(b.logger).
+		SetStrict(false).
+		Build()
+	if err != nil {
+		return
+	}
+
+	delegate, err := NewPrivateClusterCatalogItemsServer().
+		SetLogger(b.logger).
+		SetNotifier(b.notifier).
+		SetAttributionLogic(b.attributionLogic).
+		SetTenancyLogic(b.tenancyLogic).
+		SetMetricsRegisterer(b.metricsRegisterer).
+		Build()
+	if err != nil {
+		return
+	}
+
+	result = &ClusterCatalogItemsServer{
+		logger:    b.logger,
+		delegate:  delegate,
+		inMapper:  inMapper,
+		outMapper: outMapper,
+	}
+	return
+}
+
+func (s *ClusterCatalogItemsServer) List(ctx context.Context,
+	request *publicv1.ClusterCatalogItemsListRequest) (response *publicv1.ClusterCatalogItemsListResponse, err error) {
+	privateRequest := &privatev1.ClusterCatalogItemsListRequest{}
+	privateRequest.SetOffset(request.GetOffset())
+	privateRequest.SetLimit(request.GetLimit())
+	privateRequest.SetFilter(request.GetFilter())
+	privateRequest.SetOrder(request.GetOrder())
+
+	privateResponse, err := s.delegate.List(ctx, privateRequest)
+	if err != nil {
+		return nil, err
+	}
+
+	privateItems := privateResponse.GetItems()
+	publicItems := make([]*publicv1.ClusterCatalogItem, len(privateItems))
+	for i, privateItem := range privateItems {
+		publicItem := &publicv1.ClusterCatalogItem{}
+		err = s.outMapper.Copy(ctx, privateItem, publicItem)
+		if err != nil {
+			s.logger.ErrorContext(ctx, "Failed to map private cluster catalog item to public", slog.Any("error", err))
+			return nil, grpcstatus.Errorf(grpccodes.Internal, "failed to process cluster catalog items")
+		}
+		publicItems[i] = publicItem
+	}
+
+	response = &publicv1.ClusterCatalogItemsListResponse{}
+	response.SetSize(privateResponse.GetSize())
+	response.SetTotal(privateResponse.GetTotal())
+	response.SetItems(publicItems)
+	return
+}
+
+func (s *ClusterCatalogItemsServer) Get(ctx context.Context,
+	request *publicv1.ClusterCatalogItemsGetRequest) (response *publicv1.ClusterCatalogItemsGetResponse, err error) {
+	privateRequest := &privatev1.ClusterCatalogItemsGetRequest{}
+	privateRequest.SetId(request.GetId())
+
+	privateResponse, err := s.delegate.Get(ctx, privateRequest)
+	if err != nil {
+		return nil, err
+	}
+
+	publicCatalogItem := &publicv1.ClusterCatalogItem{}
+	err = s.outMapper.Copy(ctx, privateResponse.GetObject(), publicCatalogItem)
+	if err != nil {
+		s.logger.ErrorContext(ctx, "Failed to map private cluster catalog item to public", slog.Any("error", err))
+		return nil, grpcstatus.Errorf(grpccodes.Internal, "failed to process cluster catalog item")
+	}
+
+	response = &publicv1.ClusterCatalogItemsGetResponse{}
+	response.SetObject(publicCatalogItem)
+	return
+}
+
+func (s *ClusterCatalogItemsServer) Create(ctx context.Context,
+	request *publicv1.ClusterCatalogItemsCreateRequest) (response *publicv1.ClusterCatalogItemsCreateResponse, err error) {
+	publicCatalogItem := request.GetObject()
+	if publicCatalogItem == nil {
+		err = grpcstatus.Errorf(grpccodes.InvalidArgument, "object is mandatory")
+		return
+	}
+	privateCatalogItem := &privatev1.ClusterCatalogItem{}
+	err = s.inMapper.Copy(ctx, publicCatalogItem, privateCatalogItem)
+	if err != nil {
+		s.logger.ErrorContext(ctx, "Failed to map public cluster catalog item to private", slog.Any("error", err))
+		err = grpcstatus.Errorf(grpccodes.Internal, "failed to process cluster catalog item")
+		return
+	}
+
+	privateRequest := &privatev1.ClusterCatalogItemsCreateRequest{}
+	privateRequest.SetObject(privateCatalogItem)
+	privateResponse, err := s.delegate.Create(ctx, privateRequest)
+	if err != nil {
+		return nil, err
+	}
+
+	createdPublicCatalogItem := &publicv1.ClusterCatalogItem{}
+	err = s.outMapper.Copy(ctx, privateResponse.GetObject(), createdPublicCatalogItem)
+	if err != nil {
+		s.logger.ErrorContext(ctx, "Failed to map private cluster catalog item to public", slog.Any("error", err))
+		err = grpcstatus.Errorf(grpccodes.Internal, "failed to process cluster catalog item")
+		return
+	}
+
+	response = &publicv1.ClusterCatalogItemsCreateResponse{}
+	response.SetObject(createdPublicCatalogItem)
+	return
+}
+
+func (s *ClusterCatalogItemsServer) Update(ctx context.Context,
+	request *publicv1.ClusterCatalogItemsUpdateRequest) (response *publicv1.ClusterCatalogItemsUpdateResponse, err error) {
+	publicCatalogItem := request.GetObject()
+	if publicCatalogItem == nil {
+		err = grpcstatus.Errorf(grpccodes.InvalidArgument, "object is mandatory")
+		return
+	}
+	id := publicCatalogItem.GetId()
+	if id == "" {
+		err = grpcstatus.Errorf(grpccodes.InvalidArgument, "object identifier is mandatory")
+		return
+	}
+
+	getRequest := &privatev1.ClusterCatalogItemsGetRequest{}
+	getRequest.SetId(id)
+	getResponse, err := s.delegate.Get(ctx, getRequest)
+	if err != nil {
+		return nil, err
+	}
+	existingPrivateCatalogItem := getResponse.GetObject()
+
+	err = s.inMapper.Copy(ctx, publicCatalogItem, existingPrivateCatalogItem)
+	if err != nil {
+		s.logger.ErrorContext(ctx, "Failed to map public cluster catalog item to private", slog.Any("error", err))
+		err = grpcstatus.Errorf(grpccodes.Internal, "failed to process cluster catalog item")
+		return
+	}
+
+	privateRequest := &privatev1.ClusterCatalogItemsUpdateRequest{}
+	privateRequest.SetObject(existingPrivateCatalogItem)
+	privateRequest.SetLock(request.GetLock())
+	privateResponse, err := s.delegate.Update(ctx, privateRequest)
+	if err != nil {
+		return nil, err
+	}
+
+	updatedPublicCatalogItem := &publicv1.ClusterCatalogItem{}
+	err = s.outMapper.Copy(ctx, privateResponse.GetObject(), updatedPublicCatalogItem)
+	if err != nil {
+		s.logger.ErrorContext(ctx, "Failed to map private cluster catalog item to public", slog.Any("error", err))
+		err = grpcstatus.Errorf(grpccodes.Internal, "failed to process cluster catalog item")
+		return
+	}
+
+	response = &publicv1.ClusterCatalogItemsUpdateResponse{}
+	response.SetObject(updatedPublicCatalogItem)
+	return
+}
+
+func (s *ClusterCatalogItemsServer) Delete(ctx context.Context,
+	request *publicv1.ClusterCatalogItemsDeleteRequest) (response *publicv1.ClusterCatalogItemsDeleteResponse, err error) {
+	privateRequest := &privatev1.ClusterCatalogItemsDeleteRequest{}
+	privateRequest.SetId(request.GetId())
+
+	_, err = s.delegate.Delete(ctx, privateRequest)
+	if err != nil {
+		return nil, err
+	}
+
+	response = &publicv1.ClusterCatalogItemsDeleteResponse{}
+	return
+}

--- a/internal/servers/cluster_catalog_items_server_test.go
+++ b/internal/servers/cluster_catalog_items_server_test.go
@@ -1,0 +1,267 @@
+/*
+Copyright (c) 2025 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package servers
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"google.golang.org/protobuf/proto"
+
+	publicv1 "github.com/osac-project/fulfillment-service/internal/api/osac/public/v1"
+	"github.com/osac-project/fulfillment-service/internal/database"
+	"github.com/osac-project/fulfillment-service/internal/database/dao"
+)
+
+var _ = Describe("Cluster catalog items server", func() {
+	var (
+		ctx context.Context
+		tx  database.Tx
+	)
+
+	BeforeEach(func() {
+		var err error
+
+		ctx = context.Background()
+
+		db := server.MakeDatabase()
+		DeferCleanup(db.Close)
+		pool, err := pgxpool.New(ctx, db.MakeURL())
+		Expect(err).ToNot(HaveOccurred())
+		DeferCleanup(pool.Close)
+
+		tm, err := database.NewTxManager().
+			SetLogger(logger).
+			SetPool(pool).
+			Build()
+		Expect(err).ToNot(HaveOccurred())
+
+		tx, err = tm.Begin(ctx)
+		Expect(err).ToNot(HaveOccurred())
+		DeferCleanup(func() {
+			err := tm.End(ctx, tx)
+			Expect(err).ToNot(HaveOccurred())
+		})
+		ctx = database.TxIntoContext(ctx, tx)
+
+		err = dao.CreateTables[*publicv1.ClusterCatalogItem](ctx)
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	Describe("Creation", func() {
+		It("Can be built if all the required parameters are set", func() {
+			server, err := NewClusterCatalogItemsServer().
+				SetLogger(logger).
+				SetAttributionLogic(attribution).
+				SetTenancyLogic(tenancy).
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(server).ToNot(BeNil())
+		})
+
+		It("Fails if logger is not set", func() {
+			server, err := NewClusterCatalogItemsServer().
+				SetAttributionLogic(attribution).
+				SetTenancyLogic(tenancy).
+				Build()
+			Expect(err).To(MatchError("logger is mandatory"))
+			Expect(server).To(BeNil())
+		})
+
+		It("Fails if tenancy logic is not set", func() {
+			server, err := NewClusterCatalogItemsServer().
+				SetLogger(logger).
+				SetAttributionLogic(attribution).
+				Build()
+			Expect(err).To(MatchError("tenancy logic is mandatory"))
+			Expect(server).To(BeNil())
+		})
+	})
+
+	Describe("Behaviour", func() {
+		var server *ClusterCatalogItemsServer
+
+		BeforeEach(func() {
+			var err error
+
+			server, err = NewClusterCatalogItemsServer().
+				SetLogger(logger).
+				SetAttributionLogic(attribution).
+				SetTenancyLogic(tenancy).
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("Creates object", func() {
+			response, err := server.Create(ctx, publicv1.ClusterCatalogItemsCreateRequest_builder{
+				Object: publicv1.ClusterCatalogItem_builder{
+					Title:       "My cluster catalog item",
+					Description: "My description.",
+					Template:    "my-template-id",
+					Published:   true,
+				}.Build(),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+			Expect(response).ToNot(BeNil())
+			object := response.GetObject()
+			Expect(object).ToNot(BeNil())
+			Expect(object.GetId()).ToNot(BeEmpty())
+			Expect(object.GetTitle()).To(Equal("My cluster catalog item"))
+			Expect(object.GetTemplate()).To(Equal("my-template-id"))
+			Expect(object.GetPublished()).To(BeTrue())
+		})
+
+		It("List objects", func() {
+			const count = 10
+			for i := range count {
+				_, err := server.Create(ctx, publicv1.ClusterCatalogItemsCreateRequest_builder{
+					Object: publicv1.ClusterCatalogItem_builder{
+						Title:    fmt.Sprintf("Catalog item %d", i),
+						Template: "my-template-id",
+					}.Build(),
+				}.Build())
+				Expect(err).ToNot(HaveOccurred())
+			}
+
+			response, err := server.List(ctx, publicv1.ClusterCatalogItemsListRequest_builder{}.Build())
+			Expect(err).ToNot(HaveOccurred())
+			Expect(response).ToNot(BeNil())
+			Expect(response.GetItems()).To(HaveLen(count))
+		})
+
+		It("List objects with limit", func() {
+			const count = 10
+			for i := range count {
+				_, err := server.Create(ctx, publicv1.ClusterCatalogItemsCreateRequest_builder{
+					Object: publicv1.ClusterCatalogItem_builder{
+						Title:    fmt.Sprintf("Catalog item %d", i),
+						Template: "my-template-id",
+					}.Build(),
+				}.Build())
+				Expect(err).ToNot(HaveOccurred())
+			}
+
+			response, err := server.List(ctx, publicv1.ClusterCatalogItemsListRequest_builder{
+				Limit: proto.Int32(1),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+			Expect(response.GetSize()).To(BeNumerically("==", 1))
+		})
+
+		It("List objects with filter", func() {
+			const count = 10
+			var objects []*publicv1.ClusterCatalogItem
+			for i := range count {
+				response, err := server.Create(ctx, publicv1.ClusterCatalogItemsCreateRequest_builder{
+					Object: publicv1.ClusterCatalogItem_builder{
+						Title:    fmt.Sprintf("Catalog item %d", i),
+						Template: "my-template-id",
+					}.Build(),
+				}.Build())
+				Expect(err).ToNot(HaveOccurred())
+				objects = append(objects, response.GetObject())
+			}
+
+			for _, object := range objects {
+				response, err := server.List(ctx, publicv1.ClusterCatalogItemsListRequest_builder{
+					Filter: proto.String(fmt.Sprintf("this.id == '%s'", object.GetId())),
+				}.Build())
+				Expect(err).ToNot(HaveOccurred())
+				Expect(response.GetSize()).To(BeNumerically("==", 1))
+				Expect(response.GetItems()[0].GetId()).To(Equal(object.GetId()))
+			}
+		})
+
+		It("Get object", func() {
+			createResponse, err := server.Create(ctx, publicv1.ClusterCatalogItemsCreateRequest_builder{
+				Object: publicv1.ClusterCatalogItem_builder{
+					Title:       "My catalog item",
+					Description: "My description.",
+					Template:    "my-template-id",
+				}.Build(),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+
+			getResponse, err := server.Get(ctx, publicv1.ClusterCatalogItemsGetRequest_builder{
+				Id: createResponse.GetObject().GetId(),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+			Expect(proto.Equal(createResponse.GetObject(), getResponse.GetObject())).To(BeTrue())
+		})
+
+		It("Update object", func() {
+			createResponse, err := server.Create(ctx, publicv1.ClusterCatalogItemsCreateRequest_builder{
+				Object: publicv1.ClusterCatalogItem_builder{
+					Title:       "Original title",
+					Description: "Original description.",
+					Template:    "my-template-id",
+				}.Build(),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+			object := createResponse.GetObject()
+
+			updateResponse, err := server.Update(ctx, publicv1.ClusterCatalogItemsUpdateRequest_builder{
+				Object: publicv1.ClusterCatalogItem_builder{
+					Id:          object.GetId(),
+					Title:       "Updated title",
+					Description: "Updated description.",
+					Template:    "my-template-id",
+				}.Build(),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+			Expect(updateResponse.GetObject().GetTitle()).To(Equal("Updated title"))
+			Expect(updateResponse.GetObject().GetDescription()).To(Equal("Updated description."))
+
+			getResponse, err := server.Get(ctx, publicv1.ClusterCatalogItemsGetRequest_builder{
+				Id: object.GetId(),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+			Expect(getResponse.GetObject().GetTitle()).To(Equal("Updated title"))
+			Expect(getResponse.GetObject().GetDescription()).To(Equal("Updated description."))
+		})
+
+		It("Delete object", func() {
+			createResponse, err := server.Create(ctx, publicv1.ClusterCatalogItemsCreateRequest_builder{
+				Object: publicv1.ClusterCatalogItem_builder{
+					Title:    "My catalog item",
+					Template: "my-template-id",
+				}.Build(),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+			object := createResponse.GetObject()
+
+			_, err = tx.Exec(
+				ctx,
+				`update cluster_catalog_items set finalizers = '{"a"}' where id = $1`,
+				object.GetId(),
+			)
+			Expect(err).ToNot(HaveOccurred())
+
+			_, err = server.Delete(ctx, publicv1.ClusterCatalogItemsDeleteRequest_builder{
+				Id: object.GetId(),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+
+			getResponse, err := server.Get(ctx, publicv1.ClusterCatalogItemsGetRequest_builder{
+				Id: object.GetId(),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+			Expect(getResponse.GetObject().GetMetadata().GetDeletionTimestamp()).ToNot(BeNil())
+		})
+
+	})
+})

--- a/internal/servers/compute_instance_catalog_items_server.go
+++ b/internal/servers/compute_instance_catalog_items_server.go
@@ -1,0 +1,274 @@
+/*
+Copyright (c) 2025 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package servers
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+
+	"github.com/prometheus/client_golang/prometheus"
+	grpccodes "google.golang.org/grpc/codes"
+	grpcstatus "google.golang.org/grpc/status"
+
+	privatev1 "github.com/osac-project/fulfillment-service/internal/api/osac/private/v1"
+	publicv1 "github.com/osac-project/fulfillment-service/internal/api/osac/public/v1"
+	"github.com/osac-project/fulfillment-service/internal/auth"
+	"github.com/osac-project/fulfillment-service/internal/database"
+)
+
+type ComputeInstanceCatalogItemsServerBuilder struct {
+	logger            *slog.Logger
+	notifier          *database.Notifier
+	attributionLogic  auth.AttributionLogic
+	tenancyLogic      auth.TenancyLogic
+	metricsRegisterer prometheus.Registerer
+}
+
+var _ publicv1.ComputeInstanceCatalogItemsServer = (*ComputeInstanceCatalogItemsServer)(nil)
+
+type ComputeInstanceCatalogItemsServer struct {
+	publicv1.UnimplementedComputeInstanceCatalogItemsServer
+
+	logger    *slog.Logger
+	delegate  privatev1.ComputeInstanceCatalogItemsServer
+	inMapper  *GenericMapper[*publicv1.ComputeInstanceCatalogItem, *privatev1.ComputeInstanceCatalogItem]
+	outMapper *GenericMapper[*privatev1.ComputeInstanceCatalogItem, *publicv1.ComputeInstanceCatalogItem]
+}
+
+func NewComputeInstanceCatalogItemsServer() *ComputeInstanceCatalogItemsServerBuilder {
+	return &ComputeInstanceCatalogItemsServerBuilder{}
+}
+
+func (b *ComputeInstanceCatalogItemsServerBuilder) SetLogger(value *slog.Logger) *ComputeInstanceCatalogItemsServerBuilder {
+	b.logger = value
+	return b
+}
+
+func (b *ComputeInstanceCatalogItemsServerBuilder) SetNotifier(value *database.Notifier) *ComputeInstanceCatalogItemsServerBuilder {
+	b.notifier = value
+	return b
+}
+
+func (b *ComputeInstanceCatalogItemsServerBuilder) SetAttributionLogic(value auth.AttributionLogic) *ComputeInstanceCatalogItemsServerBuilder {
+	b.attributionLogic = value
+	return b
+}
+
+func (b *ComputeInstanceCatalogItemsServerBuilder) SetTenancyLogic(value auth.TenancyLogic) *ComputeInstanceCatalogItemsServerBuilder {
+	b.tenancyLogic = value
+	return b
+}
+
+func (b *ComputeInstanceCatalogItemsServerBuilder) SetMetricsRegisterer(value prometheus.Registerer) *ComputeInstanceCatalogItemsServerBuilder {
+	b.metricsRegisterer = value
+	return b
+}
+
+func (b *ComputeInstanceCatalogItemsServerBuilder) Build() (result *ComputeInstanceCatalogItemsServer, err error) {
+	if b.logger == nil {
+		err = errors.New("logger is mandatory")
+		return
+	}
+	if b.tenancyLogic == nil {
+		err = errors.New("tenancy logic is mandatory")
+		return
+	}
+
+	inMapper, err := NewGenericMapper[*publicv1.ComputeInstanceCatalogItem, *privatev1.ComputeInstanceCatalogItem]().
+		SetLogger(b.logger).
+		SetStrict(true).
+		Build()
+	if err != nil {
+		return
+	}
+	outMapper, err := NewGenericMapper[*privatev1.ComputeInstanceCatalogItem, *publicv1.ComputeInstanceCatalogItem]().
+		SetLogger(b.logger).
+		SetStrict(false).
+		Build()
+	if err != nil {
+		return
+	}
+
+	delegate, err := NewPrivateComputeInstanceCatalogItemsServer().
+		SetLogger(b.logger).
+		SetNotifier(b.notifier).
+		SetAttributionLogic(b.attributionLogic).
+		SetTenancyLogic(b.tenancyLogic).
+		SetMetricsRegisterer(b.metricsRegisterer).
+		Build()
+	if err != nil {
+		return
+	}
+
+	result = &ComputeInstanceCatalogItemsServer{
+		logger:    b.logger,
+		delegate:  delegate,
+		inMapper:  inMapper,
+		outMapper: outMapper,
+	}
+	return
+}
+
+func (s *ComputeInstanceCatalogItemsServer) List(ctx context.Context,
+	request *publicv1.ComputeInstanceCatalogItemsListRequest) (response *publicv1.ComputeInstanceCatalogItemsListResponse, err error) {
+	privateRequest := &privatev1.ComputeInstanceCatalogItemsListRequest{}
+	privateRequest.SetOffset(request.GetOffset())
+	privateRequest.SetLimit(request.GetLimit())
+	privateRequest.SetFilter(request.GetFilter())
+	privateRequest.SetOrder(request.GetOrder())
+
+	privateResponse, err := s.delegate.List(ctx, privateRequest)
+	if err != nil {
+		return nil, err
+	}
+
+	privateItems := privateResponse.GetItems()
+	publicItems := make([]*publicv1.ComputeInstanceCatalogItem, len(privateItems))
+	for i, privateItem := range privateItems {
+		publicItem := &publicv1.ComputeInstanceCatalogItem{}
+		err = s.outMapper.Copy(ctx, privateItem, publicItem)
+		if err != nil {
+			s.logger.ErrorContext(ctx, "Failed to map private compute instance catalog item to public", slog.Any("error", err))
+			return nil, grpcstatus.Errorf(grpccodes.Internal, "failed to process compute instance catalog items")
+		}
+		publicItems[i] = publicItem
+	}
+
+	response = &publicv1.ComputeInstanceCatalogItemsListResponse{}
+	response.SetSize(privateResponse.GetSize())
+	response.SetTotal(privateResponse.GetTotal())
+	response.SetItems(publicItems)
+	return
+}
+
+func (s *ComputeInstanceCatalogItemsServer) Get(ctx context.Context,
+	request *publicv1.ComputeInstanceCatalogItemsGetRequest) (response *publicv1.ComputeInstanceCatalogItemsGetResponse, err error) {
+	privateRequest := &privatev1.ComputeInstanceCatalogItemsGetRequest{}
+	privateRequest.SetId(request.GetId())
+
+	privateResponse, err := s.delegate.Get(ctx, privateRequest)
+	if err != nil {
+		return nil, err
+	}
+
+	publicCatalogItem := &publicv1.ComputeInstanceCatalogItem{}
+	err = s.outMapper.Copy(ctx, privateResponse.GetObject(), publicCatalogItem)
+	if err != nil {
+		s.logger.ErrorContext(ctx, "Failed to map private compute instance catalog item to public", slog.Any("error", err))
+		return nil, grpcstatus.Errorf(grpccodes.Internal, "failed to process compute instance catalog item")
+	}
+
+	response = &publicv1.ComputeInstanceCatalogItemsGetResponse{}
+	response.SetObject(publicCatalogItem)
+	return
+}
+
+func (s *ComputeInstanceCatalogItemsServer) Create(ctx context.Context,
+	request *publicv1.ComputeInstanceCatalogItemsCreateRequest) (response *publicv1.ComputeInstanceCatalogItemsCreateResponse, err error) {
+	publicCatalogItem := request.GetObject()
+	if publicCatalogItem == nil {
+		err = grpcstatus.Errorf(grpccodes.InvalidArgument, "object is mandatory")
+		return
+	}
+	privateCatalogItem := &privatev1.ComputeInstanceCatalogItem{}
+	err = s.inMapper.Copy(ctx, publicCatalogItem, privateCatalogItem)
+	if err != nil {
+		s.logger.ErrorContext(ctx, "Failed to map public compute instance catalog item to private", slog.Any("error", err))
+		err = grpcstatus.Errorf(grpccodes.Internal, "failed to process compute instance catalog item")
+		return
+	}
+
+	privateRequest := &privatev1.ComputeInstanceCatalogItemsCreateRequest{}
+	privateRequest.SetObject(privateCatalogItem)
+	privateResponse, err := s.delegate.Create(ctx, privateRequest)
+	if err != nil {
+		return nil, err
+	}
+
+	createdPublicCatalogItem := &publicv1.ComputeInstanceCatalogItem{}
+	err = s.outMapper.Copy(ctx, privateResponse.GetObject(), createdPublicCatalogItem)
+	if err != nil {
+		s.logger.ErrorContext(ctx, "Failed to map private compute instance catalog item to public", slog.Any("error", err))
+		err = grpcstatus.Errorf(grpccodes.Internal, "failed to process compute instance catalog item")
+		return
+	}
+
+	response = &publicv1.ComputeInstanceCatalogItemsCreateResponse{}
+	response.SetObject(createdPublicCatalogItem)
+	return
+}
+
+func (s *ComputeInstanceCatalogItemsServer) Update(ctx context.Context,
+	request *publicv1.ComputeInstanceCatalogItemsUpdateRequest) (response *publicv1.ComputeInstanceCatalogItemsUpdateResponse, err error) {
+	publicCatalogItem := request.GetObject()
+	if publicCatalogItem == nil {
+		err = grpcstatus.Errorf(grpccodes.InvalidArgument, "object is mandatory")
+		return
+	}
+	id := publicCatalogItem.GetId()
+	if id == "" {
+		err = grpcstatus.Errorf(grpccodes.InvalidArgument, "object identifier is mandatory")
+		return
+	}
+
+	getRequest := &privatev1.ComputeInstanceCatalogItemsGetRequest{}
+	getRequest.SetId(id)
+	getResponse, err := s.delegate.Get(ctx, getRequest)
+	if err != nil {
+		return nil, err
+	}
+	existingPrivateCatalogItem := getResponse.GetObject()
+
+	err = s.inMapper.Copy(ctx, publicCatalogItem, existingPrivateCatalogItem)
+	if err != nil {
+		s.logger.ErrorContext(ctx, "Failed to map public compute instance catalog item to private", slog.Any("error", err))
+		err = grpcstatus.Errorf(grpccodes.Internal, "failed to process compute instance catalog item")
+		return
+	}
+
+	privateRequest := &privatev1.ComputeInstanceCatalogItemsUpdateRequest{}
+	privateRequest.SetObject(existingPrivateCatalogItem)
+	privateRequest.SetLock(request.GetLock())
+	privateResponse, err := s.delegate.Update(ctx, privateRequest)
+	if err != nil {
+		return nil, err
+	}
+
+	updatedPublicCatalogItem := &publicv1.ComputeInstanceCatalogItem{}
+	err = s.outMapper.Copy(ctx, privateResponse.GetObject(), updatedPublicCatalogItem)
+	if err != nil {
+		s.logger.ErrorContext(ctx, "Failed to map private compute instance catalog item to public", slog.Any("error", err))
+		err = grpcstatus.Errorf(grpccodes.Internal, "failed to process compute instance catalog item")
+		return
+	}
+
+	response = &publicv1.ComputeInstanceCatalogItemsUpdateResponse{}
+	response.SetObject(updatedPublicCatalogItem)
+	return
+}
+
+func (s *ComputeInstanceCatalogItemsServer) Delete(ctx context.Context,
+	request *publicv1.ComputeInstanceCatalogItemsDeleteRequest) (response *publicv1.ComputeInstanceCatalogItemsDeleteResponse, err error) {
+	privateRequest := &privatev1.ComputeInstanceCatalogItemsDeleteRequest{}
+	privateRequest.SetId(request.GetId())
+
+	_, err = s.delegate.Delete(ctx, privateRequest)
+	if err != nil {
+		return nil, err
+	}
+
+	response = &publicv1.ComputeInstanceCatalogItemsDeleteResponse{}
+	return
+}

--- a/internal/servers/compute_instance_catalog_items_server_test.go
+++ b/internal/servers/compute_instance_catalog_items_server_test.go
@@ -1,0 +1,266 @@
+/*
+Copyright (c) 2025 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package servers
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"google.golang.org/protobuf/proto"
+
+	publicv1 "github.com/osac-project/fulfillment-service/internal/api/osac/public/v1"
+	"github.com/osac-project/fulfillment-service/internal/database"
+	"github.com/osac-project/fulfillment-service/internal/database/dao"
+)
+
+var _ = Describe("Compute instance catalog items server", func() {
+	var (
+		ctx context.Context
+		tx  database.Tx
+	)
+
+	BeforeEach(func() {
+		var err error
+
+		ctx = context.Background()
+
+		db := server.MakeDatabase()
+		DeferCleanup(db.Close)
+		pool, err := pgxpool.New(ctx, db.MakeURL())
+		Expect(err).ToNot(HaveOccurred())
+		DeferCleanup(pool.Close)
+
+		tm, err := database.NewTxManager().
+			SetLogger(logger).
+			SetPool(pool).
+			Build()
+		Expect(err).ToNot(HaveOccurred())
+
+		tx, err = tm.Begin(ctx)
+		Expect(err).ToNot(HaveOccurred())
+		DeferCleanup(func() {
+			err := tm.End(ctx, tx)
+			Expect(err).ToNot(HaveOccurred())
+		})
+		ctx = database.TxIntoContext(ctx, tx)
+
+		err = dao.CreateTables[*publicv1.ComputeInstanceCatalogItem](ctx)
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	Describe("Creation", func() {
+		It("Can be built if all the required parameters are set", func() {
+			server, err := NewComputeInstanceCatalogItemsServer().
+				SetLogger(logger).
+				SetAttributionLogic(attribution).
+				SetTenancyLogic(tenancy).
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(server).ToNot(BeNil())
+		})
+
+		It("Fails if logger is not set", func() {
+			server, err := NewComputeInstanceCatalogItemsServer().
+				SetAttributionLogic(attribution).
+				SetTenancyLogic(tenancy).
+				Build()
+			Expect(err).To(MatchError("logger is mandatory"))
+			Expect(server).To(BeNil())
+		})
+
+		It("Fails if tenancy logic is not set", func() {
+			server, err := NewComputeInstanceCatalogItemsServer().
+				SetLogger(logger).
+				SetAttributionLogic(attribution).
+				Build()
+			Expect(err).To(MatchError("tenancy logic is mandatory"))
+			Expect(server).To(BeNil())
+		})
+	})
+
+	Describe("Behaviour", func() {
+		var server *ComputeInstanceCatalogItemsServer
+
+		BeforeEach(func() {
+			var err error
+
+			server, err = NewComputeInstanceCatalogItemsServer().
+				SetLogger(logger).
+				SetAttributionLogic(attribution).
+				SetTenancyLogic(tenancy).
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("Creates object", func() {
+			response, err := server.Create(ctx, publicv1.ComputeInstanceCatalogItemsCreateRequest_builder{
+				Object: publicv1.ComputeInstanceCatalogItem_builder{
+					Title:       "My CI catalog item",
+					Description: "My description.",
+					Template:    "my-ci-template-id",
+					Published:   true,
+				}.Build(),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+			Expect(response).ToNot(BeNil())
+			object := response.GetObject()
+			Expect(object).ToNot(BeNil())
+			Expect(object.GetId()).ToNot(BeEmpty())
+			Expect(object.GetTitle()).To(Equal("My CI catalog item"))
+			Expect(object.GetTemplate()).To(Equal("my-ci-template-id"))
+			Expect(object.GetPublished()).To(BeTrue())
+		})
+
+		It("List objects", func() {
+			const count = 10
+			for i := range count {
+				_, err := server.Create(ctx, publicv1.ComputeInstanceCatalogItemsCreateRequest_builder{
+					Object: publicv1.ComputeInstanceCatalogItem_builder{
+						Title:    fmt.Sprintf("CI catalog item %d", i),
+						Template: "my-ci-template-id",
+					}.Build(),
+				}.Build())
+				Expect(err).ToNot(HaveOccurred())
+			}
+
+			response, err := server.List(ctx, publicv1.ComputeInstanceCatalogItemsListRequest_builder{}.Build())
+			Expect(err).ToNot(HaveOccurred())
+			Expect(response).ToNot(BeNil())
+			Expect(response.GetItems()).To(HaveLen(count))
+		})
+
+		It("List objects with limit", func() {
+			const count = 10
+			for i := range count {
+				_, err := server.Create(ctx, publicv1.ComputeInstanceCatalogItemsCreateRequest_builder{
+					Object: publicv1.ComputeInstanceCatalogItem_builder{
+						Title:    fmt.Sprintf("CI catalog item %d", i),
+						Template: "my-ci-template-id",
+					}.Build(),
+				}.Build())
+				Expect(err).ToNot(HaveOccurred())
+			}
+
+			response, err := server.List(ctx, publicv1.ComputeInstanceCatalogItemsListRequest_builder{
+				Limit: proto.Int32(1),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+			Expect(response.GetSize()).To(BeNumerically("==", 1))
+		})
+
+		It("List objects with filter", func() {
+			const count = 10
+			var objects []*publicv1.ComputeInstanceCatalogItem
+			for i := range count {
+				response, err := server.Create(ctx, publicv1.ComputeInstanceCatalogItemsCreateRequest_builder{
+					Object: publicv1.ComputeInstanceCatalogItem_builder{
+						Title:    fmt.Sprintf("CI catalog item %d", i),
+						Template: "my-ci-template-id",
+					}.Build(),
+				}.Build())
+				Expect(err).ToNot(HaveOccurred())
+				objects = append(objects, response.GetObject())
+			}
+
+			for _, object := range objects {
+				response, err := server.List(ctx, publicv1.ComputeInstanceCatalogItemsListRequest_builder{
+					Filter: proto.String(fmt.Sprintf("this.id == '%s'", object.GetId())),
+				}.Build())
+				Expect(err).ToNot(HaveOccurred())
+				Expect(response.GetSize()).To(BeNumerically("==", 1))
+				Expect(response.GetItems()[0].GetId()).To(Equal(object.GetId()))
+			}
+		})
+
+		It("Get object", func() {
+			createResponse, err := server.Create(ctx, publicv1.ComputeInstanceCatalogItemsCreateRequest_builder{
+				Object: publicv1.ComputeInstanceCatalogItem_builder{
+					Title:       "My CI catalog item",
+					Description: "My description.",
+					Template:    "my-ci-template-id",
+				}.Build(),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+
+			getResponse, err := server.Get(ctx, publicv1.ComputeInstanceCatalogItemsGetRequest_builder{
+				Id: createResponse.GetObject().GetId(),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+			Expect(proto.Equal(createResponse.GetObject(), getResponse.GetObject())).To(BeTrue())
+		})
+
+		It("Update object", func() {
+			createResponse, err := server.Create(ctx, publicv1.ComputeInstanceCatalogItemsCreateRequest_builder{
+				Object: publicv1.ComputeInstanceCatalogItem_builder{
+					Title:       "Original title",
+					Description: "Original description.",
+					Template:    "my-ci-template-id",
+				}.Build(),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+			object := createResponse.GetObject()
+
+			updateResponse, err := server.Update(ctx, publicv1.ComputeInstanceCatalogItemsUpdateRequest_builder{
+				Object: publicv1.ComputeInstanceCatalogItem_builder{
+					Id:          object.GetId(),
+					Title:       "Updated title",
+					Description: "Updated description.",
+					Template:    "my-ci-template-id",
+				}.Build(),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+			Expect(updateResponse.GetObject().GetTitle()).To(Equal("Updated title"))
+			Expect(updateResponse.GetObject().GetDescription()).To(Equal("Updated description."))
+
+			getResponse, err := server.Get(ctx, publicv1.ComputeInstanceCatalogItemsGetRequest_builder{
+				Id: object.GetId(),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+			Expect(getResponse.GetObject().GetTitle()).To(Equal("Updated title"))
+			Expect(getResponse.GetObject().GetDescription()).To(Equal("Updated description."))
+		})
+
+		It("Delete object", func() {
+			createResponse, err := server.Create(ctx, publicv1.ComputeInstanceCatalogItemsCreateRequest_builder{
+				Object: publicv1.ComputeInstanceCatalogItem_builder{
+					Title:    "My CI catalog item",
+					Template: "my-ci-template-id",
+				}.Build(),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+			object := createResponse.GetObject()
+
+			_, err = tx.Exec(
+				ctx,
+				`update compute_instance_catalog_items set finalizers = '{"a"}' where id = $1`,
+				object.GetId(),
+			)
+			Expect(err).ToNot(HaveOccurred())
+
+			_, err = server.Delete(ctx, publicv1.ComputeInstanceCatalogItemsDeleteRequest_builder{
+				Id: object.GetId(),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+
+			getResponse, err := server.Get(ctx, publicv1.ComputeInstanceCatalogItemsGetRequest_builder{
+				Id: object.GetId(),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+			Expect(getResponse.GetObject().GetMetadata().GetDeletionTimestamp()).ToNot(BeNil())
+		})
+	})
+})


### PR DESCRIPTION
## Summary

- Add public `ClusterCatalogItemsServer` and `ComputeInstanceCatalogItemsServer` that delegate to private servers via GenericMapper
- Tenant field silently dropped by non-strict outMapper (private has it, public doesn't) per EP PR #41
- Register both public servers in gRPC startup and REST gateway
- Add unit tests for both servers (20 tests: builder validation + CRUD behavior)

**JIRA:** [OSAC-58](https://redhat.atlassian.net/browse/OSAC-58) / [OSAC-703](https://redhat.atlassian.net/browse/OSAC-703)

**Depends on:** #520 (merged)

## Validations

- [x] `buf lint` — clean
- [x] `gofmt -s -l .` — no formatting issues
- [x] `go build ./...` — compiles clean
- [x] `ginkgo run -r internal` — all test suites passed, 0 failures

## Test plan

- [x] Builder validation: logger, tenancy logic required
- [x] CRUD operations: create, list, list with limit, list with filter, get, update, delete
- [x] Delete with finalizers (raw SQL to add finalizer, matching existing public server test pattern)

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New Cluster Catalog Items API and Compute Instance Catalog Items API with full CRUD and list/filter support, exposed via gRPC and REST.
  * Both APIs are now registered and available from service startup.

* **Bug Fixes / Behavior**
  * Create/Update requests now enforce basic input validation and return appropriate errors for missing fields.

* **Tests**
  * Comprehensive server test suites added to validate lifecycle operations (create, list, get, update, delete).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/osac-project/fulfillment-service/pull/536)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->