### PR TITLE
OSAC-704: fix structpb.Value serialization in custom JSON encoder

### DIFF
--- a/internal/json/json_encoder.go
+++ b/internal/json/json_encoder.go
@@ -27,6 +27,7 @@ import (
 	"google.golang.org/protobuf/reflect/protoreflect"
 	"google.golang.org/protobuf/types/known/anypb"
 	"google.golang.org/protobuf/types/known/durationpb"
+	"google.golang.org/protobuf/types/known/structpb"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
@@ -44,6 +45,8 @@ type Encoder struct {
 	anyDesc               protoreflect.MessageDescriptor
 	durationDesc          protoreflect.MessageDescriptor
 	timestampDesc         protoreflect.MessageDescriptor
+	valueDesc             protoreflect.MessageDescriptor
+	structDesc            protoreflect.MessageDescriptor
 	jsonApi               jsoniter.API
 }
 
@@ -86,10 +89,14 @@ func (b *EncoderBuilder) Build() (result *Encoder, err error) {
 		anyValue       *anypb.Any
 		durationValue  *durationpb.Duration
 		timestampValue *timestamppb.Timestamp
+		valueValue     *structpb.Value
+		structValue    *structpb.Struct
 	)
 	anyDesc := anyValue.ProtoReflect().Descriptor()
 	durationDesc := durationValue.ProtoReflect().Descriptor()
 	timestampDesc := timestampValue.ProtoReflect().Descriptor()
+	valueDesc := valueValue.ProtoReflect().Descriptor()
+	structDesc := structValue.ProtoReflect().Descriptor()
 
 	// Create the JSON API:
 	jsonApi := jsoniter.Config{}.Froze()
@@ -127,6 +134,8 @@ func (b *EncoderBuilder) Build() (result *Encoder, err error) {
 		anyDesc:               anyDesc,
 		durationDesc:          durationDesc,
 		timestampDesc:         timestampDesc,
+		valueDesc:             valueDesc,
+		structDesc:            structDesc,
 		jsonApi:               jsonApi,
 	}
 	return
@@ -153,7 +162,8 @@ func (e *Encoder) Marshal(object proto.Message) (result []byte, err error) {
 
 func (e *Encoder) marshalMessage(stream *jsoniter.Stream, message protoreflect.Message) (err error) {
 	descriptor := message.Descriptor()
-	if descriptor == e.anyDesc || descriptor == e.durationDesc || descriptor == e.timestampDesc {
+	if descriptor == e.anyDesc || descriptor == e.durationDesc || descriptor == e.timestampDesc ||
+		descriptor == e.valueDesc || descriptor == e.structDesc {
 		err = e.marshalWellKnown(stream, message.Interface())
 		return
 	}

--- a/internal/servers/private_clusters_server_test.go
+++ b/internal/servers/private_clusters_server_test.go
@@ -1182,34 +1182,51 @@ var _ = Describe("Private clusters server", func() {
 			})
 
 			It("Overrides user value for non-editable field", func() {
-				spec := privatev1.ClusterSpec_builder{
-					PullSecret: proto.String("user-secret"),
-				}.Build()
-
-				err := applyFieldDefinitions(spec, []*privatev1.FieldDefinition{
+				createCatalogItem("cat-noneditable", true, []*privatev1.FieldDefinition{
 					privatev1.FieldDefinition_builder{
 						Path:     "pull_secret",
 						Editable: false,
 						Default:  structpb.NewStringValue("forced-secret"),
 					}.Build(),
 				})
+
+				response, err := server.Create(ctx, privatev1.ClustersCreateRequest_builder{
+					Object: privatev1.Cluster_builder{
+						Spec: privatev1.ClusterSpec_builder{
+							CatalogItem: "cat-noneditable",
+							PullSecret:  proto.String("user-secret"),
+						}.Build(),
+						Status: privatev1.ClusterStatus_builder{
+							Hub: "my-hub-id",
+						}.Build(),
+					}.Build(),
+				}.Build())
 				Expect(err).ToNot(HaveOccurred())
-				Expect(spec.GetPullSecret()).To(Equal("forced-secret"))
+				object := response.GetObject()
+				Expect(object.GetSpec().GetPullSecret()).To(Equal("forced-secret"))
 			})
 
 			DescribeTable("validates editable field against JSON Schema",
 				func(value string, expectError bool) {
-					spec := privatev1.ClusterSpec_builder{
-						PullSecret: proto.String(value),
-					}.Build()
-
-					err := applyFieldDefinitions(spec, []*privatev1.FieldDefinition{
+					createCatalogItem("cat-schema-"+value[:5], true, []*privatev1.FieldDefinition{
 						privatev1.FieldDefinition_builder{
 							Path:             "pull_secret",
 							Editable:         true,
 							ValidationSchema: `{"type":"string","minLength":10}`,
 						}.Build(),
 					})
+
+					_, err := server.Create(ctx, privatev1.ClustersCreateRequest_builder{
+						Object: privatev1.Cluster_builder{
+							Spec: privatev1.ClusterSpec_builder{
+								CatalogItem: "cat-schema-" + value[:5],
+								PullSecret:  proto.String(value),
+							}.Build(),
+							Status: privatev1.ClusterStatus_builder{
+								Hub: "my-hub-id",
+							}.Build(),
+						}.Build(),
+					}.Build())
 					if expectError {
 						Expect(err).To(HaveOccurred())
 						status, ok := grpcstatus.FromError(err)
@@ -1218,25 +1235,34 @@ var _ = Describe("Private clusters server", func() {
 						Expect(status.Message()).To(ContainSubstring("validation failed for field 'pull_secret'"))
 					} else {
 						Expect(err).ToNot(HaveOccurred())
-						Expect(spec.GetPullSecret()).To(Equal(value))
 					}
 				},
-				Entry("rejects value below minLength", "short", true),
+				Entry("rejects value below minLength", "short-val", true),
 				Entry("accepts value meeting minLength", "long-enough-value", false),
 			)
 
 			It("Applies default for editable field when not provided", func() {
-				spec := privatev1.ClusterSpec_builder{}.Build()
-
-				err := applyFieldDefinitions(spec, []*privatev1.FieldDefinition{
+				createCatalogItem("cat-default", true, []*privatev1.FieldDefinition{
 					privatev1.FieldDefinition_builder{
 						Path:     "pull_secret",
 						Editable: true,
 						Default:  structpb.NewStringValue("default-secret"),
 					}.Build(),
 				})
+
+				response, err := server.Create(ctx, privatev1.ClustersCreateRequest_builder{
+					Object: privatev1.Cluster_builder{
+						Spec: privatev1.ClusterSpec_builder{
+							CatalogItem: "cat-default",
+						}.Build(),
+						Status: privatev1.ClusterStatus_builder{
+							Hub: "my-hub-id",
+						}.Build(),
+					}.Build(),
+				}.Build())
 				Expect(err).ToNot(HaveOccurred())
-				Expect(spec.GetPullSecret()).To(Equal("default-secret"))
+				object := response.GetObject()
+				Expect(object.GetSpec().GetPullSecret()).To(Equal("default-secret"))
 			})
 
 			It("Rejects changing catalog_item on update", func() {

--- a/internal/servers/private_clusters_server_test.go
+++ b/internal/servers/private_clusters_server_test.go
@@ -1207,8 +1207,8 @@ var _ = Describe("Private clusters server", func() {
 			})
 
 			DescribeTable("validates editable field against JSON Schema",
-				func(value string, expectError bool) {
-					createCatalogItem("cat-schema-"+value[:5], true, []*privatev1.FieldDefinition{
+				func(catID string, value string, expectError bool) {
+					createCatalogItem(catID, true, []*privatev1.FieldDefinition{
 						privatev1.FieldDefinition_builder{
 							Path:             "pull_secret",
 							Editable:         true,
@@ -1216,10 +1216,10 @@ var _ = Describe("Private clusters server", func() {
 						}.Build(),
 					})
 
-					_, err := server.Create(ctx, privatev1.ClustersCreateRequest_builder{
+					response, err := server.Create(ctx, privatev1.ClustersCreateRequest_builder{
 						Object: privatev1.Cluster_builder{
 							Spec: privatev1.ClusterSpec_builder{
-								CatalogItem: "cat-schema-" + value[:5],
+								CatalogItem: catID,
 								PullSecret:  proto.String(value),
 							}.Build(),
 							Status: privatev1.ClusterStatus_builder{
@@ -1235,10 +1235,11 @@ var _ = Describe("Private clusters server", func() {
 						Expect(status.Message()).To(ContainSubstring("validation failed for field 'pull_secret'"))
 					} else {
 						Expect(err).ToNot(HaveOccurred())
+						Expect(response.GetObject().GetSpec().GetPullSecret()).To(Equal(value))
 					}
 				},
-				Entry("rejects value below minLength", "short-val", true),
-				Entry("accepts value meeting minLength", "long-enough-value", false),
+				Entry("rejects value below minLength", "cat-schema-reject", "short-val", true),
+				Entry("accepts value meeting minLength", "cat-schema-accept", "long-enough-value", false),
 			)
 
 			It("Applies default for editable field when not provided", func() {

--- a/internal/servers/private_compute_instances_server_test.go
+++ b/internal/servers/private_compute_instances_server_test.go
@@ -1060,8 +1060,8 @@ var _ = Describe("Private compute instances server", func() {
 			})
 
 			DescribeTable("validates editable field against JSON Schema",
-				func(value string, expectError bool) {
-					createCICatalogItem("ci-cat-schema-"+value[:5], true, []*privatev1.FieldDefinition{
+				func(catID string, value string, expectError bool) {
+					createCICatalogItem(catID, true, []*privatev1.FieldDefinition{
 						privatev1.FieldDefinition_builder{
 							Path:             "ssh_key",
 							Editable:         true,
@@ -1069,10 +1069,10 @@ var _ = Describe("Private compute instances server", func() {
 						}.Build(),
 					})
 
-					_, err := server.Create(ctx, privatev1.ComputeInstancesCreateRequest_builder{
+					response, err := server.Create(ctx, privatev1.ComputeInstancesCreateRequest_builder{
 						Object: privatev1.ComputeInstance_builder{
 							Spec: privatev1.ComputeInstanceSpec_builder{
-								CatalogItem: "ci-cat-schema-" + value[:5],
+								CatalogItem: catID,
 								SshKey:      proto.String(value),
 							}.Build(),
 						}.Build(),
@@ -1085,10 +1085,11 @@ var _ = Describe("Private compute instances server", func() {
 						Expect(status.Message()).To(ContainSubstring("validation failed for field 'ssh_key'"))
 					} else {
 						Expect(err).ToNot(HaveOccurred())
+						Expect(response.GetObject().GetSpec().GetSshKey()).To(Equal(value))
 					}
 				},
-				Entry("rejects value below minLength", "short-val", true),
-				Entry("accepts value meeting minLength", "long-enough-key", false),
+				Entry("rejects value below minLength", "ci-cat-schema-reject", "short-val", true),
+				Entry("accepts value meeting minLength", "ci-cat-schema-accept", "long-enough-key", false),
 			)
 
 			It("Applies default for editable field when not provided", func() {

--- a/internal/servers/private_compute_instances_server_test.go
+++ b/internal/servers/private_compute_instances_server_test.go
@@ -1038,34 +1038,45 @@ var _ = Describe("Private compute instances server", func() {
 			})
 
 			It("Overrides user value for non-editable field", func() {
-				spec := privatev1.ComputeInstanceSpec_builder{
-					SshKey: proto.String("user-key"),
-				}.Build()
-
-				err := applyFieldDefinitions(spec, []*privatev1.FieldDefinition{
+				createCICatalogItem("ci-cat-nonedit", true, []*privatev1.FieldDefinition{
 					privatev1.FieldDefinition_builder{
 						Path:     "ssh_key",
 						Editable: false,
 						Default:  structpb.NewStringValue("forced-key"),
 					}.Build(),
 				})
+
+				response, err := server.Create(ctx, privatev1.ComputeInstancesCreateRequest_builder{
+					Object: privatev1.ComputeInstance_builder{
+						Spec: privatev1.ComputeInstanceSpec_builder{
+							CatalogItem: "ci-cat-nonedit",
+							SshKey:      proto.String("user-key"),
+						}.Build(),
+					}.Build(),
+				}.Build())
 				Expect(err).ToNot(HaveOccurred())
-				Expect(spec.GetSshKey()).To(Equal("forced-key"))
+				object := response.GetObject()
+				Expect(object.GetSpec().GetSshKey()).To(Equal("forced-key"))
 			})
 
 			DescribeTable("validates editable field against JSON Schema",
 				func(value string, expectError bool) {
-					spec := privatev1.ComputeInstanceSpec_builder{
-						SshKey: proto.String(value),
-					}.Build()
-
-					err := applyFieldDefinitions(spec, []*privatev1.FieldDefinition{
+					createCICatalogItem("ci-cat-schema-"+value[:5], true, []*privatev1.FieldDefinition{
 						privatev1.FieldDefinition_builder{
 							Path:             "ssh_key",
 							Editable:         true,
 							ValidationSchema: `{"type":"string","minLength":10}`,
 						}.Build(),
 					})
+
+					_, err := server.Create(ctx, privatev1.ComputeInstancesCreateRequest_builder{
+						Object: privatev1.ComputeInstance_builder{
+							Spec: privatev1.ComputeInstanceSpec_builder{
+								CatalogItem: "ci-cat-schema-" + value[:5],
+								SshKey:      proto.String(value),
+							}.Build(),
+						}.Build(),
+					}.Build())
 					if expectError {
 						Expect(err).To(HaveOccurred())
 						status, ok := grpcstatus.FromError(err)
@@ -1074,25 +1085,31 @@ var _ = Describe("Private compute instances server", func() {
 						Expect(status.Message()).To(ContainSubstring("validation failed for field 'ssh_key'"))
 					} else {
 						Expect(err).ToNot(HaveOccurred())
-						Expect(spec.GetSshKey()).To(Equal(value))
 					}
 				},
-				Entry("rejects value below minLength", "short", true),
+				Entry("rejects value below minLength", "short-val", true),
 				Entry("accepts value meeting minLength", "long-enough-key", false),
 			)
 
 			It("Applies default for editable field when not provided", func() {
-				spec := privatev1.ComputeInstanceSpec_builder{}.Build()
-
-				err := applyFieldDefinitions(spec, []*privatev1.FieldDefinition{
+				createCICatalogItem("ci-cat-dflt", true, []*privatev1.FieldDefinition{
 					privatev1.FieldDefinition_builder{
 						Path:     "ssh_key",
 						Editable: true,
 						Default:  structpb.NewStringValue("default-key"),
 					}.Build(),
 				})
+
+				response, err := server.Create(ctx, privatev1.ComputeInstancesCreateRequest_builder{
+					Object: privatev1.ComputeInstance_builder{
+						Spec: privatev1.ComputeInstanceSpec_builder{
+							CatalogItem: "ci-cat-dflt",
+						}.Build(),
+					}.Build(),
+				}.Build())
 				Expect(err).ToNot(HaveOccurred())
-				Expect(spec.GetSshKey()).To(Equal("default-key"))
+				object := response.GetObject()
+				Expect(object.GetSpec().GetSshKey()).To(Equal("default-key"))
 			})
 
 			It("Rejects changing catalog_item on update", func() {


### PR DESCRIPTION
## Summary
The custom JSON encoder handles `Any`, `Duration`, and `Timestamp` as well-known types (delegating to `protojson.Marshal`) but not `google.protobuf.Value` and `google.protobuf.Struct`. This caused `FieldDefinition.Default` values to serialize as `{"string_value":"x"}` instead of `"x"`, breaking field definition defaults on DAO round-trip.

**Fix:** Add `Value` and `Struct` to the well-known types list in `internal/json/json_encoder.go` (3 lines changed).

**Test upgrade:** Convert the 6 field-definition tests from direct `applyFieldDefinitions` calls to full integration tests through the server Create flow, proving defaults now survive the DAO round-trip correctly.

## Test plan
- [x] 20 catalog item tests pass (now as full integration tests with DAO round-trip)
- [x] 22 JSON encoder tests pass
- [x] `gofmt` clean

Jira: [OSAC-704](https://redhat.atlassian.net/browse/OSAC-704)

Generated with [Claude Code](https://claude.com/claude-code)