### PR TITLE
OSAC-830: Add private server for Public IP Attachments resource

### DIFF
--- a/internal/cmd/service/start/grpcserver/start_grpc_server_cmd.go
+++ b/internal/cmd/service/start/grpcserver/start_grpc_server_cmd.go
@@ -852,6 +852,20 @@ func (c *runnerContext) run(cmd *cobra.Command, argv []string) error {
 	}
 	privatev1.RegisterPublicIPsServer(grpcServer, privatePublicIPsServer)
 
+	// Create the private public IP attachments server:
+	c.logger.InfoContext(ctx, "Creating private public IP attachments server")
+	privatePublicIPAttachmentsServer, err := servers.NewPrivatePublicIPAttachmentsServer().
+		SetLogger(c.logger).
+		SetNotifier(notifier).
+		SetAttributionLogic(privateAttributionLogic).
+		SetTenancyLogic(tenancyLogic).
+		SetMetricsRegisterer(metricsRegisterer).
+		Build()
+	if err != nil {
+		return fmt.Errorf("failed to create private public IP attachments server: %w", err)
+	}
+	privatev1.RegisterPublicIPAttachmentsServer(grpcServer, privatePublicIPAttachmentsServer)
+
 	// Create the public organizations server:
 	c.logger.InfoContext(ctx, "Creating public organizations server")
 	publicOrganizationsServer, err := servers.NewOrganizationsServer().

--- a/internal/cmd/service/start/restgateway/start_rest_gateway_cmd.go
+++ b/internal/cmd/service/start/restgateway/start_rest_gateway_cmd.go
@@ -275,6 +275,10 @@ func (c *runnerContext) run(cmd *cobra.Command, argv []string) error {
 	if err != nil {
 		return err
 	}
+	err = privatev1.RegisterPublicIPAttachmentsHandler(ctx, gatewayMux, c.grpcClient)
+	if err != nil {
+		return err
+	}
 	err = privatev1.RegisterRolesHandler(ctx, gatewayMux, c.grpcClient)
 	if err != nil {
 		return err

--- a/internal/database/migrations/38_create_public_ip_attachments_tables.down.sql
+++ b/internal/database/migrations/38_create_public_ip_attachments_tables.down.sql
@@ -1,0 +1,24 @@
+--
+-- Copyright (c) 2026 Red Hat Inc.
+--
+-- Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+-- the License. You may obtain a copy of the License at
+--
+--   http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+-- an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+-- specific language governing permissions and limitations under the License.
+--
+
+drop index if exists public_ip_attachments_by_label;
+
+drop index if exists public_ip_attachments_by_tenant;
+
+drop index if exists public_ip_attachments_by_owner;
+
+drop index if exists public_ip_attachments_by_name;
+
+drop table if exists archived_public_ip_attachments;
+
+drop table if exists public_ip_attachments;

--- a/internal/database/migrations/38_create_public_ip_attachments_tables.up.sql
+++ b/internal/database/migrations/38_create_public_ip_attachments_tables.up.sql
@@ -1,0 +1,47 @@
+--
+-- Copyright (c) 2026 Red Hat Inc.
+--
+-- Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+-- the License. You may obtain a copy of the License at
+--
+--   http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+-- an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+-- specific language governing permissions and limitations under the License.
+--
+
+-- Create the public IP attachments tables and related indices.
+
+create table public_ip_attachments (
+  id text not null primary key,
+  name text not null default '',
+  creation_timestamp timestamp with time zone not null default now(),
+  deletion_timestamp timestamp with time zone not null default 'epoch',
+  finalizers text[] not null default '{}',
+  creators text[] not null default '{}',
+  tenants text[] not null default '{}',
+  labels jsonb not null default '{}'::jsonb,
+  annotations jsonb not null default '{}'::jsonb,
+  version integer not null default 0,
+  data jsonb not null
+);
+
+create table archived_public_ip_attachments (
+  id text not null,
+  name text not null default '',
+  creation_timestamp timestamp with time zone not null,
+  deletion_timestamp timestamp with time zone not null,
+  archival_timestamp timestamp with time zone not null default now(),
+  creators text[] not null default '{}',
+  tenants text[] not null default '{}',
+  labels jsonb not null default '{}'::jsonb,
+  annotations jsonb not null default '{}'::jsonb,
+  version integer not null default 0,
+  data jsonb not null
+);
+
+create index public_ip_attachments_by_name on public_ip_attachments (name);
+create index public_ip_attachments_by_owner on public_ip_attachments using gin (creators);
+create index public_ip_attachments_by_tenant on public_ip_attachments using gin (tenants);
+create index public_ip_attachments_by_label on public_ip_attachments using gin (labels);

--- a/internal/servers/private_public_ip_attachments_server.go
+++ b/internal/servers/private_public_ip_attachments_server.go
@@ -1,0 +1,137 @@
+/*
+Copyright (c) 2026 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package servers
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+
+	"github.com/prometheus/client_golang/prometheus"
+
+	privatev1 "github.com/osac-project/fulfillment-service/internal/api/osac/private/v1"
+	"github.com/osac-project/fulfillment-service/internal/auth"
+	"github.com/osac-project/fulfillment-service/internal/database"
+)
+
+type PrivatePublicIPAttachmentsServerBuilder struct {
+	logger            *slog.Logger
+	notifier          *database.Notifier
+	attributionLogic  auth.AttributionLogic
+	tenancyLogic      auth.TenancyLogic
+	metricsRegisterer prometheus.Registerer
+}
+
+var _ privatev1.PublicIPAttachmentsServer = (*PrivatePublicIPAttachmentsServer)(nil)
+
+type PrivatePublicIPAttachmentsServer struct {
+	privatev1.UnimplementedPublicIPAttachmentsServer
+
+	logger  *slog.Logger
+	generic *GenericServer[*privatev1.PublicIPAttachment]
+}
+
+func NewPrivatePublicIPAttachmentsServer() *PrivatePublicIPAttachmentsServerBuilder {
+	return &PrivatePublicIPAttachmentsServerBuilder{}
+}
+
+func (b *PrivatePublicIPAttachmentsServerBuilder) SetLogger(value *slog.Logger) *PrivatePublicIPAttachmentsServerBuilder {
+	b.logger = value
+	return b
+}
+
+func (b *PrivatePublicIPAttachmentsServerBuilder) SetNotifier(value *database.Notifier) *PrivatePublicIPAttachmentsServerBuilder {
+	b.notifier = value
+	return b
+}
+
+func (b *PrivatePublicIPAttachmentsServerBuilder) SetAttributionLogic(value auth.AttributionLogic) *PrivatePublicIPAttachmentsServerBuilder {
+	b.attributionLogic = value
+	return b
+}
+
+func (b *PrivatePublicIPAttachmentsServerBuilder) SetTenancyLogic(value auth.TenancyLogic) *PrivatePublicIPAttachmentsServerBuilder {
+	b.tenancyLogic = value
+	return b
+}
+
+func (b *PrivatePublicIPAttachmentsServerBuilder) SetMetricsRegisterer(value prometheus.Registerer) *PrivatePublicIPAttachmentsServerBuilder {
+	b.metricsRegisterer = value
+	return b
+}
+
+func (b *PrivatePublicIPAttachmentsServerBuilder) Build() (result *PrivatePublicIPAttachmentsServer, err error) {
+	if b.logger == nil {
+		err = errors.New("logger is mandatory")
+		return
+	}
+	if b.tenancyLogic == nil {
+		err = errors.New("tenancy logic is mandatory")
+		return
+	}
+
+	generic, err := NewGenericServer[*privatev1.PublicIPAttachment]().
+		SetLogger(b.logger).
+		SetService(privatev1.PublicIPAttachments_ServiceDesc.ServiceName).
+		SetNotifier(b.notifier).
+		SetAttributionLogic(b.attributionLogic).
+		SetTenancyLogic(b.tenancyLogic).
+		SetMetricsRegisterer(b.metricsRegisterer).
+		Build()
+	if err != nil {
+		return
+	}
+
+	result = &PrivatePublicIPAttachmentsServer{
+		logger:  b.logger,
+		generic: generic,
+	}
+	return
+}
+
+func (s *PrivatePublicIPAttachmentsServer) List(ctx context.Context,
+	request *privatev1.PublicIPAttachmentsListRequest) (response *privatev1.PublicIPAttachmentsListResponse, err error) {
+	err = s.generic.List(ctx, request, &response)
+	return
+}
+
+func (s *PrivatePublicIPAttachmentsServer) Get(ctx context.Context,
+	request *privatev1.PublicIPAttachmentsGetRequest) (response *privatev1.PublicIPAttachmentsGetResponse, err error) {
+	err = s.generic.Get(ctx, request, &response)
+	return
+}
+
+func (s *PrivatePublicIPAttachmentsServer) Create(ctx context.Context,
+	request *privatev1.PublicIPAttachmentsCreateRequest) (response *privatev1.PublicIPAttachmentsCreateResponse, err error) {
+	err = s.generic.Create(ctx, request, &response)
+	return
+}
+
+func (s *PrivatePublicIPAttachmentsServer) Update(ctx context.Context,
+	request *privatev1.PublicIPAttachmentsUpdateRequest) (response *privatev1.PublicIPAttachmentsUpdateResponse, err error) {
+	err = s.generic.Update(ctx, request, &response)
+	return
+}
+
+func (s *PrivatePublicIPAttachmentsServer) Delete(ctx context.Context,
+	request *privatev1.PublicIPAttachmentsDeleteRequest) (response *privatev1.PublicIPAttachmentsDeleteResponse, err error) {
+	err = s.generic.Delete(ctx, request, &response)
+	return
+}
+
+func (s *PrivatePublicIPAttachmentsServer) Signal(ctx context.Context,
+	request *privatev1.PublicIPAttachmentsSignalRequest) (response *privatev1.PublicIPAttachmentsSignalResponse, err error) {
+	err = s.generic.Signal(ctx, request, &response)
+	return
+}

--- a/internal/servers/private_public_ip_attachments_server_test.go
+++ b/internal/servers/private_public_ip_attachments_server_test.go
@@ -1,0 +1,286 @@
+/*
+Copyright (c) 2026 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package servers
+
+import (
+	"context"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/fieldmaskpb"
+
+	privatev1 "github.com/osac-project/fulfillment-service/internal/api/osac/private/v1"
+	"github.com/osac-project/fulfillment-service/internal/database"
+	"github.com/osac-project/fulfillment-service/internal/database/dao"
+)
+
+var _ = Describe("Private public IP attachments server", func() {
+	var (
+		ctx                       context.Context
+		tx                        database.Tx
+		publicIPAttachmentsServer *PrivatePublicIPAttachmentsServer
+	)
+
+	BeforeEach(func() {
+		var err error
+
+		ctx = context.Background()
+
+		db := server.MakeDatabase()
+		DeferCleanup(db.Close)
+		pool, err := pgxpool.New(ctx, db.MakeURL())
+		Expect(err).ToNot(HaveOccurred())
+		DeferCleanup(pool.Close)
+
+		tm, err := database.NewTxManager().
+			SetLogger(logger).
+			SetPool(pool).
+			Build()
+		Expect(err).ToNot(HaveOccurred())
+
+		tx, err = tm.Begin(ctx)
+		Expect(err).ToNot(HaveOccurred())
+		DeferCleanup(func() {
+			err := tm.End(ctx, tx)
+			Expect(err).ToNot(HaveOccurred())
+		})
+		ctx = database.TxIntoContext(ctx, tx)
+
+		err = dao.CreateTables[*privatev1.PublicIPAttachment](ctx)
+		Expect(err).ToNot(HaveOccurred())
+
+		publicIPAttachmentsServer, err = NewPrivatePublicIPAttachmentsServer().
+			SetLogger(logger).
+			SetAttributionLogic(attribution).
+			SetTenancyLogic(tenancy).
+			Build()
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	Describe("Creation", func() {
+		It("Can be built if all required parameters are set", func() {
+			server, err := NewPrivatePublicIPAttachmentsServer().
+				SetLogger(logger).
+				SetAttributionLogic(attribution).
+				SetTenancyLogic(tenancy).
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(server).ToNot(BeNil())
+		})
+
+		It("Fails if logger is not set", func() {
+			server, err := NewPrivatePublicIPAttachmentsServer().
+				SetAttributionLogic(attribution).
+				SetTenancyLogic(tenancy).
+				Build()
+			Expect(err).To(MatchError("logger is mandatory"))
+			Expect(server).To(BeNil())
+		})
+
+		It("Fails if tenancy logic is not set", func() {
+			server, err := NewPrivatePublicIPAttachmentsServer().
+				SetLogger(logger).
+				SetAttributionLogic(attribution).
+				Build()
+			Expect(err).To(MatchError("tenancy logic is mandatory"))
+			Expect(server).To(BeNil())
+		})
+	})
+
+	Describe("Behaviour", func() {
+		It("Creates a public IP attachment", func() {
+			response, err := publicIPAttachmentsServer.Create(ctx, privatev1.PublicIPAttachmentsCreateRequest_builder{
+				Object: privatev1.PublicIPAttachment_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name: "my-attachment",
+					}.Build(),
+					Spec: privatev1.PublicIPAttachmentSpec_builder{
+						PublicIp:        "019728a4-3f5c-7def-8abc-1234567890ab",
+						ComputeInstance: proto.String("01972f1b-a4e9-7c82-9def-abcdef123456"),
+					}.Build(),
+				}.Build(),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+			Expect(response).ToNot(BeNil())
+			Expect(response.GetObject()).ToNot(BeNil())
+			Expect(response.GetObject().GetId()).ToNot(BeEmpty())
+			Expect(response.GetObject().GetMetadata().GetName()).To(Equal("my-attachment"))
+			Expect(response.GetObject().GetSpec().GetPublicIp()).To(Equal("019728a4-3f5c-7def-8abc-1234567890ab"))
+			Expect(response.GetObject().GetSpec().GetComputeInstance()).To(Equal("01972f1b-a4e9-7c82-9def-abcdef123456"))
+		})
+
+		It("Lists public IP attachments", func() {
+			_, err := publicIPAttachmentsServer.Create(ctx, privatev1.PublicIPAttachmentsCreateRequest_builder{
+				Object: privatev1.PublicIPAttachment_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name: "attachment-a",
+					}.Build(),
+					Spec: privatev1.PublicIPAttachmentSpec_builder{
+						PublicIp:        "ip-a",
+						ComputeInstance: proto.String("ci-a"),
+					}.Build(),
+				}.Build(),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+
+			_, err = publicIPAttachmentsServer.Create(ctx, privatev1.PublicIPAttachmentsCreateRequest_builder{
+				Object: privatev1.PublicIPAttachment_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name: "attachment-b",
+					}.Build(),
+					Spec: privatev1.PublicIPAttachmentSpec_builder{
+						PublicIp:        "ip-b",
+						ComputeInstance: proto.String("ci-b"),
+					}.Build(),
+				}.Build(),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+
+			listResponse, err := publicIPAttachmentsServer.List(ctx, privatev1.PublicIPAttachmentsListRequest_builder{}.Build())
+			Expect(err).ToNot(HaveOccurred())
+			Expect(listResponse.GetSize()).To(Equal(int32(2)))
+			Expect(listResponse.GetItems()).To(HaveLen(2))
+		})
+
+		It("Gets a public IP attachment", func() {
+			createResponse, err := publicIPAttachmentsServer.Create(ctx, privatev1.PublicIPAttachmentsCreateRequest_builder{
+				Object: privatev1.PublicIPAttachment_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name: "my-attachment",
+					}.Build(),
+					Spec: privatev1.PublicIPAttachmentSpec_builder{
+						PublicIp:        "ip-1",
+						ComputeInstance: proto.String("ci-1"),
+					}.Build(),
+				}.Build(),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+
+			getResponse, err := publicIPAttachmentsServer.Get(ctx, privatev1.PublicIPAttachmentsGetRequest_builder{
+				Id: createResponse.GetObject().GetId(),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+			Expect(getResponse.GetObject().GetId()).To(Equal(createResponse.GetObject().GetId()))
+			Expect(getResponse.GetObject().GetMetadata().GetName()).To(Equal("my-attachment"))
+			Expect(getResponse.GetObject().GetSpec().GetPublicIp()).To(Equal("ip-1"))
+			Expect(getResponse.GetObject().GetSpec().GetComputeInstance()).To(Equal("ci-1"))
+		})
+
+		It("Updates a public IP attachment", func() {
+			createResponse, err := publicIPAttachmentsServer.Create(ctx, privatev1.PublicIPAttachmentsCreateRequest_builder{
+				Object: privatev1.PublicIPAttachment_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name: "my-attachment",
+					}.Build(),
+					Spec: privatev1.PublicIPAttachmentSpec_builder{
+						PublicIp:        "ip-original",
+						ComputeInstance: proto.String("ci-original"),
+					}.Build(),
+				}.Build(),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+
+			updateResponse, err := publicIPAttachmentsServer.Update(ctx, privatev1.PublicIPAttachmentsUpdateRequest_builder{
+				Object: privatev1.PublicIPAttachment_builder{
+					Id: createResponse.GetObject().GetId(),
+					Spec: privatev1.PublicIPAttachmentSpec_builder{
+						PublicIp: "ip-updated",
+					}.Build(),
+				}.Build(),
+				UpdateMask: &fieldmaskpb.FieldMask{
+					Paths: []string{
+						"spec.public_ip",
+					},
+				},
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+			Expect(updateResponse.GetObject().GetSpec().GetPublicIp()).To(Equal("ip-updated"))
+		})
+
+		It("Ignores fields not included in the update mask", func() {
+			createResponse, err := publicIPAttachmentsServer.Create(ctx, privatev1.PublicIPAttachmentsCreateRequest_builder{
+				Object: privatev1.PublicIPAttachment_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name: "my-attachment",
+					}.Build(),
+					Spec: privatev1.PublicIPAttachmentSpec_builder{
+						PublicIp:        "ip-original",
+						ComputeInstance: proto.String("ci-original"),
+					}.Build(),
+				}.Build(),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+
+			updateResponse, err := publicIPAttachmentsServer.Update(ctx, privatev1.PublicIPAttachmentsUpdateRequest_builder{
+				Object: privatev1.PublicIPAttachment_builder{
+					Id: createResponse.GetObject().GetId(),
+					Spec: privatev1.PublicIPAttachmentSpec_builder{
+						PublicIp:        "ip-updated",
+						ComputeInstance: proto.String("ci-updated"),
+					}.Build(),
+				}.Build(),
+				UpdateMask: &fieldmaskpb.FieldMask{
+					Paths: []string{
+						"spec.public_ip",
+					},
+				},
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+			Expect(updateResponse.GetObject().GetSpec().GetPublicIp()).To(Equal("ip-updated"))
+			Expect(updateResponse.GetObject().GetSpec().GetComputeInstance()).To(Equal("ci-original"))
+		})
+
+		It("Deletes a public IP attachment", func() {
+			createResponse, err := publicIPAttachmentsServer.Create(ctx, privatev1.PublicIPAttachmentsCreateRequest_builder{
+				Object: privatev1.PublicIPAttachment_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name: "my-attachment",
+					}.Build(),
+					Spec: privatev1.PublicIPAttachmentSpec_builder{
+						PublicIp:        "ip-1",
+						ComputeInstance: proto.String("ci-1"),
+					}.Build(),
+				}.Build(),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+
+			_, err = publicIPAttachmentsServer.Delete(ctx, privatev1.PublicIPAttachmentsDeleteRequest_builder{
+				Id: createResponse.GetObject().GetId(),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("Signals a public IP attachment", func() {
+			createResponse, err := publicIPAttachmentsServer.Create(ctx, privatev1.PublicIPAttachmentsCreateRequest_builder{
+				Object: privatev1.PublicIPAttachment_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name: "my-attachment",
+					}.Build(),
+					Spec: privatev1.PublicIPAttachmentSpec_builder{
+						PublicIp:        "ip-1",
+						ComputeInstance: proto.String("ci-1"),
+					}.Build(),
+				}.Build(),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+
+			_, err = publicIPAttachmentsServer.Signal(ctx, privatev1.PublicIPAttachmentsSignalRequest_builder{
+				Id: createResponse.GetObject().GetId(),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+		})
+	})
+})


### PR DESCRIPTION
[OSAC-830](https://redhat.atlassian.net/browse/OSAC-830)

Implements the private server for Public IP Attachment resources.  There is currently no validation and only basic CRUD is implemented - follow up tickets are planned for validation and the public server.