### PR TITLE
Fix image publish race on rapid main merges

### DIFF
--- a/.github/workflows/publish-image.yaml
+++ b/.github/workflows/publish-image.yaml
@@ -9,8 +9,8 @@ on:
       - 'v*'
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-image
-  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}-image
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:
   contents: read


### PR DESCRIPTION
## Problem

When multiple PRs merge to main within seconds, `cancel-in-progress: true` kills earlier image builds. All main pushes share concurrency group `Container image-refs/heads/main-image`. Result: only the last commit gets a published image. Earlier commits have phantom tags in GHCR, causing downstream osac-installer bump PRs to fail pulling non-existent images.

Observed: 3 PRs merged within 90 seconds (530, 557, 545). Only `sha-bd81c00` (PR 545) was published. Tags `sha-2d70429` and `sha-ba5c774` don't exist. osac-installer PRs 134 and 135 failed with rollout stuck on image pull.

## Fix

- `github.ref` → `github.sha`: each main push gets its own concurrency group
- `cancel-in-progress: true` → only for PRs, not main pushes