### PR TITLE
NO-ISSUE: Tidy up test output

### DIFF
--- a/internal/apiclient/apiclient_suite_test.go
+++ b/internal/apiclient/apiclient_suite_test.go
@@ -25,7 +25,7 @@ import (
 
 func TestAPIClient(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "APIClient package")
+	RunSpecs(t, "API client package")
 }
 
 var (

--- a/internal/cmd/cli/create/cluster/create_cluster_cmd_test.go
+++ b/internal/cmd/cli/create/cluster/create_cluster_cmd_test.go
@@ -21,6 +21,8 @@ import (
 var _ = Describe("Create cluster flag registration", func() {
 	It("should register --catalog-item flag", func() {
 		cmd := Cmd()
+		cmd.SetOut(GinkgoWriter)
+		cmd.SetErr(GinkgoWriter)
 		flag := cmd.Flags().Lookup("catalog-item")
 		Expect(flag).NotTo(BeNil())
 		Expect(flag.Usage).To(ContainSubstring("Catalog item"))
@@ -28,12 +30,16 @@ var _ = Describe("Create cluster flag registration", func() {
 
 	It("should still register --template flag", func() {
 		cmd := Cmd()
+		cmd.SetOut(GinkgoWriter)
+		cmd.SetErr(GinkgoWriter)
 		flag := cmd.Flags().Lookup("template")
 		Expect(flag).NotTo(BeNil())
 	})
 
 	It("should register --catalog-item without a short flag", func() {
 		cmd := Cmd()
+		cmd.SetOut(GinkgoWriter)
+		cmd.SetErr(GinkgoWriter)
 		flag := cmd.Flags().Lookup("catalog-item")
 		Expect(flag).NotTo(BeNil())
 		Expect(flag.Shorthand).To(BeEmpty())
@@ -41,6 +47,8 @@ var _ = Describe("Create cluster flag registration", func() {
 
 	It("should keep -t as shorthand for --template", func() {
 		cmd := Cmd()
+		cmd.SetOut(GinkgoWriter)
+		cmd.SetErr(GinkgoWriter)
 		flag := cmd.Flags().Lookup("template")
 		Expect(flag).NotTo(BeNil())
 		Expect(flag.Shorthand).To(Equal("t"))
@@ -50,6 +58,8 @@ var _ = Describe("Create cluster flag registration", func() {
 var _ = Describe("Create cluster flag validation", func() {
 	It("should return error when both --catalog-item and --template are set", func() {
 		cmd := Cmd()
+		cmd.SetOut(GinkgoWriter)
+		cmd.SetErr(GinkgoWriter)
 		cmd.SetArgs([]string{"--catalog-item", "cat-001", "--template", "tpl-001", "--name", "test"})
 		err := cmd.Execute()
 		Expect(err).To(HaveOccurred())
@@ -60,6 +70,8 @@ var _ = Describe("Create cluster flag validation", func() {
 
 	It("should return error when neither --catalog-item nor --template is set", func() {
 		cmd := Cmd()
+		cmd.SetOut(GinkgoWriter)
+		cmd.SetErr(GinkgoWriter)
 		cmd.SetArgs([]string{"--name", "test"})
 		err := cmd.Execute()
 		Expect(err).To(HaveOccurred())

--- a/internal/cmd/cli/create/cluster/create_cluster_suite_test.go
+++ b/internal/cmd/cli/create/cluster/create_cluster_suite_test.go
@@ -22,5 +22,5 @@ import (
 
 func TestCreateCluster(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "Create Cluster Suite")
+	RunSpecs(t, "Create cluster command")
 }

--- a/internal/cmd/cli/create/computeinstance/computeinstance_suite_test.go
+++ b/internal/cmd/cli/create/computeinstance/computeinstance_suite_test.go
@@ -22,5 +22,5 @@ import (
 
 func TestComputeInstance(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "Compute Instance Suite")
+	RunSpecs(t, "Create compute instance command")
 }

--- a/internal/cmd/cli/create/computeinstance/create_compute_instance_cmd_test.go
+++ b/internal/cmd/cli/create/computeinstance/create_compute_instance_cmd_test.go
@@ -109,6 +109,8 @@ var _ = Describe("buildSpec", func() {
 var _ = Describe("Create computeinstance flag registration", func() {
 	It("should register --catalog-item flag", func() {
 		cmd := Cmd()
+		cmd.SetOut(GinkgoWriter)
+		cmd.SetErr(GinkgoWriter)
 		flag := cmd.Flags().Lookup("catalog-item")
 		Expect(flag).NotTo(BeNil())
 		Expect(flag.Usage).To(ContainSubstring("Catalog item"))
@@ -116,12 +118,16 @@ var _ = Describe("Create computeinstance flag registration", func() {
 
 	It("should still register --template flag", func() {
 		cmd := Cmd()
+		cmd.SetOut(GinkgoWriter)
+		cmd.SetErr(GinkgoWriter)
 		flag := cmd.Flags().Lookup("template")
 		Expect(flag).NotTo(BeNil())
 	})
 
 	It("should register --catalog-item without a short flag", func() {
 		cmd := Cmd()
+		cmd.SetOut(GinkgoWriter)
+		cmd.SetErr(GinkgoWriter)
 		flag := cmd.Flags().Lookup("catalog-item")
 		Expect(flag).NotTo(BeNil())
 		Expect(flag.Shorthand).To(BeEmpty())
@@ -129,6 +135,8 @@ var _ = Describe("Create computeinstance flag registration", func() {
 
 	It("should keep -t as shorthand for --template", func() {
 		cmd := Cmd()
+		cmd.SetOut(GinkgoWriter)
+		cmd.SetErr(GinkgoWriter)
 		flag := cmd.Flags().Lookup("template")
 		Expect(flag).NotTo(BeNil())
 		Expect(flag.Shorthand).To(Equal("t"))
@@ -138,6 +146,8 @@ var _ = Describe("Create computeinstance flag registration", func() {
 var _ = Describe("Create computeinstance flag validation", func() {
 	It("should return error when both --catalog-item and --template are set", func() {
 		cmd := Cmd()
+		cmd.SetOut(GinkgoWriter)
+		cmd.SetErr(GinkgoWriter)
 		cmd.SetArgs([]string{"--catalog-item", "cat-001", "--template", "tpl-001", "--name", "test"})
 		err := cmd.Execute()
 		Expect(err).To(HaveOccurred())
@@ -148,6 +158,8 @@ var _ = Describe("Create computeinstance flag validation", func() {
 
 	It("should return error when neither --catalog-item nor --template is set", func() {
 		cmd := Cmd()
+		cmd.SetOut(GinkgoWriter)
+		cmd.SetErr(GinkgoWriter)
 		cmd.SetArgs([]string{"--name", "test"})
 		err := cmd.Execute()
 		Expect(err).To(HaveOccurred())

--- a/internal/cmd/cli/create/netutil/netutil_suite_test.go
+++ b/internal/cmd/cli/create/netutil/netutil_suite_test.go
@@ -22,5 +22,5 @@ import (
 
 func TestNetutil(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "Netutil Suite")
+	RunSpecs(t, "Network utilities package")
 }

--- a/internal/cmd/cli/create/securitygroup/create_securitygroup_suite_test.go
+++ b/internal/cmd/cli/create/securitygroup/create_securitygroup_suite_test.go
@@ -11,7 +11,7 @@ Unless required by applicable law or agreed to in writing, software distributed 
 language governing permissions and limitations under the License.
 */
 
-package virtualnetwork
+package securitygroup
 
 import (
 	"testing"
@@ -20,7 +20,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-func TestCreateVirtualNetwork(t *testing.T) {
+func TestSecurityGroup(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "CreateVirtualNetwork command")
+	RunSpecs(t, "Create security group command")
 }

--- a/internal/cmd/cli/create/virtualnetwork/create_virtualnetwork_suite_test.go
+++ b/internal/cmd/cli/create/virtualnetwork/create_virtualnetwork_suite_test.go
@@ -11,7 +11,7 @@ Unless required by applicable law or agreed to in writing, software distributed 
 language governing permissions and limitations under the License.
 */
 
-package securitygroup
+package virtualnetwork
 
 import (
 	"testing"
@@ -20,7 +20,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-func TestSecurityGroup(t *testing.T) {
+func TestCreateVirtualNetwork(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "SecurityGroup command")
+	RunSpecs(t, "Create virtual network command")
 }

--- a/internal/cmd/cli/describe/cluster/describe_cluster_suite_test.go
+++ b/internal/cmd/cli/describe/cluster/describe_cluster_suite_test.go
@@ -22,5 +22,5 @@ import (
 
 func TestDescribeCluster(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "Describe Cluster Suite")
+	RunSpecs(t, "Describe cluster command")
 }

--- a/internal/cmd/cli/describe/computeinstance/describe_computeinstance_suite_test.go
+++ b/internal/cmd/cli/describe/computeinstance/describe_computeinstance_suite_test.go
@@ -22,5 +22,5 @@ import (
 
 func TestDescribeComputeInstance(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "Describe Compute Instance Suite")
+	RunSpecs(t, "Describe compute instance command")
 }

--- a/internal/cmd/cli/describe/publicip/describe_publicip_suite_test.go
+++ b/internal/cmd/cli/describe/publicip/describe_publicip_suite_test.go
@@ -22,5 +22,5 @@ import (
 
 func TestDescribePublicIP(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "Describe PublicIP Suite")
+	RunSpecs(t, "Describe public IP command")
 }

--- a/internal/cmd/cli/describe/securitygroup/describe_securitygroup_suite_test.go
+++ b/internal/cmd/cli/describe/securitygroup/describe_securitygroup_suite_test.go
@@ -22,5 +22,5 @@ import (
 
 func TestDescribeSecurityGroup(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "Describe SecurityGroup Suite")
+	RunSpecs(t, "Describe security group command")
 }

--- a/internal/cmd/cli/describe/virtualnetwork/describe_virtualnetwork_suite_test.go
+++ b/internal/cmd/cli/describe/virtualnetwork/describe_virtualnetwork_suite_test.go
@@ -22,5 +22,5 @@ import (
 
 func TestDescribeVirtualNetwork(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "Describe Virtual Network Suite")
+	RunSpecs(t, "Describe virtual network command")
 }

--- a/internal/controllers/organization/organization_suite_test.go
+++ b/internal/controllers/organization/organization_suite_test.go
@@ -29,7 +29,7 @@ var (
 
 func TestOrganizationReconciler(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "Organization Reconciler Suite")
+	RunSpecs(t, "Organization controller")
 }
 
 var _ = BeforeSuite(func() {

--- a/internal/controllers/project/project_reconciler_function_test.go
+++ b/internal/controllers/project/project_reconciler_function_test.go
@@ -15,7 +15,6 @@ package project
 
 import (
 	"context"
-	"log/slog"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -173,13 +172,13 @@ var _ = Describe("Validation and Activation", func() {
 
 		var err error
 		resourceManager, err = idp.NewResourceManager().
-			SetLogger(slog.Default()).
+			SetLogger(logger).
 			SetClient(mockIdpClient).
 			Build()
 		Expect(err).ToNot(HaveOccurred())
 
 		functionObj = &function{
-			logger:          slog.Default(),
+			logger:          logger,
 			projectsClient:  mockClient,
 			resourceManager: resourceManager,
 		}

--- a/internal/controllers/project/project_suite_test.go
+++ b/internal/controllers/project/project_suite_test.go
@@ -14,13 +14,27 @@ language governing permissions and limitations under the License.
 package project
 
 import (
+	"log/slog"
 	"testing"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/osac-project/fulfillment-service/internal/logging"
 )
 
 func TestProject(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "Project Controller Suite")
+	RunSpecs(t, "Project controller")
 }
+
+var logger *slog.Logger
+
+var _ = BeforeSuite(func() {
+	var err error
+
+	logger, err = logging.NewLogger().
+		SetLevel(slog.LevelDebug.String()).
+		SetWriter(GinkgoWriter).
+		Build()
+	Expect(err).ToNot(HaveOccurred())
+})

--- a/internal/controllers/publicip/publicip_suite_test.go
+++ b/internal/controllers/publicip/publicip_suite_test.go
@@ -24,7 +24,7 @@ import (
 
 func TestPublicIP(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "PublicIP controller")
+	RunSpecs(t, "Public IP controller")
 }
 
 // Logger used for tests:

--- a/internal/controllers/publicippool/public_ip_pool_suite_test.go
+++ b/internal/controllers/publicippool/public_ip_pool_suite_test.go
@@ -24,7 +24,7 @@ import (
 
 func TestPublicIPPool(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "PublicIPPool controller")
+	RunSpecs(t, "Public IP pool controller")
 }
 
 var logger *slog.Logger

--- a/internal/idp/idp_suite_test.go
+++ b/internal/idp/idp_suite_test.go
@@ -25,7 +25,7 @@ import (
 
 func TestIdp(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "IdP package")
+	RunSpecs(t, "Identity provider package")
 }
 
 var (

--- a/internal/idp/resource_manager_test.go
+++ b/internal/idp/resource_manager_test.go
@@ -15,7 +15,6 @@ package idp
 
 import (
 	"context"
-	"log/slog"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -27,7 +26,6 @@ var _ = Describe("ResourceManager", func() {
 		ctx           context.Context
 		ctrl          *gomock.Controller
 		mockClient    *MockClient
-		logger        *slog.Logger
 		manager       *ResourceManager
 		testProjectID string
 		testTenant    string
@@ -38,7 +36,6 @@ var _ = Describe("ResourceManager", func() {
 		ctx = context.Background()
 		ctrl = gomock.NewController(GinkgoT())
 		mockClient = NewMockClient(ctrl)
-		logger = slog.Default()
 
 		testProjectID = "project-123"
 		testTenant = "acme"


### PR DESCRIPTION
## Summary

This fixes several tests that were writing output directly to the standard
output streams instead of to the Ginkgo writer, resulting in polluted test
summaries. It also updates some test suites to use more uniform naming for
their descriptions and file names.

## Test plan

- Run `ginkgo run -r internal` and verify all tests pass.
- Verify test output is no longer polluted with stray log messages or
  command help text outside of the Ginkgo per-test output.