### PR TITLE
Clearer messages for virtualnetwork ID requirement in help

### DIFF
--- a/internal/cmd/cli/create/securitygroup/create_securitygroup_cmd.go
+++ b/internal/cmd/cli/create/securitygroup/create_securitygroup_cmd.go
@@ -281,13 +281,13 @@ Examples:
 
 {{ bt 3 }}shell
 # Create a security group with an HTTP ingress rule
-{{ binary }} create securitygroup --name web-sg --virtual-network vnet-abc123 \
+{{ binary }} create securitygroup --name web-sg --virtual-network <virtualnetwork-id> \
 --ingress protocol=tcp,port-from=80,port-to=80,ipv4-cidr=0.0.0.0/0
 {{ bt 3 }}
 
 {{ bt 3 }}shell
 # Create a security group with multiple rules
-{{ binary }} create securitygroup --name app-sg --virtual-network vnet-abc123 \
+{{ binary }} create securitygroup --name app-sg --virtual-network <virtualnetwork-id> \
 --ingress protocol=tcp,port-from=443,port-to=443,ipv4-cidr=0.0.0.0/0 \
 --ingress protocol=icmp,ipv4-cidr=10.0.0.0/8 \
 --egress protocol=all


### PR DESCRIPTION
The help command for securitygroup creation was suggesting it's possible to use the virtualnetwork name instead of ID.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated security group CLI command help text to use placeholder format for virtual network identifiers in command examples.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/osac-project/fulfillment-service/pull/544?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->