### PR TITLE
NO-ISSUE: Remove credentials and tokens from debug logs

### DIFF
--- a/internal/oauth/oauth_code_flow.go
+++ b/internal/oauth/oauth_code_flow.go
@@ -297,7 +297,7 @@ func (f *codeFlow) serve(w http.ResponseWriter, r *http.Request) {
 		"Received redirect request",
 		slog.String("method", r.Method),
 		slog.String("path", r.URL.Path),
-		slog.Any("query", query),
+		slog.Any("!query", query),
 	)
 
 	// Check for error parameter:

--- a/internal/oauth/oauth_credentials_flow.go
+++ b/internal/oauth/oauth_credentials_flow.go
@@ -34,21 +34,8 @@ func (f *credentialsFlow) run(ctx context.Context) (result *auth.Token, err erro
 	}
 	tokenResponse, err := f.source.sendTokenForm(ctx, tokenRequest)
 	if err != nil {
-		f.logger.ErrorContext(
-			ctx,
-			"Failed to request token",
-			slog.String("url", f.source.tokenEndpoint),
-			slog.Any("request", tokenRequest),
-			slog.Any("error", err),
-		)
 		return
 	}
-	f.logger.DebugContext(
-		ctx,
-		"Received token response",
-		slog.Any("response", tokenRequest),
-		slog.Any("request", tokenResponse),
-	)
 	result = &auth.Token{
 		Access:  tokenResponse.AccessToken,
 		Refresh: tokenResponse.RefreshToken,

--- a/internal/oauth/oauth_device_flow.go
+++ b/internal/oauth/oauth_device_flow.go
@@ -72,8 +72,8 @@ func (f *deviceFlow) run(ctx context.Context) (result *auth.Token, err error) {
 		slog.Int("interval", authResponse.Interval),
 		slog.String("!device_code", authResponse.DeviceCode),
 		slog.String("!user_code", authResponse.UserCode),
-		slog.String("verification_uri", authResponse.VerificationUri),
-		slog.String("verification_uri_complete", authResponse.VerificationUriComplete),
+		slog.String("!verification_uri", authResponse.VerificationUri),
+		slog.String("!verification_uri_complete", authResponse.VerificationUriComplete),
 	)
 
 	// If the server has provided an expiration time for the code, then we will use that. Otherwise we will use
@@ -208,11 +208,6 @@ func (f *deviceFlow) run(ctx context.Context) (result *auth.Token, err error) {
 			return
 		}
 	}
-	f.logger.DebugContext(
-		ctx,
-		"Received token response",
-		slog.Any("response", tokenResponse),
-	)
 
 	// Notify user of authentication success:
 	err = f.listener.End(ctx, FlowEndEvent{

--- a/internal/oauth/oauth_password_flow.go
+++ b/internal/oauth/oauth_password_flow.go
@@ -36,22 +36,8 @@ func (f *passwordFlow) run(ctx context.Context) (result *auth.Token, err error) 
 	}
 	tokenResponse, err := f.source.sendTokenForm(ctx, tokenRequest)
 	if err != nil {
-		f.logger.ErrorContext(
-			ctx,
-			"Failed to request token",
-			slog.String("url", f.source.tokenEndpoint),
-			slog.String("username", f.source.username),
-			slog.Any("request", tokenRequest),
-			slog.Any("error", err),
-		)
 		return
 	}
-	f.logger.DebugContext(
-		ctx,
-		"Received token response",
-		slog.String("username", f.source.username),
-		slog.Any("response", tokenResponse),
-	)
 	result = &auth.Token{
 		Access:  tokenResponse.AccessToken,
 		Refresh: tokenResponse.RefreshToken,

--- a/internal/oauth/oauth_token_source.go
+++ b/internal/oauth/oauth_token_source.go
@@ -722,10 +722,6 @@ func (s *TokenSource) runFlow(ctx context.Context) (result *auth.Token, err erro
 // is not 200 then an error is returned. The error will be of type `endpointError` if the server returned a valid JSON
 // error response with at least the `error` field. Otherwise will be a generic error.
 func (s *TokenSource) sendForm(ctx context.Context, endpoint string, form any, result any) error {
-	logger := s.logger.With(
-		slog.String("endpoint", endpoint),
-		slog.Any("form", form),
-	)
 	values, err := query.Values(form)
 	if err != nil {
 		return err
@@ -737,9 +733,10 @@ func (s *TokenSource) sendForm(ctx context.Context, endpoint string, form any, r
 	defer func() {
 		err := response.Body.Close()
 		if err != nil {
-			logger.ErrorContext(
+			s.logger.ErrorContext(
 				ctx,
 				"Failed to close response body",
+				slog.String("endpoint", endpoint),
 				slog.Any("error", err),
 			)
 		}
@@ -788,9 +785,10 @@ func (s *TokenSource) sendForm(ctx context.Context, endpoint string, form any, r
 		}
 		return &endpointErr
 	default:
-		logger.ErrorContext(
+		s.logger.ErrorContext(
 			ctx,
 			"Unexpected response code",
+			slog.String("endpoint", endpoint),
 			slog.Int("code", response.StatusCode),
 		)
 		return fmt.Errorf(
@@ -803,6 +801,16 @@ func (s *TokenSource) sendForm(ctx context.Context, endpoint string, form any, r
 func (s *TokenSource) sendTokenForm(ctx context.Context,
 	request tokenEndpointRequest) (response tokenEndpointResponse, err error) {
 	err = s.sendForm(ctx, s.tokenEndpoint, &request, &response)
+	if err != nil {
+		s.logger.ErrorContext(
+			ctx,
+			"Failed to send token form",
+			slog.String("endpoint", s.tokenEndpoint),
+			slog.Any("!request", request),
+			slog.Any("error", err),
+		)
+		return
+	}
 	return
 }
 


### PR DESCRIPTION
## Summary

- Remove log statements from the OAuth flow implementations that were writing
  sensitive data (client secrets, passwords, access tokens, refresh tokens) to
  debug and error logs.
- Remove the form data from the `sendForm` logger context, where it was
  attached to a local logger and could surface credentials in every subsequent
  log line.
- Centralize token request error logging in `sendTokenForm` with the request
  marked using the `!` field name prefix so it is redacted by default.
- Add the `!` prefix to the redirect `query` field in the authorization code
  flow and to `verification_uri` / `verification_uri_complete` in the device
  flow, since these can embed authorization codes or user codes.

## Test plan

- [x] `ginkgo run internal/oauth` passes (91 specs).