### PR TITLE
NO-ISSUE: group github-actions and add docker ecosystem in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,4 +1,4 @@
-# Set update schedule for GitHub Actions and Go modules
+# Set update schedule for GitHub Actions, Go modules, and container images
 
 version: 2
 updates:
@@ -7,6 +7,12 @@ updates:
   schedule:
     # Check for updates to GitHub Actions every week
     interval: "weekly"
+  groups:
+    github-actions:
+      patterns:
+        - "*"
+  commit-message:
+    prefix: "NO-ISSUE"
 - package-ecosystem: "gomod"
   directory: "/"
   schedule:
@@ -14,6 +20,17 @@ updates:
     interval: "weekly"
   groups:
     go-dependencies:
+      patterns:
+        - "*"
+  commit-message:
+    prefix: "NO-ISSUE"
+- package-ecosystem: "docker"
+  directory: "/"
+  schedule:
+    # Check for updates to container base images every week
+    interval: "weekly"
+  groups:
+    container-images:
       patterns:
         - "*"
   commit-message:


### PR DESCRIPTION
- Group GitHub Actions updates under a single `github-actions` group (consistent with how Go deps are already grouped)
- Add `docker` ecosystem to track and group base container image updates from the `Containerfile`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced Dependabot configuration to organize GitHub Actions updates
  * Enabled weekly automated checks for Docker base image updates

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/osac-project/fulfillment-service/pull/594?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->