### PR TITLE
OSAC-902: Add Keycloak authorization resource type

### DIFF
--- a/internal/idp/keycloak/const.go
+++ b/internal/idp/keycloak/const.go
@@ -50,3 +50,13 @@ var keycloakIdpManagerRoles = []string{
 	"view-identity-providers",
 	"view-realm",
 }
+
+// Authorization scope constants define actions that can be performed on protected resources.
+// These are used with Keycloak Authorization Services to control fine-grained access to Projects.
+const (
+	// ScopeViewProject allows viewing project details and status
+	ScopeViewProject = "VIEW_PROJECT"
+
+	// ScopeManageProject allows updating project metadata, deleting project, and managing permissions
+	ScopeManageProject = "MANAGE_PROJECT"
+)

--- a/internal/idp/keycloak/types.go
+++ b/internal/idp/keycloak/types.go
@@ -206,3 +206,83 @@ func fromKeycloakOrganization(kcOrg *keycloakOrganization) *idp.Organization {
 		Attributes:  kcOrg.Attributes,
 	}
 }
+
+// Authorization Services types
+// These map to Keycloak Authorization Services (UMA 2.0) REST API.
+// See: https://www.keycloak.org/docs/latest/authorization_services/
+
+// keycloakAuthorizationResource represents a protected resource in Keycloak Authorization Services.
+type keycloakAuthorizationResource struct {
+	ID         string              `json:"_id,omitempty"`
+	Name       string              `json:"name,omitempty"`
+	Type       string              `json:"type,omitempty"`
+	Scopes     []*keycloakScope    `json:"scopes,omitempty"`
+	URIs       []string            `json:"uris,omitempty"`
+	Attributes map[string][]string `json:"attributes,omitempty"`
+}
+
+// keycloakScope represents an authorization scope.
+type keycloakScope struct {
+	ID          string `json:"id,omitempty"`
+	Name        string `json:"name,omitempty"`
+	DisplayName string `json:"displayName,omitempty"`
+	IconURI     string `json:"iconUri,omitempty"`
+}
+
+// AuthorizationResource represents a protected resource exposed to controllers.
+// Each Project is represented as an authorization resource.
+type AuthorizationResource struct {
+	// ID is the unique identifier assigned by Keycloak
+	ID string
+
+	// Name is the resource name (e.g., "PROJECT-acme-web-app")
+	Name string
+
+	// Type is the resource type (e.g., "urn:osac:resources:project")
+	Type string
+
+	// Scopes are the actions that can be performed on this resource
+	Scopes []string
+
+	// URIs are optional resource URIs
+	URIs []string
+
+	// Attributes for additional metadata
+	Attributes map[string][]string
+}
+
+// Conversion functions for authorization resources
+
+func toKeycloakAuthorizationResource(resource *AuthorizationResource) *keycloakAuthorizationResource {
+	var scopes []*keycloakScope
+	for _, scopeName := range resource.Scopes {
+		scopes = append(scopes, &keycloakScope{
+			Name: scopeName,
+		})
+	}
+
+	return &keycloakAuthorizationResource{
+		ID:         resource.ID,
+		Name:       resource.Name,
+		Type:       resource.Type,
+		Scopes:     scopes,
+		URIs:       resource.URIs,
+		Attributes: resource.Attributes,
+	}
+}
+
+func fromKeycloakAuthorizationResource(kcResource *keycloakAuthorizationResource) *AuthorizationResource {
+	var scopes []string
+	for _, scope := range kcResource.Scopes {
+		scopes = append(scopes, scope.Name)
+	}
+
+	return &AuthorizationResource{
+		ID:         kcResource.ID,
+		Name:       kcResource.Name,
+		Type:       kcResource.Type,
+		Scopes:     scopes,
+		URIs:       kcResource.URIs,
+		Attributes: kcResource.Attributes,
+	}
+}


### PR DESCRIPTION
# Description

Authorization resources are keycloak resources that will be used to manage permissions on OSAC resources such as Projects.

# Testing 
- [x] `go build ./...` compiles cleanly
- [x] All unit test suites pass (`ginkgo run -r ./internal`)

Assisted-by: Claude

/cc @jhernand 