### PR TITLE
OSAC-902: Add Authorization Resource Functions

### DIFF
--- a/internal/idp/client.go
+++ b/internal/idp/client.go
@@ -64,4 +64,11 @@ type Client interface {
 	// - Okta: Assigns User Administrator role
 	// - Azure AD: Assigns User Administrator role
 	AssignIdpManagerPermissions(ctx context.Context, userID string) error
+
+	// Authorization resource operations (Keycloak Authorization Services / UMA 2.0)
+	// These methods manage fine-grained permissions on resources like Projects.
+	// Note: Not all IdPs support this - it's primarily a Keycloak feature.
+	CreateAuthorizationResource(ctx context.Context, resource *AuthorizationResource) (*AuthorizationResource, error)
+	GetAuthorizationResource(ctx context.Context, resourceID string) (*AuthorizationResource, error)
+	DeleteAuthorizationResource(ctx context.Context, resourceID string) error
 }

--- a/internal/idp/client_mock.go
+++ b/internal/idp/client_mock.go
@@ -96,6 +96,21 @@ func (mr *MockClientMockRecorder) AssignOrganizationRolesToUser(ctx, organizatio
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AssignOrganizationRolesToUser", reflect.TypeOf((*MockClient)(nil).AssignOrganizationRolesToUser), ctx, organizationName, userID, roles)
 }
 
+// CreateAuthorizationResource mocks base method.
+func (m *MockClient) CreateAuthorizationResource(ctx context.Context, resource *AuthorizationResource) (*AuthorizationResource, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreateAuthorizationResource", ctx, resource)
+	ret0, _ := ret[0].(*AuthorizationResource)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CreateAuthorizationResource indicates an expected call of CreateAuthorizationResource.
+func (mr *MockClientMockRecorder) CreateAuthorizationResource(ctx, resource any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateAuthorizationResource", reflect.TypeOf((*MockClient)(nil).CreateAuthorizationResource), ctx, resource)
+}
+
 // CreateOrganization mocks base method.
 func (m *MockClient) CreateOrganization(ctx context.Context, org *Organization) (*Organization, error) {
 	m.ctrl.T.Helper()
@@ -126,6 +141,20 @@ func (mr *MockClientMockRecorder) CreateUser(ctx, organizationName, user any) *g
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateUser", reflect.TypeOf((*MockClient)(nil).CreateUser), ctx, organizationName, user)
 }
 
+// DeleteAuthorizationResource mocks base method.
+func (m *MockClient) DeleteAuthorizationResource(ctx context.Context, resourceID string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteAuthorizationResource", ctx, resourceID)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteAuthorizationResource indicates an expected call of DeleteAuthorizationResource.
+func (mr *MockClientMockRecorder) DeleteAuthorizationResource(ctx, resourceID any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteAuthorizationResource", reflect.TypeOf((*MockClient)(nil).DeleteAuthorizationResource), ctx, resourceID)
+}
+
 // DeleteOrganization mocks base method.
 func (m *MockClient) DeleteOrganization(ctx context.Context, name string) error {
 	m.ctrl.T.Helper()
@@ -152,6 +181,21 @@ func (m *MockClient) DeleteUser(ctx context.Context, organizationName, userID st
 func (mr *MockClientMockRecorder) DeleteUser(ctx, organizationName, userID any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteUser", reflect.TypeOf((*MockClient)(nil).DeleteUser), ctx, organizationName, userID)
+}
+
+// GetAuthorizationResource mocks base method.
+func (m *MockClient) GetAuthorizationResource(ctx context.Context, resourceID string) (*AuthorizationResource, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetAuthorizationResource", ctx, resourceID)
+	ret0, _ := ret[0].(*AuthorizationResource)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetAuthorizationResource indicates an expected call of GetAuthorizationResource.
+func (mr *MockClientMockRecorder) GetAuthorizationResource(ctx, resourceID any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAuthorizationResource", reflect.TypeOf((*MockClient)(nil).GetAuthorizationResource), ctx, resourceID)
 }
 
 // GetOrganization mocks base method.

--- a/internal/idp/keycloak/client.go
+++ b/internal/idp/keycloak/client.go
@@ -38,6 +38,7 @@ type Client struct {
 
 	realmName               string
 	realmManagementClientID string
+	authorizationClientUUID string // Cached internal UUID of the authorization services client
 }
 
 // ClientBuilder builds a Keycloak client.
@@ -650,6 +651,100 @@ func (c *Client) deleteBreakGlassAccount(ctx context.Context, organizationName, 
 	if err != nil {
 		return fmt.Errorf("failed to delete break-glass user: %w", err)
 	}
+
+	return nil
+}
+
+// getAuthorizationClientUUID retrieves and caches the internal UUID of the authorization services client.
+// The first call queries Keycloak; subsequent calls return the cached value.
+func (c *Client) getAuthorizationClientUUID(ctx context.Context) (string, error) {
+	// Return cached value if available
+	if c.authorizationClientUUID != "" {
+		return c.authorizationClientUUID, nil
+	}
+
+	// First call - look up the UUID using existing function
+	clientUUID, err := c.GetRealmClientByClientID(ctx, authorizationClientID, c.realmName)
+	if err != nil {
+		return "", err
+	}
+
+	// Cache the result
+	c.authorizationClientUUID = clientUUID
+	return clientUUID, nil
+}
+
+// CreateAuthorizationResource creates a new authorization resource in Keycloak Authorization Services.
+func (c *Client) CreateAuthorizationResource(ctx context.Context, resource *idp.AuthorizationResource) (*idp.AuthorizationResource, error) {
+	if resource == nil {
+		return nil, fmt.Errorf("authorization resource is nil")
+	}
+	if resource.Type == "" {
+		resource.Type = ResourceTypeProject
+	}
+	kcResource := toKeycloakAuthorizationResource(resource)
+
+	clientInternalID, err := c.getAuthorizationClientUUID(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get authorization client ID: %w", err)
+	}
+
+	// Create the resource via Keycloak Authorization Services REST API
+	path := fmt.Sprintf("/admin/realms/%s/clients/%s/authz/resource-server/resource", c.realmName, clientInternalID)
+	response, err := c.httpClient.DoRequest(ctx, http.MethodPost, path, kcResource)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create authorization resource: %w", err)
+	}
+	defer response.Body.Close()
+
+	// Decode the created resource (includes the assigned ID)
+	var createdResource keycloakAuthorizationResource
+	if err = json.NewDecoder(response.Body).Decode(&createdResource); err != nil {
+		return nil, fmt.Errorf("failed to decode authorization resource response: %w", err)
+	}
+
+	return fromKeycloakAuthorizationResource(&createdResource), nil
+}
+
+// GetAuthorizationResource retrieves an authorization resource by ID from Keycloak Authorization Services.
+func (c *Client) GetAuthorizationResource(ctx context.Context, resourceID string) (*idp.AuthorizationResource, error) {
+	clientInternalID, err := c.getAuthorizationClientUUID(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get authorization client ID: %w", err)
+	}
+
+	// Get the resource via Keycloak Authorization Services REST API
+	path := fmt.Sprintf("/admin/realms/%s/clients/%s/authz/resource-server/resource/%s",
+		c.realmName, clientInternalID, url.PathEscape(resourceID))
+	response, err := c.httpClient.DoRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get authorization resource: %w", err)
+	}
+	defer response.Body.Close()
+
+	var kcResource keycloakAuthorizationResource
+	if err = json.NewDecoder(response.Body).Decode(&kcResource); err != nil {
+		return nil, fmt.Errorf("failed to decode authorization resource response: %w", err)
+	}
+
+	return fromKeycloakAuthorizationResource(&kcResource), nil
+}
+
+// DeleteAuthorizationResource deletes an authorization resource by ID from Keycloak Authorization Services.
+func (c *Client) DeleteAuthorizationResource(ctx context.Context, resourceID string) error {
+	clientInternalID, err := c.getAuthorizationClientUUID(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to get authorization client ID: %w", err)
+	}
+
+	// Delete the resource via Keycloak Authorization Services REST API
+	path := fmt.Sprintf("/admin/realms/%s/clients/%s/authz/resource-server/resource/%s",
+		c.realmName, clientInternalID, url.PathEscape(resourceID))
+	response, err := c.httpClient.DoRequest(ctx, http.MethodDelete, path, nil)
+	if err != nil {
+		return fmt.Errorf("failed to delete authorization resource: %w", err)
+	}
+	defer response.Body.Close()
 
 	return nil
 }

--- a/internal/idp/keycloak/client_test.go
+++ b/internal/idp/keycloak/client_test.go
@@ -1060,6 +1060,259 @@ var _ = Describe("Keycloak Client", func() {
 			Expect(serverCalled).To(BeFalse()) // Still no HTTP call
 		})
 	})
+
+	Describe("CreateAuthorizationResource", func() {
+		It("creates an authorization resource in Keycloak", func() {
+			var receivedResource *keycloakAuthorizationResource
+			server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				// First call: lookup authorization client UUID
+				if r.Method == http.MethodGet && r.URL.Path == "/admin/realms/osac/clients" && r.URL.Query().Get("clientId") == "osac-authorization" {
+					response := []keycloakClient{{
+						ID:       "auth-client-uuid-123",
+						ClientID: "osac-authorization",
+					}}
+					w.Header().Set("Content-Type", "application/json")
+					json.NewEncoder(w).Encode(response)
+					return
+				}
+
+				// Second call: create authorization resource
+				if r.Method == http.MethodPost && r.URL.Path == "/admin/realms/osac/clients/auth-client-uuid-123/authz/resource-server/resource" {
+					receivedResource = &keycloakAuthorizationResource{}
+					json.NewDecoder(r.Body).Decode(receivedResource)
+
+					response := keycloakAuthorizationResource{
+						ID:         "resource-uuid-456",
+						Name:       receivedResource.Name,
+						Type:       receivedResource.Type,
+						Scopes:     receivedResource.Scopes,
+						URIs:       receivedResource.URIs,
+						Attributes: receivedResource.Attributes,
+					}
+					w.Header().Set("Content-Type", "application/json")
+					json.NewEncoder(w).Encode(response)
+					return
+				}
+
+				w.WriteHeader(http.StatusNotFound)
+			}))
+
+			client = createTestClient(server.URL)
+
+			resource := &idp.AuthorizationResource{
+				Name: "PROJECT-acme-web-app",
+				Scopes: []string{
+					idp.ScopeViewProject,
+					idp.ScopeManageProject,
+				},
+				Attributes: map[string][]string{
+					"project_id": {"project-123"},
+					"tenant":     {"acme"},
+				},
+			}
+
+			createdResource, err := client.CreateAuthorizationResource(ctx, resource)
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(createdResource).ToNot(BeNil())
+			Expect(createdResource.ID).To(Equal("resource-uuid-456"))
+			Expect(createdResource.Name).To(Equal("PROJECT-acme-web-app"))
+			Expect(createdResource.Scopes).To(ConsistOf(idp.ScopeViewProject, idp.ScopeManageProject))
+			Expect(receivedResource.Name).To(Equal("PROJECT-acme-web-app"))
+		})
+
+		It("caches the authorization client UUID on subsequent calls", func() {
+			clientLookupCount := 0
+			server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				// Client UUID lookup
+				if r.Method == http.MethodGet && r.URL.Path == "/admin/realms/osac/clients" {
+					clientLookupCount++
+					response := []keycloakClient{{
+						ID:       "auth-client-uuid-123",
+						ClientID: "osac-authorization",
+					}}
+					w.Header().Set("Content-Type", "application/json")
+					json.NewEncoder(w).Encode(response)
+					return
+				}
+
+				// Create resource
+				if r.Method == http.MethodPost {
+					response := keycloakAuthorizationResource{
+						ID:   "resource-uuid",
+						Name: "PROJECT-test",
+					}
+					w.Header().Set("Content-Type", "application/json")
+					json.NewEncoder(w).Encode(response)
+					return
+				}
+
+				w.WriteHeader(http.StatusNotFound)
+			}))
+
+			client = createTestClient(server.URL)
+
+			resource := &idp.AuthorizationResource{Name: "PROJECT-test"}
+
+			// First call - should lookup client UUID
+			_, err := client.CreateAuthorizationResource(ctx, resource)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(clientLookupCount).To(Equal(1))
+
+			// Second call - should use cached UUID
+			_, err = client.CreateAuthorizationResource(ctx, resource)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(clientLookupCount).To(Equal(1)) // Should still be 1 (cached)
+		})
+
+		It("returns error when authorization client not found", func() {
+			server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.Method == http.MethodGet && r.URL.Path == "/admin/realms/osac/clients" {
+					// Return empty list
+					w.Header().Set("Content-Type", "application/json")
+					json.NewEncoder(w).Encode([]keycloakClient{})
+					return
+				}
+				w.WriteHeader(http.StatusNotFound)
+			}))
+
+			client = createTestClient(server.URL)
+
+			resource := &idp.AuthorizationResource{Name: "PROJECT-test"}
+			_, err := client.CreateAuthorizationResource(ctx, resource)
+
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("failed to get authorization client ID"))
+		})
+	})
+
+	Describe("GetAuthorizationResource", func() {
+		It("retrieves an authorization resource by ID", func() {
+			server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				// Client UUID lookup
+				if r.Method == http.MethodGet && r.URL.Path == "/admin/realms/osac/clients" {
+					response := []keycloakClient{{
+						ID:       "auth-client-uuid-123",
+						ClientID: "osac-authorization",
+					}}
+					w.Header().Set("Content-Type", "application/json")
+					json.NewEncoder(w).Encode(response)
+					return
+				}
+
+				// Get resource
+				if r.Method == http.MethodGet && r.URL.Path == "/admin/realms/osac/clients/auth-client-uuid-123/authz/resource-server/resource/resource-456" {
+					response := keycloakAuthorizationResource{
+						ID:   "resource-456",
+						Name: "PROJECT-acme-web-app",
+						Scopes: []string{
+							idp.ScopeViewProject,
+							idp.ScopeManageProject,
+						},
+					}
+					w.Header().Set("Content-Type", "application/json")
+					json.NewEncoder(w).Encode(response)
+					return
+				}
+
+				w.WriteHeader(http.StatusNotFound)
+			}))
+
+			client = createTestClient(server.URL)
+
+			resource, err := client.GetAuthorizationResource(ctx, "resource-456")
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(resource).ToNot(BeNil())
+			Expect(resource.ID).To(Equal("resource-456"))
+			Expect(resource.Name).To(Equal("PROJECT-acme-web-app"))
+			Expect(resource.Scopes).To(ConsistOf(idp.ScopeViewProject, idp.ScopeManageProject))
+		})
+
+		It("returns error when resource not found", func() {
+			server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				// Client UUID lookup
+				if r.Method == http.MethodGet && r.URL.Path == "/admin/realms/osac/clients" {
+					response := []keycloakClient{{
+						ID:       "auth-client-uuid-123",
+						ClientID: "osac-authorization",
+					}}
+					w.Header().Set("Content-Type", "application/json")
+					json.NewEncoder(w).Encode(response)
+					return
+				}
+
+				// Resource not found
+				w.WriteHeader(http.StatusNotFound)
+			}))
+
+			client = createTestClient(server.URL)
+
+			_, err := client.GetAuthorizationResource(ctx, "nonexistent-resource")
+
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("failed to get authorization resource"))
+		})
+	})
+
+	Describe("DeleteAuthorizationResource", func() {
+		It("deletes an authorization resource by ID", func() {
+			deletedResourceID := ""
+			server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				// Client UUID lookup
+				if r.Method == http.MethodGet && r.URL.Path == "/admin/realms/osac/clients" {
+					response := []keycloakClient{{
+						ID:       "auth-client-uuid-123",
+						ClientID: "osac-authorization",
+					}}
+					w.Header().Set("Content-Type", "application/json")
+					json.NewEncoder(w).Encode(response)
+					return
+				}
+
+				// Delete resource
+				if r.Method == http.MethodDelete && r.URL.Path == "/admin/realms/osac/clients/auth-client-uuid-123/authz/resource-server/resource/resource-456" {
+					deletedResourceID = "resource-456"
+					w.WriteHeader(http.StatusNoContent)
+					return
+				}
+
+				w.WriteHeader(http.StatusNotFound)
+			}))
+
+			client = createTestClient(server.URL)
+
+			err := client.DeleteAuthorizationResource(ctx, "resource-456")
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(deletedResourceID).To(Equal("resource-456"))
+		})
+
+		It("returns error when deletion fails", func() {
+			server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				// Client UUID lookup
+				if r.Method == http.MethodGet && r.URL.Path == "/admin/realms/osac/clients" {
+					response := []keycloakClient{{
+						ID:       "auth-client-uuid-123",
+						ClientID: "osac-authorization",
+					}}
+					w.Header().Set("Content-Type", "application/json")
+					json.NewEncoder(w).Encode(response)
+					return
+				}
+
+				// Deletion fails
+				w.WriteHeader(http.StatusInternalServerError)
+			}))
+
+			client = createTestClient(server.URL)
+
+			err := client.DeleteAuthorizationResource(ctx, "resource-456")
+
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("failed to delete authorization resource"))
+		})
+	})
 })
 
 func createTestClient(serverURL string) *Client {

--- a/internal/idp/manager_test.go
+++ b/internal/idp/manager_test.go
@@ -216,6 +216,27 @@ func (m *mockClient) AssignIdpManagerPermissions(ctx context.Context, userID str
 	return m.AssignClientRolesToUser(ctx, "", userID, "realm-management", roles)
 }
 
+func (m *mockClient) CreateAuthorizationResource(ctx context.Context, resource *AuthorizationResource) (*AuthorizationResource, error) {
+	return &AuthorizationResource{
+		ID:         "resource-id",
+		Name:       resource.Name,
+		Type:       resource.Type,
+		Scopes:     resource.Scopes,
+		Attributes: resource.Attributes,
+	}, nil
+}
+
+func (m *mockClient) GetAuthorizationResource(ctx context.Context, resourceID string) (*AuthorizationResource, error) {
+	return &AuthorizationResource{
+		ID:   resourceID,
+		Name: "PROJECT-test-project",
+	}, nil
+}
+
+func (m *mockClient) DeleteAuthorizationResource(ctx context.Context, resourceID string) error {
+	return nil
+}
+
 var _ = Describe("OrganizationManager", func() {
 	var (
 		ctx     context.Context


### PR DESCRIPTION
# Description

Add and implement Authorization Resource functions in the IDP and Keycloak client to manage these resources. They'll be used by the Project controller and eventually other resource controllers that we want to have fine-grained authorization on.

# Testing
- [x] `go build ./...` compiles cleanly
- [x] All unit test suites pass (`ginkgo run -r ./internal`)

Assisted-by: Claude

/cc @jhernand 