### PR TITLE
OSAC-902: Move generic authorization resource type to IDP

### DIFF
--- a/internal/idp/const.go
+++ b/internal/idp/const.go
@@ -1,0 +1,24 @@
+/*
+Copyright (c) 2026 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package idp
+
+// Authorization scope constants define actions that can be performed on protected resources.
+// These are used with Keycloak Authorization Services to control fine-grained access to Projects.
+const (
+	// ScopeViewProject allows viewing project details and status
+	ScopeViewProject = "VIEW_PROJECT"
+
+	// ScopeManageProject allows updating project metadata, deleting project, and managing permissions
+	ScopeManageProject = "MANAGE_PROJECT"
+)

--- a/internal/idp/keycloak/const.go
+++ b/internal/idp/keycloak/const.go
@@ -18,6 +18,10 @@ package keycloak
 // realm and is the only client we interact with for role assignments.
 const realmManagementClientID = "realm-management"
 
+// authorizationClientID is the clientId of the Keycloak client that has Authorization Services enabled.
+// This client manages authorization resources for Projects and other protected resources.
+const authorizationClientID = "osac-authorization"
+
 // keycloakRealmManagementRoles are the standard Keycloak administrative roles.
 //
 // NOTE: These are CLIENT roles (Keycloak client roles), not organization roles.
@@ -51,12 +55,8 @@ var keycloakIdpManagerRoles = []string{
 	"view-realm",
 }
 
-// Authorization scope constants define actions that can be performed on protected resources.
-// These are used with Keycloak Authorization Services to control fine-grained access to Projects.
+// Authorization resource type constants define the types of protected resources.
 const (
-	// ScopeViewProject allows viewing project details and status
-	ScopeViewProject = "VIEW_PROJECT"
-
-	// ScopeManageProject allows updating project metadata, deleting project, and managing permissions
-	ScopeManageProject = "MANAGE_PROJECT"
+	// ResourceTypeProject is the type identifier for Project authorization resources
+	ResourceTypeProject = "urn:osac:resources:project"
 )

--- a/internal/idp/keycloak/types.go
+++ b/internal/idp/keycloak/types.go
@@ -216,72 +216,29 @@ type keycloakAuthorizationResource struct {
 	ID         string              `json:"_id,omitempty"`
 	Name       string              `json:"name,omitempty"`
 	Type       string              `json:"type,omitempty"`
-	Scopes     []*keycloakScope    `json:"scopes,omitempty"`
+	Scopes     []string            `json:"scopes,omitempty"`
 	URIs       []string            `json:"uris,omitempty"`
 	Attributes map[string][]string `json:"attributes,omitempty"`
 }
 
-// keycloakScope represents an authorization scope.
-type keycloakScope struct {
-	ID          string `json:"id,omitempty"`
-	Name        string `json:"name,omitempty"`
-	DisplayName string `json:"displayName,omitempty"`
-	IconURI     string `json:"iconUri,omitempty"`
-}
-
-// AuthorizationResource represents a protected resource exposed to controllers.
-// Each Project is represented as an authorization resource.
-type AuthorizationResource struct {
-	// ID is the unique identifier assigned by Keycloak
-	ID string
-
-	// Name is the resource name (e.g., "PROJECT-acme-web-app")
-	Name string
-
-	// Type is the resource type (e.g., "urn:osac:resources:project")
-	Type string
-
-	// Scopes are the actions that can be performed on this resource
-	Scopes []string
-
-	// URIs are optional resource URIs
-	URIs []string
-
-	// Attributes for additional metadata
-	Attributes map[string][]string
-}
-
 // Conversion functions for authorization resources
-
-func toKeycloakAuthorizationResource(resource *AuthorizationResource) *keycloakAuthorizationResource {
-	var scopes []*keycloakScope
-	for _, scopeName := range resource.Scopes {
-		scopes = append(scopes, &keycloakScope{
-			Name: scopeName,
-		})
-	}
-
+func toKeycloakAuthorizationResource(resource *idp.AuthorizationResource) *keycloakAuthorizationResource {
 	return &keycloakAuthorizationResource{
 		ID:         resource.ID,
 		Name:       resource.Name,
 		Type:       resource.Type,
-		Scopes:     scopes,
+		Scopes:     resource.Scopes,
 		URIs:       resource.URIs,
 		Attributes: resource.Attributes,
 	}
 }
 
-func fromKeycloakAuthorizationResource(kcResource *keycloakAuthorizationResource) *AuthorizationResource {
-	var scopes []string
-	for _, scope := range kcResource.Scopes {
-		scopes = append(scopes, scope.Name)
-	}
-
-	return &AuthorizationResource{
+func fromKeycloakAuthorizationResource(kcResource *keycloakAuthorizationResource) *idp.AuthorizationResource {
+	return &idp.AuthorizationResource{
 		ID:         kcResource.ID,
 		Name:       kcResource.Name,
 		Type:       kcResource.Type,
-		Scopes:     scopes,
+		Scopes:     kcResource.Scopes,
 		URIs:       kcResource.URIs,
 		Attributes: kcResource.Attributes,
 	}

--- a/internal/idp/types.go
+++ b/internal/idp/types.go
@@ -60,3 +60,24 @@ type Role struct {
 	ContainerID string // The ID of the organization or client that contains this role
 	Attributes  map[string][]string
 }
+
+// AuthorizationResource represents a protected resource in an authorization system.
+type AuthorizationResource struct {
+	// ID is the unique identifier assigned by the authorization system
+	ID string
+
+	// Name is the resource name (e.g., "PROJECT-acme-web-app")
+	Name string
+
+	// Type is the resource type (e.g., "urn:osac:resources:project")
+	Type string
+
+	// Scopes are the actions that can be performed on this resource
+	Scopes []string
+
+	// URIs are optional resource URIs
+	URIs []string
+
+	// Attributes for additional metadata
+	Attributes map[string][]string
+}


### PR DESCRIPTION
# Description

Originally the type was in Keycloak's types but it should be in the general IDP library. Also removes the keycloak scope type since it's unnecessary and adds a few needed constants.

# Testing
- [x] `go build ./...` compiles cleanly
- [x] All unit test suites pass (`ginkgo run -r ./internal`)

Assisted-by: Claude

/cc @jhernand 