### PR TITLE
NO-ISSUE: Fix OAuth browser templates not rendering

### DIFF
--- a/internal/oauth/templates/auth_error.html
+++ b/internal/oauth/templates/auth_error.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Authentication failed</title>
-    {{ template "styles" . }}
+    {{ execute "styles.html" . }}
     <style>
         .error-details {
             margin-top: var(--pf-t--global--spacer--md);

--- a/internal/oauth/templates/auth_success.html
+++ b/internal/oauth/templates/auth_success.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Authentication successful</title>
-    {{ template "styles" . }}
+    {{ execute "styles.html" . }}
 </head>
 <body>
     <div class="auth-container">

--- a/internal/oauth/templates/no_code.html
+++ b/internal/oauth/templates/no_code.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Authentication failed</title>
-    {{ template "styles" . }}
+    {{ execute "styles.html" . }}
 </head>
 <body>
     <div class="auth-container">

--- a/internal/oauth/templates/state_mismatch.html
+++ b/internal/oauth/templates/state_mismatch.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Authentication failed</title>
-    {{ template "styles" . }}
+    {{ execute "styles.html" . }}
 </head>
 <body>
     <div class="auth-container">

--- a/internal/oauth/templates/styles.html
+++ b/internal/oauth/templates/styles.html
@@ -1,4 +1,3 @@
-{{ define "styles" }}
 <link rel="stylesheet" href="https://unpkg.com/@patternfly/patternfly@6/patternfly.min.css">
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css">
 <style>
@@ -15,4 +14,3 @@
         padding: var(--pf-t--global--spacer--3xl);
     }
 </style>
-{{ end }}

--- a/internal/oauth/templates/token_exchange_failed.html
+++ b/internal/oauth/templates/token_exchange_failed.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Authentication failed</title>
-    {{ template "styles" . }}
+    {{ execute "styles.html" . }}
 </head>
 <body>
     <div class="auth-container">


### PR DESCRIPTION
## Summary

The lazy template loading introduced in commit 63ad9a5 broke the OAuth authentication browser
templates. The templates use `{{ template "styles" . }}` to include shared styles defined via
`{{ define "styles" }}` in `styles.html`. With lazy loading only the explicitly requested
template is parsed on first use, so the `styles` named template defined inside `styles.html` is
never loaded when other templates try to reference it. This results in a blank page in the
browser after authentication.

The fix replaces the Go built-in `{{ template }}` action with the custom `{{ execute }}` function
provided by the templating engine. Unlike the built-in action, `execute` goes through
`ensureLoaded` which correctly triggers lazy loading by filename. The `{{ define "styles" }}`/
`{{ end }}` wrapper in `styles.html` is also removed so that the content belongs to the
file-level template `styles.html` rather than a nested named template.

## Screenshots

### Before:

<img width="688" height="373" alt="before" src="https://github.com/user-attachments/assets/915f0438-c0a6-4e67-821c-10ffa2bc6cd2" />

### After:

<img width="688" height="373" alt="after" src="https://github.com/user-attachments/assets/866308bf-c4ff-4c33-a118-2e6a1566722f" />

## Test plan

- [x] Unit tests pass for `internal/templating` and `internal/oauth` packages.
- [x] Manually run `osac login` and verify the browser shows the styled success/error pages.