### PR TITLE
NO-ISSUE: Remove unnecessary SetFlags calls from login command

### DIFF
--- a/internal/cmd/cli/login/login_cmd.go
+++ b/internal/cmd/cli/login/login_cmd.go
@@ -252,7 +252,6 @@ func (c *runnerContext) run(cmd *cobra.Command, args []string) error {
 	// Create an anonymous gRPC client that we will use to fetch the metadata:
 	grpcConn, err := network.NewGrpcClient().
 		SetLogger(c.logger).
-		SetFlags(c.flags, network.GrpcClientName).
 		SetPlaintext(c.plaintext).
 		SetInsecure(c.args.insecure).
 		SetCaPool(c.caPool).
@@ -361,7 +360,6 @@ func (c *runnerContext) run(cmd *cobra.Command, args []string) error {
 	}
 	grpcConn, err = network.NewGrpcClient().
 		SetLogger(c.logger).
-		SetFlags(c.flags, network.GrpcClientName).
 		SetPlaintext(c.plaintext).
 		SetInsecure(c.args.insecure).
 		SetCaPool(c.caPool).


### PR DESCRIPTION
## Summary

The login command called `SetFlags` on the `GrpcClientBuilder` to read gRPC client
flags from the command's flag set. However, the login command never registered those
flags via `AddGrpcClientFlags`, causing a runtime error: "flag accessed but not
defined: grpc-server-network".

The `SetFlags` calls were redundant because the builder already receives all the
needed values explicitly through `SetPlaintext`, `SetInsecure`, `SetCaPool`, and
`SetAddress`.

## Test plan

- [x] `go build ./cmd/osac` compiles successfully
- [x] Run `osac login` and verify the error no longer occurs