### PR TITLE
NO-ISSUE: Log gRPC error message instead of stack trace in the logging interceptor

### DIFF
--- a/internal/logging/logging_interceptor.go
+++ b/internal/logging/logging_interceptor.go
@@ -310,22 +310,34 @@ func (i *Interceptor) UnaryClient(ctx context.Context, method string, request, r
 	// Write the details of the response:
 	timeElapsed := time.Since(timeBefore)
 	timeField := slog.Duration("duration", timeElapsed)
-	codeField := slog.String("code", grpcstatus.Code(err).String())
 	responseFields := []any{
 		methodField,
 		targetField,
 		timeField,
-		codeField,
+	}
+	status, ok := grpcstatus.FromError(err)
+	if ok {
+		codeField := slog.String("code", status.Code().String())
+		responseFields = append(responseFields, codeField)
+		message := status.Message()
+		if message != "" {
+			messageField := slog.String("message", message)
+			responseFields = append(responseFields, messageField)
+		}
+		details := status.Details()
+		if len(details) > 0 {
+			detailsField := slog.Any("details", details)
+			responseFields = append(responseFields, detailsField)
+		}
+	} else {
+		errField := slog.Any("error", err)
+		responseFields = append(responseFields, errField)
 	}
 	if i.bodies && response != nil {
 		bodyField, ok := i.dumpMessage(ctx, "response", response)
 		if ok {
 			responseFields = append(responseFields, bodyField)
 		}
-	}
-	if err != nil {
-		errField := slog.Any("error", err)
-		responseFields = append(responseFields, errField)
 	}
 	i.logger.DebugContext(ctx, "Received unary response", responseFields...)
 

--- a/internal/logging/logging_interceptor_test.go
+++ b/internal/logging/logging_interceptor_test.go
@@ -16,6 +16,7 @@ package logging
 import (
 	"bytes"
 	"context"
+	"errors"
 	"io"
 	"log/slog"
 	"net"
@@ -48,13 +49,15 @@ var _ = Describe("Interceptor", func() {
 		// Create the context:
 		ctx = context.Background()
 
-		// Create a buffer for the log output:
+		// Prepare the writer so that it will write to a buffer in memory and also to the Ginkgo writer, so that
+		// the log messages are also visible in the test output.
 		buffer = &bytes.Buffer{}
+		writer := io.MultiWriter(buffer, GinkgoWriter)
 
 		// Create a logger that writes to the buffer:
 		logger, err = NewLogger().
 			SetLevel(slog.LevelDebug.String()).
-			SetOut(buffer).
+			SetOut(writer).
 			Build()
 		Expect(err).ToNot(HaveOccurred())
 
@@ -130,14 +133,14 @@ var _ = Describe("Interceptor", func() {
 
 			// Verify response log:
 			responseMessage := messages[1]
-			Expect(responseMessage["msg"]).To(Equal("Received unary response"))
-			Expect(responseMessage["method"]).To(Equal(method))
-			Expect(responseMessage["target"]).To(Equal(listener.Addr().String()))
-			Expect(responseMessage["code"]).To(Equal("OK"))
-			Expect(responseMessage["response"]).To(HaveKey("myString"))
+			Expect(responseMessage).To(HaveKeyWithValue("msg", "Received unary response"))
+			Expect(responseMessage).To(HaveKeyWithValue("method", method))
+			Expect(responseMessage).To(HaveKeyWithValue("target", listener.Addr().String()))
+			Expect(responseMessage).To(HaveKeyWithValue("code", "OK"))
+			Expect(responseMessage).To(HaveKeyWithValue("response", HaveKey("myString")))
 		})
 
-		It("Logs errors in unary client calls", func() {
+		It("Logs gRPC errors in unary client calls", func() {
 			method := "/test.Service/TestMethod"
 
 			// Mock request and response:
@@ -160,11 +163,41 @@ var _ = Describe("Interceptor", func() {
 			messages := Parse(buffer)
 			Expect(messages).To(HaveLen(2))
 
-			// Verify response log contains error:
+			// Verify response log contains error code but no error detail:
 			responseMessage := messages[1]
-			Expect(responseMessage["msg"]).To(Equal("Received unary response"))
-			Expect(responseMessage["code"]).To(Equal("NotFound"))
-			Expect(responseMessage["error"]).ToNot(BeNil())
+			Expect(responseMessage).To(HaveKeyWithValue("msg", "Received unary response"))
+			Expect(responseMessage).To(HaveKeyWithValue("code", "NotFound"))
+			Expect(responseMessage).To(HaveKeyWithValue("message", "not found"))
+			Expect(responseMessage).ToNot(HaveKey("error"))
+		})
+
+		It("Logs other errors in unary client calls", func() {
+			method := "/test.Service/TestMethod"
+
+			// Mock request and response:
+			request := &testsv1.Object{}
+			response := &testsv1.Object{}
+
+			// Mock invoker that returns an error:
+			invoker := func(context.Context, string, any, any, *grpc.ClientConn, ...grpc.CallOption) error {
+				return errors.New("my error")
+			}
+
+			// Call the interceptor:
+			err := interceptor.UnaryClient(ctx, method, request, response, conn, invoker)
+			_, ok := grpcstatus.FromError(err)
+			Expect(ok).To(BeFalse())
+
+			// Parse the log messages:
+			messages := Parse(buffer)
+			Expect(messages).To(HaveLen(2))
+
+			// Verify response log contains error code but no error detail:
+			responseMessage := messages[1]
+			Expect(responseMessage).To(HaveKeyWithValue("msg", "Received unary response"))
+			Expect(responseMessage).ToNot(HaveKey("code"))
+			Expect(responseMessage).ToNot(HaveKey("message"))
+			Expect(responseMessage).To(HaveKeyWithValue("error", HaveKeyWithValue("message", "my error")))
 		})
 
 		It("Skips logging for reflection methods", func() {


### PR DESCRIPTION
## Summary

- The logging interceptor was writing the full error object, including the stack trace, for
  gRPC error responses. That stack trace always points to the interceptor itself and is not
  useful. Now, for gRPC errors, the interceptor logs the status `code`, `message`, and
  `details` as separate structured fields instead.
- For non-gRPC errors the complete error, including the stack trace, is still written.
- Tests updated to match the new behavior, and a new test added for the non-gRPC error path.

## Test plan

- [x] Existing unit tests updated and passing locally.
- [x] New test added for non-gRPC errors.