### PR TITLE
NO-ISSUE: Replace multi-valued `tenants` and `creators` in `public_ip_attachments`

### DIFF
--- a/internal/database/migrations/42_singular_tenant_and_creator_in_public_ip_attachments_tables.up.sql
+++ b/internal/database/migrations/42_singular_tenant_and_creator_in_public_ip_attachments_tables.up.sql
@@ -1,0 +1,34 @@
+--
+-- Copyright (c) 2026 Red Hat Inc.
+--
+-- Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+-- the License. You may obtain a copy of the License at
+--
+--   http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+-- an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+-- specific language governing permissions and limitations under the License.
+--
+
+-- This migration replaces the multi-valued 'creators' column (text[]) with a single-valued 'creator' column (text) on
+-- all resource tables and their archived counterparts. The first element of the array is preserved as the new scalar
+-- value.
+
+-- Migrate the tenants array to a single tenant value:
+alter table public_ip_attachments add column tenant text not null default '';
+update public_ip_attachments set tenant = coalesce(tenants[1], '');
+alter table public_ip_attachments drop column tenants;
+
+-- Recreate index on the tenant column:
+drop index if exists public_ip_attachments_by_tenant;
+create index public_ip_attachments_by_tenant on public_ip_attachments (tenant);
+
+-- Migrate the creators array to a single creator value:
+alter table public_ip_attachments add column creator text not null default '';
+update public_ip_attachments set creator = coalesce(creators[1], '');
+alter table public_ip_attachments drop column creators;
+
+-- Recreate index on the creator column:
+drop index if exists public_ip_attachments_by_owner;
+create index public_ip_attachments_by_owner on public_ip_attachments (creator);

--- a/internal/database/migrations/42_singular_tenant_and_creator_in_public_ip_attachments_tables_test.go
+++ b/internal/database/migrations/42_singular_tenant_and_creator_in_public_ip_attachments_tables_test.go
@@ -1,0 +1,107 @@
+/*
+Copyright (c) 2026 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package migrations
+
+import (
+	. "github.com/onsi/ginkgo/v2/dsl/table"
+	. "github.com/onsi/gomega"
+)
+
+var _ = DescribeMigration("Replace tenants array with single tenant in public ip attachments tables", func() {
+	DescribeTable(
+		"Migrates the tenants array to a single tenant value in public ip attachments tables",
+		func(tenants []string, expectedTenant string) {
+			// Insert a row with the old creators array column:
+			_, err := pool.Exec(
+				ctx,
+				`insert into public_ip_attachments (id, tenants, data) values ('123', $1, '{}')`,
+				tenants,
+			)
+			Expect(err).ToNot(HaveOccurred())
+
+			// Run the migration:
+			err = tool.Migrate(ctx, 42)
+			Expect(err).ToNot(HaveOccurred())
+
+			// Verify the tenant column has the expected value:
+			var actual string
+			row := pool.QueryRow(
+				ctx,
+				`select tenant from public_ip_attachments where id = '123'`,
+			)
+			err = row.Scan(&actual)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(actual).To(Equal(expectedTenant))
+		},
+		Entry(
+			"Single tenant",
+			[]string{"my-tenant"},
+			"my-tenant",
+		),
+		Entry(
+			"Multiple tenants takes first",
+			[]string{"first", "second", "third"},
+			"first",
+		),
+		Entry(
+			"Empty array",
+			[]string{},
+			"",
+		),
+	)
+})
+
+var _ = DescribeMigration("Replace creators array with single creator in public ip attachments tables", func() {
+	DescribeTable(
+		"Migrates the creators array to a single creator value in public ip attachments tables",
+		func(creators []string, expectedCreator string) {
+			// Insert a row with the old creators array column:
+			_, err := pool.Exec(
+				ctx,
+				`insert into public_ip_attachments (id, creators, data) values ('123', $1, '{}')`,
+				creators,
+			)
+			Expect(err).ToNot(HaveOccurred())
+
+			// Run the migration:
+			err = tool.Migrate(ctx, 42)
+			Expect(err).ToNot(HaveOccurred())
+
+			// Verify the creator column has the expected value:
+			var actual string
+			row := pool.QueryRow(
+				ctx,
+				`select creator from public_ip_attachments where id = '123'`,
+			)
+			err = row.Scan(&actual)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(actual).To(Equal(expectedCreator))
+		},
+		Entry(
+			"Single creator",
+			[]string{"my-creator"},
+			"my-creator",
+		),
+		Entry(
+			"Multiple creators takes first",
+			[]string{"first", "second", "third"},
+			"first",
+		),
+		Entry(
+			"Empty array",
+			[]string{},
+			"",
+		),
+	)
+})


### PR DESCRIPTION
## Summary

- Adds migration 42 to convert the `public_ip_attachments` table from
  `tenants text[]` and `creators text[]` to scalar `tenant text` and
  `creator text`, preserving the first array element.
- Fixes a regression introduced by a rebase: migration 38 (which creates
  the `public_ip_attachments` table) landed after the patch that replaced
  multi-valued fields with singular ones, leaving this table with the old
  format that breaks the DAO layer.
- Includes migration unit tests verifying the conversion for single values,
  multiple values (takes first), and empty arrays.

## Why this wasn't caught earlier

Unit tests don't run with all migrations applied sequentially, and there
are no integration tests for public IP attachments yet.

## Test plan

- [x] Migration unit tests pass (`ginkgo run internal/database/migrations`)