### PR TITLE
NO-ISSUE: Add security contexts to service chart deployments

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -50,6 +50,14 @@
                         "port": 30003
                 },
                 {
+                        "name": "attach console-proxy",
+                        "type": "go",
+                        "request": "attach",
+                        "mode": "remote",
+                        "host": "127.0.0.1",
+                        "port": 30004
+                },
+                {
                         "name": "start grpc-server (guest tenancy)",
                         "type": "go",
                         "request": "launch",

--- a/README.md
+++ b/README.md
@@ -340,13 +340,14 @@ kubectl get configmap ca-bundle -n osac -o json | jq -r '.data["bundle.pem"]' > 
 In the integration tests environment you can use the usual Kubernetes tools and logs for
 debugging, but you can also set the `IT_DEBUG` environment variable to `true`. That will add the
 `dlv` debugger to the container image, use it to run the binaries of the gRPC server, the REST
-gateway and the controller, and expose the debugger on the following ports:
+gateway, the controller and the console proxy, and expose the debugger on the following ports:
 
-| Component    | Port  |
-|--------------|-------|
-| gRPC server  | 30001 |
-| REST gateway | 30002 |
-| Controller   | 30003 |
+| Component     | Port  |
+|---------------|-------|
+| gRPC server   | 30001 |
+| REST gateway  | 30002 |
+| Controller    | 30003 |
+| Console proxy | 30004 |
 
 For example, to connect to the gRPC server debugger from Visual Studio Code, add the following
 configuration to your `.vscode/launch.json` file:

--- a/charts/service/templates/_helpers.tpl
+++ b/charts/service/templates/_helpers.tpl
@@ -38,3 +38,26 @@ Return the hostname for the fulfillment internal API. Fails if 'internalHostname
 {{- define "fulfillment-internal-api.hostname" -}}
 {{- required "internalHostname is required" .Values.internalHostname -}}
 {{- end -}}
+
+{{/*
+Container security context for service containers. In debug mode SYS_PTRACE is added and the seccomp profile is set to
+unconfined so that delve can attach.
+*/}}
+{{- define "fulfillment.containerSecurityContext" -}}
+allowPrivilegeEscalation: false
+runAsNonRoot: true
+readOnlyRootFilesystem: true
+capabilities:
+  drop:
+  - ALL
+  {{- if .Values.debug }}
+  add:
+  - SYS_PTRACE
+  {{- end }}
+seccompProfile:
+  {{- if .Values.debug }}
+  type: Unconfined
+  {{- else }}
+  type: RuntimeDefault
+  {{- end }}
+{{- end -}}

--- a/charts/service/templates/console-proxy/deployment.yaml
+++ b/charts/service/templates/console-proxy/deployment.yaml
@@ -24,7 +24,7 @@ spec:
       app: fulfillment-console-proxy
   replicas: 1
   strategy:
-    type: RollingUpdate
+    type: {{ if .Values.debug }}Recreate{{ else }}RollingUpdate{{ end }}
   template:
     metadata:
       labels:
@@ -49,13 +49,8 @@ spec:
             path: tls.key
       containers:
       - name: console-proxy
+        securityContext: {{ include "fulfillment.containerSecurityContext" . | fromYaml | toJson }}
         image: {{ .Values.images.service }}
-        securityContext:
-          allowPrivilegeEscalation: false
-          readOnlyRootFilesystem: true
-          capabilities:
-            drop:
-            - ALL
         volumeMounts:
         - name: cas
           mountPath: /etc/fulfillment-console-proxy/tls/cas
@@ -65,7 +60,19 @@ spec:
           mountPath: /etc/fulfillment-token-encryption
           readOnly: true
         command:
+        {{ if .Values.debug }}
+        - dlv
+        - exec
         - /usr/local/bin/fulfillment-service
+        - --headless
+        - --api-version=2
+        - --listen=:30004
+        - --accept-multiclient
+        - --continue
+        - --
+        {{ else}}
+        - /usr/local/bin/fulfillment-service
+        {{ end }}
         - start
         - console-proxy
         - --log-level={{ .Values.log.level }}
@@ -90,6 +97,13 @@ spec:
         - name: metrics
           containerPort: 8002
           protocol: TCP
+        {{ if .Values.debug }}
+        - name: debug
+          containerPort: 30004
+          hostPort: 30004
+          protocol: TCP
+        {{ end }}
+        {{ if not .Values.debug }}
         livenessProbe:
           tcpSocket:
             port: 8000
@@ -110,3 +124,4 @@ spec:
           periodSeconds: 10
           timeoutSeconds: 5
           failureThreshold: 5
+        {{ end }}

--- a/charts/service/templates/controller/deployment.yaml
+++ b/charts/service/templates/controller/deployment.yaml
@@ -34,6 +34,8 @@ spec:
       labels:
         app: fulfillment-controller
     spec:
+      securityContext:
+        runAsNonRoot: true
       volumes:
       - name: cas
         configMap:
@@ -89,6 +91,7 @@ spec:
           {{- end }}
       containers:
       - name: controller
+        securityContext: {{ include "fulfillment.containerSecurityContext" . | fromYaml | toJson }}
         image: {{ .Values.images.service }}
         volumeMounts:
         - name: cas

--- a/charts/service/templates/grpc-server/deployment.yaml
+++ b/charts/service/templates/grpc-server/deployment.yaml
@@ -79,13 +79,8 @@ spec:
           type: RuntimeDefault
       containers:
       - name: grpc-server
+        securityContext: {{ include "fulfillment.containerSecurityContext" . | fromYaml | toJson }}
         image: {{ .Values.images.service }}
-        securityContext:
-          allowPrivilegeEscalation: false
-          readOnlyRootFilesystem: true
-          capabilities:
-            drop:
-            - ALL
         volumeMounts:
         - name: cas
           mountPath: /etc/fulfillment-grpc-server/tls/cas

--- a/charts/service/templates/ingress-proxy/deployment.yaml
+++ b/charts/service/templates/ingress-proxy/deployment.yaml
@@ -26,6 +26,8 @@ spec:
       labels:
         app: fulfillment-ingress-proxy
     spec:
+      securityContext:
+        runAsNonRoot: true
       volumes:
       - name: config
         configMap:
@@ -35,6 +37,18 @@ spec:
           secretName: fulfillment-api-tls
       containers:
       - name: envoy
+        securityContext:
+          allowPrivilegeEscalation: false
+          runAsNonRoot: true
+          {{- if ne .Values.variant "openshift" }}
+          runAsUser: 101
+          {{- end }}
+          readOnlyRootFilesystem: true
+          capabilities:
+            drop:
+            - ALL
+          seccompProfile:
+            type: RuntimeDefault
         image: {{ .Values.images.envoy }}
         volumeMounts:
         - name: config

--- a/charts/service/templates/rest-gateway/deployment.yaml
+++ b/charts/service/templates/rest-gateway/deployment.yaml
@@ -30,6 +30,8 @@ spec:
       labels:
         app: fulfillment-rest-gateway
     spec:
+      securityContext:
+        runAsNonRoot: true
       volumes:
       - name: cas
         configMap:
@@ -39,6 +41,7 @@ spec:
           secretName: fulfillment-rest-gateway-tls
       containers:
       - name: rest-gateway
+        securityContext: {{ include "fulfillment.containerSecurityContext" . | fromYaml | toJson }}
         image: {{ .Values.images.service }}
         volumeMounts:
         - name: cas

--- a/it/it_tool.go
+++ b/it/it_tool.go
@@ -173,6 +173,7 @@ func (b *ToolBuilder) SetKeepService(value bool) *ToolBuilder {
 // - gRPC server: 30001
 // - REST gateway: 30002
 // - Controller: 30003
+// - Console proxy: 30004
 func (b *ToolBuilder) SetDebug(value bool) *ToolBuilder {
 	b.debug = value
 	return b
@@ -553,6 +554,7 @@ func (t *Tool) startCluster(ctx context.Context) error {
 		builder.AddPortMapping("127.0.0.1", 30001, 30001) // gRPC server.
 		builder.AddPortMapping("127.0.0.1", 30002, 30002) // REST gateway.
 		builder.AddPortMapping("127.0.0.1", 30003, 30003) // Controller.
+		builder.AddPortMapping("127.0.0.1", 30004, 30004) // Console proxy.
 	}
 	if t.caKeyFile != "" && t.caCrtFile != "" {
 		builder.SetCaFiles(t.caKeyFile, t.caCrtFile)


### PR DESCRIPTION
## Summary

Add pod and container security contexts to all Deployment templates in the
service Helm chart: `grpc-server`, `rest-gateway`, `controller`,
`console-proxy`, and `ingress-proxy`.

Each pod gets `runAsNonRoot: true` at the pod level. Each container gets
`allowPrivilegeEscalation: false`, `runAsNonRoot: true`,
`capabilities.drop: ["ALL"]`, `readOnlyRootFilesystem: true`, and
`seccompProfile.type: RuntimeDefault`.

The pod security context deliberately omits `runAsUser` and `fsGroup` because
OpenShift's default `restricted-v2` SCC uses `MustRunAsRange` for `runAsUser`
and `MustRunAs` for `fsGroup`, which require the requested UID/GID to fall
within the namespace's pre-allocated range. Hardcoding a UID such as 1000
would cause pod admission to fail on OpenShift. On vanilla Kubernetes
`runAsNonRoot: true` passes as long as the image declares a non-root default
user; on OpenShift the SCC overrides it with the namespace-allocated UID. This
allows a single deployment configuration to work on both platforms.

The `ingress-proxy` uses the upstream Envoy image which runs as root by
default. Since we cannot modify that image, the Envoy container sets
`runAsUser: 101` (the `envoy` user) conditionally when the variant is not
`openshift`.

## Test plan

- [ ] Integration tests pass on a fresh Kind cluster
- [ ] Verify pods start correctly on OpenShift with `restricted-v2` SCC

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new debug-access target for the console proxy on port `30004`.
  * Debug mode now uses a dedicated startup path for easier remote attachment.

* **Bug Fixes**
  * Adjusted deployment behavior so probes are disabled in debug mode and normal rollout behavior is preserved otherwise.

* **Chores**
  * Strengthened container and pod security settings across service components, including non-root execution and tighter runtime restrictions.
  * Updated setup documentation and local debug configuration to reflect the new console proxy target.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->