### PR TITLE
OSAC-705: Catalog items — CLI surface

### DIFF
--- a/internal/cmd/cli/create/cluster/create_cluster_cmd.go
+++ b/internal/cmd/cli/create/cluster/create_cluster_cmd.go
@@ -236,8 +236,7 @@ func (c *runnerContext) run(cmd *cobra.Command, args []string) error {
 	if c.args.catalogItem != "" {
 		// Catalog item path: skip template lookup entirely (per D-04).
 		specBuilder := publicv1.ClusterSpec_builder{
-			// TODO(OSAC-704): Uncomment when Phase 4 adds CatalogItem to ClusterSpec.
-			// CatalogItem: c.args.catalogItem,
+			CatalogItem: c.args.catalogItem,
 		}
 		if pullSecret != "" {
 			specBuilder.PullSecret = &pullSecret

--- a/internal/cmd/cli/create/cluster/create_cluster_cmd.go
+++ b/internal/cmd/cli/create/cluster/create_cluster_cmd.go
@@ -66,6 +66,12 @@ func Cmd() *cobra.Command {
 		"",
 		"Template identifier or name",
 	)
+	flags.StringVar(
+		&runner.args.catalogItem,
+		"catalog-item",
+		"",
+		"Catalog item identifier. Replaces --template.",
+	)
 	flags.StringSliceVarP(
 		&runner.args.templateParameterValues,
 		"template-parameter",
@@ -122,6 +128,8 @@ func Cmd() *cobra.Command {
 		"",
 		"CIDR for the cluster's service network. If omitted, the server default is used.",
 	)
+	result.MarkFlagsMutuallyExclusive("catalog-item", "template")
+	result.MarkFlagsOneRequired("catalog-item", "template")
 	return result
 }
 
@@ -129,6 +137,7 @@ type runnerContext struct {
 	args struct {
 		name                    string
 		template                string
+		catalogItem             string
 		templateParameterValues []string
 		templateParameterFiles  []string
 		pullSecret              string
@@ -161,6 +170,20 @@ func (c *runnerContext) run(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to load templates: %w", err)
 	}
 
+	// Reject template parameters when using catalog item (per D-04):
+	if c.args.catalogItem != "" {
+		if len(c.args.templateParameterValues) > 0 || len(c.args.templateParameterFiles) > 0 {
+			return fmt.Errorf(
+				"--template-parameter and --template-parameter-file are not supported with --catalog-item",
+			)
+		}
+	}
+
+	// Deprecation warning for --template (per D-03):
+	if c.args.template != "" {
+		fmt.Fprintf(os.Stderr, "Warning: --template is deprecated, use --catalog-item instead\n")
+	}
+
 	// Get the configuration:
 	cfg, err := config.Load(ctx)
 	if err != nil {
@@ -168,11 +191,6 @@ func (c *runnerContext) run(cmd *cobra.Command, args []string) error {
 	}
 	if cfg.Address == "" {
 		return fmt.Errorf("there is no configuration, run the 'login' command")
-	}
-
-	// Check that we have a template:
-	if c.args.template == "" {
-		return fmt.Errorf("template identifier or name is required")
 	}
 
 	// Create the gRPC connection from the configuration:
@@ -197,6 +215,71 @@ func (c *runnerContext) run(cmd *cobra.Command, args []string) error {
 	c.templatesClient = publicv1.NewClusterTemplatesClient(conn)
 	c.clustersClient = publicv1.NewClustersClient(conn)
 
+	// Resolve credentials before branching (used in both catalog-item and template paths):
+	pullSecret := c.args.pullSecret
+	if c.args.pullSecretFile != "" {
+		data, readErr := os.ReadFile(c.args.pullSecretFile)
+		if readErr != nil {
+			return fmt.Errorf("failed to read pull secret file '%s': %w", c.args.pullSecretFile, readErr)
+		}
+		pullSecret = strings.TrimSpace(string(data))
+	}
+	sshPublicKey := c.args.sshPublicKey
+	if c.args.sshPublicKeyFile != "" {
+		data, readErr := os.ReadFile(c.args.sshPublicKeyFile)
+		if readErr != nil {
+			return fmt.Errorf("failed to read SSH public key file '%s': %w", c.args.sshPublicKeyFile, readErr)
+		}
+		sshPublicKey = strings.TrimSpace(string(data))
+	}
+
+	if c.args.catalogItem != "" {
+		// Catalog item path: skip template lookup entirely (per D-04).
+		specBuilder := publicv1.ClusterSpec_builder{
+			// TODO(OSAC-704): Uncomment when Phase 4 adds CatalogItem to ClusterSpec.
+			// CatalogItem: c.args.catalogItem,
+		}
+		if pullSecret != "" {
+			specBuilder.PullSecret = &pullSecret
+		}
+		if sshPublicKey != "" {
+			specBuilder.SshPublicKey = &sshPublicKey
+		}
+		if c.args.releaseImage != "" {
+			specBuilder.ReleaseImage = &c.args.releaseImage
+		}
+		if c.args.podCIDR != "" || c.args.serviceCIDR != "" {
+			networkBuilder := publicv1.ClusterNetwork_builder{}
+			if c.args.podCIDR != "" {
+				networkBuilder.PodCidr = &c.args.podCIDR
+			}
+			if c.args.serviceCIDR != "" {
+				networkBuilder.ServiceCidr = &c.args.serviceCIDR
+			}
+			specBuilder.Network = networkBuilder.Build()
+		}
+
+		cluster := publicv1.Cluster_builder{
+			Metadata: publicv1.Metadata_builder{
+				Name: c.args.name,
+			}.Build(),
+			Spec: specBuilder.Build(),
+		}.Build()
+
+		response, err := c.clustersClient.Create(ctx, publicv1.ClustersCreateRequest_builder{
+			Object: cluster,
+		}.Build())
+		if err != nil {
+			return fmt.Errorf("failed to create cluster: %w", err)
+		}
+
+		cluster = response.Object
+		c.console.Infof(ctx, "Created cluster '%s'.\n", cluster.Id)
+		return nil
+	}
+
+	// Legacy template path (existing code continues below):
+
 	// Fetch the cluster template:
 	template, err := c.findTemplate(ctx)
 	if err != nil {
@@ -216,26 +299,6 @@ func (c *runnerContext) run(cmd *cobra.Command, args []string) error {
 			"Issues":     templateParameterIssues,
 		})
 		return exit.Error(1)
-	}
-
-	// Resolve pull secret (--pull-secret-file takes precedence over --pull-secret):
-	pullSecret := c.args.pullSecret
-	if c.args.pullSecretFile != "" {
-		data, readErr := os.ReadFile(c.args.pullSecretFile)
-		if readErr != nil {
-			return fmt.Errorf("failed to read pull secret file '%s': %w", c.args.pullSecretFile, readErr)
-		}
-		pullSecret = strings.TrimSpace(string(data))
-	}
-
-	// Resolve SSH public key (--ssh-public-key-file takes precedence over --ssh-public-key):
-	sshPublicKey := c.args.sshPublicKey
-	if c.args.sshPublicKeyFile != "" {
-		data, readErr := os.ReadFile(c.args.sshPublicKeyFile)
-		if readErr != nil {
-			return fmt.Errorf("failed to read SSH public key file '%s': %w", c.args.sshPublicKeyFile, readErr)
-		}
-		sshPublicKey = strings.TrimSpace(string(data))
 	}
 
 	// Build the cluster spec:

--- a/internal/cmd/cli/create/cluster/create_cluster_cmd_test.go
+++ b/internal/cmd/cli/create/cluster/create_cluster_cmd_test.go
@@ -1,0 +1,70 @@
+/*
+Copyright (c) 2025 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package cluster
+
+import (
+	. "github.com/onsi/ginkgo/v2/dsl/core"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Create cluster flag registration", func() {
+	It("should register --catalog-item flag", func() {
+		cmd := Cmd()
+		flag := cmd.Flags().Lookup("catalog-item")
+		Expect(flag).NotTo(BeNil())
+		Expect(flag.Usage).To(ContainSubstring("Catalog item"))
+	})
+
+	It("should still register --template flag", func() {
+		cmd := Cmd()
+		flag := cmd.Flags().Lookup("template")
+		Expect(flag).NotTo(BeNil())
+	})
+
+	It("should register --catalog-item without a short flag", func() {
+		cmd := Cmd()
+		flag := cmd.Flags().Lookup("catalog-item")
+		Expect(flag).NotTo(BeNil())
+		Expect(flag.Shorthand).To(BeEmpty())
+	})
+
+	It("should keep -t as shorthand for --template", func() {
+		cmd := Cmd()
+		flag := cmd.Flags().Lookup("template")
+		Expect(flag).NotTo(BeNil())
+		Expect(flag.Shorthand).To(Equal("t"))
+	})
+})
+
+var _ = Describe("Create cluster flag validation", func() {
+	It("should return error when both --catalog-item and --template are set", func() {
+		cmd := Cmd()
+		cmd.SetArgs([]string{"--catalog-item", "cat-001", "--template", "tpl-001", "--name", "test"})
+		err := cmd.Execute()
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("if any flags in the group"))
+		Expect(err.Error()).To(ContainSubstring("catalog-item"))
+		Expect(err.Error()).To(ContainSubstring("template"))
+	})
+
+	It("should return error when neither --catalog-item nor --template is set", func() {
+		cmd := Cmd()
+		cmd.SetArgs([]string{"--name", "test"})
+		err := cmd.Execute()
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("at least one of the flags"))
+		Expect(err.Error()).To(ContainSubstring("catalog-item"))
+		Expect(err.Error()).To(ContainSubstring("template"))
+	})
+})

--- a/internal/cmd/cli/create/cluster/create_cluster_suite_test.go
+++ b/internal/cmd/cli/create/cluster/create_cluster_suite_test.go
@@ -1,0 +1,26 @@
+/*
+Copyright (c) 2025 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package cluster
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestCreateCluster(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Create Cluster Suite")
+}

--- a/internal/cmd/cli/create/computeinstance/create_compute_instance_cmd.go
+++ b/internal/cmd/cli/create/computeinstance/create_compute_instance_cmd.go
@@ -66,6 +66,12 @@ func Cmd() *cobra.Command {
 		"",
 		"Template identifier or name",
 	)
+	flags.StringVar(
+		&runner.args.catalogItem,
+		"catalog-item",
+		"",
+		"Catalog item identifier. Replaces --template.",
+	)
 	flags.StringSliceVarP(
 		&runner.args.templateParameterValues,
 		"template-parameter",
@@ -157,6 +163,8 @@ func Cmd() *cobra.Command {
 	flags.MarkDeprecated("subnet", "use --network-attachment instead")
 	flags.MarkDeprecated("security-group", "use --network-attachment instead")
 
+	result.MarkFlagsMutuallyExclusive("catalog-item", "template")
+	result.MarkFlagsOneRequired("catalog-item", "template")
 	return result
 }
 
@@ -164,6 +172,7 @@ type runnerContext struct {
 	args struct {
 		name                    string
 		template                string
+		catalogItem             string
 		templateParameterValues []string
 		templateParameterFiles  []string
 		cores                   int32
@@ -201,6 +210,20 @@ func (c *runnerContext) run(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to load templates: %w", err)
 	}
 
+	// Reject template parameters when using catalog item (per D-04):
+	if c.args.catalogItem != "" {
+		if len(c.args.templateParameterValues) > 0 || len(c.args.templateParameterFiles) > 0 {
+			return fmt.Errorf(
+				"--template-parameter and --template-parameter-file are not supported with --catalog-item",
+			)
+		}
+	}
+
+	// Deprecation warning for --template (per D-03):
+	if c.args.template != "" {
+		fmt.Fprintf(os.Stderr, "Warning: --template is deprecated, use --catalog-item instead\n")
+	}
+
 	// Get the configuration:
 	cfg, err := config.Load(ctx)
 	if err != nil {
@@ -208,11 +231,6 @@ func (c *runnerContext) run(cmd *cobra.Command, args []string) error {
 	}
 	if cfg.Address == "" {
 		return fmt.Errorf("there is no configuration, run the 'login' command")
-	}
-
-	// Check that we have a template:
-	if c.args.template == "" {
-		return fmt.Errorf("template identifier or name is required")
 	}
 
 	// Create the gRPC connection from the configuration:
@@ -236,6 +254,34 @@ func (c *runnerContext) run(cmd *cobra.Command, args []string) error {
 	// Create the gRPC clients:
 	c.templatesClient = publicv1.NewComputeInstanceTemplatesClient(conn)
 	c.computeInstancesClient = publicv1.NewComputeInstancesClient(conn)
+
+	if c.args.catalogItem != "" {
+		// Catalog item path: skip template lookup entirely (per D-04).
+		specResult, specErr := c.buildSpecFromCatalogItem(c.args.catalogItem)
+		if specErr != nil {
+			return specErr
+		}
+
+		computeInstance := publicv1.ComputeInstance_builder{
+			Metadata: publicv1.Metadata_builder{
+				Name: c.args.name,
+			}.Build(),
+			Spec: specResult,
+		}.Build()
+
+		response, err := c.computeInstancesClient.Create(ctx, publicv1.ComputeInstancesCreateRequest_builder{
+			Object: computeInstance,
+		}.Build())
+		if err != nil {
+			return fmt.Errorf("failed to create compute instance: %w", err)
+		}
+
+		computeInstance = response.Object
+		c.console.Infof(ctx, "Created compute instance '%s'.\n", computeInstance.Id)
+		return nil
+	}
+
+	// Legacy template path (existing code continues below):
 
 	// Fetch the compute instance template:
 	template, err := c.findTemplate(ctx)
@@ -810,6 +856,47 @@ func parseNetworkAttachmentFlag(s string) (*publicv1.NetworkAttachment, error) {
 		Subnet:         subnet,
 		SecurityGroups: securityGroups,
 	}.Build(), nil
+}
+
+// buildSpecFromCatalogItem builds the spec for catalog-item-based creation.
+func (c *runnerContext) buildSpecFromCatalogItem(catalogItemID string) (*publicv1.ComputeInstanceSpec, error) {
+	spec := publicv1.ComputeInstanceSpec_builder{
+		CatalogItem: catalogItemID,
+	}
+	if c.args.imageSourceRef != "" {
+		spec.Image = publicv1.ComputeInstanceImage_builder{
+			SourceType: c.args.imageSourceType,
+			SourceRef:  c.args.imageSourceRef,
+		}.Build()
+	}
+	if c.args.cores > 0 {
+		spec.Cores = proto.Int32(c.args.cores)
+	}
+	if c.args.memoryGiB > 0 {
+		spec.MemoryGib = proto.Int32(c.args.memoryGiB)
+	}
+	if c.args.sshKey != "" {
+		spec.SshKey = proto.String(c.args.sshKey)
+	}
+	if c.args.bootDiskSizeGiB > 0 {
+		spec.BootDisk = publicv1.ComputeInstanceDisk_builder{
+			SizeGib: c.args.bootDiskSizeGiB,
+		}.Build()
+	}
+	if len(c.args.additionalDisks) > 0 {
+		disks, diskErr := parseAdditionalDisks(c.args.additionalDisks)
+		if diskErr != nil {
+			return nil, diskErr
+		}
+		spec.AdditionalDisks = disks
+	}
+	if c.args.runStrategy != "" {
+		spec.RunStrategy = proto.String(c.args.runStrategy)
+	}
+	if c.args.userData != "" {
+		spec.UserData = proto.String(c.args.userData)
+	}
+	return spec.Build(), nil
 }
 
 // parseAdditionalDisks parses disk sizes in GiB.

--- a/internal/cmd/cli/create/computeinstance/create_compute_instance_cmd_test.go
+++ b/internal/cmd/cli/create/computeinstance/create_compute_instance_cmd_test.go
@@ -105,3 +105,54 @@ var _ = Describe("buildSpec", func() {
 		Expect(proto.Equal(spec, want)).To(BeTrue(), "spec should equal expected spec")
 	})
 })
+
+var _ = Describe("Create computeinstance flag registration", func() {
+	It("should register --catalog-item flag", func() {
+		cmd := Cmd()
+		flag := cmd.Flags().Lookup("catalog-item")
+		Expect(flag).NotTo(BeNil())
+		Expect(flag.Usage).To(ContainSubstring("Catalog item"))
+	})
+
+	It("should still register --template flag", func() {
+		cmd := Cmd()
+		flag := cmd.Flags().Lookup("template")
+		Expect(flag).NotTo(BeNil())
+	})
+
+	It("should register --catalog-item without a short flag", func() {
+		cmd := Cmd()
+		flag := cmd.Flags().Lookup("catalog-item")
+		Expect(flag).NotTo(BeNil())
+		Expect(flag.Shorthand).To(BeEmpty())
+	})
+
+	It("should keep -t as shorthand for --template", func() {
+		cmd := Cmd()
+		flag := cmd.Flags().Lookup("template")
+		Expect(flag).NotTo(BeNil())
+		Expect(flag.Shorthand).To(Equal("t"))
+	})
+})
+
+var _ = Describe("Create computeinstance flag validation", func() {
+	It("should return error when both --catalog-item and --template are set", func() {
+		cmd := Cmd()
+		cmd.SetArgs([]string{"--catalog-item", "cat-001", "--template", "tpl-001", "--name", "test"})
+		err := cmd.Execute()
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("if any flags in the group"))
+		Expect(err.Error()).To(ContainSubstring("catalog-item"))
+		Expect(err.Error()).To(ContainSubstring("template"))
+	})
+
+	It("should return error when neither --catalog-item nor --template is set", func() {
+		cmd := Cmd()
+		cmd.SetArgs([]string{"--name", "test"})
+		err := cmd.Execute()
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("at least one of the flags"))
+		Expect(err.Error()).To(ContainSubstring("catalog-item"))
+		Expect(err.Error()).To(ContainSubstring("template"))
+	})
+})

--- a/internal/cmd/cli/describe/cluster/describe_cluster.go
+++ b/internal/cmd/cli/describe/cluster/describe_cluster.go
@@ -100,9 +100,12 @@ func buildFilter(ref string) string {
 
 func renderCluster(w io.Writer, cluster *publicv1.Cluster) {
 	writer := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
-	template := "-"
+	catalogItem := "-"
 	if cluster.Spec != nil {
-		template = cluster.Spec.Template
+		// TODO(OSAC-704): Uncomment when Phase 4 adds CatalogItem to ClusterSpec.
+		// if catalogItemID := cluster.Spec.GetCatalogItem(); catalogItemID != "" {
+		//     catalogItem = catalogItemID
+		// }
 	}
 	state := "-"
 	if cluster.Status != nil {
@@ -110,7 +113,7 @@ func renderCluster(w io.Writer, cluster *publicv1.Cluster) {
 		state = strings.TrimPrefix(state, "CLUSTER_STATE_")
 	}
 	fmt.Fprintf(writer, "ID:\t%s\n", cluster.Id)
-	fmt.Fprintf(writer, "Template:\t%s\n", template)
+	fmt.Fprintf(writer, "Catalog Item:\t%s\n", catalogItem)
 	fmt.Fprintf(writer, "State:\t%s\n", state)
 	writer.Flush()
 }

--- a/internal/cmd/cli/describe/cluster/describe_cluster.go
+++ b/internal/cmd/cli/describe/cluster/describe_cluster.go
@@ -102,10 +102,9 @@ func renderCluster(w io.Writer, cluster *publicv1.Cluster) {
 	writer := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
 	catalogItem := "-"
 	if cluster.Spec != nil {
-		// TODO(OSAC-704): Uncomment when Phase 4 adds CatalogItem to ClusterSpec.
-		// if catalogItemID := cluster.Spec.GetCatalogItem(); catalogItemID != "" {
-		//     catalogItem = catalogItemID
-		// }
+		if catalogItemID := cluster.Spec.GetCatalogItem(); catalogItemID != "" {
+			catalogItem = catalogItemID
+		}
 	}
 	state := "-"
 	if cluster.Status != nil {

--- a/internal/cmd/cli/describe/cluster/describe_cluster_test.go
+++ b/internal/cmd/cli/describe/cluster/describe_cluster_test.go
@@ -64,16 +64,17 @@ var _ = Describe("Rendering tests", func() {
 		}.Build()
 		output := formatCluster(cluster)
 		Expect(output).To(ContainSubstring("cluster-001"))
-		Expect(output).To(ContainSubstring("tpl-ha-001"))
+		Expect(output).To(MatchRegexp(`Catalog Item:\s+-`))
+		Expect(output).NotTo(ContainSubstring("Template:"))
 		Expect(output).To(ContainSubstring("READY"))
 	})
 
-	It("should show '-' for template when spec is nil", func() {
+	It("should show '-' for catalog item when spec is nil", func() {
 		cluster := publicv1.Cluster_builder{
 			Id: "cluster-002",
 		}.Build()
 		output := formatCluster(cluster)
-		Expect(output).To(MatchRegexp(`Template:\s+-`))
+		Expect(output).To(MatchRegexp(`Catalog Item:\s+-`))
 	})
 
 	It("should show '-' for state when status is nil", func() {
@@ -107,6 +108,29 @@ var _ = Describe("Rendering tests", func() {
 		Expect(output).To(ContainSubstring("PROGRESSING"))
 		Expect(output).NotTo(ContainSubstring("CLUSTER_STATE_"))
 	})
+
+	It("should NOT show Template: row", func() {
+		cluster := publicv1.Cluster_builder{
+			Id: "cluster-006",
+			Spec: &publicv1.ClusterSpec{
+				Template: "tpl-ha-001",
+			},
+		}.Build()
+		output := formatCluster(cluster)
+		Expect(output).NotTo(ContainSubstring("Template:"))
+		Expect(output).To(ContainSubstring("Catalog Item:"))
+	})
+
+	It("should show '-' for catalog item when spec is nil", func() {
+		cluster := publicv1.Cluster_builder{
+			Id: "cluster-007",
+		}.Build()
+		output := formatCluster(cluster)
+		Expect(output).To(MatchRegexp(`Catalog Item:\s+-`))
+	})
+
+	// TODO(OSAC-704): Add test for "should show catalog item ID when set"
+	// once ClusterSpec.GetCatalogItem() exists from Phase 4.
 })
 
 var _ = Describe("Multi-result guard", func() {

--- a/internal/cmd/cli/describe/cluster/describe_cluster_test.go
+++ b/internal/cmd/cli/describe/cluster/describe_cluster_test.go
@@ -129,8 +129,16 @@ var _ = Describe("Rendering tests", func() {
 		Expect(output).To(MatchRegexp(`Catalog Item:\s+-`))
 	})
 
-	// TODO(OSAC-704): Add test for "should show catalog item ID when set"
-	// once ClusterSpec.GetCatalogItem() exists from Phase 4.
+	It("should show catalog item ID when set", func() {
+		cluster := publicv1.Cluster_builder{
+			Id: "cluster-008",
+			Spec: publicv1.ClusterSpec_builder{
+				CatalogItem: "my-catalog-item-id",
+			}.Build(),
+		}.Build()
+		output := formatCluster(cluster)
+		Expect(output).To(MatchRegexp(`Catalog Item:\s+my-catalog-item-id`))
+	})
 })
 
 var _ = Describe("Multi-result guard", func() {

--- a/internal/cmd/cli/describe/computeinstance/describe_computeinstance_cmd.go
+++ b/internal/cmd/cli/describe/computeinstance/describe_computeinstance_cmd.go
@@ -103,10 +103,9 @@ func renderComputeInstance(w io.Writer, ci *publicv1.ComputeInstance) {
 	writer := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
 	catalogItem := "-"
 	if ci.Spec != nil {
-		// TODO(OSAC-704): Uncomment when Phase 4 adds CatalogItem to ComputeInstanceSpec.
-		// if catalogItemID := ci.Spec.GetCatalogItem(); catalogItemID != "" {
-		//     catalogItem = catalogItemID
-		// }
+		if catalogItemID := ci.Spec.GetCatalogItem(); catalogItemID != "" {
+			catalogItem = catalogItemID
+		}
 	}
 	state := "-"
 	if ci.Status != nil {

--- a/internal/cmd/cli/describe/computeinstance/describe_computeinstance_cmd.go
+++ b/internal/cmd/cli/describe/computeinstance/describe_computeinstance_cmd.go
@@ -101,9 +101,12 @@ func buildFilter(ref string) string {
 
 func renderComputeInstance(w io.Writer, ci *publicv1.ComputeInstance) {
 	writer := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
-	template := "-"
+	catalogItem := "-"
 	if ci.Spec != nil {
-		template = ci.Spec.Template
+		// TODO(OSAC-704): Uncomment when Phase 4 adds CatalogItem to ComputeInstanceSpec.
+		// if catalogItemID := ci.Spec.GetCatalogItem(); catalogItemID != "" {
+		//     catalogItem = catalogItemID
+		// }
 	}
 	state := "-"
 	if ci.Status != nil {
@@ -111,7 +114,7 @@ func renderComputeInstance(w io.Writer, ci *publicv1.ComputeInstance) {
 		state = strings.TrimPrefix(state, "COMPUTE_INSTANCE_STATE_")
 	}
 	fmt.Fprintf(writer, "ID:\t%s\n", ci.Id)
-	fmt.Fprintf(writer, "Template:\t%s\n", template)
+	fmt.Fprintf(writer, "Catalog Item:\t%s\n", catalogItem)
 	fmt.Fprintf(writer, "State:\t%s\n", state)
 	if ci.Status != nil && ci.Status.GetLastRestartedAt() != nil {
 		fmt.Fprintf(writer, "Last Restarted At:\t%s\n", ci.Status.GetLastRestartedAt().AsTime().Format(time.RFC3339))

--- a/internal/cmd/cli/describe/computeinstance/describe_computeinstance_test.go
+++ b/internal/cmd/cli/describe/computeinstance/describe_computeinstance_test.go
@@ -132,8 +132,15 @@ var _ = Describe("Describe Compute Instance", func() {
 		Expect(output).To(ContainSubstring("Catalog Item:"))
 	})
 
-	// TODO(OSAC-704): Add test for "should show catalog item ID when set"
-	// once ComputeInstanceSpec.GetCatalogItem() exists from Phase 4.
+	It("should show catalog item ID when set", func() {
+		ci := &publicv1.ComputeInstance{
+			Spec: publicv1.ComputeInstanceSpec_builder{
+				CatalogItem: "my-ci-catalog-item",
+			}.Build(),
+		}
+		output := formatComputeInstance(ci)
+		Expect(output).To(MatchRegexp(`Catalog Item:\s+my-ci-catalog-item`))
+	})
 })
 
 var _ = Describe("CEL filter construction", func() {

--- a/internal/cmd/cli/describe/computeinstance/describe_computeinstance_test.go
+++ b/internal/cmd/cli/describe/computeinstance/describe_computeinstance_test.go
@@ -43,7 +43,8 @@ var _ = Describe("Describe Compute Instance", func() {
 		}
 		output := formatComputeInstance(ci)
 		Expect(output).To(ContainSubstring("ci-001"))
-		Expect(output).To(ContainSubstring("tpl-small-001"))
+		Expect(output).To(MatchRegexp(`Catalog Item:\s+-`))
+		Expect(output).NotTo(ContainSubstring("Template:"))
 		Expect(output).To(ContainSubstring("RUNNING"))
 	})
 
@@ -59,12 +60,12 @@ var _ = Describe("Describe Compute Instance", func() {
 		Expect(output).NotTo(ContainSubstring("COMPUTE_INSTANCE_STATE_"))
 	})
 
-	It("should show '-' for template when spec is nil", func() {
+	It("should show '-' for catalog item when spec is nil", func() {
 		ci := &publicv1.ComputeInstance{
 			Id: "ci-003",
 		}
 		output := formatComputeInstance(ci)
-		Expect(output).To(MatchRegexp(`Template:\s+-`))
+		Expect(output).To(MatchRegexp(`Catalog Item:\s+-`))
 	})
 
 	It("should display last_restarted_at when set", func() {
@@ -81,6 +82,8 @@ var _ = Describe("Describe Compute Instance", func() {
 		}
 
 		output := formatComputeInstance(ci)
+		Expect(output).NotTo(ContainSubstring("Template:"))
+		Expect(output).To(ContainSubstring("Catalog Item:"))
 		Expect(output).To(ContainSubstring("Last Restarted At:"))
 		Expect(output).To(ContainSubstring("2026-03-15T10:30:00Z"))
 	})
@@ -97,6 +100,8 @@ var _ = Describe("Describe Compute Instance", func() {
 		}
 
 		output := formatComputeInstance(ci)
+		Expect(output).NotTo(ContainSubstring("Template:"))
+		Expect(output).To(ContainSubstring("Catalog Item:"))
 		Expect(output).NotTo(ContainSubstring("Last Restarted At:"))
 	})
 
@@ -109,9 +114,26 @@ var _ = Describe("Describe Compute Instance", func() {
 		}
 
 		output := formatComputeInstance(ci)
+		Expect(output).NotTo(ContainSubstring("Template:"))
+		Expect(output).To(ContainSubstring("Catalog Item:"))
 		Expect(output).To(MatchRegexp(`State:\s+-`))
 		Expect(output).NotTo(ContainSubstring("Last Restarted At:"))
 	})
+
+	It("should NOT show Template: row even when template is set on spec", func() {
+		ci := &publicv1.ComputeInstance{
+			Id: "ci-010",
+			Spec: &publicv1.ComputeInstanceSpec{
+				Template: "tpl-small-001",
+			},
+		}
+		output := formatComputeInstance(ci)
+		Expect(output).NotTo(ContainSubstring("Template:"))
+		Expect(output).To(ContainSubstring("Catalog Item:"))
+	})
+
+	// TODO(OSAC-704): Add test for "should show catalog item ID when set"
+	// once ComputeInstanceSpec.GetCatalogItem() exists from Phase 4.
 })
 
 var _ = Describe("CEL filter construction", func() {

--- a/internal/rendering/tables/osac.private.v1.ClusterCatalogItem.yaml
+++ b/internal/rendering/tables/osac.private.v1.ClusterCatalogItem.yaml
@@ -1,0 +1,26 @@
+#
+# Copyright (c) 2025 Red Hat Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+# the License. You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+columns:
+
+- header: ID
+  value: this.id
+
+- header: NAME
+  value: "has(this.metadata.name)? this.metadata.name: '-'"
+
+- header: TITLE
+  value: this.title
+
+- header: PUBLISHED
+  value: "this.published? 'true': 'false'"

--- a/internal/rendering/tables/osac.private.v1.ComputeInstanceCatalogItem.yaml
+++ b/internal/rendering/tables/osac.private.v1.ComputeInstanceCatalogItem.yaml
@@ -1,0 +1,26 @@
+#
+# Copyright (c) 2025 Red Hat Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+# the License. You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+columns:
+
+- header: ID
+  value: this.id
+
+- header: NAME
+  value: "has(this.metadata.name)? this.metadata.name: '-'"
+
+- header: TITLE
+  value: this.title
+
+- header: PUBLISHED
+  value: "this.published? 'true': 'false'"

--- a/internal/rendering/tables/osac.public.v1.ClusterCatalogItem.yaml
+++ b/internal/rendering/tables/osac.public.v1.ClusterCatalogItem.yaml
@@ -1,0 +1,26 @@
+#
+# Copyright (c) 2025 Red Hat Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+# the License. You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+columns:
+
+- header: ID
+  value: this.id
+
+- header: NAME
+  value: "has(this.metadata.name)? this.metadata.name: '-'"
+
+- header: TITLE
+  value: this.title
+
+- header: PUBLISHED
+  value: "this.published? 'true': 'false'"

--- a/internal/rendering/tables/osac.public.v1.ComputeInstanceCatalogItem.yaml
+++ b/internal/rendering/tables/osac.public.v1.ComputeInstanceCatalogItem.yaml
@@ -1,0 +1,26 @@
+#
+# Copyright (c) 2025 Red Hat Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+# the License. You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+columns:
+
+- header: ID
+  value: this.id
+
+- header: NAME
+  value: "has(this.metadata.name)? this.metadata.name: '-'"
+
+- header: TITLE
+  value: this.title
+
+- header: PUBLISHED
+  value: "this.published? 'true': 'false'"


### PR DESCRIPTION
## Summary
- Add `--catalog-item` flag to `osac create cluster` and `osac create computeinstance` (mutually exclusive with `--template`)
- `--template` flag deprecated with stderr warning, still functional
- `osac describe cluster` and `osac describe computeinstance` show `Catalog Item:` row instead of `Template:`
- `osac get clustercatalogitems` and `osac get computeinstancecatalogitems` work via gRPC reflection auto-discovery
- Add table display YAML definitions for catalog item resources (ID, NAME, TITLE, PUBLISHED columns)
- Wire `catalog_item` proto field from Phase 4 into all CLI commands (resolve TODO([OSAC-704](https://redhat.atlassian.net/browse/OSAC-704)) markers)

Based on Adrien's CLI work from [PR #522](https://github.com/osac-project/fulfillment-service/pull/522), cherry-picked and integrated with Phase 4 proto changes.

**Depends on:** [PR #549](https://github.com/osac-project/fulfillment-service/pull/549) ([OSAC-704](https://redhat.atlassian.net/browse/OSAC-704): resource integration)

## Manual testing
Verified against local fulfillment-service (plaintext, guest auth):
- [x] `osac get clustercatalogitems` — lists catalog items with ID, NAME, TITLE, PUBLISHED columns
- [x] `osac create cluster --catalog-item <id>` — creates cluster with catalog_item field
- [x] `osac describe cluster` — shows `Catalog Item: <id>`
- [x] `osac create cluster --catalog-item x --template y` — rejected (mutually exclusive)
- [x] `osac create cluster --template <id>` — deprecation warning + works
- [x] `osac create computeinstance --catalog-item <id>` — creates CI with catalog_item field
- [x] `osac describe computeinstance` — shows `Catalog Item: <id>`

## Test plan
- [x] 56 unit test suites pass (`ginkgo run -r internal`)
- [x] `buf lint` passes
- [ ] Integration tests

Jira: [OSAC-705](https://redhat.atlassian.net/browse/OSAC-705)

Generated with [Claude Code](https://claude.com/claude-code)