### PR TITLE
OSAC-360: use ubi10/go-toolset:1.26 builder and ubi10-minimal:10.2 runtime

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -1,20 +1,13 @@
 # First stage is to build the image that contains the image with all the development tools needed to build the binary.
-FROM registry.access.redhat.com/hi/go:1.26-builder AS builder
+FROM registry.access.redhat.com/ubi10/go-toolset:1.26 AS builder
 
 # Set this to 'true' to build the binary with debugging symbols and disabling optimizations.
 ARG DEBUG=false
 
-# Install packages:
-RUN \
-  set -e; \
-  pkgs=(git); \
-  dnf install -y "${pkgs[@]}"; \
-  dnf clean all -y
-
 # Copy only the 'go.mod' and 'go.sum' files and try to download the required modules, so that hopefully this will be
 # in a layer that can be cached reused for builds that don't change the dependencies.
-WORKDIR /source
-COPY go.mod go.sum /source/
+WORKDIR /opt/app-root/src
+COPY go.mod go.sum /opt/app-root/src/
 RUN \
   set -e; \
   go mod download
@@ -25,7 +18,7 @@ RUN \
 ARG VERSION=""
 
 # Copy the rest of the source and build the binary:
-COPY . /source/
+COPY --chown=1001:1001 . /opt/app-root/src/
 RUN \
   set -e; \
   version="${VERSION}"; \
@@ -44,12 +37,13 @@ FROM builder AS dlv-builder
 RUN go install github.com/go-delve/delve/cmd/dlv@latest
 
 # Common runtime base with the service binary.
-FROM registry.access.redhat.com/hi/core-runtime:latest-openssl AS runtime-base
-COPY --from=builder /source/fulfillment-service /usr/local/bin
+FROM registry.access.redhat.com/ubi10-minimal:10.2 AS runtime-base
+COPY --from=builder /opt/app-root/src/fulfillment-service /usr/local/bin
+USER 1001
 
 # Debug variant — adds dlv on top of the base; build with: podman build --target runtime-debug .
 FROM runtime-base AS runtime-debug
-COPY --from=dlv-builder /go/bin/dlv /usr/local/bin
+COPY --from=dlv-builder /opt/app-root/src/go/bin/dlv /usr/local/bin
 
 # Default (non-debug) runtime — must stay last so plain `podman build .` targets it.
 FROM runtime-base AS runtime


### PR DESCRIPTION
Replace internal hardened images with publicly available UBI 10 equivalents:

- Builder: `registry.access.redhat.com/ubi10/go-toolset:1.26` (Go 1.26 pre-installed, git pre-installed)
- Runtime: `registry.access.redhat.com/ubi10-minimal:10.2`

The build workspace uses `/opt/app-root/src` (writable by uid 1001, the go-toolset default user), so no `USER root` is needed. The dlv path is updated from `/go/bin/dlv` to `/opt/app-root/src/go/bin/dlv` to match go-toolset's `GOPATH`.

Fixes: [OSAC-360](https://redhat.atlassian.net/browse/OSAC-360)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated container deployment configuration to use Red Hat UBI toolset and Red Hat UBI 10.2 minimal runtime image for improved compatibility and security.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/osac-project/fulfillment-service/pull/592?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->