### PR TITLE
NO-ISSUE: Add flags and environment variables for config and cache dirs

### DIFF
--- a/cmd/osac/main.go
+++ b/cmd/osac/main.go
@@ -27,8 +27,7 @@ func main() {
 	ctx := context.Background()
 
 	// Execute the main command:
-	root := cli.Root()
-	err := root.ExecuteContext(ctx)
+	err := run(ctx)
 	if err != nil {
 		exitErr, ok := err.(exit.Error)
 		if ok {
@@ -38,4 +37,12 @@ func main() {
 			os.Exit(1)
 		}
 	}
+}
+
+func run(ctx context.Context) error {
+	root, err := cli.Root()
+	if err != nil {
+		return err
+	}
+	return root.ExecuteContext(ctx)
 }

--- a/internal/cmd/cli/root_cmd.go
+++ b/internal/cmd/cli/root_cmd.go
@@ -37,10 +37,10 @@ import (
 	"github.com/osac-project/fulfillment-service/internal/terminal"
 )
 
-func Root() *cobra.Command {
+func Root() (result *cobra.Command, err error) {
 	// create the runner and the command:
 	runner := &runnerContext{}
-	result := &cobra.Command{
+	result = &cobra.Command{
 		Use:               "osac",
 		Short:             "CLI for the Open Sovereign AI Cloud platform",
 		SilenceUsage:      true,
@@ -48,8 +48,48 @@ func Root() *cobra.Command {
 		PersistentPreRunE: runner.persistentPreRun,
 	}
 
+	// Determine the name of the binary, as we will use it to determine the cache and config directories:
+	runner.binaryName = filepath.Base(os.Args[0])
+
+	// Determine the default configuration directory:
+	userConfigDir, err := os.UserConfigDir()
+	if err != nil {
+		err = fmt.Errorf("failed to determine user configuration directory: %w", err)
+		return
+	}
+	defaultConfigDir := filepath.Join(userConfigDir, runner.binaryName)
+
+	// Determine the default cache directory:
+	userCacheDir, err := os.UserCacheDir()
+	if err != nil {
+		err = fmt.Errorf("failed to determine user cache directory: %w", err)
+		return
+	}
+	defaultCacheDir := filepath.Join(userCacheDir, runner.binaryName)
+
 	// Add flags:
-	logging.AddFlags(result.PersistentFlags())
+	flags := result.PersistentFlags()
+	logging.AddFlags(flags)
+	flags.StringVar(
+		&runner.args.configDir,
+		configFlag,
+		defaultConfigDir,
+		fmt.Sprintf(
+			"Directory where the configuration files are stored. Can also be set with the '%s' "+
+				"environment variable.",
+			configEnvVar,
+		),
+	)
+	flags.StringVar(
+		&runner.args.cacheDir,
+		cacheFlag,
+		defaultCacheDir,
+		fmt.Sprintf(
+			"Directory where the cache and log files are stored. Can also be set with the '%s' "+
+				"environment variable.",
+			cacheEnvVar,
+		),
+	)
 
 	// Add commands:
 	result.AddCommand(annotate.Cmd())
@@ -64,36 +104,72 @@ func Root() *cobra.Command {
 	result.AddCommand(logout.Cmd())
 	result.AddCommand(version.Cmd())
 
-	return result
+	return
 }
 
 type runnerContext struct {
+	binaryName string
+	args       struct {
+		configDir string
+		cacheDir  string
+	}
 }
 
 func (c *runnerContext) persistentPreRun(cmd *cobra.Command, args []string) error {
-	// In order to avoid mixing log messages with output we configure the log to go by default to a file in the user
-	// cache directory.
-	//
-	// The path of the cache directory and of the log file are calculated from the name from the name of the binary.
-	// For example, if the name of the binary is `osac` then the cache directory will be
-	// `~/.cache/osac` and the log file will be `~/.cache/osac/osac.log`.
-	baseName := filepath.Base(os.Args[0])
-	userCacheDir, err := os.UserCacheDir()
-	if err != nil {
-		return err
+	var err error
+
+	// Get the actual flags:
+	flags := cmd.Flags()
+
+	// Determine the configuration directory, using the environment variable only if the user hasn't explicitly set the flag:
+	configDir := c.args.configDir
+	if !flags.Changed(configFlag) {
+		value := os.Getenv(configEnvVar)
+		if value != "" {
+			configDir = value
+		}
 	}
-	cacheDir := filepath.Join(userCacheDir, baseName)
+	configDir, err = filepath.Abs(configDir)
+	if err != nil {
+		return fmt.Errorf(
+			"failed to calculate absolute path of config directory '%s': %w",
+			configDir, err,
+		)
+	}
+	err = os.MkdirAll(configDir, 0700)
+	if errors.Is(err, os.ErrExist) {
+		err = nil
+	}
+	if err != nil {
+		return fmt.Errorf("failed to create config directory '%s': %w", configDir, err)
+	}
+
+	// Determine the cache directory, using the environment variable only if the user hasn't explicitly set the flag:
+	cacheDir := c.args.cacheDir
+	if !flags.Changed(cacheFlag) {
+		value := os.Getenv(cacheEnvVar)
+		if value != "" {
+			cacheDir = value
+		}
+	}
+	cacheDir, err = filepath.Abs(cacheDir)
+	if err != nil {
+		return fmt.Errorf(
+			"failed to calculate absolute path of cache directory '%s': %w",
+			cacheDir, err,
+		)
+	}
 	err = os.MkdirAll(cacheDir, 0700)
 	if errors.Is(err, os.ErrExist) {
 		err = nil
 	}
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to create cache directory '%s': %w", cacheDir, err)
 	}
-	logFile := filepath.Join(cacheDir, baseName+".log")
 
 	// By the default the logger is configured to write to the log file, and only errors. This Will be overriden by
 	// the command line flags.
+	logFile := filepath.Join(cacheDir, c.binaryName+".log")
 	logger, err := logging.NewLogger().
 		SetFile(logFile).
 		SetFlags(cmd.Flags()).
@@ -105,6 +181,7 @@ func (c *runnerContext) persistentPreRun(cmd *cobra.Command, args []string) erro
 	// Create and load the settings:
 	settings, err := config.NewSettings().
 		SetLogger(logger).
+		SetDir(configDir).
 		Build()
 	if err != nil {
 		return fmt.Errorf("failed to create settings: %w", err)
@@ -131,3 +208,15 @@ func (c *runnerContext) persistentPreRun(cmd *cobra.Command, args []string) erro
 
 	return nil
 }
+
+// Names of command line flags:
+const (
+	configFlag = "config"
+	cacheFlag  = "cache"
+)
+
+// Names of the environment variables:
+const (
+	configEnvVar = "OSAC_CONFIG"
+	cacheEnvVar  = "OSAC_CACHE"
+)

--- a/internal/config/config_context_test.go
+++ b/internal/config/config_context_test.go
@@ -15,6 +15,7 @@ package config
 
 import (
 	"context"
+	"os"
 
 	. "github.com/onsi/ginkgo/v2/dsl/core"
 	. "github.com/onsi/gomega"
@@ -22,8 +23,12 @@ import (
 
 var _ = Describe("Context", func() {
 	It("Extracts settings from the context if previously added", func() {
+		tmp, err := os.MkdirTemp("", "*.test")
+		Expect(err).ToNot(HaveOccurred())
+		DeferCleanup(os.RemoveAll, tmp)
 		settings, err := NewSettings().
 			SetLogger(logger).
+			SetDir(tmp).
 			Build()
 		Expect(err).ToNot(HaveOccurred())
 		ctx := SettingsIntoContext(context.Background(), settings)

--- a/internal/config/config_secret_store.go
+++ b/internal/config/config_secret_store.go
@@ -56,9 +56,9 @@ func (b *SecretStoreBuilder) SetLogger(value *slog.Logger) *SecretStoreBuilder {
 	return b
 }
 
-// SetDir sets the directory where the file-based secret store will write its file. This is optional and intended for
-// unit tests where it is convenient to use a temporary directory to avoid overwriting the settings of a real user. If
-// not set, the default user configuration directory is used.
+// SetDir sets the directory where the settings are stored. This is mandatory. It affects both the file-based fallback
+// store (which writes to this directory) and the keyring-backed store (which uses the directory path to scope its
+// keyring key, ensuring that independent configurations do not collide).
 func (b *SecretStoreBuilder) SetDir(value string) *SecretStoreBuilder {
 	b.dir = value
 	return b
@@ -79,6 +79,7 @@ func (b *SecretStoreBuilder) Build() (result SecretStore, err error) {
 	if probeErr == nil || errors.Is(probeErr, keyring.ErrNotFound) {
 		result, err = NewKeyringSecretStore().
 			SetLogger(b.logger).
+			SetDir(b.dir).
 			Build()
 	} else {
 		result, err = NewFileSecretStore().
@@ -94,6 +95,7 @@ func (b *SecretStoreBuilder) Build() (result SecretStore, err error) {
 // keyring. Don't create instances of this type directly, use the NewKeyringSecretStore function instead.
 type KeyringSecretStoreBuilder struct {
 	logger *slog.Logger
+	dir    string
 }
 
 // NewKeyringSecretStore creates a builder that can then be used to configure and create a keyring-backed secret store.
@@ -107,25 +109,46 @@ func (b *KeyringSecretStoreBuilder) SetLogger(value *slog.Logger) *KeyringSecret
 	return b
 }
 
+// SetDir sets the configuration directory. The keyring key is scoped to this directory so that independent
+// configurations stored in different directories do not share secrets. This is mandatory.
+func (b *KeyringSecretStoreBuilder) SetDir(value string) *KeyringSecretStoreBuilder {
+	b.dir = value
+	return b
+}
+
 // Build uses the data stored in the builder to create and configure a new keyring-backed secret store.
 func (b *KeyringSecretStoreBuilder) Build() (result SecretStore, err error) {
+	// Check parameters:
 	if b.logger == nil {
 		err = errors.New("logger is mandatory")
 		return
 	}
+	if b.dir == "" {
+		err = errors.New("directory is mandatory")
+		return
+	}
+
+	// The keyring key is always 'secrets:<dir>' where 'dir' is the absolute path of the configuration directory.
+	key := keyringKey + ":" + b.dir
+
+	// Create the store:
 	result = &keyringSecretStore{
 		logger: b.logger,
+		key:    key,
 	}
 	return
 }
 
-// keyringSecretStore stores secret data as a single entry in the operating system keyring.
+// keyringSecretStore stores secret data as a single entry in the operating system keyring. The key field is
+// computed at build time and varies depending on the configuration directory, so that independent configurations
+// do not share secrets.
 type keyringSecretStore struct {
 	logger *slog.Logger
+	key    string
 }
 
 func (s *keyringSecretStore) Load(ctx context.Context, object any) error {
-	data, err := keyring.Get(keyringService, keyringKey)
+	data, err := keyring.Get(keyringService, s.key)
 	if errors.Is(err, keyring.ErrNotFound) {
 		s.logger.DebugContext(
 			ctx,
@@ -144,7 +167,7 @@ func (s *keyringSecretStore) Load(ctx context.Context, object any) error {
 		ctx,
 		"Loaded secrets from keyring",
 		slog.String("service", keyringService),
-		slog.String("key", keyringKey),
+		slog.String("key", s.key),
 		slog.Any("!settings", object),
 	)
 	return nil
@@ -152,7 +175,7 @@ func (s *keyringSecretStore) Load(ctx context.Context, object any) error {
 
 func (s *keyringSecretStore) Save(ctx context.Context, object any) error {
 	if object == nil {
-		err := keyring.Delete(keyringService, keyringKey)
+		err := keyring.Delete(keyringService, s.key)
 		if err != nil && !errors.Is(err, keyring.ErrNotFound) {
 			return fmt.Errorf("failed to delete from keyring: %w", err)
 		}
@@ -166,7 +189,7 @@ func (s *keyringSecretStore) Save(ctx context.Context, object any) error {
 	if err != nil {
 		return fmt.Errorf("failed to marshal secrets: %w", err)
 	}
-	err = keyring.Set(keyringService, keyringKey, string(data))
+	err = keyring.Set(keyringService, s.key, string(data))
 	if err != nil {
 		return fmt.Errorf("failed to write to keyring: %w", err)
 	}
@@ -174,7 +197,7 @@ func (s *keyringSecretStore) Save(ctx context.Context, object any) error {
 		ctx,
 		"Saved secrets to keyring",
 		slog.String("service", keyringService),
-		slog.String("key", keyringKey),
+		slog.String("key", s.key),
 		slog.Any("!settings", object),
 	)
 	return nil
@@ -198,9 +221,8 @@ func (b *FileSecretStoreBuilder) SetLogger(value *slog.Logger) *FileSecretStoreB
 	return b
 }
 
-// SetDir sets the directory where the secrets file will be written. This is optional and intended for unit tests
-// where it is convenient to use a temporary directory to avoid overwriting the settings of a real user. If not set,
-// the default user configuration directory is used.
+// SetDir sets the directory where the secrets file will be written. When not set, the default user configuration
+// directory is used.
 func (b *FileSecretStoreBuilder) SetDir(value string) *FileSecretStoreBuilder {
 	b.dir = value
 	return b

--- a/internal/config/config_secret_store_test.go
+++ b/internal/config/config_secret_store_test.go
@@ -45,6 +45,7 @@ var _ = Describe("Secret store", func() {
 			keyring.MockInit()
 			store, err := NewSecretStore().
 				SetLogger(logger).
+				SetDir("/some/dir").
 				Build()
 			Expect(err).ToNot(HaveOccurred())
 			Expect(store).To(BeAssignableToTypeOf(&keyringSecretStore{}))
@@ -54,6 +55,7 @@ var _ = Describe("Secret store", func() {
 			keyring.MockInitWithError(fmt.Errorf("keyring backend not available"))
 			store, err := NewSecretStore().
 				SetLogger(logger).
+				SetDir("/some/dir").
 				Build()
 			Expect(err).ToNot(HaveOccurred())
 			Expect(store).To(BeAssignableToTypeOf(&fileSecretStore{}))
@@ -82,6 +84,33 @@ var _ = Describe("Secret store", func() {
 			file := filepath.Join(tmp, "secrets.json")
 			Expect(file).To(BeAnExistingFile())
 		})
+
+		It("Passes the directory to the keyring store when the keyring is available", func() {
+			// Create the store using a temporary directory:
+			keyring.MockInit()
+			tmp, err := os.MkdirTemp("", "*.test")
+			Expect(err).ToNot(HaveOccurred())
+			store, err := NewSecretStore().
+				SetLogger(logger).
+				SetDir(tmp).
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+
+			// Save a secret to force the creation of the secrets file:
+			err = store.Save(ctx, &mySecret{
+				User:     "my-user",
+				Password: "my-pass",
+			})
+			Expect(err).ToNot(HaveOccurred())
+
+			// Check that the secret was saved to the keyring under the key 'secrets:...':
+			data, err := keyring.Get("osac", "secrets:"+tmp)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(data).To(MatchJSON(`{
+				"user": "my-user",
+				"password": "my-pass"
+			}`))
+		})
 	})
 
 	Describe("Keyring store", func() {
@@ -96,8 +125,16 @@ var _ = Describe("Secret store", func() {
 			// Create the store
 			store, err = NewKeyringSecretStore().
 				SetLogger(logger).
+				SetDir("/my/config").
 				Build()
 			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("Fails if directory is empty", func() {
+			_, err := NewKeyringSecretStore().
+				SetLogger(logger).
+				Build()
+			Expect(err).To(HaveOccurred())
 		})
 
 		It("Saves data", func() {
@@ -110,7 +147,7 @@ var _ = Describe("Secret store", func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			// Verify that the data has been saved to the keyring:
-			data, err := keyring.Get("osac", "secrets")
+			data, err := keyring.Get("osac", "secrets:/my/config")
 			Expect(err).ToNot(HaveOccurred())
 			Expect(data).To(MatchJSON(`{
 				"user": "my-user",
@@ -120,7 +157,7 @@ var _ = Describe("Secret store", func() {
 
 		It("Loads data", func() {
 			// Save the data to the keyring directly:
-			err := keyring.Set("osac", "secrets", `{
+			err := keyring.Set("osac", "secrets:/my/config", `{
 				"user": "my-user",
 				"password": "my-pass"
 			}`)
@@ -148,7 +185,7 @@ var _ = Describe("Secret store", func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			// Verify that the keyring is empty:
-			_, err = keyring.Get("osac", "secrets")
+			_, err = keyring.Get("osac", "secrets:/my/config")
 			Expect(err).To(MatchError(keyring.ErrNotFound))
 
 		})
@@ -156,6 +193,42 @@ var _ = Describe("Secret store", func() {
 		It("Does not fail when clearing an already empty store", func() {
 			err := store.Save(ctx, nil)
 			Expect(err).ToNot(HaveOccurred())
+		})
+	})
+
+	Describe("Keyring store isolation", func() {
+		BeforeEach(func() {
+			keyring.MockInit()
+		})
+
+		It("Isolates secrets between different directories", func() {
+			storeA, err := NewKeyringSecretStore().
+				SetLogger(logger).
+				SetDir("/dir-a").
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+
+			storeB, err := NewKeyringSecretStore().
+				SetLogger(logger).
+				SetDir("/dir-b").
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+
+			err = storeA.Save(ctx, &mySecret{User: "user-a", Password: "pass-a"})
+			Expect(err).ToNot(HaveOccurred())
+
+			err = storeB.Save(ctx, &mySecret{User: "user-b", Password: "pass-b"})
+			Expect(err).ToNot(HaveOccurred())
+
+			var secretA mySecret
+			err = storeA.Load(ctx, &secretA)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(secretA.User).To(Equal("user-a"))
+
+			var secretB mySecret
+			err = storeB.Load(ctx, &secretB)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(secretB.User).To(Equal("user-b"))
 		})
 	})
 

--- a/internal/config/config_settings.go
+++ b/internal/config/config_settings.go
@@ -64,9 +64,7 @@ func (b *SettingsBuilder) SetLogger(value *slog.Logger) *SettingsBuilder {
 	return b
 }
 
-// SetDir sets the directory where the settings files will be stored. This is optional and intended for unit tests
-// where it is convenient to use a temporary directory to avoid overwriting the settings of a real user. If not set,
-// the default user configuration directory is used.
+// SetDir sets the directory where the settings files will be stored. This is mandatory.
 func (b *SettingsBuilder) SetDir(value string) *SettingsBuilder {
 	b.dir = value
 	return b
@@ -79,22 +77,15 @@ func (b *SettingsBuilder) Build() (result *Settings, err error) {
 		err = errors.New("logger is mandatory")
 		return
 	}
-
-	// Resolve the directory:
-	dir := b.dir
-	if dir == "" {
-		var configDir string
-		configDir, err = os.UserConfigDir()
-		if err != nil {
-			return
-		}
-		dir = filepath.Join(configDir, "osac")
+	if b.dir == "" {
+		err = errors.New("directory is mandatory")
+		return
 	}
 
 	// Create the object:
 	result = &Settings{
 		logger: b.logger,
-		dir:    dir,
+		dir:    b.dir,
 		lock:   &sync.RWMutex{},
 	}
 	return

--- a/internal/config/config_settings_test.go
+++ b/internal/config/config_settings_test.go
@@ -49,6 +49,15 @@ var _ = Describe("Settings", func() {
 	Describe("Builder", func() {
 		It("Fails if logger is nil", func() {
 			settings, err := NewSettings().
+				SetDir(tmp).
+				Build()
+			Expect(err).To(HaveOccurred())
+			Expect(settings).To(BeNil())
+		})
+
+		It("Fails if directory is empty", func() {
+			settings, err := NewSettings().
+				SetLogger(logger).
 				Build()
 			Expect(err).To(HaveOccurred())
 			Expect(settings).To(BeNil())
@@ -197,8 +206,8 @@ var _ = Describe("Settings", func() {
 			err = settings.Save(ctx)
 			Expect(err).ToNot(HaveOccurred())
 
-			// Verify that the keyring contains the expected data:
-			data, err := keyring.Get("osac", "secrets")
+			// Verify that the keyring contains the expected data under the scoped key:
+			data, err := keyring.Get("osac", "secrets:"+tmp)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(data).To(MatchJSON(`{
 				"access_token": "my-access-token",
@@ -236,8 +245,8 @@ var _ = Describe("Settings", func() {
 			})
 			Expect(err).ToNot(HaveOccurred())
 
-			// Verify that the keyring contains the expected data:
-			data, err := keyring.Get("osac", "secrets")
+			// Verify that the keyring contains the expected data under the scoped key:
+			data, err := keyring.Get("osac", "secrets:"+tmp)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(data).To(MatchJSON(`{
 				"access_token": "new-access",


### PR DESCRIPTION
## Summary

- Makes the configuration and cache directories configurable via `--config` / `--cache` flags
  and `OSAC_CONFIG` / `OSAC_CACHE` environment variables (defaults remain `~/.config/osac` and
  `~/.cache/osac`).
- Scopes the keyring secret store key to the configuration directory path (e.g.
  `secrets:/my/config/dir`) so that independent configurations do not collide.
- Makes the directory parameter mandatory in both the `Settings` and `KeyringSecretStore` builders,
  and returns an error from `Root()` so directory-resolution failures are reported early.

## Test plan

- [x] Unit tests pass (`ginkgo run -r internal` — all 57 suites green).
- [x] Manual verification: run `osac --config /tmp/test-config login` and confirm secrets are
  stored under the scoped keyring key.
- [x] Verify that `OSAC_CONFIG=/tmp/alt osac login` respects the environment variable.