### PR TITLE
NO-ISSUE: Drop `OAuth` prefix from CLI flags and config settings

### DIFF
--- a/internal/cmd/cli/login/login_cmd.go
+++ b/internal/cmd/cli/login/login_cmd.go
@@ -43,6 +43,7 @@ import (
 var templatesFS embed.FS
 
 func Cmd() *cobra.Command {
+	// Create the runner and the command:
 	runner := &runnerContext{}
 	result := &cobra.Command{
 		Use:                   "login [FLAGS] ADDRESS",
@@ -50,6 +51,8 @@ func Cmd() *cobra.Command {
 		Short:                 "Save connection and authentication details.",
 		RunE:                  runner.run,
 	}
+
+	// Define the flags:
 	flags := result.Flags()
 	flags.BoolVar(
 		&runner.args.plaintext,
@@ -98,29 +101,29 @@ func Cmd() *cobra.Command {
 			"execution.",
 	)
 	flags.StringVar(
-		&runner.args.oauthIssuer,
-		"oauth-issuer",
+		&runner.args.issuer,
+		"issuer",
 		"",
-		"OAuth issuer URL. This is optional. By default the first issuer advertised by the server is used.",
+		"OAuth issuer URL. This is optional. By default the issuer advertised by the server is used.",
 	)
 	flags.StringVar(
-		&runner.args.oauthFlow,
-		"oauth-flow",
-		string(oauth.DeviceFlow),
+		&runner.args.flow,
+		"flow",
+		defaultFlow,
 		fmt.Sprintf(
 			"OAuth flow to use. Must be '%s', '%s', '%s' or '%s'.",
 			oauth.CodeFlow, oauth.DeviceFlow, oauth.CredentialsFlow, oauth.PasswordFlow,
 		),
 	)
 	flags.StringVar(
-		&runner.args.oauthClientId,
-		"oauth-client-id",
-		"osac-cli",
+		&runner.args.clientId,
+		"client-id",
+		defaultClientId,
 		"OAuth client identifier.",
 	)
 	flags.StringVar(
-		&runner.args.oauthClientSecret,
-		"oauth-client-secret",
+		&runner.args.clientSecret,
+		"client-secret",
 		"",
 		fmt.Sprintf(
 			"OAuth client secret. This is required for the '%s' flow.",
@@ -128,14 +131,14 @@ func Cmd() *cobra.Command {
 		),
 	)
 	flags.StringSliceVar(
-		&runner.args.oauthScopes,
-		"oauth-scopes",
+		&runner.args.scopes,
+		"scopes",
 		[]string{},
 		"Comma separated list of OAuth scopes to request.",
 	)
 	flags.StringVar(
-		&runner.args.oauthRedirectUri,
-		"oauth-redirect-uri",
+		&runner.args.redirectUri,
+		"redirect-uri",
 		defaultRedirectUri,
 		fmt.Sprintf(
 			"Redirect URI to use for the OAuth code flow. The default value '%s' means "+
@@ -144,8 +147,8 @@ func Cmd() *cobra.Command {
 		),
 	)
 	flags.StringVar(
-		&runner.args.oauthUser,
-		"oauth-user",
+		&runner.args.user,
+		"user",
 		"",
 		fmt.Sprintf(
 			"OAuth user name. This is required for the '%s' flow.",
@@ -153,18 +156,79 @@ func Cmd() *cobra.Command {
 		),
 	)
 	flags.StringVar(
-		&runner.args.oauthPassword,
-		"oauth-password",
+		&runner.args.password,
+		"password",
 		"",
 		fmt.Sprintf(
 			"OAuth password. This is required for the '%s' flow.",
 			oauth.PasswordFlow,
 		),
 	)
+
+	// Define the depreacated alternatives for the OAuth flags:
+	flags.StringVar(
+		&runner.args.issuer,
+		"oauth-issuer",
+		"",
+		"Alternative for the '--issuer' flag.",
+	)
+	flags.MarkDeprecated("oauth-issuer", "use '--issuer' instead")
+	flags.StringVar(
+		&runner.args.flow,
+		"oauth-flow",
+		defaultFlow,
+		"Alternative for the '--flow' flag.",
+	)
+	flags.MarkDeprecated("oauth-flow", "use '--flow' instead")
+	flags.StringVar(
+		&runner.args.clientId,
+		"oauth-client-id",
+		defaultClientId,
+		"Deprecated alternative for the '--client-id' flag.",
+	)
+	flags.MarkDeprecated("oauth-client-id", "use '--client-id' instead")
+	flags.StringVar(
+		&runner.args.clientSecret,
+		"oauth-client-secret",
+		"",
+		"Deprecated alternative for the '--client-secret' flag.",
+	)
+	flags.MarkDeprecated("oauth-client-secret", "use '--client-secret' instead")
+	flags.StringSliceVar(
+		&runner.args.scopes,
+		"oauth-scopes",
+		[]string{},
+		"Deprecated alternative for the '--scopes' flag.",
+	)
+	flags.MarkDeprecated("oauth-scopes", "use '--scopes' instead")
+	flags.StringVar(
+		&runner.args.redirectUri,
+		"oauth-redirect-uri",
+		defaultRedirectUri,
+		"Deprecated alternative for the '--redirect-uri' flag.",
+	)
+	flags.MarkDeprecated("oauth-redirect-uri", "use '--redirect-uri' instead")
+	flags.StringVar(
+		&runner.args.user,
+		"oauth-user",
+		"",
+		"Deprecated alternative for the '--user' flag.",
+	)
+	flags.MarkDeprecated("oauth-user", "use '--user' instead")
+	flags.StringVar(
+		&runner.args.password,
+		"oauth-password",
+		"",
+		"Deprecated alternative for the '--password' flag.",
+	)
+	flags.MarkDeprecated("oauth-password", "use '--password' instead")
+
+	// Mark hidden flags:
 	flags.MarkHidden("address")
 	flags.MarkHidden("private")
 	flags.MarkHidden("token")
 	flags.MarkHidden("token-script")
+
 	return result
 }
 
@@ -177,21 +241,21 @@ type runnerContext struct {
 	caPool     *x509.CertPool
 	tokenStore auth.TokenStore
 	args       struct {
-		plaintext         bool
-		insecure          bool
-		caFiles           []string
-		address           string
-		private           bool
-		token             string
-		tokenScript       string
-		oauthIssuer       string
-		oauthFlow         string
-		oauthClientId     string
-		oauthClientSecret string
-		oauthScopes       []string
-		oauthRedirectUri  string
-		oauthUser         string
-		oauthPassword     string
+		plaintext    bool
+		insecure     bool
+		caFiles      []string
+		address      string
+		private      bool
+		token        string
+		tokenScript  string
+		issuer       string
+		flow         string
+		clientId     string
+		clientSecret string
+		scopes       []string
+		redirectUri  string
+		user         string
+		password     string
 	}
 }
 
@@ -344,14 +408,14 @@ func (c *runnerContext) run(cmd *cobra.Command, args []string) error {
 	} else if c.args.tokenScript != "" {
 		cfg.SetTokenScript(c.args.tokenScript)
 	} else if tokenIssuer != "" {
-		cfg.SetOauthIssuer(tokenIssuer)
-		cfg.SetOAuthFlow(oauth.Flow(c.args.oauthFlow))
-		cfg.SetOAuthClientId(c.args.oauthClientId)
-		cfg.SetOAuthClientSecret(c.args.oauthClientSecret)
-		cfg.SetOAuthScopes(c.args.oauthScopes)
-		cfg.SetOAuthRedirectUri(c.args.oauthRedirectUri)
-		cfg.SetOAuthUser(c.args.oauthUser)
-		cfg.SetOAuthPassword(c.args.oauthPassword)
+		cfg.SetIssuer(tokenIssuer)
+		cfg.SetFlow(oauth.Flow(c.args.flow))
+		cfg.SetClientId(c.args.clientId)
+		cfg.SetClientSecret(c.args.clientSecret)
+		cfg.SetScopes(c.args.scopes)
+		cfg.SetRedirectUri(c.args.redirectUri)
+		cfg.SetUser(c.args.user)
+		cfg.SetPassword(c.args.password)
 	}
 
 	// Replace the gRPC anonymous connection with the authenticated one:
@@ -475,13 +539,13 @@ func (c *runnerContext) createTokenSource(ctx context.Context, tokenIssuer strin
 			SetCaPool(c.caPool).
 			SetInteractive(true).
 			SetIssuer(tokenIssuer).
-			SetFlow(oauth.Flow(c.args.oauthFlow)).
-			SetClientId(c.args.oauthClientId).
-			SetClientSecret(c.args.oauthClientSecret).
-			SetScopes(c.args.oauthScopes...).
-			SetRedirectUri(c.args.oauthRedirectUri).
-			SetUsername(c.args.oauthUser).
-			SetPassword(c.args.oauthPassword).
+			SetFlow(oauth.Flow(c.args.flow)).
+			SetClientId(c.args.clientId).
+			SetClientSecret(c.args.clientSecret).
+			SetScopes(c.args.scopes...).
+			SetRedirectUri(c.args.redirectUri).
+			SetUsername(c.args.user).
+			SetPassword(c.args.password).
 			Build()
 		if err != nil {
 			err = fmt.Errorf("failed to create OAuth token source: %w", err)
@@ -549,6 +613,12 @@ func (l *oauthFlowListener) End(ctx context.Context, event oauth.FlowEndEvent) e
 	}
 	return nil
 }
+
+// defaultFlow is the default OAuth flow to use.
+const defaultFlow = string(oauth.DeviceFlow)
+
+// defaultClientId is the default OAuth client identifier to use.
+const defaultClientId = "osac-cli"
 
 // defaultRedirectUri is the default redirect URI used for the OAuth code flow. The value 'http://localhost:0' means
 // binding to localhost on a randomly selected port.

--- a/internal/config/config_settings.go
+++ b/internal/config/config_settings.go
@@ -102,28 +102,28 @@ func (b *SettingsBuilder) Build() (result *Settings, err error) {
 
 // generalSettings contains the non-secret fields of the configuration. These are persisted to a JSON file.
 type generalSettings struct {
-	TokenScript      string     `json:"token_script,omitempty"`
-	Plaintext        bool       `json:"plaintext,omitempty"`
-	Insecure         bool       `json:"insecure,omitempty"`
-	CaFiles          []CaFile   `json:"ca_files,omitempty"`
-	Address          string     `json:"address,omitempty"`
-	Private          bool       `json:"private,omitempty"`
-	OAuthFlow        oauth.Flow `json:"oauth_flow,omitempty"`
-	OAuthIssuer      string     `json:"oauth_issuer,omitempty"`
-	OAuthScopes      []string   `json:"oauth_scopes,omitempty"`
-	OAuthRedirectUri string     `json:"oauth_redirect_uri,omitempty"`
+	TokenScript string     `json:"token_script,omitempty"`
+	Plaintext   bool       `json:"plaintext,omitempty"`
+	Insecure    bool       `json:"insecure,omitempty"`
+	CaFiles     []CaFile   `json:"ca_files,omitempty"`
+	Address     string     `json:"address,omitempty"`
+	Private     bool       `json:"private,omitempty"`
+	Flow        oauth.Flow `json:"flow,omitempty"`
+	Issuer      string     `json:"issuer,omitempty"`
+	Scopes      []string   `json:"scopes,omitempty"`
+	RedirectUri string     `json:"redirect_uri,omitempty"`
 }
 
 // secretSettings contains the secret fields of the configuration. These are stored as a single
 // JSON-encoded entry in the operating system keyring rather than in the configuration file.
 type secretSettings struct {
-	AccessToken       string    `json:"access_token,omitempty"`
-	RefreshToken      string    `json:"refresh_token,omitempty"`
-	TokenExpiry       time.Time `json:"token_expiry,omitempty"`
-	OAuthClientId     string    `json:"oauth_client_id,omitempty"`
-	OAuthClientSecret string    `json:"oauth_client_secret,omitempty"`
-	OAuthUser         string    `json:"oauth_user,omitempty"`
-	OAuthPassword     string    `json:"oauth_password,omitempty"`
+	AccessToken  string    `json:"access_token,omitempty"`
+	RefreshToken string    `json:"refresh_token,omitempty"`
+	TokenExpiry  time.Time `json:"token_expiry,omitempty"`
+	ClientId     string    `json:"client_id,omitempty"`
+	ClientSecret string    `json:"client_secret,omitempty"`
+	User         string    `json:"user,omitempty"`
+	Password     string    `json:"password,omitempty"`
 }
 
 // CaFile represents a CA certificate file with its name and optionally its content. The content is stored for relative
@@ -211,44 +211,44 @@ func (s *Settings) SetTokenExpiry(value time.Time) {
 	s.secret.TokenExpiry = value
 }
 
-// OAuthFlow returns the OAuth flow type.
-func (s *Settings) OAuthFlow() oauth.Flow {
-	return s.general.OAuthFlow
+// Flow returns the OAuth flow type.
+func (s *Settings) Flow() oauth.Flow {
+	return s.general.Flow
 }
 
-// SetOAuthFlow sets the OAuth flow type.
-func (s *Settings) SetOAuthFlow(value oauth.Flow) {
-	s.general.OAuthFlow = value
+// SetFlow sets the OAuth flow type.
+func (s *Settings) SetFlow(value oauth.Flow) {
+	s.general.Flow = value
 }
 
-// OAuthIssuer returns the OAuth issuer URL.
-func (s *Settings) OAuthIssuer() string {
-	return s.general.OAuthIssuer
+// Issuer returns the OAuth issuer URL.
+func (s *Settings) Issuer() string {
+	return s.general.Issuer
 }
 
-// SetOauthIssuer sets the OAuth issuer URL.
-func (s *Settings) SetOauthIssuer(value string) {
-	s.general.OAuthIssuer = value
+// SetIssuer sets the OAuth issuer URL.
+func (s *Settings) SetIssuer(value string) {
+	s.general.Issuer = value
 }
 
-// OAuthScopes returns the OAuth scopes.
-func (s *Settings) OAuthScopes() []string {
-	return s.general.OAuthScopes
+// Scopes returns the OAuth scopes.
+func (s *Settings) Scopes() []string {
+	return s.general.Scopes
 }
 
-// SetOAuthScopes sets the OAuth scopes.
-func (s *Settings) SetOAuthScopes(value []string) {
-	s.general.OAuthScopes = value
+// SetScopes sets the OAuth scopes.
+func (s *Settings) SetScopes(value []string) {
+	s.general.Scopes = value
 }
 
-// OAuthRedirectUri returns the OAuth redirect URI.
-func (s *Settings) OAuthRedirectUri() string {
-	return s.general.OAuthRedirectUri
+// RedirectUri returns the OAuth redirect URI.
+func (s *Settings) RedirectUri() string {
+	return s.general.RedirectUri
 }
 
-// SetOAuthRedirectUri sets the OAuth redirect URI.
-func (s *Settings) SetOAuthRedirectUri(value string) {
-	s.general.OAuthRedirectUri = value
+// SetRedirectUri sets the OAuth redirect URI.
+func (s *Settings) SetRedirectUri(value string) {
+	s.general.RedirectUri = value
 }
 
 // SetAccessToken sets the access token.
@@ -261,24 +261,24 @@ func (s *Settings) SetRefreshToken(value string) {
 	s.secret.RefreshToken = value
 }
 
-// SetOAuthClientId sets the OAuth client identifier.
-func (s *Settings) SetOAuthClientId(value string) {
-	s.secret.OAuthClientId = value
+// SetClientId sets the OAuth client identifier.
+func (s *Settings) SetClientId(value string) {
+	s.secret.ClientId = value
 }
 
-// SetOAuthClientSecret sets the OAuth client secret.
-func (s *Settings) SetOAuthClientSecret(value string) {
-	s.secret.OAuthClientSecret = value
+// SetClientSecret sets the OAuth client secret.
+func (s *Settings) SetClientSecret(value string) {
+	s.secret.ClientSecret = value
 }
 
-// SetOAuthUser sets the OAuth user name.
-func (s *Settings) SetOAuthUser(value string) {
-	s.secret.OAuthUser = value
+// SetUser sets the OAuth user name.
+func (s *Settings) SetUser(value string) {
+	s.secret.User = value
 }
 
-// SetOAuthPassword sets the OAuth password.
-func (s *Settings) SetOAuthPassword(value string) {
-	s.secret.OAuthPassword = value
+// SetPassword sets the OAuth password.
+func (s *Settings) SetPassword(value string) {
+	s.secret.Password = value
 }
 
 // Load populates the settings from the configuration file and the secret store.
@@ -407,7 +407,7 @@ func (c *Settings) TokenSource(ctx context.Context) (result auth.TokenSource, er
 	tokenStore := c.TokenStore()
 
 	// If an OAuth flow has been configured, then use it to create a non interactive OAuth token source:
-	if c.general.OAuthFlow != "" {
+	if c.general.Flow != "" {
 		var caPool *x509.CertPool
 		caPool, err = c.CaPool(ctx)
 		if err != nil {
@@ -416,15 +416,15 @@ func (c *Settings) TokenSource(ctx context.Context) (result auth.TokenSource, er
 		}
 		result, err = oauth.NewTokenSource().
 			SetLogger(c.logger).
-			SetFlow(c.general.OAuthFlow).
+			SetFlow(c.general.Flow).
 			SetInteractive(false).
-			SetIssuer(c.general.OAuthIssuer).
-			SetClientId(c.secret.OAuthClientId).
-			SetClientSecret(c.secret.OAuthClientSecret).
-			SetScopes(c.general.OAuthScopes...).
-			SetRedirectUri(c.general.OAuthRedirectUri).
-			SetUsername(c.secret.OAuthUser).
-			SetPassword(c.secret.OAuthPassword).
+			SetIssuer(c.general.Issuer).
+			SetClientId(c.secret.ClientId).
+			SetClientSecret(c.secret.ClientSecret).
+			SetScopes(c.general.Scopes...).
+			SetRedirectUri(c.general.RedirectUri).
+			SetUsername(c.secret.User).
+			SetPassword(c.secret.Password).
 			SetInsecure(c.general.Insecure).
 			SetCaPool(caPool).
 			SetStore(tokenStore).

--- a/internal/config/config_settings_test.go
+++ b/internal/config/config_settings_test.go
@@ -66,10 +66,10 @@ var _ = Describe("Settings", func() {
 			content := []byte(`{
 				"address": "api.example.com:443",
 				"insecure": true,
-				"oauth_flow": "code",
-				"oauth_issuer": "https://example.com",
-				"oauth_redirect_uri": "https://example.com/callback",
-				"oauth_scopes": ["openid"],
+				"flow": "code",
+				"issuer": "https://example.com",
+				"redirect_uri": "https://example.com/callback",
+				"scopes": ["openid"],
 				"private": true
 			}`)
 			err := os.WriteFile(file, content, 0600)
@@ -87,10 +87,10 @@ var _ = Describe("Settings", func() {
 			// Verify the settings:
 			Expect(settings.Address()).To(Equal("api.example.com:443"))
 			Expect(settings.Insecure()).To(BeTrue())
-			Expect(settings.OAuthFlow()).To(Equal(oauth.CodeFlow))
-			Expect(settings.OAuthIssuer()).To(Equal("https://example.com"))
-			Expect(settings.OAuthRedirectUri()).To(Equal("https://example.com/callback"))
-			Expect(settings.OAuthScopes()).To(Equal([]string{"openid"}))
+			Expect(settings.Flow()).To(Equal(oauth.CodeFlow))
+			Expect(settings.Issuer()).To(Equal("https://example.com"))
+			Expect(settings.RedirectUri()).To(Equal("https://example.com/callback"))
+			Expect(settings.Scopes()).To(Equal([]string{"openid"}))
 			Expect(settings.Private()).To(BeTrue())
 		})
 
@@ -104,10 +104,10 @@ var _ = Describe("Settings", func() {
 			settings.SetAddress("api.example.com:443")
 			settings.SetInsecure(true)
 			settings.SetPrivate(true)
-			settings.SetOAuthFlow(oauth.CodeFlow)
-			settings.SetOAuthRedirectUri("https://example.com/callback")
-			settings.SetOAuthScopes([]string{"openid"})
-			settings.SetOauthIssuer("https://example.com")
+			settings.SetFlow(oauth.CodeFlow)
+			settings.SetRedirectUri("https://example.com/callback")
+			settings.SetScopes([]string{"openid"})
+			settings.SetIssuer("https://example.com")
 			err = settings.Save(ctx)
 			Expect(err).ToNot(HaveOccurred())
 
@@ -118,10 +118,10 @@ var _ = Describe("Settings", func() {
 			Expect(content).To(MatchJSON(`{
 				"address": "api.example.com:443",
 				"insecure": true,
-				"oauth_flow": "code",
-				"oauth_issuer": "https://example.com",
-				"oauth_redirect_uri": "https://example.com/callback",
-				"oauth_scopes": ["openid"],
+				"flow": "code",
+				"issuer": "https://example.com",
+				"redirect_uri": "https://example.com/callback",
+				"scopes": ["openid"],
 				"private": true
 			}`))
 		})
@@ -136,10 +136,10 @@ var _ = Describe("Settings", func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(settings.Address()).To(BeEmpty())
 			Expect(settings.Insecure()).To(BeFalse())
-			Expect(settings.OAuthFlow()).To(Equal(oauth.Flow("")))
-			Expect(settings.OAuthIssuer()).To(BeEmpty())
-			Expect(settings.OAuthRedirectUri()).To(BeEmpty())
-			Expect(settings.OAuthScopes()).To(BeEmpty())
+			Expect(settings.Flow()).To(Equal(oauth.Flow("")))
+			Expect(settings.Issuer()).To(BeEmpty())
+			Expect(settings.RedirectUri()).To(BeEmpty())
+			Expect(settings.Scopes()).To(BeEmpty())
 			Expect(settings.Private()).To(BeFalse())
 		})
 
@@ -188,10 +188,10 @@ var _ = Describe("Settings", func() {
 				Build()
 			Expect(err).ToNot(HaveOccurred())
 			settings.SetTokenExpiry(time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC))
-			settings.SetOAuthClientId("my-client")
-			settings.SetOAuthClientSecret("my-secret")
-			settings.SetOAuthUser("my-user")
-			settings.SetOAuthPassword("my-password")
+			settings.SetClientId("my-client")
+			settings.SetClientSecret("my-secret")
+			settings.SetUser("my-user")
+			settings.SetPassword("my-password")
 			settings.SetAccessToken("my-access-token")
 			settings.SetRefreshToken("my-refresh-token")
 			err = settings.Save(ctx)
@@ -204,10 +204,10 @@ var _ = Describe("Settings", func() {
 				"access_token": "my-access-token",
 				"refresh_token": "my-refresh-token",
 				"token_expiry": "2026-06-01T12:00:00Z",
-				"oauth_client_id": "my-client",
-				"oauth_client_secret": "my-secret",
-				"oauth_user": "my-user",
-				"oauth_password": "my-password"
+				"client_id": "my-client",
+				"client_secret": "my-secret",
+				"user": "my-user",
+				"password": "my-password"
 			}`))
 
 			// Verify that the settings file is empty:
@@ -260,10 +260,10 @@ var _ = Describe("Settings", func() {
 				Build()
 			Expect(err).ToNot(HaveOccurred())
 			settings.SetTokenExpiry(time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC))
-			settings.SetOAuthClientId("my-client")
-			settings.SetOAuthClientSecret("my-secret")
-			settings.SetOAuthUser("my-user")
-			settings.SetOAuthPassword("my-password")
+			settings.SetClientId("my-client")
+			settings.SetClientSecret("my-secret")
+			settings.SetUser("my-user")
+			settings.SetPassword("my-password")
 			settings.SetAccessToken("my-access-token")
 			settings.SetRefreshToken("my-refresh-token")
 			err = settings.Save(ctx)
@@ -277,10 +277,10 @@ var _ = Describe("Settings", func() {
 				"access_token": "my-access-token",
 				"refresh_token": "my-refresh-token",
 				"token_expiry": "2026-06-01T12:00:00Z",
-				"oauth_client_id": "my-client",
-				"oauth_client_secret": "my-secret",
-				"oauth_user": "my-user",
-				"oauth_password": "my-password"
+				"client_id": "my-client",
+				"client_secret": "my-secret",
+				"user": "my-user",
+				"password": "my-password"
 			}`))
 		})
 


### PR DESCRIPTION
## Summary

- Renames login command flags like `--oauth-issuer`, `--oauth-flow`, `--oauth-client-id`, etc. to
  shorter forms (`--issuer`, `--flow`, `--client-id`, ...) and keeps the old `--oauth-*` names as
  deprecated aliases for backward compatibility.
- Renames the corresponding `Settings` struct fields, JSON tags, and getter/setter methods to drop
  the `OAuth` prefix (e.g. `OAuthFlow`/`SetOAuthFlow` becomes `Flow`/`SetFlow`).
- Extracts `defaultFlow` and `defaultClientId` constants to avoid repeating string literals.

## Test plan

- [x] Run `ginkgo run -r internal` to verify all unit tests pass with the renamed methods.
- [x] Verify that using the old `--oauth-*` flags still works and prints a deprecation warning.
- [x] Verify that using the new short flags (`--issuer`, `--flow`, etc.) works as expected.