### PR TITLE
NO-ISSUE: Remove verbose debug logging from token sources

### DIFF
--- a/internal/auth/auth_file_token_source.go
+++ b/internal/auth/auth_file_token_source.go
@@ -126,15 +126,6 @@ func (s *fileTokenSource) Token(ctx context.Context) (result *Token, err error) 
 			Access: token,
 		}
 		s.timestamp = timestamp
-		s.logger.DebugContext(
-			ctx,
-			"Successfully loaded token from file",
-		)
-	} else {
-		s.logger.DebugContext(
-			ctx,
-			"Using token from file, file has not changed",
-		)
 	}
 
 	// Return the token:

--- a/internal/oauth/oauth_token_source.go
+++ b/internal/oauth/oauth_token_source.go
@@ -486,12 +486,6 @@ func (s *TokenSource) Token(ctx context.Context) (result *auth.Token, err error)
 
 	// If the loaded token doesn't expire soon, then we can use it directly, there is no need to request a new one:
 	if loaded != nil && s.isFresh(loaded) {
-		s.logger.DebugContext(
-			ctx,
-			"Using token loaded from storage",
-			slog.String("!access", loaded.Access),
-			slog.Time("expiry", loaded.Expiry),
-		)
 		result = loaded
 		return
 	}
@@ -499,11 +493,6 @@ func (s *TokenSource) Token(ctx context.Context) (result *auth.Token, err error)
 	// If we have a refresh token, then we can try to use it to renew the access token. If this fails we will
 	// report it in the log, and continue with the next step to get a new token.
 	if loaded != nil && loaded.Refresh != "" {
-		s.logger.DebugContext(
-			ctx,
-			"Using refresh token from storage",
-			slog.String("!refresh", loaded.Refresh),
-		)
 		result, err = s.runRefresh(ctx, loaded.Refresh)
 		if err == nil {
 			return


### PR DESCRIPTION
## Summary

- Remove debug log messages that fire on every `Token()` call during normal
  operation in `fileTokenSource` and OAuth `TokenSource`, reducing log noise
  when activity is normal.
- Error and state-change messages (file reloads, refresh failures) are
  preserved so failures remain visible.

## Test plan

- [x] Verify `ginkgo run -r internal` passes.
- [x] Confirm that error-path log messages still appear when token files are
      missing or unreadable.
- [x] Confirm that debug logs for actual file changes (reload) are still
      emitted.