### PR TITLE
NO-ISSUE: Convert `EffectiveNetworkAttachments` tests to Ginkgo

### DIFF
--- a/internal/computeinstancespec/computeinstanceasspec_suite_test.go
+++ b/internal/computeinstancespec/computeinstanceasspec_suite_test.go
@@ -1,0 +1,26 @@
+/*
+Copyright (c) 2026 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package computeinstancespec
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2/dsl/core"
+	. "github.com/onsi/gomega"
+)
+
+func TestComputeInstanceSpec(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Compute instance spec package")
+}

--- a/internal/computeinstancespec/effective_network_test.go
+++ b/internal/computeinstancespec/effective_network_test.go
@@ -14,139 +14,151 @@ language governing permissions and limitations under the License.
 package computeinstancespec
 
 import (
-	"testing"
-
 	"github.com/google/go-cmp/cmp"
+	. "github.com/onsi/ginkgo/v2/dsl/core"
+	. "github.com/onsi/ginkgo/v2/dsl/table"
+	. "github.com/onsi/gomega"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/testing/protocmp"
 
 	privatev1 "github.com/osac-project/fulfillment-service/internal/api/osac/private/v1"
 )
 
-func TestEffectiveNetworkAttachments(t *testing.T) {
-	t.Parallel()
-	cases := []struct {
-		name    string
-		spec    *privatev1.ComputeInstanceSpec
-		want    []*privatev1.NetworkAttachment
-		wantErr bool
-	}{
-		{
-			name:    "nil spec",
-			spec:    nil,
-			want:    nil,
-			wantErr: false,
+var _ = Describe("Effective network attachments", func() {
+	type Case struct {
+		Spec    *privatev1.ComputeInstanceSpec
+		Want    []*privatev1.NetworkAttachment
+		WantErr bool
+	}
+
+	DescribeTable(
+		"Resolves network attachments",
+		func(c Case) {
+			got, err := EffectiveNetworkAttachments(c.Spec)
+			if c.WantErr {
+				Expect(err).To(HaveOccurred())
+				return
+			}
+			Expect(err).ToNot(HaveOccurred())
+			Expect(cmp.Diff(c.Want, got, protocmp.Transform())).To(BeEmpty())
 		},
-		{
-			name:    "empty",
-			spec:    privatev1.ComputeInstanceSpec_builder{}.Build(),
-			want:    nil,
-			wantErr: false,
-		},
-		{
-			name: "legacy subnet empty string",
-			spec: privatev1.ComputeInstanceSpec_builder{
-				Subnet: proto.String(""),
-			}.Build(),
-			want:    nil,
-			wantErr: false, // treat as no networking specified
-		},
-		{
-			name: "legacy subnet only",
-			spec: privatev1.ComputeInstanceSpec_builder{
-				Subnet: proto.String("sn-1"),
-			}.Build(),
-			want: []*privatev1.NetworkAttachment{
-				privatev1.NetworkAttachment_builder{Subnet: "sn-1"}.Build(),
+		Entry(
+			"Nil spec",
+			Case{
+				Spec:    nil,
+				Want:    nil,
+				WantErr: false,
 			},
-			wantErr: false,
-		},
-		{
-			name: "legacy subnet and security groups",
-			spec: privatev1.ComputeInstanceSpec_builder{
-				Subnet:         proto.String("sn-1"),
-				SecurityGroups: []string{"sg-1", "sg-2"},
-			}.Build(),
-			want: []*privatev1.NetworkAttachment{
-				privatev1.NetworkAttachment_builder{
-					Subnet:         "sn-1",
+		),
+		Entry(
+			"Empty",
+			Case{
+				Spec:    privatev1.ComputeInstanceSpec_builder{}.Build(),
+				Want:    nil,
+				WantErr: false,
+			},
+		),
+		Entry(
+			"Legacy subnet empty string",
+			Case{
+				Spec: privatev1.ComputeInstanceSpec_builder{
+					Subnet: proto.String(""),
+				}.Build(),
+				Want:    nil,
+				WantErr: false,
+			},
+		),
+		Entry(
+			"Legacy subnet only",
+			Case{
+				Spec: privatev1.ComputeInstanceSpec_builder{
+					Subnet: proto.String("sn-1"),
+				}.Build(),
+				Want: []*privatev1.NetworkAttachment{
+					privatev1.NetworkAttachment_builder{Subnet: "sn-1"}.Build(),
+				},
+				WantErr: false,
+			},
+		),
+		Entry(
+			"Legacy subnet and security groups",
+			Case{
+				Spec: privatev1.ComputeInstanceSpec_builder{
+					Subnet:         proto.String("sn-1"),
 					SecurityGroups: []string{"sg-1", "sg-2"},
 				}.Build(),
+				Want: []*privatev1.NetworkAttachment{
+					privatev1.NetworkAttachment_builder{
+						Subnet:         "sn-1",
+						SecurityGroups: []string{"sg-1", "sg-2"},
+					}.Build(),
+				},
+				WantErr: false,
 			},
-			wantErr: false,
-		},
-		{
-			name: "legacy security groups only",
-			spec: privatev1.ComputeInstanceSpec_builder{
-				SecurityGroups: []string{"sg-1"},
-			}.Build(),
-			want:    nil,
-			wantErr: true, // subnet is required when security_groups are set
-		},
-		{
-			name: "network_attachments only",
-			spec: privatev1.ComputeInstanceSpec_builder{
-				NetworkAttachments: []*privatev1.NetworkAttachment{
+		),
+		Entry(
+			"Legacy security groups only",
+			Case{
+				Spec: privatev1.ComputeInstanceSpec_builder{
+					SecurityGroups: []string{"sg-1"},
+				}.Build(),
+				Want:    nil,
+				WantErr: true,
+			},
+		),
+		Entry(
+			"Network attachments only",
+			Case{
+				Spec: privatev1.ComputeInstanceSpec_builder{
+					NetworkAttachments: []*privatev1.NetworkAttachment{
+						privatev1.NetworkAttachment_builder{Subnet: "a"}.Build(),
+						privatev1.NetworkAttachment_builder{Subnet: "b"}.Build(),
+					},
+				}.Build(),
+				Want: []*privatev1.NetworkAttachment{
 					privatev1.NetworkAttachment_builder{Subnet: "a"}.Build(),
 					privatev1.NetworkAttachment_builder{Subnet: "b"}.Build(),
 				},
-			}.Build(),
-			want: []*privatev1.NetworkAttachment{
-				privatev1.NetworkAttachment_builder{Subnet: "a"}.Build(),
-				privatev1.NetworkAttachment_builder{Subnet: "b"}.Build(),
+				WantErr: false,
+			}),
+		Entry(
+			"Conflict legacy subnet with network attachments",
+			Case{
+				Spec: privatev1.ComputeInstanceSpec_builder{
+					Subnet: proto.String("sn-1"),
+					NetworkAttachments: []*privatev1.NetworkAttachment{
+						privatev1.NetworkAttachment_builder{Subnet: "a"}.Build(),
+					},
+				}.Build(),
+				Want:    nil,
+				WantErr: true,
 			},
-			wantErr: false,
-		},
-		{
-			name: "conflict legacy subnet with network_attachments",
-			spec: privatev1.ComputeInstanceSpec_builder{
-				Subnet: proto.String("sn-1"),
-				NetworkAttachments: []*privatev1.NetworkAttachment{
-					privatev1.NetworkAttachment_builder{Subnet: "a"}.Build(),
-				},
-			}.Build(),
-			want:    nil,
-			wantErr: true,
-		},
-		{
-			name: "conflict legacy security_groups with network_attachments",
-			spec: privatev1.ComputeInstanceSpec_builder{
-				SecurityGroups: []string{"sg-1"},
-				NetworkAttachments: []*privatev1.NetworkAttachment{
-					privatev1.NetworkAttachment_builder{Subnet: "a"}.Build(),
-				},
-			}.Build(),
-			want:    nil,
-			wantErr: true,
-		},
-		{
-			name: "conflict deprecated subnet present but empty string with network_attachments",
-			spec: privatev1.ComputeInstanceSpec_builder{
-				Subnet: proto.String(""),
-				NetworkAttachments: []*privatev1.NetworkAttachment{
-					privatev1.NetworkAttachment_builder{Subnet: "a"}.Build(),
-				},
-			}.Build(),
-			want:    nil,
-			wantErr: true,
-		},
-	}
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
-			got, err := EffectiveNetworkAttachments(tc.spec)
-			if tc.wantErr {
-				if err == nil {
-					t.Fatal("expected error")
-				}
-				return
-			}
-			if err != nil {
-				t.Fatalf("unexpected err: %v", err)
-			}
-			if diff := cmp.Diff(tc.want, got, protocmp.Transform()); diff != "" {
-				t.Fatalf("(-want +got):\n%s", diff)
-			}
-		})
-	}
-}
+		),
+		Entry(
+			"Conflict legacy security groups with network attachments",
+			Case{
+				Spec: privatev1.ComputeInstanceSpec_builder{
+					SecurityGroups: []string{"sg-1"},
+					NetworkAttachments: []*privatev1.NetworkAttachment{
+						privatev1.NetworkAttachment_builder{Subnet: "a"}.Build(),
+					},
+				}.Build(),
+				Want:    nil,
+				WantErr: true,
+			},
+		),
+		Entry(
+			"Conflict deprecated subnet present but empty string with network_attachments",
+			Case{
+				Spec: privatev1.ComputeInstanceSpec_builder{
+					Subnet: proto.String(""),
+					NetworkAttachments: []*privatev1.NetworkAttachment{
+						privatev1.NetworkAttachment_builder{Subnet: "a"}.Build(),
+					},
+				}.Build(),
+				Want:    nil,
+				WantErr: true,
+			},
+		),
+	)
+})


### PR DESCRIPTION
## Summary

- Convert the `EffectiveNetworkAttachments` tests from standard `testing.T`
  table-driven style to Ginkgo `Describe` / `DescribeTable` with `Entry` blocks.
- Add a Ginkgo suite file for the `computeinstancespec` package.

Using `DescribeTable` makes it possible to focus on a particular test case
with `FEntry`, which helps when debugging, and makes the output of
`ginkgo run` consistent and less noisy across all packages.

## Test plan

- [x] `ginkgo run internal/computeinstancespec` passes (10 specs, 0 failures).