### PR TITLE
OSAC-204: Add IDP type and functions to IDP client

### DIFF
--- a/internal/idp/client.go
+++ b/internal/idp/client.go
@@ -21,8 +21,14 @@ import (
 
 // Client is the generic interface for identity provider admin operations.
 // Different IdP providers (Keycloak, Auth0, Okta, etc.) implement this interface.
+//
+// For Keycloak:
+// - One realm contains all OSAC (e.g., "osac" realm)
+// - Organizations map to Keycloak Organizations within that realm
+// - Identity providers are realm-level resources assigned to organizations
 type Client interface {
 	// Organization operations
+	// These manage Keycloak Organizations within the configured realm.
 	CreateOrganization(ctx context.Context, org *Organization) (*Organization, error)
 	GetOrganization(ctx context.Context, name string) (*Organization, error)
 	DeleteOrganization(ctx context.Context, name string) error
@@ -71,4 +77,22 @@ type Client interface {
 	CreateAuthorizationResource(ctx context.Context, resource *AuthorizationResource) (*AuthorizationResource, error)
 	GetAuthorizationResource(ctx context.Context, resourceID string) (*AuthorizationResource, error)
 	DeleteAuthorizationResource(ctx context.Context, resourceID string) error
+
+	// Identity Provider operations
+	// GetIdentityProvider retrieves an external identity provider configuration by alias at the realm level.
+	// This returns the IdP without verifying organization assignment.
+	GetIdentityProvider(ctx context.Context, alias string) (*IdentityProvider, error)
+
+	// ListAllIdentityProviders lists all external identity providers configured at the realm level.
+	// These are the IdPs available for assignment to organizations.
+	// Returns an empty slice if no IdPs are configured in the realm.
+	ListAllIdentityProviders(ctx context.Context) ([]*IdentityProvider, error)
+
+	// GetOrganizationIdentityProvider retrieves an IdP by alias and verifies it's assigned to the organization.
+	// Returns an error if the IdP is not assigned to the organization.
+	GetOrganizationIdentityProvider(ctx context.Context, organizationName, alias string) (*IdentityProvider, error)
+
+	// ListIdentityProviders lists all external identity providers assigned to a specific organization.
+	// Returns an empty slice if no IdPs are assigned to the organization.
+	ListIdentityProviders(ctx context.Context, organizationName string) ([]*IdentityProvider, error)
 }

--- a/internal/idp/client_mock.go
+++ b/internal/idp/client_mock.go
@@ -198,6 +198,21 @@ func (mr *MockClientMockRecorder) GetAuthorizationResource(ctx, resourceID any) 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAuthorizationResource", reflect.TypeOf((*MockClient)(nil).GetAuthorizationResource), ctx, resourceID)
 }
 
+// GetIdentityProvider mocks base method.
+func (m *MockClient) GetIdentityProvider(ctx context.Context, alias string) (*IdentityProvider, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetIdentityProvider", ctx, alias)
+	ret0, _ := ret[0].(*IdentityProvider)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetIdentityProvider indicates an expected call of GetIdentityProvider.
+func (mr *MockClientMockRecorder) GetIdentityProvider(ctx, alias any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetIdentityProvider", reflect.TypeOf((*MockClient)(nil).GetIdentityProvider), ctx, alias)
+}
+
 // GetOrganization mocks base method.
 func (m *MockClient) GetOrganization(ctx context.Context, name string) (*Organization, error) {
 	m.ctrl.T.Helper()
@@ -211,6 +226,21 @@ func (m *MockClient) GetOrganization(ctx context.Context, name string) (*Organiz
 func (mr *MockClientMockRecorder) GetOrganization(ctx, name any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetOrganization", reflect.TypeOf((*MockClient)(nil).GetOrganization), ctx, name)
+}
+
+// GetOrganizationIdentityProvider mocks base method.
+func (m *MockClient) GetOrganizationIdentityProvider(ctx context.Context, organizationName, alias string) (*IdentityProvider, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetOrganizationIdentityProvider", ctx, organizationName, alias)
+	ret0, _ := ret[0].(*IdentityProvider)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetOrganizationIdentityProvider indicates an expected call of GetOrganizationIdentityProvider.
+func (mr *MockClientMockRecorder) GetOrganizationIdentityProvider(ctx, organizationName, alias any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetOrganizationIdentityProvider", reflect.TypeOf((*MockClient)(nil).GetOrganizationIdentityProvider), ctx, organizationName, alias)
 }
 
 // GetUser mocks base method.
@@ -258,6 +288,21 @@ func (mr *MockClientMockRecorder) GetUserOrganizationRoles(ctx, organizationName
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUserOrganizationRoles", reflect.TypeOf((*MockClient)(nil).GetUserOrganizationRoles), ctx, organizationName, userID)
 }
 
+// ListAllIdentityProviders mocks base method.
+func (m *MockClient) ListAllIdentityProviders(ctx context.Context) ([]*IdentityProvider, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListAllIdentityProviders", ctx)
+	ret0, _ := ret[0].([]*IdentityProvider)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListAllIdentityProviders indicates an expected call of ListAllIdentityProviders.
+func (mr *MockClientMockRecorder) ListAllIdentityProviders(ctx any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListAllIdentityProviders", reflect.TypeOf((*MockClient)(nil).ListAllIdentityProviders), ctx)
+}
+
 // ListClientRoles mocks base method.
 func (m *MockClient) ListClientRoles(ctx context.Context, organizationName, clientID string) ([]*Role, error) {
 	m.ctrl.T.Helper()
@@ -271,6 +316,21 @@ func (m *MockClient) ListClientRoles(ctx context.Context, organizationName, clie
 func (mr *MockClientMockRecorder) ListClientRoles(ctx, organizationName, clientID any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListClientRoles", reflect.TypeOf((*MockClient)(nil).ListClientRoles), ctx, organizationName, clientID)
+}
+
+// ListIdentityProviders mocks base method.
+func (m *MockClient) ListIdentityProviders(ctx context.Context, organizationName string) ([]*IdentityProvider, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListIdentityProviders", ctx, organizationName)
+	ret0, _ := ret[0].([]*IdentityProvider)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListIdentityProviders indicates an expected call of ListIdentityProviders.
+func (mr *MockClientMockRecorder) ListIdentityProviders(ctx, organizationName any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListIdentityProviders", reflect.TypeOf((*MockClient)(nil).ListIdentityProviders), ctx, organizationName)
 }
 
 // ListOrganizationRoles mocks base method.

--- a/internal/idp/keycloak/client.go
+++ b/internal/idp/keycloak/client.go
@@ -32,10 +32,16 @@ import (
 )
 
 // Client is a Keycloak-specific implementation of the idp.Client interface.
+//
+// Architecture:
+// - One Keycloak realm contains all OSAC (default: "osac" realm)
+// - OSAC organizations map to Keycloak Organizations within that realm
+// - Identity providers are realm-level resources assigned to organizations
 type Client struct {
 	logger     *slog.Logger
 	httpClient *apiclient.Client
 
+	// realmName is the single Keycloak realm that contains all OSAC organizations
 	realmName               string
 	realmManagementClientID string
 	authorizationClientUUID string // Cached internal UUID of the authorization services client
@@ -78,6 +84,7 @@ func (b *ClientBuilder) SetTokenSource(value auth.TokenSource) *ClientBuilder {
 }
 
 // SetRealmName sets the realm name.
+// This is the single Keycloak realm that contains all OSAC organizations.
 // If not set, the default realm name is "osac".
 func (b *ClientBuilder) SetRealmName(value string) *ClientBuilder {
 	b.realmName = value
@@ -747,4 +754,133 @@ func (c *Client) DeleteAuthorizationResource(ctx context.Context, resourceID str
 	defer response.Body.Close()
 
 	return nil
+}
+
+// GetIdentityProvider retrieves an identity provider configuration by alias at the realm level.
+func (c *Client) GetIdentityProvider(ctx context.Context, alias string) (*idp.IdentityProvider, error) {
+	c.logger.InfoContext(ctx, "Getting identity provider",
+		slog.String("realm", c.realmName),
+		slog.String("alias", alias),
+	)
+
+	path := fmt.Sprintf("/admin/realms/%s/identity-provider/instances/%s",
+		url.PathEscape(c.realmName),
+		url.PathEscape(alias),
+	)
+
+	response, err := c.httpClient.DoRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get identity provider: %w", err)
+	}
+	defer response.Body.Close()
+
+	var kcIdp keycloakIdentityProvider
+	if err := json.NewDecoder(response.Body).Decode(&kcIdp); err != nil {
+		return nil, fmt.Errorf("failed to decode identity provider response: %w", err)
+	}
+
+	return fromKeycloakIdentityProvider(&kcIdp), nil
+}
+
+// ListAllIdentityProviders lists all identity providers configured at the realm level.
+// These are all IdPs.
+func (c *Client) ListAllIdentityProviders(ctx context.Context) ([]*idp.IdentityProvider, error) {
+	c.logger.InfoContext(ctx, "Listing all identity providers",
+		slog.String("realm", c.realmName),
+	)
+
+	path := fmt.Sprintf("/admin/realms/%s/identity-provider/instances", url.PathEscape(c.realmName))
+
+	response, err := c.httpClient.DoRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list identity providers: %w", err)
+	}
+	defer response.Body.Close()
+
+	var kcIdps []keycloakIdentityProvider
+	if err := json.NewDecoder(response.Body).Decode(&kcIdps); err != nil {
+		return nil, fmt.Errorf("failed to decode identity providers response: %w", err)
+	}
+
+	idps := make([]*idp.IdentityProvider, 0, len(kcIdps))
+	for i := range kcIdps {
+		idps = append(idps, fromKeycloakIdentityProvider(&kcIdps[i]))
+	}
+
+	return idps, nil
+}
+
+// GetOrganizationIdentityProvider retrieves an IdP by alias and verifies it's assigned to the organization.
+func (c *Client) GetOrganizationIdentityProvider(ctx context.Context, organizationName, alias string) (*idp.IdentityProvider, error) {
+	c.logger.InfoContext(ctx, "Getting organization identity provider",
+		slog.String("organization", organizationName),
+		slog.String("alias", alias),
+	)
+
+	// Get the organization to obtain its ID
+	org, err := c.GetOrganization(ctx, organizationName)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get organization: %w", err)
+	}
+
+	// Get the IdP directly from the organization endpoint
+	path := fmt.Sprintf("/admin/realms/%s/organizations/%s/identity-providers/%s",
+		url.PathEscape(c.realmName),
+		url.PathEscape(org.ID),
+		url.PathEscape(alias),
+	)
+
+	response, err := c.httpClient.DoRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get organization identity provider: %w", err)
+	}
+	defer response.Body.Close()
+
+	var kcIdp keycloakIdentityProvider
+	if err := json.NewDecoder(response.Body).Decode(&kcIdp); err != nil {
+		return nil, fmt.Errorf("failed to decode identity provider response: %w", err)
+	}
+
+	return fromKeycloakIdentityProvider(&kcIdp), nil
+}
+
+// ListIdentityProviders lists all identity providers assigned to an organization.
+func (c *Client) ListIdentityProviders(ctx context.Context, organizationName string) ([]*idp.IdentityProvider, error) {
+	c.logger.InfoContext(ctx, "Listing organization identity providers",
+		slog.String("organization", organizationName),
+	)
+
+	// Get the organization to obtain its ID
+	org, err := c.GetOrganization(ctx, organizationName)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get organization: %w", err)
+	}
+
+	path := fmt.Sprintf("/admin/realms/%s/organizations/%s/identity-providers",
+		url.PathEscape(c.realmName),
+		url.PathEscape(org.ID),
+	)
+
+	response, err := c.httpClient.DoRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list organization identity providers: %w", err)
+	}
+	defer response.Body.Close()
+
+	var kcIdps []keycloakIdentityProvider
+	if err := json.NewDecoder(response.Body).Decode(&kcIdps); err != nil {
+		return nil, fmt.Errorf("failed to decode organization identity providers response: %w", err)
+	}
+
+	idps := make([]*idp.IdentityProvider, 0, len(kcIdps))
+	for i := range kcIdps {
+		idps = append(idps, fromKeycloakIdentityProvider(&kcIdps[i]))
+	}
+
+	c.logger.InfoContext(ctx, "Listed organization identity providers",
+		slog.String("organization", organizationName),
+		slog.Int("count", len(idps)),
+	)
+
+	return idps, nil
 }

--- a/internal/idp/keycloak/client_test.go
+++ b/internal/idp/keycloak/client_test.go
@@ -1313,6 +1313,321 @@ var _ = Describe("Keycloak Client", func() {
 			Expect(err.Error()).To(ContainSubstring("failed to delete authorization resource"))
 		})
 	})
+
+	Describe("Identity Provider Operations", func() {
+		Describe("GetIdentityProvider", func() {
+			It("retrieves an identity provider by alias", func() {
+				server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					if r.Method == http.MethodGet && r.URL.Path == "/admin/realms/osac/identity-provider/instances/corporate-ldap" {
+						response := keycloakIdentityProvider{
+							Alias:       "corporate-ldap",
+							DisplayName: "Corporate LDAP",
+							InternalID:  "idp-123",
+							ProviderID:  "ldap",
+							Enabled:     true,
+							Config: map[string]string{
+								"connectionUrl": "ldap://ldap.example.com:389",
+								"bindDn":        "cn=admin,dc=example,dc=com",
+							},
+						}
+						w.Header().Set("Content-Type", "application/json")
+						w.WriteHeader(http.StatusOK)
+						json.NewEncoder(w).Encode(response)
+						return
+					}
+					w.WriteHeader(http.StatusNotFound)
+				}))
+
+				client = createTestClient(server.URL)
+
+				idpProvider, err := client.GetIdentityProvider(ctx, "corporate-ldap")
+				Expect(err).ToNot(HaveOccurred())
+				Expect(idpProvider).ToNot(BeNil())
+				Expect(idpProvider.Alias).To(Equal("corporate-ldap"))
+				Expect(idpProvider.DisplayName).To(Equal("Corporate LDAP"))
+				Expect(idpProvider.Type).To(Equal("ldap"))
+				Expect(idpProvider.Enabled).To(BeTrue())
+				Expect(idpProvider.Config).To(HaveKeyWithValue("connectionUrl", "ldap://ldap.example.com:389"))
+			})
+
+			It("returns an error when IdP not found", func() {
+				server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					w.WriteHeader(http.StatusNotFound)
+				}))
+
+				client = createTestClient(server.URL)
+
+				_, err := client.GetIdentityProvider(ctx, "nonexistent")
+				Expect(err).To(HaveOccurred())
+			})
+		})
+
+		Describe("ListAllIdentityProviders", func() {
+			It("lists all identity providers in the realm", func() {
+				server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					if r.Method == http.MethodGet && r.URL.Path == "/admin/realms/osac/identity-provider/instances" {
+						response := []keycloakIdentityProvider{
+							{
+								Alias:       "corporate-ldap",
+								DisplayName: "Corporate LDAP",
+								ProviderID:  "ldap",
+								Enabled:     true,
+							},
+							{
+								Alias:       "okta-sso",
+								DisplayName: "Okta SSO",
+								ProviderID:  "oidc",
+								Enabled:     true,
+							},
+							{
+								Alias:       "disabled-saml",
+								DisplayName: "Disabled SAML",
+								ProviderID:  "saml",
+								Enabled:     false,
+							},
+						}
+						w.Header().Set("Content-Type", "application/json")
+						w.WriteHeader(http.StatusOK)
+						json.NewEncoder(w).Encode(response)
+						return
+					}
+					w.WriteHeader(http.StatusNotFound)
+				}))
+
+				client = createTestClient(server.URL)
+
+				idps, err := client.ListAllIdentityProviders(ctx)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(idps).To(HaveLen(3))
+				Expect(idps[0].Alias).To(Equal("corporate-ldap"))
+				Expect(idps[0].Type).To(Equal("ldap"))
+				Expect(idps[1].Alias).To(Equal("okta-sso"))
+				Expect(idps[1].Type).To(Equal("oidc"))
+				Expect(idps[2].Alias).To(Equal("disabled-saml"))
+				Expect(idps[2].Enabled).To(BeFalse())
+			})
+
+			It("returns empty list when no IdPs configured", func() {
+				server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					if r.Method == http.MethodGet && r.URL.Path == "/admin/realms/osac/identity-provider/instances" {
+						response := []keycloakIdentityProvider{}
+						w.Header().Set("Content-Type", "application/json")
+						w.WriteHeader(http.StatusOK)
+						json.NewEncoder(w).Encode(response)
+						return
+					}
+					w.WriteHeader(http.StatusNotFound)
+				}))
+
+				client = createTestClient(server.URL)
+
+				idps, err := client.ListAllIdentityProviders(ctx)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(idps).To(BeEmpty())
+			})
+		})
+
+		Describe("GetOrganizationIdentityProvider", func() {
+			It("retrieves an IdP assigned to an organization", func() {
+				server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					// Handle GetOrganization request
+					if r.Method == http.MethodGet && r.URL.Path == "/admin/realms/osac/organizations" && r.URL.RawQuery == "exact=true&search=test-org" {
+						response := []keycloakOrganization{{
+							ID:   "org-123",
+							Name: "test-org",
+						}}
+						w.Header().Set("Content-Type", "application/json")
+						w.WriteHeader(http.StatusOK)
+						json.NewEncoder(w).Encode(response)
+						return
+					}
+
+					// Handle GetOrganizationIdentityProvider request
+					if r.Method == http.MethodGet && r.URL.Path == "/admin/realms/osac/organizations/org-123/identity-providers/corporate-ldap" {
+						response := keycloakIdentityProvider{
+							Alias:       "corporate-ldap",
+							DisplayName: "Corporate LDAP",
+							ProviderID:  "ldap",
+							Enabled:     true,
+							Config: map[string]string{
+								"connectionUrl": "ldap://ldap.example.com:389",
+							},
+						}
+						w.Header().Set("Content-Type", "application/json")
+						w.WriteHeader(http.StatusOK)
+						json.NewEncoder(w).Encode(response)
+						return
+					}
+
+					w.WriteHeader(http.StatusNotFound)
+				}))
+
+				client = createTestClient(server.URL)
+
+				idpProvider, err := client.GetOrganizationIdentityProvider(ctx, "test-org", "corporate-ldap")
+				Expect(err).ToNot(HaveOccurred())
+				Expect(idpProvider).ToNot(BeNil())
+				Expect(idpProvider.Alias).To(Equal("corporate-ldap"))
+				Expect(idpProvider.DisplayName).To(Equal("Corporate LDAP"))
+				Expect(idpProvider.Type).To(Equal("ldap"))
+			})
+
+			It("returns error when IdP not assigned to organization", func() {
+				server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					// Handle GetOrganization request
+					if r.Method == http.MethodGet && r.URL.Path == "/admin/realms/osac/organizations" && r.URL.RawQuery == "exact=true&search=test-org" {
+						response := []keycloakOrganization{{
+							ID:   "org-123",
+							Name: "test-org",
+						}}
+						w.Header().Set("Content-Type", "application/json")
+						w.WriteHeader(http.StatusOK)
+						json.NewEncoder(w).Encode(response)
+						return
+					}
+
+					// IdP not assigned to organization
+					if r.Method == http.MethodGet && r.URL.Path == "/admin/realms/osac/organizations/org-123/identity-providers/nonexistent" {
+						w.WriteHeader(http.StatusNotFound)
+						return
+					}
+
+					w.WriteHeader(http.StatusNotFound)
+				}))
+
+				client = createTestClient(server.URL)
+
+				_, err := client.GetOrganizationIdentityProvider(ctx, "test-org", "nonexistent")
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("failed to get organization identity provider"))
+			})
+
+			It("returns error when organization not found", func() {
+				server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					// Organization doesn't exist
+					if r.Method == http.MethodGet && r.URL.Path == "/admin/realms/osac/organizations" {
+						response := []keycloakOrganization{}
+						w.Header().Set("Content-Type", "application/json")
+						w.WriteHeader(http.StatusOK)
+						json.NewEncoder(w).Encode(response)
+						return
+					}
+					w.WriteHeader(http.StatusNotFound)
+				}))
+
+				client = createTestClient(server.URL)
+
+				_, err := client.GetOrganizationIdentityProvider(ctx, "nonexistent-org", "corporate-ldap")
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("organization"))
+			})
+		})
+
+		Describe("ListIdentityProviders", func() {
+			It("lists IdPs assigned to an organization", func() {
+				server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					// Handle GetOrganization request
+					if r.Method == http.MethodGet && r.URL.Path == "/admin/realms/osac/organizations" && r.URL.RawQuery == "exact=true&search=test-org" {
+						response := []keycloakOrganization{{
+							ID:   "org-123",
+							Name: "test-org",
+						}}
+						w.Header().Set("Content-Type", "application/json")
+						w.WriteHeader(http.StatusOK)
+						json.NewEncoder(w).Encode(response)
+						return
+					}
+
+					// Handle ListIdentityProviders request
+					if r.Method == http.MethodGet && r.URL.Path == "/admin/realms/osac/organizations/org-123/identity-providers" {
+						response := []keycloakIdentityProvider{
+							{
+								Alias:       "corporate-ldap",
+								DisplayName: "Corporate LDAP",
+								ProviderID:  "ldap",
+								Enabled:     true,
+							},
+							{
+								Alias:       "okta-sso",
+								DisplayName: "Okta SSO",
+								ProviderID:  "oidc",
+								Enabled:     true,
+							},
+						}
+						w.Header().Set("Content-Type", "application/json")
+						w.WriteHeader(http.StatusOK)
+						json.NewEncoder(w).Encode(response)
+						return
+					}
+
+					w.WriteHeader(http.StatusNotFound)
+				}))
+
+				client = createTestClient(server.URL)
+
+				idps, err := client.ListIdentityProviders(ctx, "test-org")
+				Expect(err).ToNot(HaveOccurred())
+				Expect(idps).To(HaveLen(2))
+				Expect(idps[0].Alias).To(Equal("corporate-ldap"))
+				Expect(idps[0].Type).To(Equal("ldap"))
+				Expect(idps[1].Alias).To(Equal("okta-sso"))
+				Expect(idps[1].Type).To(Equal("oidc"))
+			})
+
+			It("returns empty list when no IdPs assigned to organization", func() {
+				server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					// Handle GetOrganization request
+					if r.Method == http.MethodGet && r.URL.Path == "/admin/realms/osac/organizations" && r.URL.RawQuery == "exact=true&search=test-org" {
+						response := []keycloakOrganization{{
+							ID:   "org-123",
+							Name: "test-org",
+						}}
+						w.Header().Set("Content-Type", "application/json")
+						w.WriteHeader(http.StatusOK)
+						json.NewEncoder(w).Encode(response)
+						return
+					}
+
+					// No IdPs assigned
+					if r.Method == http.MethodGet && r.URL.Path == "/admin/realms/osac/organizations/org-123/identity-providers" {
+						response := []keycloakIdentityProvider{}
+						w.Header().Set("Content-Type", "application/json")
+						w.WriteHeader(http.StatusOK)
+						json.NewEncoder(w).Encode(response)
+						return
+					}
+
+					w.WriteHeader(http.StatusNotFound)
+				}))
+
+				client = createTestClient(server.URL)
+
+				idps, err := client.ListIdentityProviders(ctx, "test-org")
+				Expect(err).ToNot(HaveOccurred())
+				Expect(idps).To(BeEmpty())
+			})
+
+			It("returns error when organization not found", func() {
+				server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					// Organization doesn't exist
+					if r.Method == http.MethodGet && r.URL.Path == "/admin/realms/osac/organizations" {
+						response := []keycloakOrganization{}
+						w.Header().Set("Content-Type", "application/json")
+						w.WriteHeader(http.StatusOK)
+						json.NewEncoder(w).Encode(response)
+						return
+					}
+					w.WriteHeader(http.StatusNotFound)
+				}))
+
+				client = createTestClient(server.URL)
+
+				_, err := client.ListIdentityProviders(ctx, "nonexistent-org")
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("organization"))
+			})
+		})
+	})
 })
 
 func createTestClient(serverURL string) *Client {

--- a/internal/idp/keycloak/types.go
+++ b/internal/idp/keycloak/types.go
@@ -243,3 +243,47 @@ func fromKeycloakAuthorizationResource(kcResource *keycloakAuthorizationResource
 		Attributes: kcResource.Attributes,
 	}
 }
+
+// Identity Provider types
+// These map to Keycloak Identity Provider REST API.
+// See: https://www.keycloak.org/docs-api/latest/rest-api/index.html#_identity_providers_resource
+
+// keycloakIdentityProvider represents an external identity provider configuration in Keycloak.
+// Identity providers are configured at the realm level and can be linked to specific organizations.
+type keycloakIdentityProvider struct {
+	Alias       string            `json:"alias,omitempty"`
+	DisplayName string            `json:"displayName,omitempty"`
+	InternalID  string            `json:"internalId,omitempty"`
+	ProviderID  string            `json:"providerId,omitempty"` // "ldap", "oidc", "saml", etc.
+	Enabled     bool              `json:"enabled,omitempty"`
+	Config      map[string]string `json:"config,omitempty"` // Provider-specific configuration
+}
+
+// Conversion functions for identity providers
+func toKeycloakIdentityProvider(idpProvider *idp.IdentityProvider) *keycloakIdentityProvider {
+	if idpProvider == nil {
+		return nil
+	}
+
+	return &keycloakIdentityProvider{
+		Alias:       idpProvider.Alias,
+		DisplayName: idpProvider.DisplayName,
+		ProviderID:  idpProvider.Type,
+		Enabled:     idpProvider.Enabled,
+		Config:      idpProvider.Config,
+	}
+}
+
+func fromKeycloakIdentityProvider(kcIdp *keycloakIdentityProvider) *idp.IdentityProvider {
+	if kcIdp == nil {
+		return nil
+	}
+
+	return &idp.IdentityProvider{
+		Alias:       kcIdp.Alias,
+		DisplayName: kcIdp.DisplayName,
+		Type:        kcIdp.ProviderID,
+		Enabled:     kcIdp.Enabled,
+		Config:      kcIdp.Config,
+	}
+}

--- a/internal/idp/manager_test.go
+++ b/internal/idp/manager_test.go
@@ -237,6 +237,23 @@ func (m *mockClient) DeleteAuthorizationResource(ctx context.Context, resourceID
 	return nil
 }
 
+// Identity Provider stub methods
+func (m *mockClient) GetIdentityProvider(ctx context.Context, alias string) (*IdentityProvider, error) {
+	return nil, nil
+}
+
+func (m *mockClient) ListAllIdentityProviders(ctx context.Context) ([]*IdentityProvider, error) {
+	return nil, nil
+}
+
+func (m *mockClient) GetOrganizationIdentityProvider(ctx context.Context, organizationName, alias string) (*IdentityProvider, error) {
+	return nil, nil
+}
+
+func (m *mockClient) ListIdentityProviders(ctx context.Context, organizationName string) ([]*IdentityProvider, error) {
+	return nil, nil
+}
+
 var _ = Describe("OrganizationManager", func() {
 	var (
 		ctx     context.Context

--- a/internal/idp/types.go
+++ b/internal/idp/types.go
@@ -81,3 +81,30 @@ type AuthorizationResource struct {
 	// Attributes for additional metadata
 	Attributes map[string][]string
 }
+
+// IdentityProvider represents an external identity provider configuration.
+// This represents the connection to an upstream IdP (LDAP/AD/OIDC/SAML/etc) that
+// users authenticate against.
+type IdentityProvider struct {
+	// Alias is the unique name for this IdP within the realm
+	Alias string
+
+	// DisplayName is the human-readable name for this IdP
+	DisplayName string
+
+	// Type is the IdP provider type as a free-form string.
+	// Common values: "ldap", "kerberos", "oidc", "saml", "google", "github", "facebook", "microsoft"
+	// The exact set of supported values depends on the underlying IdP system (e.g., Keycloak).
+	Type string
+
+	// Enabled indicates whether this IdP is active
+	Enabled bool
+
+	// Config contains provider-specific configuration settings.
+	// Secrets are automatically filtered by the IdP system and never returned in GET responses.
+	// Example keys:
+	// - LDAP: connectionUrl, bindDn, usersDn, authType, vendor
+	// - OIDC: authorizationUrl, tokenUrl, clientId, issuer, defaultScope
+	// - SAML: singleSignOnServiceUrl, singleLogoutServiceUrl, signingCertificate
+	Config map[string]string
+}


### PR DESCRIPTION
# Description

Add IDP type and functions to manage external IDPs that can be used and managed by a tenant.

# Testing

- [x] `go build ./...` compiles cleanly
- [x] All unit test suites pass (`ginkgo run -r ./internal`)

/cc @jhernand 
