### PR TITLE
NO-ISSUE: Add `SharedTenant` and `SystemTenant` named constants

### DIFF
--- a/internal/auth/default_tenancy_logic.go
+++ b/internal/auth/default_tenancy_logic.go
@@ -83,7 +83,7 @@ func (p *DefaultTenancyLogic) DetermineDefaultTenant(ctx context.Context) (resul
 		return
 	}
 	if !assignable.Finite() {
-		result = "shared"
+		result = SharedTenant
 		return
 	}
 	inclusions := assignable.Inclusions()

--- a/internal/auth/default_tenancy_logic_test.go
+++ b/internal/auth/default_tenancy_logic_test.go
@@ -127,7 +127,7 @@ var _ = Describe("Default tenancy logic", func() {
 			ctx = ContextWithSubject(ctx, subject)
 			result, err := logic.DetermineDefaultTenant(ctx)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(result).To(Equal("shared"))
+			Expect(result).To(Equal(SharedTenant))
 		})
 
 		It("Fails if the subject has an empty tenants set", func() {

--- a/internal/auth/tenancy_logic.go
+++ b/internal/auth/tenancy_logic.go
@@ -37,11 +37,17 @@ type TenancyLogic interface {
 	DetermineVisibleTenants(ctx context.Context) (collections.Set[string], error)
 }
 
+// SystemTenant is the tenant that is assigned to objects that are only visible to the system.
+const SystemTenant = "system"
+
 // SystemTenants is the set of tenants that are assigned to objects that are only visible to the system.
-var SystemTenants = collections.NewSet("system")
+var SystemTenants = collections.NewSet(SystemTenant)
+
+// SharedTenant is the tenant that is always visible to all users.
+const SharedTenant = "shared"
 
 // SharedTenants is the set of tenants that are always visible to all users.
-var SharedTenants = collections.NewSet("shared")
+var SharedTenants = collections.NewSet(SharedTenant)
 
 // AllTenants is the set of all tenants that are possible.
 var AllTenants = collections.NewUniversalSet[string]()

--- a/internal/servers/clusters_server_test.go
+++ b/internal/servers/clusters_server_test.go
@@ -182,7 +182,7 @@ var _ = Describe("Clusters server", func() {
 						Title:       "ACME 1TiB",
 						Description: "ACME 1TiB.",
 						Metadata: privatev1.Metadata_builder{
-							Tenant: "shared",
+							Tenant: auth.SharedTenant,
 						}.Build(),
 					}.Build()).
 				Do(ctx)
@@ -194,7 +194,7 @@ var _ = Describe("Clusters server", func() {
 						Title:       "ACME GPU",
 						Description: "ACME GPU.",
 						Metadata: privatev1.Metadata_builder{
-							Tenant: "shared",
+							Tenant: auth.SharedTenant,
 						}.Build(),
 					}.Build(),
 				).
@@ -207,7 +207,7 @@ var _ = Describe("Clusters server", func() {
 						Title:       "HAL 9000",
 						Description: "Heuristically programmed ALgorithmic computer.",
 						Metadata: privatev1.Metadata_builder{
-							Tenant: "shared",
+							Tenant: auth.SharedTenant,
 						}.Build(),
 					}.Build(),
 				).
@@ -222,7 +222,7 @@ var _ = Describe("Clusters server", func() {
 						Title:       "My template",
 						Description: "My template",
 						Metadata: privatev1.Metadata_builder{
-							Tenant: "shared",
+							Tenant: auth.SharedTenant,
 						}.Build(),
 						NodeSets: map[string]*privatev1.ClusterTemplateNodeSet{
 							"compute": privatev1.ClusterTemplateNodeSet_builder{
@@ -250,7 +250,7 @@ var _ = Describe("Clusters server", func() {
 						Description: "My deleted template",
 						Metadata: privatev1.Metadata_builder{
 							Finalizers: []string{"a"},
-							Tenant:     "shared",
+							Tenant:     auth.SharedTenant,
 						}.Build(),
 					}.Build(),
 				).
@@ -269,7 +269,7 @@ var _ = Describe("Clusters server", func() {
 						Title:       "My with parameters",
 						Description: "My with parameters.",
 						Metadata: privatev1.Metadata_builder{
-							Tenant: "shared",
+							Tenant: auth.SharedTenant,
 						}.Build(),
 						Parameters: []*privatev1.ClusterTemplateParameterDefinition{
 							privatev1.ClusterTemplateParameterDefinition_builder{
@@ -934,7 +934,7 @@ var _ = Describe("Clusters server", func() {
 				SetObject(
 					privatev1.Cluster_builder{
 						Metadata: privatev1.Metadata_builder{
-							Tenant: "shared",
+							Tenant: auth.SharedTenant,
 						}.Build(),
 						Spec: privatev1.ClusterSpec_builder{
 							Template: "my_template",
@@ -1017,7 +1017,7 @@ var _ = Describe("Clusters server", func() {
 				SetObject(
 					privatev1.Cluster_builder{
 						Metadata: privatev1.Metadata_builder{
-							Tenant: "shared",
+							Tenant: auth.SharedTenant,
 						}.Build(),
 						Spec: privatev1.ClusterSpec_builder{
 							Template: "my_template",
@@ -1629,7 +1629,7 @@ var _ = Describe("Clusters server", func() {
 					Id:    "acme_1tib",
 					Title: "ACME 1TiB",
 					Metadata: privatev1.Metadata_builder{
-						Tenant: "shared",
+						Tenant: auth.SharedTenant,
 					}.Build(),
 				}.Build()).
 				Do(ctx)
@@ -1646,7 +1646,7 @@ var _ = Describe("Clusters server", func() {
 					Id:    "my_template",
 					Title: "My template",
 					Metadata: privatev1.Metadata_builder{
-						Tenant: "shared",
+						Tenant: auth.SharedTenant,
 					}.Build(),
 					NodeSets: map[string]*privatev1.ClusterTemplateNodeSet{
 						"compute": privatev1.ClusterTemplateNodeSet_builder{

--- a/internal/servers/compute_instances_server_test.go
+++ b/internal/servers/compute_instances_server_test.go
@@ -28,6 +28,7 @@ import (
 
 	privatev1 "github.com/osac-project/fulfillment-service/internal/api/osac/private/v1"
 	publicv1 "github.com/osac-project/fulfillment-service/internal/api/osac/public/v1"
+	"github.com/osac-project/fulfillment-service/internal/auth"
 	"github.com/osac-project/fulfillment-service/internal/database"
 	"github.com/osac-project/fulfillment-service/internal/database/dao"
 )
@@ -152,7 +153,7 @@ var _ = Describe("Compute instances server", func() {
 				Title:       "Test Template",
 				Description: "Test template for validation",
 				Metadata: privatev1.Metadata_builder{
-					Tenant: "shared",
+					Tenant: auth.SharedTenant,
 				}.Build(),
 				Parameters: []*privatev1.ComputeInstanceTemplateParameterDefinition{
 					{

--- a/internal/servers/network_classes_server_test.go
+++ b/internal/servers/network_classes_server_test.go
@@ -27,6 +27,7 @@ import (
 
 	privatev1 "github.com/osac-project/fulfillment-service/internal/api/osac/private/v1"
 	publicv1 "github.com/osac-project/fulfillment-service/internal/api/osac/public/v1"
+	"github.com/osac-project/fulfillment-service/internal/auth"
 	"github.com/osac-project/fulfillment-service/internal/database"
 	"github.com/osac-project/fulfillment-service/internal/database/dao"
 )
@@ -514,7 +515,7 @@ var _ = Describe("Network classes server", func() {
 					ImplementationStrategy: "ovn-kubernetes",
 					IsDefault:              proto.Bool(true),
 					Metadata: privatev1.Metadata_builder{
-						Tenant: "shared",
+						Tenant: auth.SharedTenant,
 					}.Build(),
 					Status: privatev1.NetworkClassStatus_builder{
 						State: privatev1.NetworkClassState_NETWORK_CLASS_STATE_READY,
@@ -529,7 +530,7 @@ var _ = Describe("Network classes server", func() {
 					ImplementationStrategy: "ovn-kubernetes",
 					IsDefault:              proto.Bool(true),
 					Metadata: privatev1.Metadata_builder{
-						Tenant: "shared",
+						Tenant: auth.SharedTenant,
 					}.Build(),
 					Status: privatev1.NetworkClassStatus_builder{
 						State: privatev1.NetworkClassState_NETWORK_CLASS_STATE_READY,
@@ -661,7 +662,7 @@ var _ = Describe("Network classes server", func() {
 					ImplementationStrategy: "ovn-kubernetes",
 					IsDefault:              proto.Bool(true),
 					Metadata: privatev1.Metadata_builder{
-						Tenant: "shared",
+						Tenant: auth.SharedTenant,
 					}.Build(),
 					Status: privatev1.NetworkClassStatus_builder{
 						State: privatev1.NetworkClassState_NETWORK_CLASS_STATE_READY,
@@ -715,7 +716,7 @@ var _ = Describe("Network classes server", func() {
 					ImplementationStrategy: "ovn-kubernetes",
 					IsDefault:              proto.Bool(true),
 					Metadata: privatev1.Metadata_builder{
-						Tenant: "shared",
+						Tenant: auth.SharedTenant,
 					}.Build(),
 					Status: privatev1.NetworkClassStatus_builder{
 						State: privatev1.NetworkClassState_NETWORK_CLASS_STATE_READY,
@@ -730,7 +731,7 @@ var _ = Describe("Network classes server", func() {
 					ImplementationStrategy: "ovn-kubernetes",
 					IsDefault:              proto.Bool(true),
 					Metadata: privatev1.Metadata_builder{
-						Tenant: "shared",
+						Tenant: auth.SharedTenant,
 					}.Build(),
 					Status: privatev1.NetworkClassStatus_builder{
 						State: privatev1.NetworkClassState_NETWORK_CLASS_STATE_READY,
@@ -755,7 +756,7 @@ var _ = Describe("Network classes server", func() {
 					ImplementationStrategy: "ovn-kubernetes",
 					IsDefault:              proto.Bool(true),
 					Metadata: privatev1.Metadata_builder{
-						Tenant: "shared",
+						Tenant: auth.SharedTenant,
 					}.Build(),
 					Status: privatev1.NetworkClassStatus_builder{
 						State: privatev1.NetworkClassState_NETWORK_CLASS_STATE_READY,
@@ -770,7 +771,7 @@ var _ = Describe("Network classes server", func() {
 					ImplementationStrategy: "ovn-kubernetes",
 					IsDefault:              proto.Bool(true),
 					Metadata: privatev1.Metadata_builder{
-						Tenant: "shared",
+						Tenant: auth.SharedTenant,
 					}.Build(),
 					Status: privatev1.NetworkClassStatus_builder{
 						State: privatev1.NetworkClassState_NETWORK_CLASS_STATE_READY,

--- a/internal/servers/private_clusters_server_test.go
+++ b/internal/servers/private_clusters_server_test.go
@@ -28,6 +28,7 @@ import (
 	"google.golang.org/protobuf/types/known/fieldmaskpb"
 
 	privatev1 "github.com/osac-project/fulfillment-service/internal/api/osac/private/v1"
+	"github.com/osac-project/fulfillment-service/internal/auth"
 	"github.com/osac-project/fulfillment-service/internal/database"
 	"github.com/osac-project/fulfillment-service/internal/database/dao"
 	"github.com/osac-project/fulfillment-service/internal/uuid"
@@ -151,7 +152,7 @@ var _ = Describe("Private clusters server", func() {
 						Id: "acme-1ti-id",
 						Metadata: privatev1.Metadata_builder{
 							Name:   "acme-1ti-name",
-							Tenant: "shared",
+							Tenant: auth.SharedTenant,
 						}.Build(),
 						Title:       "ACME 1TiB",
 						Description: "ACME 1TiB.",
@@ -165,7 +166,7 @@ var _ = Describe("Private clusters server", func() {
 						Id: "acme-gpu-id",
 						Metadata: privatev1.Metadata_builder{
 							Name:   "acme-gpu-name",
-							Tenant: "shared",
+							Tenant: auth.SharedTenant,
 						}.Build(),
 						Title:       "ACME GPU",
 						Description: "ACME GPU.",
@@ -181,7 +182,7 @@ var _ = Describe("Private clusters server", func() {
 						Id: "my-template-id",
 						Metadata: privatev1.Metadata_builder{
 							Name:   "my-template-name",
-							Tenant: "shared",
+							Tenant: auth.SharedTenant,
 						}.Build(),
 						Title:       "My template",
 						Description: "My template",
@@ -209,7 +210,7 @@ var _ = Describe("Private clusters server", func() {
 							Title:       fmt.Sprintf("My template %d", i),
 							Description: fmt.Sprintf("My template %d", i),
 							Metadata: privatev1.Metadata_builder{
-								Tenant: "shared",
+								Tenant: auth.SharedTenant,
 							}.Build(),
 							NodeSets: map[string]*privatev1.ClusterTemplateNodeSet{
 								"compute": privatev1.ClusterTemplateNodeSet_builder{

--- a/internal/servers/private_compute_instances_server_test.go
+++ b/internal/servers/private_compute_instances_server_test.go
@@ -29,6 +29,7 @@ import (
 	"google.golang.org/protobuf/types/known/wrapperspb"
 
 	privatev1 "github.com/osac-project/fulfillment-service/internal/api/osac/private/v1"
+	"github.com/osac-project/fulfillment-service/internal/auth"
 	"github.com/osac-project/fulfillment-service/internal/database"
 	"github.com/osac-project/fulfillment-service/internal/database/dao"
 )
@@ -94,7 +95,7 @@ var _ = Describe("Private compute instances server", func() {
 		nc := privatev1.NetworkClass_builder{
 			ImplementationStrategy: "test-strategy",
 			Metadata: privatev1.Metadata_builder{
-				Tenant: "shared",
+				Tenant: auth.SharedTenant,
 			}.Build(),
 			Capabilities: privatev1.NetworkClassCapabilities_builder{
 				SupportsIpv4:      true,
@@ -121,7 +122,7 @@ var _ = Describe("Private compute instances server", func() {
 
 		vn := privatev1.VirtualNetwork_builder{
 			Metadata: privatev1.Metadata_builder{
-				Tenant: "shared",
+				Tenant: auth.SharedTenant,
 			}.Build(),
 			Spec: privatev1.VirtualNetworkSpec_builder{
 				Ipv4Cidr:     proto.String("10.0.0.0/16"),
@@ -147,7 +148,7 @@ var _ = Describe("Private compute instances server", func() {
 
 		subnet := privatev1.Subnet_builder{
 			Metadata: privatev1.Metadata_builder{
-				Tenant: "shared",
+				Tenant: auth.SharedTenant,
 			}.Build(),
 			Spec: privatev1.SubnetSpec_builder{
 				VirtualNetwork: vnID,
@@ -173,7 +174,7 @@ var _ = Describe("Private compute instances server", func() {
 
 		sg := privatev1.SecurityGroup_builder{
 			Metadata: privatev1.Metadata_builder{
-				Tenant: "shared",
+				Tenant: auth.SharedTenant,
 			}.Build(),
 			Spec: privatev1.SecurityGroupSpec_builder{
 				VirtualNetwork: vnID,
@@ -262,7 +263,7 @@ var _ = Describe("Private compute instances server", func() {
 				Title:       "Test Template",
 				Description: "Test template for validation",
 				Metadata: privatev1.Metadata_builder{
-					Tenant: "shared",
+					Tenant: auth.SharedTenant,
 				}.Build(),
 				Parameters: []*privatev1.ComputeInstanceTemplateParameterDefinition{
 					{
@@ -795,7 +796,7 @@ var _ = Describe("Private compute instances server", func() {
 				Title:       "No Defaults Template",
 				Description: "Template without spec defaults",
 				Metadata: privatev1.Metadata_builder{
-					Tenant: "shared",
+					Tenant: auth.SharedTenant,
 				}.Build(),
 			}.Build()
 			_, err = templatesDao.Create().SetObject(template).Do(ctx)
@@ -835,7 +836,7 @@ var _ = Describe("Private compute instances server", func() {
 				Title:       "Bare Template",
 				Description: "Template without defaults",
 				Metadata: privatev1.Metadata_builder{
-					Tenant: "shared",
+					Tenant: auth.SharedTenant,
 				}.Build(),
 			}.Build()
 			_, err = templatesDao.Create().SetObject(template).Do(ctx)
@@ -877,7 +878,7 @@ var _ = Describe("Private compute instances server", func() {
 				Title:       "Partial Defaults Template",
 				Description: "Template with partial spec defaults",
 				Metadata: privatev1.Metadata_builder{
-					Tenant: "shared",
+					Tenant: auth.SharedTenant,
 				}.Build(),
 				SpecDefaults: privatev1.ComputeInstanceTemplateSpecDefaults_builder{
 					Cores:       proto.Int32(2),
@@ -949,7 +950,7 @@ var _ = Describe("Private compute instances server", func() {
 				Title:       "Test Template",
 				Description: "Test template for network validation",
 				Metadata: privatev1.Metadata_builder{
-					Tenant: "shared",
+					Tenant: auth.SharedTenant,
 				}.Build(),
 				Parameters: []*privatev1.ComputeInstanceTemplateParameterDefinition{
 					{

--- a/internal/servers/private_public_ips_server_test.go
+++ b/internal/servers/private_public_ips_server_test.go
@@ -25,6 +25,7 @@ import (
 	"google.golang.org/protobuf/types/known/fieldmaskpb"
 
 	privatev1 "github.com/osac-project/fulfillment-service/internal/api/osac/private/v1"
+	"github.com/osac-project/fulfillment-service/internal/auth"
 	"github.com/osac-project/fulfillment-service/internal/database"
 	"github.com/osac-project/fulfillment-service/internal/database/dao"
 )
@@ -94,7 +95,7 @@ var _ = Describe("Private public IPs server", func() {
 		resp, err := publicIPPoolDao.Create().SetObject(
 			privatev1.PublicIPPool_builder{
 				Metadata: privatev1.Metadata_builder{
-					Tenant: "shared",
+					Tenant: auth.SharedTenant,
 				}.Build(),
 				Spec: privatev1.PublicIPPoolSpec_builder{
 					Cidrs: []string{"10.0.0.0/24"},
@@ -122,7 +123,7 @@ var _ = Describe("Private public IPs server", func() {
 		resp, err := server.Create(ctx, privatev1.PublicIPsCreateRequest_builder{
 			Object: privatev1.PublicIP_builder{
 				Metadata: privatev1.Metadata_builder{
-					Tenant: "shared",
+					Tenant: auth.SharedTenant,
 				}.Build(),
 				Spec: privatev1.PublicIPSpec_builder{
 					Pool: poolID,
@@ -208,7 +209,7 @@ var _ = Describe("Private public IPs server", func() {
 				_, err := publicIPsServer.Create(ctx, privatev1.PublicIPsCreateRequest_builder{
 					Object: privatev1.PublicIP_builder{
 						Metadata: privatev1.Metadata_builder{
-							Tenant: "shared",
+							Tenant: auth.SharedTenant,
 						}.Build(),
 					}.Build(),
 				}.Build())
@@ -223,7 +224,7 @@ var _ = Describe("Private public IPs server", func() {
 				_, err := publicIPsServer.Create(ctx, privatev1.PublicIPsCreateRequest_builder{
 					Object: privatev1.PublicIP_builder{
 						Metadata: privatev1.Metadata_builder{
-							Tenant: "shared",
+							Tenant: auth.SharedTenant,
 						}.Build(),
 						Spec: privatev1.PublicIPSpec_builder{}.Build(),
 					}.Build(),
@@ -240,7 +241,7 @@ var _ = Describe("Private public IPs server", func() {
 				response, err := publicIPsServer.Create(ctx, privatev1.PublicIPsCreateRequest_builder{
 					Object: privatev1.PublicIP_builder{
 						Metadata: privatev1.Metadata_builder{
-							Tenant: "shared",
+							Tenant: auth.SharedTenant,
 						}.Build(),
 						Spec: privatev1.PublicIPSpec_builder{
 							Pool: poolID,
@@ -279,7 +280,7 @@ var _ = Describe("Private public IPs server", func() {
 			response, err := publicIPsServer.Create(ctx, privatev1.PublicIPsCreateRequest_builder{
 				Object: privatev1.PublicIP_builder{
 					Metadata: privatev1.Metadata_builder{
-						Tenant: "shared",
+						Tenant: auth.SharedTenant,
 					}.Build(),
 					Spec: privatev1.PublicIPSpec_builder{
 						Pool: poolID,
@@ -296,7 +297,7 @@ var _ = Describe("Private public IPs server", func() {
 			response, err := publicIPsServer.Create(ctx, privatev1.PublicIPsCreateRequest_builder{
 				Object: privatev1.PublicIP_builder{
 					Metadata: privatev1.Metadata_builder{
-						Tenant: "shared",
+						Tenant: auth.SharedTenant,
 					}.Build(),
 					Spec: privatev1.PublicIPSpec_builder{
 						Pool: poolID,
@@ -315,7 +316,7 @@ var _ = Describe("Private public IPs server", func() {
 			createResponse, err := publicIPsServer.Create(ctx, privatev1.PublicIPsCreateRequest_builder{
 				Object: privatev1.PublicIP_builder{
 					Metadata: privatev1.Metadata_builder{
-						Tenant: "shared",
+						Tenant: auth.SharedTenant,
 					}.Build(),
 					Spec: privatev1.PublicIPSpec_builder{
 						Pool: poolID,
@@ -339,7 +340,7 @@ var _ = Describe("Private public IPs server", func() {
 				_, err := publicIPsServer.Create(ctx, privatev1.PublicIPsCreateRequest_builder{
 					Object: privatev1.PublicIP_builder{
 						Metadata: privatev1.Metadata_builder{
-							Tenant: "shared",
+							Tenant: auth.SharedTenant,
 						}.Build(),
 						Spec: privatev1.PublicIPSpec_builder{
 							Pool: poolID,
@@ -359,7 +360,7 @@ var _ = Describe("Private public IPs server", func() {
 				Object: privatev1.PublicIP_builder{
 					Metadata: privatev1.Metadata_builder{
 						Name:   "original-name",
-						Tenant: "shared",
+						Tenant: auth.SharedTenant,
 					}.Build(),
 					Spec: privatev1.PublicIPSpec_builder{
 						Pool: poolID,
@@ -389,7 +390,7 @@ var _ = Describe("Private public IPs server", func() {
 				Object: privatev1.PublicIP_builder{
 					Metadata: privatev1.Metadata_builder{
 						Finalizers: []string{"test-finalizer"},
-						Tenant:     "shared",
+						Tenant:     auth.SharedTenant,
 					}.Build(),
 					Spec: privatev1.PublicIPSpec_builder{
 						Pool: poolID,
@@ -425,7 +426,7 @@ var _ = Describe("Private public IPs server", func() {
 			createResponse, err := publicIPsServer.Create(ctx, privatev1.PublicIPsCreateRequest_builder{
 				Object: privatev1.PublicIP_builder{
 					Metadata: privatev1.Metadata_builder{
-						Tenant: "shared",
+						Tenant: auth.SharedTenant,
 					}.Build(),
 					Spec: privatev1.PublicIPSpec_builder{
 						Pool: poolID,
@@ -458,7 +459,7 @@ var _ = Describe("Private public IPs server", func() {
 			_, err := publicIPsServer.Create(ctx, privatev1.PublicIPsCreateRequest_builder{
 				Object: privatev1.PublicIP_builder{
 					Metadata: privatev1.Metadata_builder{
-						Tenant: "shared",
+						Tenant: auth.SharedTenant,
 					}.Build(),
 					Spec: privatev1.PublicIPSpec_builder{
 						Pool: "nonexistent-pool-id",
@@ -477,7 +478,7 @@ var _ = Describe("Private public IPs server", func() {
 			resp, err := publicIPPoolDao.Create().SetObject(
 				privatev1.PublicIPPool_builder{
 					Metadata: privatev1.Metadata_builder{
-						Tenant: "shared",
+						Tenant: auth.SharedTenant,
 					}.Build(),
 					Spec: privatev1.PublicIPPoolSpec_builder{
 						Cidrs: []string{"10.0.0.0/24"},
@@ -496,7 +497,7 @@ var _ = Describe("Private public IPs server", func() {
 			_, err = publicIPsServer.Create(ctx, privatev1.PublicIPsCreateRequest_builder{
 				Object: privatev1.PublicIP_builder{
 					Metadata: privatev1.Metadata_builder{
-						Tenant: "shared",
+						Tenant: auth.SharedTenant,
 					}.Build(),
 					Spec: privatev1.PublicIPSpec_builder{
 						Pool: pendingPoolID,
@@ -516,7 +517,7 @@ var _ = Describe("Private public IPs server", func() {
 			_, err := publicIPsServer.Create(ctx, privatev1.PublicIPsCreateRequest_builder{
 				Object: privatev1.PublicIP_builder{
 					Metadata: privatev1.Metadata_builder{
-						Tenant: "shared",
+						Tenant: auth.SharedTenant,
 					}.Build(),
 					Spec: privatev1.PublicIPSpec_builder{
 						Pool: exhaustedPoolID,
@@ -536,7 +537,7 @@ var _ = Describe("Private public IPs server", func() {
 			response, err := publicIPsServer.Create(ctx, privatev1.PublicIPsCreateRequest_builder{
 				Object: privatev1.PublicIP_builder{
 					Metadata: privatev1.Metadata_builder{
-						Tenant: "shared",
+						Tenant: auth.SharedTenant,
 					}.Build(),
 					Spec: privatev1.PublicIPSpec_builder{
 						Pool: readyPoolID,
@@ -568,7 +569,7 @@ var _ = Describe("Private public IPs server", func() {
 			_, err := publicIPsServer.Create(ctx, privatev1.PublicIPsCreateRequest_builder{
 				Object: privatev1.PublicIP_builder{
 					Metadata: privatev1.Metadata_builder{
-						Tenant: "shared",
+						Tenant: auth.SharedTenant,
 					}.Build(),
 					Spec: privatev1.PublicIPSpec_builder{
 						Pool: poolID,
@@ -592,7 +593,7 @@ var _ = Describe("Private public IPs server", func() {
 			createResponse, err := publicIPsServer.Create(ctx, privatev1.PublicIPsCreateRequest_builder{
 				Object: privatev1.PublicIP_builder{
 					Metadata: privatev1.Metadata_builder{
-						Tenant: "shared",
+						Tenant: auth.SharedTenant,
 					}.Build(),
 					Spec: privatev1.PublicIPSpec_builder{
 						Pool: poolID,
@@ -846,7 +847,7 @@ var _ = Describe("Private public IPs server", func() {
 			createResp, err := publicIPsServer.Create(ctx, privatev1.PublicIPsCreateRequest_builder{
 				Object: privatev1.PublicIP_builder{
 					Metadata: privatev1.Metadata_builder{
-						Tenant: "shared",
+						Tenant: auth.SharedTenant,
 					}.Build(),
 					Spec: privatev1.PublicIPSpec_builder{
 						Pool: poolA,
@@ -875,7 +876,7 @@ var _ = Describe("Private public IPs server", func() {
 			createResp, err := publicIPsServer.Create(ctx, privatev1.PublicIPsCreateRequest_builder{
 				Object: privatev1.PublicIP_builder{
 					Metadata: privatev1.Metadata_builder{
-						Tenant: "shared",
+						Tenant: auth.SharedTenant,
 					}.Build(),
 					Spec: privatev1.PublicIPSpec_builder{
 						Pool: poolID,

--- a/internal/servers/private_subnets_server_test.go
+++ b/internal/servers/private_subnets_server_test.go
@@ -25,6 +25,7 @@ import (
 	"google.golang.org/protobuf/proto"
 
 	privatev1 "github.com/osac-project/fulfillment-service/internal/api/osac/private/v1"
+	"github.com/osac-project/fulfillment-service/internal/auth"
 	"github.com/osac-project/fulfillment-service/internal/database"
 	"github.com/osac-project/fulfillment-service/internal/database/dao"
 )
@@ -93,7 +94,7 @@ var _ = Describe("Private subnets server", func() {
 		nc := privatev1.NetworkClass_builder{
 			ImplementationStrategy: "test-strategy",
 			Metadata: privatev1.Metadata_builder{
-				Tenant: "shared",
+				Tenant: auth.SharedTenant,
 			}.Build(),
 			Capabilities: privatev1.NetworkClassCapabilities_builder{
 				SupportsIpv4:      true,
@@ -127,7 +128,7 @@ var _ = Describe("Private subnets server", func() {
 
 		builder := privatev1.VirtualNetwork_builder{
 			Metadata: privatev1.Metadata_builder{
-				Tenant: "shared",
+				Tenant: auth.SharedTenant,
 			}.Build(),
 			Spec: privatev1.VirtualNetworkSpec_builder{
 				NetworkClass: nc.GetImplementationStrategy(),
@@ -440,7 +441,7 @@ var _ = Describe("Private subnets server", func() {
 
 				vn := privatev1.VirtualNetwork_builder{
 					Metadata: privatev1.Metadata_builder{
-						Tenant: "shared",
+						Tenant: auth.SharedTenant,
 					}.Build(),
 					Spec: privatev1.VirtualNetworkSpec_builder{
 						Ipv4Cidr:     proto.String("10.0.0.0/16"),
@@ -485,7 +486,7 @@ var _ = Describe("Private subnets server", func() {
 
 				vn := privatev1.VirtualNetwork_builder{
 					Metadata: privatev1.Metadata_builder{
-						Tenant: "shared",
+						Tenant: auth.SharedTenant,
 					}.Build(),
 					Spec: privatev1.VirtualNetworkSpec_builder{
 						Ipv4Cidr:     proto.String("10.0.0.0/16"),
@@ -700,7 +701,7 @@ var _ = Describe("Private subnets server", func() {
 
 				subnet := privatev1.Subnet_builder{
 					Metadata: privatev1.Metadata_builder{
-						Tenant: "shared",
+						Tenant: auth.SharedTenant,
 					}.Build(),
 					Spec: privatev1.SubnetSpec_builder{
 						Ipv4Cidr:       proto.String("10.0.1.0/24"),
@@ -1032,7 +1033,7 @@ var _ = Describe("Private subnets server", func() {
 				createResponse, err := server.Create(ctx, privatev1.SubnetsCreateRequest_builder{
 					Object: privatev1.Subnet_builder{
 						Metadata: privatev1.Metadata_builder{
-							Tenant: "shared",
+							Tenant: auth.SharedTenant,
 						}.Build(),
 						Spec: privatev1.SubnetSpec_builder{
 							Ipv4Cidr:       proto.String("10.0.1.0/24"),
@@ -1079,7 +1080,7 @@ var _ = Describe("Private subnets server", func() {
 				subnet := privatev1.Subnet_builder{
 					Metadata: privatev1.Metadata_builder{
 						Name:   name,
-						Tenant: "shared",
+						Tenant: auth.SharedTenant,
 					}.Build(),
 					Spec: builder.Build(),
 				}.Build()
@@ -1219,7 +1220,7 @@ var _ = Describe("Private subnets server", func() {
 
 			subnet := privatev1.Subnet_builder{
 				Metadata: privatev1.Metadata_builder{
-					Tenant: "shared",
+					Tenant: auth.SharedTenant,
 				}.Build(),
 				Spec: privatev1.SubnetSpec_builder{
 					Ipv4Cidr:       proto.String("10.0.1.0/24"),
@@ -1242,7 +1243,7 @@ var _ = Describe("Private subnets server", func() {
 
 			subnet := privatev1.Subnet_builder{
 				Metadata: privatev1.Metadata_builder{
-					Tenant: "shared",
+					Tenant: auth.SharedTenant,
 				}.Build(),
 				Spec: privatev1.SubnetSpec_builder{
 					Ipv4Cidr:       proto.String("10.0.1.0/24"),
@@ -1273,7 +1274,7 @@ var _ = Describe("Private subnets server", func() {
 				subnet := privatev1.Subnet_builder{
 					Metadata: privatev1.Metadata_builder{
 						Name:   fmt.Sprintf("subnet-%d", i),
-						Tenant: "shared",
+						Tenant: auth.SharedTenant,
 					}.Build(),
 					Spec: privatev1.SubnetSpec_builder{
 						Ipv4Cidr:       proto.String(fmt.Sprintf("10.%d.0.0/16", i)),
@@ -1305,7 +1306,7 @@ var _ = Describe("Private subnets server", func() {
 				subnet := privatev1.Subnet_builder{
 					Metadata: privatev1.Metadata_builder{
 						Name:   fmt.Sprintf("vn1-subnet-%d", i),
-						Tenant: "shared",
+						Tenant: auth.SharedTenant,
 					}.Build(),
 					Spec: privatev1.SubnetSpec_builder{
 						Ipv4Cidr:       proto.String(fmt.Sprintf("10.0.%d.0/24", i)),
@@ -1324,7 +1325,7 @@ var _ = Describe("Private subnets server", func() {
 				subnet := privatev1.Subnet_builder{
 					Metadata: privatev1.Metadata_builder{
 						Name:   fmt.Sprintf("vn2-subnet-%d", i),
-						Tenant: "shared",
+						Tenant: auth.SharedTenant,
 					}.Build(),
 					Spec: privatev1.SubnetSpec_builder{
 						Ipv4Cidr:       proto.String(fmt.Sprintf("192.168.%d.0/24", i)),
@@ -1355,7 +1356,7 @@ var _ = Describe("Private subnets server", func() {
 			subnet := privatev1.Subnet_builder{
 				Metadata: privatev1.Metadata_builder{
 					Name:   "original-name",
-					Tenant: "shared",
+					Tenant: auth.SharedTenant,
 				}.Build(),
 				Spec: privatev1.SubnetSpec_builder{
 					Ipv4Cidr:       proto.String("10.0.1.0/24"),
@@ -1392,7 +1393,7 @@ var _ = Describe("Private subnets server", func() {
 			subnet := privatev1.Subnet_builder{
 				Metadata: privatev1.Metadata_builder{
 					Finalizers: []string{"test-finalizer"},
-					Tenant:     "shared",
+					Tenant:     auth.SharedTenant,
 				}.Build(),
 				Spec: privatev1.SubnetSpec_builder{
 					Ipv4Cidr:       proto.String("10.0.1.0/24"),

--- a/internal/servers/public_ips_server_test.go
+++ b/internal/servers/public_ips_server_test.go
@@ -24,6 +24,7 @@ import (
 
 	privatev1 "github.com/osac-project/fulfillment-service/internal/api/osac/private/v1"
 	publicv1 "github.com/osac-project/fulfillment-service/internal/api/osac/public/v1"
+	"github.com/osac-project/fulfillment-service/internal/auth"
 	"github.com/osac-project/fulfillment-service/internal/database"
 	"github.com/osac-project/fulfillment-service/internal/database/dao"
 )
@@ -83,7 +84,7 @@ var _ = Describe("Public IPs server", func() {
 		resp, err := publicIPPoolDao.Create().SetObject(
 			privatev1.PublicIPPool_builder{
 				Metadata: privatev1.Metadata_builder{
-					Tenant: "shared",
+					Tenant: auth.SharedTenant,
 				}.Build(),
 				Spec: privatev1.PublicIPPoolSpec_builder{
 					Cidrs: []string{"10.0.0.0/24"},

--- a/internal/servers/security_groups_server_test.go
+++ b/internal/servers/security_groups_server_test.go
@@ -24,6 +24,7 @@ import (
 
 	privatev1 "github.com/osac-project/fulfillment-service/internal/api/osac/private/v1"
 	publicv1 "github.com/osac-project/fulfillment-service/internal/api/osac/public/v1"
+	"github.com/osac-project/fulfillment-service/internal/auth"
 	"github.com/osac-project/fulfillment-service/internal/database"
 	"github.com/osac-project/fulfillment-service/internal/database/dao"
 )
@@ -83,7 +84,7 @@ var _ = Describe("SecurityGroups server", func() {
 			Id:                     "default",
 			ImplementationStrategy: "ovn-kubernetes",
 			Metadata: privatev1.Metadata_builder{
-				Tenant: "shared",
+				Tenant: auth.SharedTenant,
 			}.Build(),
 			Capabilities: privatev1.NetworkClassCapabilities_builder{
 				SupportsIpv4:      true,
@@ -110,7 +111,7 @@ var _ = Describe("SecurityGroups server", func() {
 
 		vn := privatev1.VirtualNetwork_builder{
 			Metadata: privatev1.Metadata_builder{
-				Tenant: "shared",
+				Tenant: auth.SharedTenant,
 			}.Build(),
 			Spec: privatev1.VirtualNetworkSpec_builder{
 				Region:       "us-east-1",

--- a/internal/servers/subnets_server_test.go
+++ b/internal/servers/subnets_server_test.go
@@ -95,7 +95,7 @@ var _ = Describe("Subnets server", func() {
 			Id:                     "default",
 			ImplementationStrategy: "ovn-kubernetes",
 			Metadata: privatev1.Metadata_builder{
-				Tenant: "shared",
+				Tenant: auth.SharedTenant,
 			}.Build(),
 			Capabilities: privatev1.NetworkClassCapabilities_builder{
 				SupportsIpv4:      true,
@@ -122,7 +122,7 @@ var _ = Describe("Subnets server", func() {
 
 		vn := privatev1.VirtualNetwork_builder{
 			Metadata: privatev1.Metadata_builder{
-				Tenant: "shared",
+				Tenant: auth.SharedTenant,
 			}.Build(),
 			Spec: privatev1.VirtualNetworkSpec_builder{
 				Region:       "us-east-1",

--- a/internal/servers/virtual_networks_server_test.go
+++ b/internal/servers/virtual_networks_server_test.go
@@ -92,7 +92,7 @@ var _ = Describe("Virtual networks server", func() {
 			Id:                     "default",
 			ImplementationStrategy: "ovn-kubernetes",
 			Metadata: privatev1.Metadata_builder{
-				Tenant: "shared",
+				Tenant: auth.SharedTenant,
 			}.Build(),
 			IsDefault: proto.Bool(true),
 			Capabilities: privatev1.NetworkClassCapabilities_builder{


### PR DESCRIPTION
## Summary

Introduces `SharedTenant` and `SystemTenant` variables in the `auth` package so that the
`"shared"` and `"system"` tenant strings are defined once and referenced everywhere, reducing the
risk of typos and making future renames easier. The `SharedTenants` and `SystemTenants` sets now
derive from these variables instead of inline strings, and all test files that previously hardcoded
`"shared"` in metadata tenant fields now use `auth.SharedTenant`.

Addresses the review feedback in
https://github.com/osac-project/fulfillment-service/pull/543#pullrequestreview-4317844885.

## Test plan

- All unit tests pass (`ginkgo run -r internal`).