### PR TITLE
NO-ISSUE: Retry once on `Unauthenticated` in the gRPC client

### DIFF
--- a/internal/network/grpc_client.go
+++ b/internal/network/grpc_client.go
@@ -14,6 +14,7 @@ language governing permissions and limitations under the License.
 package network
 
 import (
+	"context"
 	"crypto/tls"
 	"crypto/x509"
 	"errors"
@@ -28,10 +29,12 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/spf13/pflag"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"
 	experiementalcredentials "google.golang.org/grpc/experimental/credentials"
 	"google.golang.org/grpc/keepalive"
+	"google.golang.org/grpc/status"
 )
 
 // GrpcClientBuilder contains the data and logic needed to create a gRPC client. Don't create instances of this object
@@ -365,6 +368,25 @@ func (b *GrpcClientBuilder) Build() (result *grpc.ClientConn, err error) {
 	unaryInterceptors := b.unaryInterceptors
 	streamInterceptors := b.streamInterceptors
 
+	// When a token source is configured, add interceptors that retry the request once when the server returns then
+	// unauthenticated status code. This handles the case where the cached token has expired or been revoked: the
+	// interceptor invalidates it and lets the next attempt fetch a fresh one.
+	//
+	// Note that currently we only do this for unary request, because streaming requests receive the error code from
+	// the server when they finish, so in order to retry the request it is necessary to create a new stream.
+	if b.tokenSource != nil {
+		retry := &unauthRetryInterceptor{
+			logger:      b.logger,
+			tokenSource: b.tokenSource,
+		}
+		unaryInterceptors = append(
+			[]grpc.UnaryClientInterceptor{
+				retry.UnaryClient,
+			},
+			unaryInterceptors...,
+		)
+	}
+
 	// Add the logging interceptor:
 	loggingInterceptor, err := logging.NewInterceptor().
 		SetLogger(b.logger).
@@ -403,6 +425,31 @@ func (b *GrpcClientBuilder) Build() (result *grpc.ClientConn, err error) {
 	// Create the client:
 	result, err = grpc.NewClient(endpoint, options...)
 	return
+}
+
+// unauthRetryInterceptor retries a gRPC call once when the server returns the unauthenticated status code. It
+// invalidates the cached token before retrying.
+type unauthRetryInterceptor struct {
+	logger      *slog.Logger
+	tokenSource auth.TokenSource
+}
+
+func (i *unauthRetryInterceptor) UnaryClient(ctx context.Context, method string, request, reply any,
+	conn *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
+	callErr := invoker(ctx, method, request, reply, conn, opts...)
+	if status.Code(callErr) != codes.Unauthenticated {
+		return callErr
+	}
+	invalidateErr := i.tokenSource.Invalidate(ctx)
+	if invalidateErr != nil {
+		i.logger.ErrorContext(
+			ctx,
+			"Failed to invalidate token after unauthenticated response",
+			slog.Any("error", invalidateErr),
+		)
+		return callErr
+	}
+	return invoker(ctx, method, request, reply, conn, opts...)
 }
 
 // Common client names:

--- a/internal/network/grpc_client_test.go
+++ b/internal/network/grpc_client_test.go
@@ -17,15 +17,20 @@ import (
 	"context"
 	"crypto/tls"
 	"net"
+	"sync/atomic"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2/dsl/core"
 	. "github.com/onsi/gomega"
+	"go.uber.org/mock/gomock"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/health"
 	healthpb "google.golang.org/grpc/health/grpc_health_v1"
 	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
 
+	"github.com/osac-project/fulfillment-service/internal/auth"
 	"github.com/osac-project/fulfillment-service/internal/testing"
 )
 
@@ -33,11 +38,14 @@ var _ = Describe("gRPC client", func() {
 	var (
 		ctx    context.Context
 		cancel context.CancelFunc
+		ctrl   *gomock.Controller
 	)
 
 	BeforeEach(func() {
 		ctx, cancel = context.WithTimeout(context.Background(), 30*time.Second)
 		DeferCleanup(cancel)
+		ctrl = gomock.NewController(GinkgoT())
+		DeferCleanup(ctrl.Finish)
 	})
 
 	It("Can't be created without a logger", func() {
@@ -328,5 +336,193 @@ var _ = Describe("gRPC client", func() {
 
 		// Verify the authority was captured and equals our custom host:
 		Expect(authority).To(Equal("my.example.com"))
+	})
+
+	It("Retries once when the server returns the unauthenticated status code", func() {
+		// Create a TLS listener:
+		tcpListener, err := net.Listen("tcp", "127.0.0.1:0")
+		Expect(err).ToNot(HaveOccurred())
+		tlsListener := tls.NewListener(tcpListener, &tls.Config{
+			Certificates: []tls.Certificate{
+				testing.LocalhostCertificate(),
+			},
+		})
+
+		// Track call count and return the unauthenticated status code only on the first call:
+		var calls atomic.Int32
+		interceptor := func(ctx context.Context, request any, info *grpc.UnaryServerInfo,
+			handler grpc.UnaryHandler) (response any, err error) {
+			if calls.Add(1) == 1 {
+				err = status.Error(codes.Unauthenticated, "token expired")
+				return
+			}
+			response, err = handler(ctx, request)
+			return
+		}
+
+		// Start the server:
+		server := grpc.NewServer(grpc.UnaryInterceptor(interceptor))
+		healthServer := health.NewServer()
+		healthpb.RegisterHealthServer(server, healthServer)
+		healthServer.SetServingStatus("", healthpb.HealthCheckResponse_SERVING)
+		go func() {
+			defer GinkgoRecover()
+			_ = server.Serve(tlsListener)
+		}()
+		defer server.Stop()
+
+		// There should be two calls to get the token, and one call to invalidate it:
+		token := &auth.Token{
+			Access: "test-token",
+			Expiry: time.Now().Add(time.Hour),
+		}
+		tokenSource := auth.NewMockTokenSource(ctrl)
+		tokenSource.EXPECT().Token(gomock.Any()).Return(token, nil).Times(2)
+		tokenSource.EXPECT().Invalidate(gomock.Any()).Return(nil).Times(1)
+
+		// Create the client with the token source so the retry interceptor is active:
+		client, err := NewGrpcClient().
+			SetLogger(logger).
+			SetAddress(tcpListener.Addr().String()).
+			SetInsecure(true).
+			SetTokenSource(tokenSource).
+			Build()
+		Expect(err).ToNot(HaveOccurred())
+		defer func() {
+			err := client.Close()
+			Expect(err).ToNot(HaveOccurred())
+		}()
+
+		// The first attempt gets the unauthenticated status code, but the retry should succeed:
+		healthClient := healthpb.NewHealthClient(client)
+		response, err := healthClient.Check(ctx, &healthpb.HealthCheckRequest{
+			Service: "",
+		})
+		Expect(err).ToNot(HaveOccurred())
+		Expect(response.Status).To(Equal(healthpb.HealthCheckResponse_SERVING))
+		Expect(calls.Load()).To(BeNumerically("==", 2))
+	})
+
+	It("Returns the unauthenticated status code when the retry also fails", func() {
+		// Create a TLS listener:
+		tcpListener, err := net.Listen("tcp", "127.0.0.1:0")
+		Expect(err).ToNot(HaveOccurred())
+		tlsListener := tls.NewListener(tcpListener, &tls.Config{
+			Certificates: []tls.Certificate{
+				testing.LocalhostCertificate(),
+			},
+		})
+
+		// Always return the unauthenticated status code:
+		var calls atomic.Int32
+		interceptor := func(ctx context.Context, request any, info *grpc.UnaryServerInfo,
+			handler grpc.UnaryHandler) (response any, err error) {
+			calls.Add(1)
+			err = status.Error(codes.Unauthenticated, "invalid credentials")
+			return
+		}
+
+		// Start the server:
+		server := grpc.NewServer(grpc.UnaryInterceptor(interceptor))
+		healthServer := health.NewServer()
+		healthpb.RegisterHealthServer(server, healthServer)
+		healthServer.SetServingStatus("", healthpb.HealthCheckResponse_SERVING)
+		go func() {
+			defer GinkgoRecover()
+			_ = server.Serve(tlsListener)
+		}()
+		defer server.Stop()
+
+		// There should be two calls to get the token, and one call to invalidate it:
+		token := &auth.Token{
+			Access: "test-token",
+			Expiry: time.Now().Add(time.Hour),
+		}
+		tokenSource := auth.NewMockTokenSource(ctrl)
+		tokenSource.EXPECT().Token(gomock.Any()).Return(token, nil).Times(2)
+		tokenSource.EXPECT().Invalidate(gomock.Any()).Return(nil).Times(1)
+
+		// Create the client:
+		client, err := NewGrpcClient().
+			SetLogger(logger).
+			SetAddress(tcpListener.Addr().String()).
+			SetInsecure(true).
+			SetTokenSource(tokenSource).
+			Build()
+		Expect(err).ToNot(HaveOccurred())
+		defer func() {
+			err := client.Close()
+			Expect(err).ToNot(HaveOccurred())
+		}()
+
+		// Both attempts fail, so the error is returned to the caller:
+		healthClient := healthpb.NewHealthClient(client)
+		_, err = healthClient.Check(ctx, &healthpb.HealthCheckRequest{
+			Service: "",
+		})
+		Expect(err).To(HaveOccurred())
+		Expect(status.Code(err)).To(Equal(codes.Unauthenticated))
+		Expect(calls.Load()).To(BeNumerically("==", 2))
+	})
+
+	It("Does not retry when the server returns a status code other than unauthenticated", func() {
+		// Create a TLS listener:
+		tcpListener, err := net.Listen("tcp", "127.0.0.1:0")
+		Expect(err).ToNot(HaveOccurred())
+		tlsListener := tls.NewListener(tcpListener, &tls.Config{
+			Certificates: []tls.Certificate{
+				testing.LocalhostCertificate(),
+			},
+		})
+
+		// Always return the permission denied status code:
+		var calls atomic.Int32
+		interceptor := func(ctx context.Context, request any, info *grpc.UnaryServerInfo,
+			handler grpc.UnaryHandler) (response any, err error) {
+			calls.Add(1)
+			err = status.Error(codes.PermissionDenied, "forbidden")
+			return
+		}
+
+		// Start the server:
+		server := grpc.NewServer(grpc.UnaryInterceptor(interceptor))
+		healthServer := health.NewServer()
+		healthpb.RegisterHealthServer(server, healthServer)
+		healthServer.SetServingStatus("", healthpb.HealthCheckResponse_SERVING)
+		go func() {
+			defer GinkgoRecover()
+			_ = server.Serve(tlsListener)
+		}()
+		defer server.Stop()
+
+		// There should be one call to get the token, and no call to invalidate it:
+		token := &auth.Token{
+			Access: "test-token",
+			Expiry: time.Now().Add(time.Hour),
+		}
+		tokenSource := auth.NewMockTokenSource(ctrl)
+		tokenSource.EXPECT().Token(gomock.Any()).Return(token, nil).Times(1)
+
+		// Create the client:
+		client, err := NewGrpcClient().
+			SetLogger(logger).
+			SetAddress(tcpListener.Addr().String()).
+			SetInsecure(true).
+			SetTokenSource(tokenSource).
+			Build()
+		Expect(err).ToNot(HaveOccurred())
+		defer func() {
+			err := client.Close()
+			Expect(err).ToNot(HaveOccurred())
+		}()
+
+		// The error is returned directly without retrying:
+		healthClient := healthpb.NewHealthClient(client)
+		_, err = healthClient.Check(ctx, &healthpb.HealthCheckRequest{
+			Service: "",
+		})
+		Expect(err).To(HaveOccurred())
+		Expect(status.Code(err)).To(Equal(codes.PermissionDenied))
+		Expect(calls.Load()).To(Equal(int32(1)))
 	})
 })


### PR DESCRIPTION
## Summary

When a `TokenSource` is configured, the gRPC client now retries a request once if the server
returns `Unauthenticated`. On the first such response the client calls `TokenSource.Invalidate`
to discard the cached token and retries, letting the `PerRPCCredentials` fetch a fresh one.
If the retry also returns `Unauthenticated` the error is passed through to the caller so the
client never loops indefinitely.

The retry logic lives in a new `unauthRetryInterceptor` placed at the outermost position in
the interceptor chain, giving logging and metrics visibility into each attempt.

## Test plan

- New test: server returns `Unauthenticated` on the first call then succeeds on the second,
  verifying the client recovers transparently, `Token` is called twice, and `Invalidate` once.
- New test: server always returns `Unauthenticated`, verifying the error reaches the caller
  after exactly two server calls and one `Invalidate`.
- New test: server returns `PermissionDenied`, verifying no retry and no `Invalidate`.
- All existing network package tests continue to pass.