### PR TITLE
OSAC-58: filter unpublished catalog items from public API

### DIFF
--- a/internal/servers/catalog_item_reference_checker.go
+++ b/internal/servers/catalog_item_reference_checker.go
@@ -1,0 +1,46 @@
+/*
+Copyright (c) 2025 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package servers
+
+import (
+	"context"
+	"fmt"
+
+	grpccodes "google.golang.org/grpc/codes"
+	grpcstatus "google.golang.org/grpc/status"
+
+	"github.com/osac-project/fulfillment-service/internal/database/dao"
+)
+
+// catalogItemReferenceChecker checks whether the caller has any resources that reference a catalog item.
+type catalogItemReferenceChecker interface {
+	hasReference(ctx context.Context, catalogItemID string) (bool, error)
+}
+
+// daoReferenceChecker implements catalogItemReferenceChecker using a GenericDAO.
+type daoReferenceChecker[Resource dao.Object] struct {
+	resourceDao *dao.GenericDAO[Resource]
+}
+
+func (c *daoReferenceChecker[Resource]) hasReference(ctx context.Context, catalogItemID string) (bool, error) {
+	filter := fmt.Sprintf("this.spec.catalog_item == %q", catalogItemID)
+	response, err := c.resourceDao.List().
+		SetFilter(filter).
+		SetLimit(1).
+		Do(ctx)
+	if err != nil {
+		return false, grpcstatus.Errorf(grpccodes.Internal, "failed to check resource references")
+	}
+	return response.GetTotal() > 0, nil
+}

--- a/internal/servers/catalog_item_reference_checker_mock.go
+++ b/internal/servers/catalog_item_reference_checker_mock.go
@@ -1,0 +1,58 @@
+/*
+Copyright (c) 2025 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package servers
+
+import (
+	"context"
+	"reflect"
+
+	"go.uber.org/mock/gomock"
+)
+
+type MockCatalogItemReferenceChecker struct {
+	ctrl     *gomock.Controller
+	recorder *MockCatalogItemReferenceCheckerMockRecorder
+	isgomock struct{}
+}
+
+type MockCatalogItemReferenceCheckerMockRecorder struct {
+	mock *MockCatalogItemReferenceChecker
+}
+
+func NewMockCatalogItemReferenceChecker(ctrl *gomock.Controller) *MockCatalogItemReferenceChecker {
+	mock := &MockCatalogItemReferenceChecker{ctrl: ctrl}
+	mock.recorder = &MockCatalogItemReferenceCheckerMockRecorder{mock}
+	return mock
+}
+
+func (m *MockCatalogItemReferenceChecker) EXPECT() *MockCatalogItemReferenceCheckerMockRecorder {
+	return m.recorder
+}
+
+func (m *MockCatalogItemReferenceChecker) hasReference(ctx context.Context, catalogItemID string) (bool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "hasReference", ctx, catalogItemID)
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (mr *MockCatalogItemReferenceCheckerMockRecorder) hasReference(ctx, catalogItemID any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(
+		mr.mock, "hasReference",
+		reflect.TypeOf((*MockCatalogItemReferenceChecker)(nil).hasReference),
+		ctx, catalogItemID,
+	)
+}

--- a/internal/servers/catalog_item_validation.go
+++ b/internal/servers/catalog_item_validation.go
@@ -15,8 +15,10 @@ package servers
 
 import (
 	"encoding/json"
+	"fmt"
 	"strings"
 
+	"github.com/google/cel-go/cel"
 	"github.com/santhosh-tekuri/jsonschema/v6"
 	grpccodes "google.golang.org/grpc/codes"
 	grpcstatus "google.golang.org/grpc/status"
@@ -27,6 +29,21 @@ import (
 	privatev1 "github.com/osac-project/fulfillment-service/internal/api/osac/private/v1"
 )
 
+// validateCELSyntax checks that a filter string is a syntactically valid, complete CEL expression.
+// This prevents filter bypass attacks where a malicious filter like "true) || (true" could
+// break out of parenthesized composition and change operator precedence.
+func validateCELSyntax(filter string) error {
+	env, err := cel.NewEnv()
+	if err != nil {
+		return fmt.Errorf("failed to create CEL environment: %w", err)
+	}
+	_, issues := env.Parse(filter)
+	if issues != nil && issues.Err() != nil {
+		return fmt.Errorf("syntax error: %w", issues.Err())
+	}
+	return nil
+}
+
 // catalogItem is implemented by both ClusterCatalogItem and ComputeInstanceCatalogItem.
 type catalogItem interface {
 	proto.Message
@@ -34,17 +51,6 @@ type catalogItem interface {
 	GetTemplate() string
 	GetFieldDefinitions() []*privatev1.FieldDefinition
 	GetMetadata() *privatev1.Metadata
-}
-
-const publishedFilter = "this.published == true"
-
-// addPublishedFilter appends a CEL clause that restricts results to published catalog items.
-// Used by public servers to hide unpublished items from end users.
-func addPublishedFilter(filter string) string {
-	if filter == "" {
-		return publishedFilter
-	}
-	return "(" + filter + ") && " + publishedFilter
 }
 
 // applyFieldDefinitions processes field definitions from a catalog item against a resource spec.

--- a/internal/servers/catalog_item_validation.go
+++ b/internal/servers/catalog_item_validation.go
@@ -36,6 +36,17 @@ type catalogItem interface {
 	GetMetadata() *privatev1.Metadata
 }
 
+const publishedFilter = "this.published == true"
+
+// addPublishedFilter appends a CEL clause that restricts results to published catalog items.
+// Used by public servers to hide unpublished items from end users.
+func addPublishedFilter(filter string) string {
+	if filter == "" {
+		return publishedFilter
+	}
+	return "(" + filter + ") && " + publishedFilter
+}
+
 // applyFieldDefinitions processes field definitions from a catalog item against a resource spec.
 // For non-editable fields: overrides user-provided values with the catalog item default.
 // For editable fields with user values: validates against the JSON Schema.

--- a/internal/servers/catalog_item_validation.go
+++ b/internal/servers/catalog_item_validation.go
@@ -14,6 +14,7 @@ language governing permissions and limitations under the License.
 package servers
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"strings"
@@ -28,6 +29,7 @@ import (
 	"google.golang.org/protobuf/types/known/structpb"
 
 	privatev1 "github.com/osac-project/fulfillment-service/internal/api/osac/private/v1"
+	"github.com/osac-project/fulfillment-service/internal/auth"
 )
 
 var (
@@ -51,6 +53,18 @@ func validateCELSyntax(filter string) error {
 		return fmt.Errorf("syntax error: %w", issues.Err())
 	}
 	return nil
+}
+
+// buildPublishedClause returns a CEL clause that shows published items to everyone
+// and unpublished items only to the user who created them.
+func buildPublishedClause(ctx context.Context) string {
+	user := auth.SubjectFromContext(ctx).User
+	return fmt.Sprintf("(this.published || this.metadata.creator == '%s')", user)
+}
+
+// isCreator checks whether the current user created the given item.
+func isCreator(ctx context.Context, itemCreator string) bool {
+	return itemCreator != "" && auth.SubjectFromContext(ctx).User == itemCreator
 }
 
 // catalogItem is implemented by both ClusterCatalogItem and ComputeInstanceCatalogItem.

--- a/internal/servers/catalog_item_validation.go
+++ b/internal/servers/catalog_item_validation.go
@@ -14,7 +14,6 @@ language governing permissions and limitations under the License.
 package servers
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"strings"
@@ -29,7 +28,6 @@ import (
 	"google.golang.org/protobuf/types/known/structpb"
 
 	privatev1 "github.com/osac-project/fulfillment-service/internal/api/osac/private/v1"
-	"github.com/osac-project/fulfillment-service/internal/auth"
 )
 
 var (
@@ -53,18 +51,6 @@ func validateCELSyntax(filter string) error {
 		return fmt.Errorf("syntax error: %w", issues.Err())
 	}
 	return nil
-}
-
-// buildPublishedClause returns a CEL clause that shows published items to everyone
-// and unpublished items only to the user who created them.
-func buildPublishedClause(ctx context.Context) string {
-	user := auth.SubjectFromContext(ctx).User
-	return fmt.Sprintf("(this.published || this.metadata.creator == '%s')", user)
-}
-
-// isCreator checks whether the current user created the given item.
-func isCreator(ctx context.Context, itemCreator string) bool {
-	return itemCreator != "" && auth.SubjectFromContext(ctx).User == itemCreator
 }
 
 // catalogItem is implemented by both ClusterCatalogItem and ComputeInstanceCatalogItem.

--- a/internal/servers/catalog_item_validation.go
+++ b/internal/servers/catalog_item_validation.go
@@ -17,6 +17,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
+	"sync"
 
 	"github.com/google/cel-go/cel"
 	"github.com/santhosh-tekuri/jsonschema/v6"
@@ -29,15 +30,23 @@ import (
 	privatev1 "github.com/osac-project/fulfillment-service/internal/api/osac/private/v1"
 )
 
+var (
+	celSyntaxEnv     *cel.Env
+	celSyntaxEnvOnce sync.Once
+	celSyntaxEnvErr  error
+)
+
 // validateCELSyntax checks that a filter string is a syntactically valid, complete CEL expression.
 // This prevents filter bypass attacks where a malicious filter like "true) || (true" could
 // break out of parenthesized composition and change operator precedence.
 func validateCELSyntax(filter string) error {
-	env, err := cel.NewEnv()
-	if err != nil {
-		return fmt.Errorf("failed to create CEL environment: %w", err)
+	celSyntaxEnvOnce.Do(func() {
+		celSyntaxEnv, celSyntaxEnvErr = cel.NewEnv()
+	})
+	if celSyntaxEnvErr != nil {
+		return fmt.Errorf("failed to create CEL environment: %w", celSyntaxEnvErr)
 	}
-	_, issues := env.Parse(filter)
+	_, issues := celSyntaxEnv.Parse(filter)
 	if issues != nil && issues.Err() != nil {
 		return fmt.Errorf("syntax error: %w", issues.Err())
 	}

--- a/internal/servers/catalog_item_validation_test.go
+++ b/internal/servers/catalog_item_validation_test.go
@@ -35,6 +35,8 @@ var _ = Describe("addPublishedFilter", func() {
 		Entry("simple filter", "this.id == '123'", "(this.id == '123') && this.published"),
 		Entry("compound filter", "this.title == 'a' && this.template == 'b'",
 			"(this.title == 'a' && this.template == 'b') && this.published"),
+		Entry("valid filter with OR is safely composed", "true || true",
+			"(true || true) && this.published"),
 	)
 
 	DescribeTable("rejects malformed filters",

--- a/internal/servers/catalog_item_validation_test.go
+++ b/internal/servers/catalog_item_validation_test.go
@@ -1,0 +1,31 @@
+/*
+Copyright (c) 2025 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package servers
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Catalog item validation", func() {
+	DescribeTable("addPublishedFilter",
+		func(input string, expected string) {
+			Expect(addPublishedFilter(input)).To(Equal(expected))
+		},
+		Entry("empty filter", "", "this.published == true"),
+		Entry("simple filter", "this.id == '123'", "(this.id == '123') && this.published == true"),
+		Entry("compound filter", "this.title == 'a' && this.template == 'b'",
+			"(this.title == 'a' && this.template == 'b') && this.published == true"),
+	)
+})

--- a/internal/servers/catalog_item_validation_test.go
+++ b/internal/servers/catalog_item_validation_test.go
@@ -18,14 +18,32 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-var _ = Describe("Catalog item validation", func() {
-	DescribeTable("addPublishedFilter",
+var _ = Describe("addPublishedFilter", func() {
+	var server *ClusterCatalogItemsServer
+
+	BeforeEach(func() {
+		server = &ClusterCatalogItemsServer{}
+	})
+
+	DescribeTable("composes filter correctly",
 		func(input string, expected string) {
-			Expect(addPublishedFilter(input)).To(Equal(expected))
+			result, err := server.addPublishedFilter(input)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result).To(Equal(expected))
 		},
-		Entry("empty filter", "", "this.published == true"),
-		Entry("simple filter", "this.id == '123'", "(this.id == '123') && this.published == true"),
+		Entry("empty filter", "", "this.published"),
+		Entry("simple filter", "this.id == '123'", "(this.id == '123') && this.published"),
 		Entry("compound filter", "this.title == 'a' && this.template == 'b'",
-			"(this.title == 'a' && this.template == 'b') && this.published == true"),
+			"(this.title == 'a' && this.template == 'b') && this.published"),
+	)
+
+	DescribeTable("rejects malformed filters",
+		func(input string) {
+			_, err := server.addPublishedFilter(input)
+			Expect(err).To(HaveOccurred())
+		},
+		Entry("unbalanced parens to bypass published", `true) || (true`),
+		Entry("unbalanced closing paren", `true)`),
+		Entry("unbalanced opening paren", `(true`),
 	)
 })

--- a/internal/servers/catalog_item_validation_test.go
+++ b/internal/servers/catalog_item_validation_test.go
@@ -14,52 +14,60 @@ language governing permissions and limitations under the License.
 package servers
 
 import (
-	"context"
-
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-
-	"github.com/osac-project/fulfillment-service/internal/auth"
-	"github.com/osac-project/fulfillment-service/internal/collections"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 var _ = Describe("addPublishedFilter", func() {
-	var (
-		server *ClusterCatalogItemsServer
-		ctx    context.Context
-	)
+	var server *ClusterCatalogItemsServer
 
 	BeforeEach(func() {
 		server = &ClusterCatalogItemsServer{}
-		ctx = auth.ContextWithSubject(context.Background(), &auth.Subject{
-			User:    "test-admin",
-			Tenants: collections.NewSet("my-tenant"),
-		})
 	})
 
 	DescribeTable("composes filter correctly",
 		func(input string, expected string) {
-			result, err := server.addPublishedFilter(ctx, input)
+			result, err := server.addPublishedFilter(input)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(result).To(Equal(expected))
 		},
-		Entry("empty filter", "",
-			"(this.published || this.metadata.creator == 'test-admin')"),
-		Entry("simple filter", "this.id == '123'",
-			"(this.id == '123') && (this.published || this.metadata.creator == 'test-admin')"),
+		Entry("empty filter", "", "this.published"),
+		Entry("simple filter", "this.id == '123'", "(this.id == '123') && this.published"),
 		Entry("compound filter", "this.title == 'a' && this.template == 'b'",
-			"(this.title == 'a' && this.template == 'b') && (this.published || this.metadata.creator == 'test-admin')"),
+			"(this.title == 'a' && this.template == 'b') && this.published"),
 		Entry("valid filter with OR is safely composed", "true || true",
-			"(true || true) && (this.published || this.metadata.creator == 'test-admin')"),
+			"(true || true) && this.published"),
 	)
 
 	DescribeTable("rejects malformed filters",
 		func(input string) {
-			_, err := server.addPublishedFilter(ctx, input)
+			_, err := server.addPublishedFilter(input)
 			Expect(err).To(HaveOccurred())
+			Expect(status.Code(err)).To(Equal(codes.InvalidArgument))
 		},
 		Entry("unbalanced parens to bypass published", `true) || (true`),
 		Entry("unbalanced closing paren", `true)`),
 		Entry("unbalanced opening paren", `(true`),
+	)
+
+	DescribeTable("validateCELSyntax",
+		func(input string, shouldPass bool) {
+			err := validateCELSyntax(input)
+			if shouldPass {
+				Expect(err).ToNot(HaveOccurred())
+			} else {
+				Expect(err).To(HaveOccurred())
+			}
+		},
+		Entry("valid simple expression", "true", true),
+		Entry("valid field reference", "this.published", true),
+		Entry("valid comparison", "this.id == '123'", true),
+		Entry("valid compound", "this.a && this.b || this.c", true),
+		Entry("unbalanced closing paren", "true)", false),
+		Entry("unbalanced opening paren", "(true", false),
+		Entry("injection attempt", `true) || (true`, false),
+		Entry("empty string is not valid CEL", "", false),
 	)
 })

--- a/internal/servers/catalog_item_validation_test.go
+++ b/internal/servers/catalog_item_validation_test.go
@@ -14,34 +14,48 @@ language governing permissions and limitations under the License.
 package servers
 
 import (
+	"context"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+
+	"github.com/osac-project/fulfillment-service/internal/auth"
+	"github.com/osac-project/fulfillment-service/internal/collections"
 )
 
 var _ = Describe("addPublishedFilter", func() {
-	var server *ClusterCatalogItemsServer
+	var (
+		server *ClusterCatalogItemsServer
+		ctx    context.Context
+	)
 
 	BeforeEach(func() {
 		server = &ClusterCatalogItemsServer{}
+		ctx = auth.ContextWithSubject(context.Background(), &auth.Subject{
+			User:    "test-admin",
+			Tenants: collections.NewSet("my-tenant"),
+		})
 	})
 
 	DescribeTable("composes filter correctly",
 		func(input string, expected string) {
-			result, err := server.addPublishedFilter(input)
+			result, err := server.addPublishedFilter(ctx, input)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(result).To(Equal(expected))
 		},
-		Entry("empty filter", "", "this.published"),
-		Entry("simple filter", "this.id == '123'", "(this.id == '123') && this.published"),
+		Entry("empty filter", "",
+			"(this.published || this.metadata.creator == 'test-admin')"),
+		Entry("simple filter", "this.id == '123'",
+			"(this.id == '123') && (this.published || this.metadata.creator == 'test-admin')"),
 		Entry("compound filter", "this.title == 'a' && this.template == 'b'",
-			"(this.title == 'a' && this.template == 'b') && this.published"),
+			"(this.title == 'a' && this.template == 'b') && (this.published || this.metadata.creator == 'test-admin')"),
 		Entry("valid filter with OR is safely composed", "true || true",
-			"(true || true) && this.published"),
+			"(true || true) && (this.published || this.metadata.creator == 'test-admin')"),
 	)
 
 	DescribeTable("rejects malformed filters",
 		func(input string) {
-			_, err := server.addPublishedFilter(input)
+			_, err := server.addPublishedFilter(ctx, input)
 			Expect(err).To(HaveOccurred())
 		},
 		Entry("unbalanced parens to bypass published", `true) || (true`),

--- a/internal/servers/cluster_catalog_items_server.go
+++ b/internal/servers/cluster_catalog_items_server.go
@@ -126,7 +126,11 @@ func (s *ClusterCatalogItemsServer) List(ctx context.Context,
 	privateRequest := &privatev1.ClusterCatalogItemsListRequest{}
 	privateRequest.SetOffset(request.GetOffset())
 	privateRequest.SetLimit(request.GetLimit())
-	privateRequest.SetFilter(addPublishedFilter(request.GetFilter()))
+	composedFilter, err := s.addPublishedFilter(request.GetFilter())
+	if err != nil {
+		return nil, err
+	}
+	privateRequest.SetFilter(composedFilter)
 	privateRequest.SetOrder(request.GetOrder())
 
 	privateResponse, err := s.delegate.List(ctx, privateRequest)
@@ -261,6 +265,16 @@ func (s *ClusterCatalogItemsServer) Update(ctx context.Context,
 	response = &publicv1.ClusterCatalogItemsUpdateResponse{}
 	response.SetObject(updatedPublicCatalogItem)
 	return
+}
+
+func (s *ClusterCatalogItemsServer) addPublishedFilter(filter string) (string, error) {
+	if filter == "" {
+		return "this.published", nil
+	}
+	if err := validateCELSyntax(filter); err != nil {
+		return "", grpcstatus.Errorf(grpccodes.InvalidArgument, "invalid filter: %v", err)
+	}
+	return "(" + filter + ") && this.published", nil
 }
 
 func (s *ClusterCatalogItemsServer) Delete(ctx context.Context,

--- a/internal/servers/cluster_catalog_items_server.go
+++ b/internal/servers/cluster_catalog_items_server.go
@@ -16,7 +16,6 @@ package servers
 import (
 	"context"
 	"errors"
-	"fmt"
 	"log/slog"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -43,11 +42,11 @@ var _ publicv1.ClusterCatalogItemsServer = (*ClusterCatalogItemsServer)(nil)
 type ClusterCatalogItemsServer struct {
 	publicv1.UnimplementedClusterCatalogItemsServer
 
-	logger      *slog.Logger
-	clustersDao *dao.GenericDAO[*privatev1.Cluster]
-	delegate    privatev1.ClusterCatalogItemsServer
-	inMapper    *GenericMapper[*publicv1.ClusterCatalogItem, *privatev1.ClusterCatalogItem]
-	outMapper   *GenericMapper[*privatev1.ClusterCatalogItem, *publicv1.ClusterCatalogItem]
+	logger           *slog.Logger
+	referenceChecker catalogItemReferenceChecker
+	delegate         privatev1.ClusterCatalogItemsServer
+	inMapper         *GenericMapper[*publicv1.ClusterCatalogItem, *privatev1.ClusterCatalogItem]
+	outMapper        *GenericMapper[*privatev1.ClusterCatalogItem, *publicv1.ClusterCatalogItem]
 }
 
 func NewClusterCatalogItemsServer() *ClusterCatalogItemsServerBuilder {
@@ -112,6 +111,7 @@ func (b *ClusterCatalogItemsServerBuilder) Build() (result *ClusterCatalogItemsS
 	if err != nil {
 		return
 	}
+	referenceChecker := &daoReferenceChecker[*privatev1.Cluster]{resourceDao: clustersDao}
 
 	delegate, err := NewPrivateClusterCatalogItemsServer().
 		SetLogger(b.logger).
@@ -125,11 +125,11 @@ func (b *ClusterCatalogItemsServerBuilder) Build() (result *ClusterCatalogItemsS
 	}
 
 	result = &ClusterCatalogItemsServer{
-		logger:      b.logger,
-		clustersDao: clustersDao,
-		delegate:    delegate,
-		inMapper:    inMapper,
-		outMapper:   outMapper,
+		logger:           b.logger,
+		referenceChecker: referenceChecker,
+		delegate:         delegate,
+		inMapper:         inMapper,
+		outMapper:        outMapper,
 	}
 	return
 }
@@ -181,7 +181,7 @@ func (s *ClusterCatalogItemsServer) Get(ctx context.Context,
 	}
 
 	if !privateResponse.GetObject().GetPublished() {
-		hasRef, refErr := s.callerHasReferencingCluster(ctx, request.GetId())
+		hasRef, refErr := s.referenceChecker.hasReference(ctx, request.GetId())
 		if refErr != nil {
 			return nil, refErr
 		}
@@ -284,19 +284,6 @@ func (s *ClusterCatalogItemsServer) Update(ctx context.Context,
 	response = &publicv1.ClusterCatalogItemsUpdateResponse{}
 	response.SetObject(updatedPublicCatalogItem)
 	return
-}
-
-func (s *ClusterCatalogItemsServer) callerHasReferencingCluster(ctx context.Context, catalogItemID string) (bool, error) {
-	filter := fmt.Sprintf("this.spec.catalog_item == %q", catalogItemID)
-	response, err := s.clustersDao.List().
-		SetFilter(filter).
-		SetLimit(1).
-		Do(ctx)
-	if err != nil {
-		s.logger.ErrorContext(ctx, "Failed to check cluster references", slog.Any("error", err))
-		return false, grpcstatus.Errorf(grpccodes.Internal, "failed to check cluster references")
-	}
-	return response.GetTotal() > 0, nil
 }
 
 func (s *ClusterCatalogItemsServer) addPublishedFilter(filter string) (string, error) {

--- a/internal/servers/cluster_catalog_items_server.go
+++ b/internal/servers/cluster_catalog_items_server.go
@@ -126,7 +126,7 @@ func (s *ClusterCatalogItemsServer) List(ctx context.Context,
 	privateRequest := &privatev1.ClusterCatalogItemsListRequest{}
 	privateRequest.SetOffset(request.GetOffset())
 	privateRequest.SetLimit(request.GetLimit())
-	privateRequest.SetFilter(request.GetFilter())
+	privateRequest.SetFilter(addPublishedFilter(request.GetFilter()))
 	privateRequest.SetOrder(request.GetOrder())
 
 	privateResponse, err := s.delegate.List(ctx, privateRequest)
@@ -161,6 +161,10 @@ func (s *ClusterCatalogItemsServer) Get(ctx context.Context,
 	privateResponse, err := s.delegate.Get(ctx, privateRequest)
 	if err != nil {
 		return nil, err
+	}
+
+	if !privateResponse.GetObject().GetPublished() {
+		return nil, grpcstatus.Errorf(grpccodes.NotFound, "catalog item not found")
 	}
 
 	publicCatalogItem := &publicv1.ClusterCatalogItem{}

--- a/internal/servers/cluster_catalog_items_server.go
+++ b/internal/servers/cluster_catalog_items_server.go
@@ -126,7 +126,7 @@ func (s *ClusterCatalogItemsServer) List(ctx context.Context,
 	privateRequest := &privatev1.ClusterCatalogItemsListRequest{}
 	privateRequest.SetOffset(request.GetOffset())
 	privateRequest.SetLimit(request.GetLimit())
-	composedFilter, err := s.addPublishedFilter(ctx, request.GetFilter())
+	composedFilter, err := s.addPublishedFilter(request.GetFilter())
 	if err != nil {
 		return nil, err
 	}
@@ -167,8 +167,7 @@ func (s *ClusterCatalogItemsServer) Get(ctx context.Context,
 		return nil, err
 	}
 
-	obj := privateResponse.GetObject()
-	if !obj.GetPublished() && !isCreator(ctx, obj.GetMetadata().GetCreator()) {
+	if !privateResponse.GetObject().GetPublished() {
 		return nil, grpcstatus.Errorf(grpccodes.NotFound, "catalog item not found")
 	}
 
@@ -268,15 +267,14 @@ func (s *ClusterCatalogItemsServer) Update(ctx context.Context,
 	return
 }
 
-func (s *ClusterCatalogItemsServer) addPublishedFilter(ctx context.Context, filter string) (string, error) {
-	publishedClause := buildPublishedClause(ctx)
+func (s *ClusterCatalogItemsServer) addPublishedFilter(filter string) (string, error) {
 	if filter == "" {
-		return publishedClause, nil
+		return "this.published", nil
 	}
 	if err := validateCELSyntax(filter); err != nil {
 		return "", grpcstatus.Errorf(grpccodes.InvalidArgument, "invalid filter: %v", err)
 	}
-	return "(" + filter + ") && " + publishedClause, nil
+	return "(" + filter + ") && this.published", nil
 }
 
 func (s *ClusterCatalogItemsServer) Delete(ctx context.Context,

--- a/internal/servers/cluster_catalog_items_server.go
+++ b/internal/servers/cluster_catalog_items_server.go
@@ -16,6 +16,7 @@ package servers
 import (
 	"context"
 	"errors"
+	"fmt"
 	"log/slog"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -25,6 +26,7 @@ import (
 	privatev1 "github.com/osac-project/fulfillment-service/internal/api/osac/private/v1"
 	publicv1 "github.com/osac-project/fulfillment-service/internal/api/osac/public/v1"
 	"github.com/osac-project/fulfillment-service/internal/auth"
+	"github.com/osac-project/fulfillment-service/internal/database/dao"
 	"github.com/osac-project/fulfillment-service/internal/events"
 )
 
@@ -41,10 +43,11 @@ var _ publicv1.ClusterCatalogItemsServer = (*ClusterCatalogItemsServer)(nil)
 type ClusterCatalogItemsServer struct {
 	publicv1.UnimplementedClusterCatalogItemsServer
 
-	logger    *slog.Logger
-	delegate  privatev1.ClusterCatalogItemsServer
-	inMapper  *GenericMapper[*publicv1.ClusterCatalogItem, *privatev1.ClusterCatalogItem]
-	outMapper *GenericMapper[*privatev1.ClusterCatalogItem, *publicv1.ClusterCatalogItem]
+	logger      *slog.Logger
+	clustersDao *dao.GenericDAO[*privatev1.Cluster]
+	delegate    privatev1.ClusterCatalogItemsServer
+	inMapper    *GenericMapper[*publicv1.ClusterCatalogItem, *privatev1.ClusterCatalogItem]
+	outMapper   *GenericMapper[*privatev1.ClusterCatalogItem, *publicv1.ClusterCatalogItem]
 }
 
 func NewClusterCatalogItemsServer() *ClusterCatalogItemsServerBuilder {
@@ -101,6 +104,15 @@ func (b *ClusterCatalogItemsServerBuilder) Build() (result *ClusterCatalogItemsS
 		return
 	}
 
+	clustersDao, err := dao.NewGenericDAO[*privatev1.Cluster]().
+		SetLogger(b.logger).
+		SetTenancyLogic(b.tenancyLogic).
+		SetMetricsRegisterer(b.metricsRegisterer).
+		Build()
+	if err != nil {
+		return
+	}
+
 	delegate, err := NewPrivateClusterCatalogItemsServer().
 		SetLogger(b.logger).
 		SetNotifier(b.notifier).
@@ -113,10 +125,11 @@ func (b *ClusterCatalogItemsServerBuilder) Build() (result *ClusterCatalogItemsS
 	}
 
 	result = &ClusterCatalogItemsServer{
-		logger:    b.logger,
-		delegate:  delegate,
-		inMapper:  inMapper,
-		outMapper: outMapper,
+		logger:      b.logger,
+		clustersDao: clustersDao,
+		delegate:    delegate,
+		inMapper:    inMapper,
+		outMapper:   outMapper,
 	}
 	return
 }
@@ -168,7 +181,13 @@ func (s *ClusterCatalogItemsServer) Get(ctx context.Context,
 	}
 
 	if !privateResponse.GetObject().GetPublished() {
-		return nil, grpcstatus.Errorf(grpccodes.NotFound, "catalog item not found")
+		hasRef, refErr := s.callerHasReferencingCluster(ctx, request.GetId())
+		if refErr != nil {
+			return nil, refErr
+		}
+		if !hasRef {
+			return nil, grpcstatus.Errorf(grpccodes.NotFound, "catalog item not found")
+		}
 	}
 
 	publicCatalogItem := &publicv1.ClusterCatalogItem{}
@@ -265,6 +284,19 @@ func (s *ClusterCatalogItemsServer) Update(ctx context.Context,
 	response = &publicv1.ClusterCatalogItemsUpdateResponse{}
 	response.SetObject(updatedPublicCatalogItem)
 	return
+}
+
+func (s *ClusterCatalogItemsServer) callerHasReferencingCluster(ctx context.Context, catalogItemID string) (bool, error) {
+	filter := fmt.Sprintf("this.spec.catalog_item == %q", catalogItemID)
+	response, err := s.clustersDao.List().
+		SetFilter(filter).
+		SetLimit(1).
+		Do(ctx)
+	if err != nil {
+		s.logger.ErrorContext(ctx, "Failed to check cluster references", slog.Any("error", err))
+		return false, grpcstatus.Errorf(grpccodes.Internal, "failed to check cluster references")
+	}
+	return response.GetTotal() > 0, nil
 }
 
 func (s *ClusterCatalogItemsServer) addPublishedFilter(filter string) (string, error) {

--- a/internal/servers/cluster_catalog_items_server.go
+++ b/internal/servers/cluster_catalog_items_server.go
@@ -126,7 +126,7 @@ func (s *ClusterCatalogItemsServer) List(ctx context.Context,
 	privateRequest := &privatev1.ClusterCatalogItemsListRequest{}
 	privateRequest.SetOffset(request.GetOffset())
 	privateRequest.SetLimit(request.GetLimit())
-	composedFilter, err := s.addPublishedFilter(request.GetFilter())
+	composedFilter, err := s.addPublishedFilter(ctx, request.GetFilter())
 	if err != nil {
 		return nil, err
 	}
@@ -167,7 +167,8 @@ func (s *ClusterCatalogItemsServer) Get(ctx context.Context,
 		return nil, err
 	}
 
-	if !privateResponse.GetObject().GetPublished() {
+	obj := privateResponse.GetObject()
+	if !obj.GetPublished() && !isCreator(ctx, obj.GetMetadata().GetCreator()) {
 		return nil, grpcstatus.Errorf(grpccodes.NotFound, "catalog item not found")
 	}
 
@@ -267,14 +268,15 @@ func (s *ClusterCatalogItemsServer) Update(ctx context.Context,
 	return
 }
 
-func (s *ClusterCatalogItemsServer) addPublishedFilter(filter string) (string, error) {
+func (s *ClusterCatalogItemsServer) addPublishedFilter(ctx context.Context, filter string) (string, error) {
+	publishedClause := buildPublishedClause(ctx)
 	if filter == "" {
-		return "this.published", nil
+		return publishedClause, nil
 	}
 	if err := validateCELSyntax(filter); err != nil {
 		return "", grpcstatus.Errorf(grpccodes.InvalidArgument, "invalid filter: %v", err)
 	}
-	return "(" + filter + ") && this.published", nil
+	return "(" + filter + ") && " + publishedClause, nil
 }
 
 func (s *ClusterCatalogItemsServer) Delete(ctx context.Context,

--- a/internal/servers/cluster_catalog_items_server_test.go
+++ b/internal/servers/cluster_catalog_items_server_test.go
@@ -24,6 +24,8 @@ import (
 	"google.golang.org/protobuf/proto"
 
 	publicv1 "github.com/osac-project/fulfillment-service/internal/api/osac/public/v1"
+	"github.com/osac-project/fulfillment-service/internal/auth"
+	"github.com/osac-project/fulfillment-service/internal/collections"
 	"github.com/osac-project/fulfillment-service/internal/database"
 )
 
@@ -36,7 +38,10 @@ var _ = Describe("Cluster catalog items server", func() {
 	BeforeEach(func() {
 		var err error
 
-		ctx = context.Background()
+		ctx = auth.ContextWithSubject(context.Background(), &auth.Subject{
+			User:    "system",
+			Tenants: collections.NewUniversalSet[string](),
+		})
 
 		db, err := server.NewInstance().Build()
 		Expect(err).ToNot(HaveOccurred())
@@ -187,7 +192,36 @@ var _ = Describe("Cluster catalog items server", func() {
 			}
 		})
 
-		It("List excludes unpublished objects", func() {
+		It("List excludes unpublished objects from other creators", func() {
+			_, err := server.Create(ctx, publicv1.ClusterCatalogItemsCreateRequest_builder{
+				Object: publicv1.ClusterCatalogItem_builder{
+					Title:     "Published item",
+					Template:  "my-template-id",
+					Published: true,
+				}.Build(),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+
+			_, err = server.Create(ctx, publicv1.ClusterCatalogItemsCreateRequest_builder{
+				Object: publicv1.ClusterCatalogItem_builder{
+					Title:     "Unpublished item",
+					Template:  "my-template-id",
+					Published: false,
+				}.Build(),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+
+			otherUserCtx := auth.ContextWithSubject(ctx, &auth.Subject{
+				User:    "other-user",
+				Tenants: collections.NewUniversalSet[string](),
+			})
+			response, err := server.List(otherUserCtx, publicv1.ClusterCatalogItemsListRequest_builder{}.Build())
+			Expect(err).ToNot(HaveOccurred())
+			Expect(response.GetItems()).To(HaveLen(1))
+			Expect(response.GetItems()[0].GetTitle()).To(Equal("Published item"))
+		})
+
+		It("List shows unpublished objects to their creator", func() {
 			_, err := server.Create(ctx, publicv1.ClusterCatalogItemsCreateRequest_builder{
 				Object: publicv1.ClusterCatalogItem_builder{
 					Title:     "Published item",
@@ -208,11 +242,10 @@ var _ = Describe("Cluster catalog items server", func() {
 
 			response, err := server.List(ctx, publicv1.ClusterCatalogItemsListRequest_builder{}.Build())
 			Expect(err).ToNot(HaveOccurred())
-			Expect(response.GetItems()).To(HaveLen(1))
-			Expect(response.GetItems()[0].GetTitle()).To(Equal("Published item"))
+			Expect(response.GetItems()).To(HaveLen(2))
 		})
 
-		It("List with user filter excludes unpublished objects", func() {
+		It("List with user filter excludes unpublished objects from other creators", func() {
 			publishedResponse, err := server.Create(ctx, publicv1.ClusterCatalogItemsCreateRequest_builder{
 				Object: publicv1.ClusterCatalogItem_builder{
 					Title:     "Target published",
@@ -243,7 +276,11 @@ var _ = Describe("Cluster catalog items server", func() {
 			targetID := publishedResponse.GetObject().GetId()
 			unpublishedID := unpublishedResponse.GetObject().GetId()
 			filter := fmt.Sprintf("this.id == '%s' || this.id == '%s'", targetID, unpublishedID)
-			response, err := server.List(ctx, publicv1.ClusterCatalogItemsListRequest_builder{
+			otherUserCtx := auth.ContextWithSubject(ctx, &auth.Subject{
+				User:    "other-user",
+				Tenants: collections.NewUniversalSet[string](),
+			})
+			response, err := server.List(otherUserCtx, publicv1.ClusterCatalogItemsListRequest_builder{
 				Filter: proto.String(filter),
 			}.Build())
 			Expect(err).ToNot(HaveOccurred())
@@ -251,7 +288,7 @@ var _ = Describe("Cluster catalog items server", func() {
 			Expect(response.GetItems()[0].GetId()).To(Equal(targetID))
 		})
 
-		It("Get returns not found for unpublished object", func() {
+		It("Get returns not found for unpublished object from other creator", func() {
 			createResponse, err := server.Create(ctx, publicv1.ClusterCatalogItemsCreateRequest_builder{
 				Object: publicv1.ClusterCatalogItem_builder{
 					Title:     "Unpublished item",
@@ -261,11 +298,32 @@ var _ = Describe("Cluster catalog items server", func() {
 			}.Build())
 			Expect(err).ToNot(HaveOccurred())
 
-			_, err = server.Get(ctx, publicv1.ClusterCatalogItemsGetRequest_builder{
+			otherUserCtx := auth.ContextWithSubject(ctx, &auth.Subject{
+				User:    "other-user",
+				Tenants: collections.NewUniversalSet[string](),
+			})
+			_, err = server.Get(otherUserCtx, publicv1.ClusterCatalogItemsGetRequest_builder{
 				Id: createResponse.GetObject().GetId(),
 			}.Build())
 			Expect(err).To(HaveOccurred())
 			Expect(status.Code(err)).To(Equal(codes.NotFound))
+		})
+
+		It("Get returns unpublished object to its creator", func() {
+			createResponse, err := server.Create(ctx, publicv1.ClusterCatalogItemsCreateRequest_builder{
+				Object: publicv1.ClusterCatalogItem_builder{
+					Title:     "Unpublished item",
+					Template:  "my-template-id",
+					Published: false,
+				}.Build(),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+
+			getResponse, err := server.Get(ctx, publicv1.ClusterCatalogItemsGetRequest_builder{
+				Id: createResponse.GetObject().GetId(),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+			Expect(getResponse.GetObject().GetTitle()).To(Equal("Unpublished item"))
 		})
 
 		It("Get object", func() {

--- a/internal/servers/cluster_catalog_items_server_test.go
+++ b/internal/servers/cluster_catalog_items_server_test.go
@@ -19,6 +19,8 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/proto"
 
 	publicv1 "github.com/osac-project/fulfillment-service/internal/api/osac/public/v1"
@@ -126,8 +128,9 @@ var _ = Describe("Cluster catalog items server", func() {
 			for i := range count {
 				_, err := server.Create(ctx, publicv1.ClusterCatalogItemsCreateRequest_builder{
 					Object: publicv1.ClusterCatalogItem_builder{
-						Title:    fmt.Sprintf("Catalog item %d", i),
-						Template: "my-template-id",
+						Title:     fmt.Sprintf("Catalog item %d", i),
+						Template:  "my-template-id",
+						Published: true,
 					}.Build(),
 				}.Build())
 				Expect(err).ToNot(HaveOccurred())
@@ -144,8 +147,9 @@ var _ = Describe("Cluster catalog items server", func() {
 			for i := range count {
 				_, err := server.Create(ctx, publicv1.ClusterCatalogItemsCreateRequest_builder{
 					Object: publicv1.ClusterCatalogItem_builder{
-						Title:    fmt.Sprintf("Catalog item %d", i),
-						Template: "my-template-id",
+						Title:     fmt.Sprintf("Catalog item %d", i),
+						Template:  "my-template-id",
+						Published: true,
 					}.Build(),
 				}.Build())
 				Expect(err).ToNot(HaveOccurred())
@@ -164,8 +168,9 @@ var _ = Describe("Cluster catalog items server", func() {
 			for i := range count {
 				response, err := server.Create(ctx, publicv1.ClusterCatalogItemsCreateRequest_builder{
 					Object: publicv1.ClusterCatalogItem_builder{
-						Title:    fmt.Sprintf("Catalog item %d", i),
-						Template: "my-template-id",
+						Title:     fmt.Sprintf("Catalog item %d", i),
+						Template:  "my-template-id",
+						Published: true,
 					}.Build(),
 				}.Build())
 				Expect(err).ToNot(HaveOccurred())
@@ -182,12 +187,53 @@ var _ = Describe("Cluster catalog items server", func() {
 			}
 		})
 
+		It("List excludes unpublished objects", func() {
+			_, err := server.Create(ctx, publicv1.ClusterCatalogItemsCreateRequest_builder{
+				Object: publicv1.ClusterCatalogItem_builder{
+					Title:     "Published item",
+					Template:  "my-template-id",
+					Published: true,
+				}.Build(),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+
+			_, err = server.Create(ctx, publicv1.ClusterCatalogItemsCreateRequest_builder{
+				Object: publicv1.ClusterCatalogItem_builder{
+					Title:    "Unpublished item",
+					Template: "my-template-id",
+				}.Build(),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+
+			response, err := server.List(ctx, publicv1.ClusterCatalogItemsListRequest_builder{}.Build())
+			Expect(err).ToNot(HaveOccurred())
+			Expect(response.GetItems()).To(HaveLen(1))
+			Expect(response.GetItems()[0].GetTitle()).To(Equal("Published item"))
+		})
+
+		It("Get returns not found for unpublished object", func() {
+			createResponse, err := server.Create(ctx, publicv1.ClusterCatalogItemsCreateRequest_builder{
+				Object: publicv1.ClusterCatalogItem_builder{
+					Title:    "Unpublished item",
+					Template: "my-template-id",
+				}.Build(),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+
+			_, err = server.Get(ctx, publicv1.ClusterCatalogItemsGetRequest_builder{
+				Id: createResponse.GetObject().GetId(),
+			}.Build())
+			Expect(err).To(HaveOccurred())
+			Expect(status.Code(err)).To(Equal(codes.NotFound))
+		})
+
 		It("Get object", func() {
 			createResponse, err := server.Create(ctx, publicv1.ClusterCatalogItemsCreateRequest_builder{
 				Object: publicv1.ClusterCatalogItem_builder{
 					Title:       "My catalog item",
 					Description: "My description.",
 					Template:    "my-template-id",
+					Published:   true,
 				}.Build(),
 			}.Build())
 			Expect(err).ToNot(HaveOccurred())
@@ -205,6 +251,7 @@ var _ = Describe("Cluster catalog items server", func() {
 					Title:       "Original title",
 					Description: "Original description.",
 					Template:    "my-template-id",
+					Published:   true,
 				}.Build(),
 			}.Build())
 			Expect(err).ToNot(HaveOccurred())
@@ -216,6 +263,7 @@ var _ = Describe("Cluster catalog items server", func() {
 					Title:       "Updated title",
 					Description: "Updated description.",
 					Template:    "my-template-id",
+					Published:   true,
 				}.Build(),
 			}.Build())
 			Expect(err).ToNot(HaveOccurred())
@@ -233,8 +281,9 @@ var _ = Describe("Cluster catalog items server", func() {
 		It("Delete object", func() {
 			createResponse, err := server.Create(ctx, publicv1.ClusterCatalogItemsCreateRequest_builder{
 				Object: publicv1.ClusterCatalogItem_builder{
-					Title:    "My catalog item",
-					Template: "my-template-id",
+					Title:     "My catalog item",
+					Template:  "my-template-id",
+					Published: true,
 				}.Build(),
 			}.Build())
 			Expect(err).ToNot(HaveOccurred())

--- a/internal/servers/cluster_catalog_items_server_test.go
+++ b/internal/servers/cluster_catalog_items_server_test.go
@@ -24,8 +24,6 @@ import (
 	"google.golang.org/protobuf/proto"
 
 	publicv1 "github.com/osac-project/fulfillment-service/internal/api/osac/public/v1"
-	"github.com/osac-project/fulfillment-service/internal/auth"
-	"github.com/osac-project/fulfillment-service/internal/collections"
 	"github.com/osac-project/fulfillment-service/internal/database"
 )
 
@@ -38,10 +36,7 @@ var _ = Describe("Cluster catalog items server", func() {
 	BeforeEach(func() {
 		var err error
 
-		ctx = auth.ContextWithSubject(context.Background(), &auth.Subject{
-			User:    "system",
-			Tenants: collections.NewUniversalSet[string](),
-		})
+		ctx = context.Background()
 
 		db, err := server.NewInstance().Build()
 		Expect(err).ToNot(HaveOccurred())
@@ -192,36 +187,7 @@ var _ = Describe("Cluster catalog items server", func() {
 			}
 		})
 
-		It("List excludes unpublished objects from other creators", func() {
-			_, err := server.Create(ctx, publicv1.ClusterCatalogItemsCreateRequest_builder{
-				Object: publicv1.ClusterCatalogItem_builder{
-					Title:     "Published item",
-					Template:  "my-template-id",
-					Published: true,
-				}.Build(),
-			}.Build())
-			Expect(err).ToNot(HaveOccurred())
-
-			_, err = server.Create(ctx, publicv1.ClusterCatalogItemsCreateRequest_builder{
-				Object: publicv1.ClusterCatalogItem_builder{
-					Title:     "Unpublished item",
-					Template:  "my-template-id",
-					Published: false,
-				}.Build(),
-			}.Build())
-			Expect(err).ToNot(HaveOccurred())
-
-			otherUserCtx := auth.ContextWithSubject(ctx, &auth.Subject{
-				User:    "other-user",
-				Tenants: collections.NewUniversalSet[string](),
-			})
-			response, err := server.List(otherUserCtx, publicv1.ClusterCatalogItemsListRequest_builder{}.Build())
-			Expect(err).ToNot(HaveOccurred())
-			Expect(response.GetItems()).To(HaveLen(1))
-			Expect(response.GetItems()[0].GetTitle()).To(Equal("Published item"))
-		})
-
-		It("List shows unpublished objects to their creator", func() {
+		It("List excludes unpublished objects", func() {
 			_, err := server.Create(ctx, publicv1.ClusterCatalogItemsCreateRequest_builder{
 				Object: publicv1.ClusterCatalogItem_builder{
 					Title:     "Published item",
@@ -242,10 +208,11 @@ var _ = Describe("Cluster catalog items server", func() {
 
 			response, err := server.List(ctx, publicv1.ClusterCatalogItemsListRequest_builder{}.Build())
 			Expect(err).ToNot(HaveOccurred())
-			Expect(response.GetItems()).To(HaveLen(2))
+			Expect(response.GetItems()).To(HaveLen(1))
+			Expect(response.GetItems()[0].GetTitle()).To(Equal("Published item"))
 		})
 
-		It("List with user filter excludes unpublished objects from other creators", func() {
+		It("List with user filter excludes unpublished objects", func() {
 			publishedResponse, err := server.Create(ctx, publicv1.ClusterCatalogItemsCreateRequest_builder{
 				Object: publicv1.ClusterCatalogItem_builder{
 					Title:     "Target published",
@@ -276,11 +243,7 @@ var _ = Describe("Cluster catalog items server", func() {
 			targetID := publishedResponse.GetObject().GetId()
 			unpublishedID := unpublishedResponse.GetObject().GetId()
 			filter := fmt.Sprintf("this.id == '%s' || this.id == '%s'", targetID, unpublishedID)
-			otherUserCtx := auth.ContextWithSubject(ctx, &auth.Subject{
-				User:    "other-user",
-				Tenants: collections.NewUniversalSet[string](),
-			})
-			response, err := server.List(otherUserCtx, publicv1.ClusterCatalogItemsListRequest_builder{
+			response, err := server.List(ctx, publicv1.ClusterCatalogItemsListRequest_builder{
 				Filter: proto.String(filter),
 			}.Build())
 			Expect(err).ToNot(HaveOccurred())
@@ -288,7 +251,7 @@ var _ = Describe("Cluster catalog items server", func() {
 			Expect(response.GetItems()[0].GetId()).To(Equal(targetID))
 		})
 
-		It("Get returns not found for unpublished object from other creator", func() {
+		It("Get returns not found for unpublished object", func() {
 			createResponse, err := server.Create(ctx, publicv1.ClusterCatalogItemsCreateRequest_builder{
 				Object: publicv1.ClusterCatalogItem_builder{
 					Title:     "Unpublished item",
@@ -298,32 +261,11 @@ var _ = Describe("Cluster catalog items server", func() {
 			}.Build())
 			Expect(err).ToNot(HaveOccurred())
 
-			otherUserCtx := auth.ContextWithSubject(ctx, &auth.Subject{
-				User:    "other-user",
-				Tenants: collections.NewUniversalSet[string](),
-			})
-			_, err = server.Get(otherUserCtx, publicv1.ClusterCatalogItemsGetRequest_builder{
+			_, err = server.Get(ctx, publicv1.ClusterCatalogItemsGetRequest_builder{
 				Id: createResponse.GetObject().GetId(),
 			}.Build())
 			Expect(err).To(HaveOccurred())
 			Expect(status.Code(err)).To(Equal(codes.NotFound))
-		})
-
-		It("Get returns unpublished object to its creator", func() {
-			createResponse, err := server.Create(ctx, publicv1.ClusterCatalogItemsCreateRequest_builder{
-				Object: publicv1.ClusterCatalogItem_builder{
-					Title:     "Unpublished item",
-					Template:  "my-template-id",
-					Published: false,
-				}.Build(),
-			}.Build())
-			Expect(err).ToNot(HaveOccurred())
-
-			getResponse, err := server.Get(ctx, publicv1.ClusterCatalogItemsGetRequest_builder{
-				Id: createResponse.GetObject().GetId(),
-			}.Build())
-			Expect(err).ToNot(HaveOccurred())
-			Expect(getResponse.GetObject().GetTitle()).To(Equal("Unpublished item"))
 		})
 
 		It("Get object", func() {

--- a/internal/servers/cluster_catalog_items_server_test.go
+++ b/internal/servers/cluster_catalog_items_server_test.go
@@ -251,6 +251,35 @@ var _ = Describe("Cluster catalog items server", func() {
 			Expect(response.GetItems()[0].GetId()).To(Equal(targetID))
 		})
 
+		It("Get returns unpublished item when caller has a referencing cluster", func() {
+			createResponse, err := server.Create(ctx, publicv1.ClusterCatalogItemsCreateRequest_builder{
+				Object: publicv1.ClusterCatalogItem_builder{
+					Title:     "Unpublished item",
+					Template:  "my-template-id",
+					Published: false,
+				}.Build(),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+			catalogItemID := createResponse.GetObject().GetId()
+
+			_, err = tx.Exec(ctx,
+				`insert into clusters (id, data, tenant) values ($1, $2, $3)`,
+				"ref-cluster-001",
+				fmt.Sprintf(`{"spec":{"catalog_item":"%s","template":"my-template-id"}}`, catalogItemID),
+				"shared",
+			)
+			Expect(err).ToNot(HaveOccurred())
+			DeferCleanup(func() {
+				_, _ = tx.Exec(ctx, `delete from clusters where id = $1`, "ref-cluster-001")
+			})
+
+			getResponse, err := server.Get(ctx, publicv1.ClusterCatalogItemsGetRequest_builder{
+				Id: catalogItemID,
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+			Expect(getResponse.GetObject().GetTitle()).To(Equal("Unpublished item"))
+		})
+
 		It("Get returns not found for unpublished object", func() {
 			createResponse, err := server.Create(ctx, publicv1.ClusterCatalogItemsCreateRequest_builder{
 				Object: publicv1.ClusterCatalogItem_builder{

--- a/internal/servers/cluster_catalog_items_server_test.go
+++ b/internal/servers/cluster_catalog_items_server_test.go
@@ -19,6 +19,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"go.uber.org/mock/gomock"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/proto"
@@ -262,16 +263,12 @@ var _ = Describe("Cluster catalog items server", func() {
 			Expect(err).ToNot(HaveOccurred())
 			catalogItemID := createResponse.GetObject().GetId()
 
-			_, err = tx.Exec(ctx,
-				`insert into clusters (id, data, tenant) values ($1, $2, $3)`,
-				"ref-cluster-001",
-				fmt.Sprintf(`{"spec":{"catalog_item":"%s","template":"my-template-id"}}`, catalogItemID),
-				"shared",
-			)
-			Expect(err).ToNot(HaveOccurred())
-			DeferCleanup(func() {
-				_, _ = tx.Exec(ctx, `delete from clusters where id = $1`, "ref-cluster-001")
-			})
+			mockCtrl := gomock.NewController(GinkgoT())
+			mockChecker := NewMockCatalogItemReferenceChecker(mockCtrl)
+			mockChecker.EXPECT().hasReference(gomock.Any(), catalogItemID).Return(true, nil)
+			originalChecker := server.referenceChecker
+			server.referenceChecker = mockChecker
+			DeferCleanup(func() { server.referenceChecker = originalChecker })
 
 			getResponse, err := server.Get(ctx, publicv1.ClusterCatalogItemsGetRequest_builder{
 				Id: catalogItemID,

--- a/internal/servers/cluster_catalog_items_server_test.go
+++ b/internal/servers/cluster_catalog_items_server_test.go
@@ -199,8 +199,9 @@ var _ = Describe("Cluster catalog items server", func() {
 
 			_, err = server.Create(ctx, publicv1.ClusterCatalogItemsCreateRequest_builder{
 				Object: publicv1.ClusterCatalogItem_builder{
-					Title:    "Unpublished item",
-					Template: "my-template-id",
+					Title:     "Unpublished item",
+					Template:  "my-template-id",
+					Published: false,
 				}.Build(),
 			}.Build())
 			Expect(err).ToNot(HaveOccurred())
@@ -211,11 +212,51 @@ var _ = Describe("Cluster catalog items server", func() {
 			Expect(response.GetItems()[0].GetTitle()).To(Equal("Published item"))
 		})
 
+		It("List with user filter excludes unpublished objects", func() {
+			publishedResponse, err := server.Create(ctx, publicv1.ClusterCatalogItemsCreateRequest_builder{
+				Object: publicv1.ClusterCatalogItem_builder{
+					Title:     "Target published",
+					Template:  "my-template-id",
+					Published: true,
+				}.Build(),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+
+			_, err = server.Create(ctx, publicv1.ClusterCatalogItemsCreateRequest_builder{
+				Object: publicv1.ClusterCatalogItem_builder{
+					Title:     "Other published",
+					Template:  "my-template-id",
+					Published: true,
+				}.Build(),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+
+			unpublishedResponse, err := server.Create(ctx, publicv1.ClusterCatalogItemsCreateRequest_builder{
+				Object: publicv1.ClusterCatalogItem_builder{
+					Title:     "Target unpublished",
+					Template:  "my-template-id",
+					Published: false,
+				}.Build(),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+
+			targetID := publishedResponse.GetObject().GetId()
+			unpublishedID := unpublishedResponse.GetObject().GetId()
+			filter := fmt.Sprintf("this.id == '%s' || this.id == '%s'", targetID, unpublishedID)
+			response, err := server.List(ctx, publicv1.ClusterCatalogItemsListRequest_builder{
+				Filter: proto.String(filter),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+			Expect(response.GetItems()).To(HaveLen(1))
+			Expect(response.GetItems()[0].GetId()).To(Equal(targetID))
+		})
+
 		It("Get returns not found for unpublished object", func() {
 			createResponse, err := server.Create(ctx, publicv1.ClusterCatalogItemsCreateRequest_builder{
 				Object: publicv1.ClusterCatalogItem_builder{
-					Title:    "Unpublished item",
-					Template: "my-template-id",
+					Title:     "Unpublished item",
+					Template:  "my-template-id",
+					Published: false,
 				}.Build(),
 			}.Build())
 			Expect(err).ToNot(HaveOccurred())

--- a/internal/servers/compute_instance_catalog_items_server.go
+++ b/internal/servers/compute_instance_catalog_items_server.go
@@ -16,6 +16,7 @@ package servers
 import (
 	"context"
 	"errors"
+	"fmt"
 	"log/slog"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -25,6 +26,7 @@ import (
 	privatev1 "github.com/osac-project/fulfillment-service/internal/api/osac/private/v1"
 	publicv1 "github.com/osac-project/fulfillment-service/internal/api/osac/public/v1"
 	"github.com/osac-project/fulfillment-service/internal/auth"
+	"github.com/osac-project/fulfillment-service/internal/database/dao"
 	"github.com/osac-project/fulfillment-service/internal/events"
 )
 
@@ -41,10 +43,11 @@ var _ publicv1.ComputeInstanceCatalogItemsServer = (*ComputeInstanceCatalogItems
 type ComputeInstanceCatalogItemsServer struct {
 	publicv1.UnimplementedComputeInstanceCatalogItemsServer
 
-	logger    *slog.Logger
-	delegate  privatev1.ComputeInstanceCatalogItemsServer
-	inMapper  *GenericMapper[*publicv1.ComputeInstanceCatalogItem, *privatev1.ComputeInstanceCatalogItem]
-	outMapper *GenericMapper[*privatev1.ComputeInstanceCatalogItem, *publicv1.ComputeInstanceCatalogItem]
+	logger              *slog.Logger
+	computeInstancesDao *dao.GenericDAO[*privatev1.ComputeInstance]
+	delegate            privatev1.ComputeInstanceCatalogItemsServer
+	inMapper            *GenericMapper[*publicv1.ComputeInstanceCatalogItem, *privatev1.ComputeInstanceCatalogItem]
+	outMapper           *GenericMapper[*privatev1.ComputeInstanceCatalogItem, *publicv1.ComputeInstanceCatalogItem]
 }
 
 func NewComputeInstanceCatalogItemsServer() *ComputeInstanceCatalogItemsServerBuilder {
@@ -101,6 +104,15 @@ func (b *ComputeInstanceCatalogItemsServerBuilder) Build() (result *ComputeInsta
 		return
 	}
 
+	computeInstancesDao, err := dao.NewGenericDAO[*privatev1.ComputeInstance]().
+		SetLogger(b.logger).
+		SetTenancyLogic(b.tenancyLogic).
+		SetMetricsRegisterer(b.metricsRegisterer).
+		Build()
+	if err != nil {
+		return
+	}
+
 	delegate, err := NewPrivateComputeInstanceCatalogItemsServer().
 		SetLogger(b.logger).
 		SetNotifier(b.notifier).
@@ -113,10 +125,11 @@ func (b *ComputeInstanceCatalogItemsServerBuilder) Build() (result *ComputeInsta
 	}
 
 	result = &ComputeInstanceCatalogItemsServer{
-		logger:    b.logger,
-		delegate:  delegate,
-		inMapper:  inMapper,
-		outMapper: outMapper,
+		logger:              b.logger,
+		computeInstancesDao: computeInstancesDao,
+		delegate:            delegate,
+		inMapper:            inMapper,
+		outMapper:           outMapper,
 	}
 	return
 }
@@ -168,7 +181,13 @@ func (s *ComputeInstanceCatalogItemsServer) Get(ctx context.Context,
 	}
 
 	if !privateResponse.GetObject().GetPublished() {
-		return nil, grpcstatus.Errorf(grpccodes.NotFound, "catalog item not found")
+		hasRef, refErr := s.callerHasReferencingComputeInstance(ctx, request.GetId())
+		if refErr != nil {
+			return nil, refErr
+		}
+		if !hasRef {
+			return nil, grpcstatus.Errorf(grpccodes.NotFound, "catalog item not found")
+		}
 	}
 
 	publicCatalogItem := &publicv1.ComputeInstanceCatalogItem{}
@@ -265,6 +284,19 @@ func (s *ComputeInstanceCatalogItemsServer) Update(ctx context.Context,
 	response = &publicv1.ComputeInstanceCatalogItemsUpdateResponse{}
 	response.SetObject(updatedPublicCatalogItem)
 	return
+}
+
+func (s *ComputeInstanceCatalogItemsServer) callerHasReferencingComputeInstance(ctx context.Context, catalogItemID string) (bool, error) {
+	filter := fmt.Sprintf("this.spec.catalog_item == %q", catalogItemID)
+	response, err := s.computeInstancesDao.List().
+		SetFilter(filter).
+		SetLimit(1).
+		Do(ctx)
+	if err != nil {
+		s.logger.ErrorContext(ctx, "Failed to check compute instance references", slog.Any("error", err))
+		return false, grpcstatus.Errorf(grpccodes.Internal, "failed to check compute instance references")
+	}
+	return response.GetTotal() > 0, nil
 }
 
 func (s *ComputeInstanceCatalogItemsServer) addPublishedFilter(filter string) (string, error) {

--- a/internal/servers/compute_instance_catalog_items_server.go
+++ b/internal/servers/compute_instance_catalog_items_server.go
@@ -126,7 +126,11 @@ func (s *ComputeInstanceCatalogItemsServer) List(ctx context.Context,
 	privateRequest := &privatev1.ComputeInstanceCatalogItemsListRequest{}
 	privateRequest.SetOffset(request.GetOffset())
 	privateRequest.SetLimit(request.GetLimit())
-	privateRequest.SetFilter(addPublishedFilter(request.GetFilter()))
+	composedFilter, err := s.addPublishedFilter(request.GetFilter())
+	if err != nil {
+		return nil, err
+	}
+	privateRequest.SetFilter(composedFilter)
 	privateRequest.SetOrder(request.GetOrder())
 
 	privateResponse, err := s.delegate.List(ctx, privateRequest)
@@ -261,6 +265,16 @@ func (s *ComputeInstanceCatalogItemsServer) Update(ctx context.Context,
 	response = &publicv1.ComputeInstanceCatalogItemsUpdateResponse{}
 	response.SetObject(updatedPublicCatalogItem)
 	return
+}
+
+func (s *ComputeInstanceCatalogItemsServer) addPublishedFilter(filter string) (string, error) {
+	if filter == "" {
+		return "this.published", nil
+	}
+	if err := validateCELSyntax(filter); err != nil {
+		return "", grpcstatus.Errorf(grpccodes.InvalidArgument, "invalid filter: %v", err)
+	}
+	return "(" + filter + ") && this.published", nil
 }
 
 func (s *ComputeInstanceCatalogItemsServer) Delete(ctx context.Context,

--- a/internal/servers/compute_instance_catalog_items_server.go
+++ b/internal/servers/compute_instance_catalog_items_server.go
@@ -16,7 +16,6 @@ package servers
 import (
 	"context"
 	"errors"
-	"fmt"
 	"log/slog"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -43,11 +42,11 @@ var _ publicv1.ComputeInstanceCatalogItemsServer = (*ComputeInstanceCatalogItems
 type ComputeInstanceCatalogItemsServer struct {
 	publicv1.UnimplementedComputeInstanceCatalogItemsServer
 
-	logger              *slog.Logger
-	computeInstancesDao *dao.GenericDAO[*privatev1.ComputeInstance]
-	delegate            privatev1.ComputeInstanceCatalogItemsServer
-	inMapper            *GenericMapper[*publicv1.ComputeInstanceCatalogItem, *privatev1.ComputeInstanceCatalogItem]
-	outMapper           *GenericMapper[*privatev1.ComputeInstanceCatalogItem, *publicv1.ComputeInstanceCatalogItem]
+	logger           *slog.Logger
+	referenceChecker catalogItemReferenceChecker
+	delegate         privatev1.ComputeInstanceCatalogItemsServer
+	inMapper         *GenericMapper[*publicv1.ComputeInstanceCatalogItem, *privatev1.ComputeInstanceCatalogItem]
+	outMapper        *GenericMapper[*privatev1.ComputeInstanceCatalogItem, *publicv1.ComputeInstanceCatalogItem]
 }
 
 func NewComputeInstanceCatalogItemsServer() *ComputeInstanceCatalogItemsServerBuilder {
@@ -112,6 +111,7 @@ func (b *ComputeInstanceCatalogItemsServerBuilder) Build() (result *ComputeInsta
 	if err != nil {
 		return
 	}
+	referenceChecker := &daoReferenceChecker[*privatev1.ComputeInstance]{resourceDao: computeInstancesDao}
 
 	delegate, err := NewPrivateComputeInstanceCatalogItemsServer().
 		SetLogger(b.logger).
@@ -125,11 +125,11 @@ func (b *ComputeInstanceCatalogItemsServerBuilder) Build() (result *ComputeInsta
 	}
 
 	result = &ComputeInstanceCatalogItemsServer{
-		logger:              b.logger,
-		computeInstancesDao: computeInstancesDao,
-		delegate:            delegate,
-		inMapper:            inMapper,
-		outMapper:           outMapper,
+		logger:           b.logger,
+		referenceChecker: referenceChecker,
+		delegate:         delegate,
+		inMapper:         inMapper,
+		outMapper:        outMapper,
 	}
 	return
 }
@@ -181,7 +181,7 @@ func (s *ComputeInstanceCatalogItemsServer) Get(ctx context.Context,
 	}
 
 	if !privateResponse.GetObject().GetPublished() {
-		hasRef, refErr := s.callerHasReferencingComputeInstance(ctx, request.GetId())
+		hasRef, refErr := s.referenceChecker.hasReference(ctx, request.GetId())
 		if refErr != nil {
 			return nil, refErr
 		}
@@ -284,19 +284,6 @@ func (s *ComputeInstanceCatalogItemsServer) Update(ctx context.Context,
 	response = &publicv1.ComputeInstanceCatalogItemsUpdateResponse{}
 	response.SetObject(updatedPublicCatalogItem)
 	return
-}
-
-func (s *ComputeInstanceCatalogItemsServer) callerHasReferencingComputeInstance(ctx context.Context, catalogItemID string) (bool, error) {
-	filter := fmt.Sprintf("this.spec.catalog_item == %q", catalogItemID)
-	response, err := s.computeInstancesDao.List().
-		SetFilter(filter).
-		SetLimit(1).
-		Do(ctx)
-	if err != nil {
-		s.logger.ErrorContext(ctx, "Failed to check compute instance references", slog.Any("error", err))
-		return false, grpcstatus.Errorf(grpccodes.Internal, "failed to check compute instance references")
-	}
-	return response.GetTotal() > 0, nil
 }
 
 func (s *ComputeInstanceCatalogItemsServer) addPublishedFilter(filter string) (string, error) {

--- a/internal/servers/compute_instance_catalog_items_server.go
+++ b/internal/servers/compute_instance_catalog_items_server.go
@@ -126,7 +126,7 @@ func (s *ComputeInstanceCatalogItemsServer) List(ctx context.Context,
 	privateRequest := &privatev1.ComputeInstanceCatalogItemsListRequest{}
 	privateRequest.SetOffset(request.GetOffset())
 	privateRequest.SetLimit(request.GetLimit())
-	privateRequest.SetFilter(request.GetFilter())
+	privateRequest.SetFilter(addPublishedFilter(request.GetFilter()))
 	privateRequest.SetOrder(request.GetOrder())
 
 	privateResponse, err := s.delegate.List(ctx, privateRequest)
@@ -161,6 +161,10 @@ func (s *ComputeInstanceCatalogItemsServer) Get(ctx context.Context,
 	privateResponse, err := s.delegate.Get(ctx, privateRequest)
 	if err != nil {
 		return nil, err
+	}
+
+	if !privateResponse.GetObject().GetPublished() {
+		return nil, grpcstatus.Errorf(grpccodes.NotFound, "catalog item not found")
 	}
 
 	publicCatalogItem := &publicv1.ComputeInstanceCatalogItem{}

--- a/internal/servers/compute_instance_catalog_items_server.go
+++ b/internal/servers/compute_instance_catalog_items_server.go
@@ -126,7 +126,7 @@ func (s *ComputeInstanceCatalogItemsServer) List(ctx context.Context,
 	privateRequest := &privatev1.ComputeInstanceCatalogItemsListRequest{}
 	privateRequest.SetOffset(request.GetOffset())
 	privateRequest.SetLimit(request.GetLimit())
-	composedFilter, err := s.addPublishedFilter(request.GetFilter())
+	composedFilter, err := s.addPublishedFilter(ctx, request.GetFilter())
 	if err != nil {
 		return nil, err
 	}
@@ -167,7 +167,8 @@ func (s *ComputeInstanceCatalogItemsServer) Get(ctx context.Context,
 		return nil, err
 	}
 
-	if !privateResponse.GetObject().GetPublished() {
+	obj := privateResponse.GetObject()
+	if !obj.GetPublished() && !isCreator(ctx, obj.GetMetadata().GetCreator()) {
 		return nil, grpcstatus.Errorf(grpccodes.NotFound, "catalog item not found")
 	}
 
@@ -267,14 +268,15 @@ func (s *ComputeInstanceCatalogItemsServer) Update(ctx context.Context,
 	return
 }
 
-func (s *ComputeInstanceCatalogItemsServer) addPublishedFilter(filter string) (string, error) {
+func (s *ComputeInstanceCatalogItemsServer) addPublishedFilter(ctx context.Context, filter string) (string, error) {
+	publishedClause := buildPublishedClause(ctx)
 	if filter == "" {
-		return "this.published", nil
+		return publishedClause, nil
 	}
 	if err := validateCELSyntax(filter); err != nil {
 		return "", grpcstatus.Errorf(grpccodes.InvalidArgument, "invalid filter: %v", err)
 	}
-	return "(" + filter + ") && this.published", nil
+	return "(" + filter + ") && " + publishedClause, nil
 }
 
 func (s *ComputeInstanceCatalogItemsServer) Delete(ctx context.Context,

--- a/internal/servers/compute_instance_catalog_items_server.go
+++ b/internal/servers/compute_instance_catalog_items_server.go
@@ -126,7 +126,7 @@ func (s *ComputeInstanceCatalogItemsServer) List(ctx context.Context,
 	privateRequest := &privatev1.ComputeInstanceCatalogItemsListRequest{}
 	privateRequest.SetOffset(request.GetOffset())
 	privateRequest.SetLimit(request.GetLimit())
-	composedFilter, err := s.addPublishedFilter(ctx, request.GetFilter())
+	composedFilter, err := s.addPublishedFilter(request.GetFilter())
 	if err != nil {
 		return nil, err
 	}
@@ -167,8 +167,7 @@ func (s *ComputeInstanceCatalogItemsServer) Get(ctx context.Context,
 		return nil, err
 	}
 
-	obj := privateResponse.GetObject()
-	if !obj.GetPublished() && !isCreator(ctx, obj.GetMetadata().GetCreator()) {
+	if !privateResponse.GetObject().GetPublished() {
 		return nil, grpcstatus.Errorf(grpccodes.NotFound, "catalog item not found")
 	}
 
@@ -268,15 +267,14 @@ func (s *ComputeInstanceCatalogItemsServer) Update(ctx context.Context,
 	return
 }
 
-func (s *ComputeInstanceCatalogItemsServer) addPublishedFilter(ctx context.Context, filter string) (string, error) {
-	publishedClause := buildPublishedClause(ctx)
+func (s *ComputeInstanceCatalogItemsServer) addPublishedFilter(filter string) (string, error) {
 	if filter == "" {
-		return publishedClause, nil
+		return "this.published", nil
 	}
 	if err := validateCELSyntax(filter); err != nil {
 		return "", grpcstatus.Errorf(grpccodes.InvalidArgument, "invalid filter: %v", err)
 	}
-	return "(" + filter + ") && " + publishedClause, nil
+	return "(" + filter + ") && this.published", nil
 }
 
 func (s *ComputeInstanceCatalogItemsServer) Delete(ctx context.Context,

--- a/internal/servers/compute_instance_catalog_items_server_test.go
+++ b/internal/servers/compute_instance_catalog_items_server_test.go
@@ -19,6 +19,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"go.uber.org/mock/gomock"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/proto"
@@ -262,16 +263,12 @@ var _ = Describe("Compute instance catalog items server", func() {
 			Expect(err).ToNot(HaveOccurred())
 			catalogItemID := createResponse.GetObject().GetId()
 
-			_, err = tx.Exec(ctx,
-				`insert into compute_instances (id, data, tenant) values ($1, $2, $3)`,
-				"ref-ci-001",
-				fmt.Sprintf(`{"spec":{"catalog_item":"%s","template":"my-ci-template-id"}}`, catalogItemID),
-				"shared",
-			)
-			Expect(err).ToNot(HaveOccurred())
-			DeferCleanup(func() {
-				_, _ = tx.Exec(ctx, `delete from compute_instances where id = $1`, "ref-ci-001")
-			})
+			mockCtrl := gomock.NewController(GinkgoT())
+			mockChecker := NewMockCatalogItemReferenceChecker(mockCtrl)
+			mockChecker.EXPECT().hasReference(gomock.Any(), catalogItemID).Return(true, nil)
+			originalChecker := server.referenceChecker
+			server.referenceChecker = mockChecker
+			DeferCleanup(func() { server.referenceChecker = originalChecker })
 
 			getResponse, err := server.Get(ctx, publicv1.ComputeInstanceCatalogItemsGetRequest_builder{
 				Id: catalogItemID,

--- a/internal/servers/compute_instance_catalog_items_server_test.go
+++ b/internal/servers/compute_instance_catalog_items_server_test.go
@@ -251,6 +251,35 @@ var _ = Describe("Compute instance catalog items server", func() {
 			Expect(response.GetItems()[0].GetId()).To(Equal(targetID))
 		})
 
+		It("Get returns unpublished item when caller has a referencing compute instance", func() {
+			createResponse, err := server.Create(ctx, publicv1.ComputeInstanceCatalogItemsCreateRequest_builder{
+				Object: publicv1.ComputeInstanceCatalogItem_builder{
+					Title:     "Unpublished item",
+					Template:  "my-ci-template-id",
+					Published: false,
+				}.Build(),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+			catalogItemID := createResponse.GetObject().GetId()
+
+			_, err = tx.Exec(ctx,
+				`insert into compute_instances (id, data, tenant) values ($1, $2, $3)`,
+				"ref-ci-001",
+				fmt.Sprintf(`{"spec":{"catalog_item":"%s","template":"my-ci-template-id"}}`, catalogItemID),
+				"shared",
+			)
+			Expect(err).ToNot(HaveOccurred())
+			DeferCleanup(func() {
+				_, _ = tx.Exec(ctx, `delete from compute_instances where id = $1`, "ref-ci-001")
+			})
+
+			getResponse, err := server.Get(ctx, publicv1.ComputeInstanceCatalogItemsGetRequest_builder{
+				Id: catalogItemID,
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+			Expect(getResponse.GetObject().GetTitle()).To(Equal("Unpublished item"))
+		})
+
 		It("Get returns not found for unpublished object", func() {
 			createResponse, err := server.Create(ctx, publicv1.ComputeInstanceCatalogItemsCreateRequest_builder{
 				Object: publicv1.ComputeInstanceCatalogItem_builder{

--- a/internal/servers/compute_instance_catalog_items_server_test.go
+++ b/internal/servers/compute_instance_catalog_items_server_test.go
@@ -199,8 +199,9 @@ var _ = Describe("Compute instance catalog items server", func() {
 
 			_, err = server.Create(ctx, publicv1.ComputeInstanceCatalogItemsCreateRequest_builder{
 				Object: publicv1.ComputeInstanceCatalogItem_builder{
-					Title:    "Unpublished item",
-					Template: "my-ci-template-id",
+					Title:     "Unpublished item",
+					Template:  "my-ci-template-id",
+					Published: false,
 				}.Build(),
 			}.Build())
 			Expect(err).ToNot(HaveOccurred())
@@ -209,6 +210,45 @@ var _ = Describe("Compute instance catalog items server", func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(response.GetItems()).To(HaveLen(1))
 			Expect(response.GetItems()[0].GetTitle()).To(Equal("Published item"))
+		})
+
+		It("List with user filter excludes unpublished objects", func() {
+			publishedResponse, err := server.Create(ctx, publicv1.ComputeInstanceCatalogItemsCreateRequest_builder{
+				Object: publicv1.ComputeInstanceCatalogItem_builder{
+					Title:     "Target published",
+					Template:  "my-ci-template-id",
+					Published: true,
+				}.Build(),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+
+			_, err = server.Create(ctx, publicv1.ComputeInstanceCatalogItemsCreateRequest_builder{
+				Object: publicv1.ComputeInstanceCatalogItem_builder{
+					Title:     "Other published",
+					Template:  "my-ci-template-id",
+					Published: true,
+				}.Build(),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+
+			unpublishedResponse, err := server.Create(ctx, publicv1.ComputeInstanceCatalogItemsCreateRequest_builder{
+				Object: publicv1.ComputeInstanceCatalogItem_builder{
+					Title:     "Target unpublished",
+					Template:  "my-ci-template-id",
+					Published: false,
+				}.Build(),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+
+			targetID := publishedResponse.GetObject().GetId()
+			unpublishedID := unpublishedResponse.GetObject().GetId()
+			filter := fmt.Sprintf("this.id == '%s' || this.id == '%s'", targetID, unpublishedID)
+			response, err := server.List(ctx, publicv1.ComputeInstanceCatalogItemsListRequest_builder{
+				Filter: proto.String(filter),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+			Expect(response.GetItems()).To(HaveLen(1))
+			Expect(response.GetItems()[0].GetId()).To(Equal(targetID))
 		})
 
 		It("Get returns not found for unpublished object", func() {

--- a/internal/servers/compute_instance_catalog_items_server_test.go
+++ b/internal/servers/compute_instance_catalog_items_server_test.go
@@ -19,6 +19,8 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/proto"
 
 	publicv1 "github.com/osac-project/fulfillment-service/internal/api/osac/public/v1"
@@ -126,8 +128,9 @@ var _ = Describe("Compute instance catalog items server", func() {
 			for i := range count {
 				_, err := server.Create(ctx, publicv1.ComputeInstanceCatalogItemsCreateRequest_builder{
 					Object: publicv1.ComputeInstanceCatalogItem_builder{
-						Title:    fmt.Sprintf("CI catalog item %d", i),
-						Template: "my-ci-template-id",
+						Title:     fmt.Sprintf("CI catalog item %d", i),
+						Template:  "my-ci-template-id",
+						Published: true,
 					}.Build(),
 				}.Build())
 				Expect(err).ToNot(HaveOccurred())
@@ -144,8 +147,9 @@ var _ = Describe("Compute instance catalog items server", func() {
 			for i := range count {
 				_, err := server.Create(ctx, publicv1.ComputeInstanceCatalogItemsCreateRequest_builder{
 					Object: publicv1.ComputeInstanceCatalogItem_builder{
-						Title:    fmt.Sprintf("CI catalog item %d", i),
-						Template: "my-ci-template-id",
+						Title:     fmt.Sprintf("CI catalog item %d", i),
+						Template:  "my-ci-template-id",
+						Published: true,
 					}.Build(),
 				}.Build())
 				Expect(err).ToNot(HaveOccurred())
@@ -164,8 +168,9 @@ var _ = Describe("Compute instance catalog items server", func() {
 			for i := range count {
 				response, err := server.Create(ctx, publicv1.ComputeInstanceCatalogItemsCreateRequest_builder{
 					Object: publicv1.ComputeInstanceCatalogItem_builder{
-						Title:    fmt.Sprintf("CI catalog item %d", i),
-						Template: "my-ci-template-id",
+						Title:     fmt.Sprintf("CI catalog item %d", i),
+						Template:  "my-ci-template-id",
+						Published: true,
 					}.Build(),
 				}.Build())
 				Expect(err).ToNot(HaveOccurred())
@@ -182,12 +187,53 @@ var _ = Describe("Compute instance catalog items server", func() {
 			}
 		})
 
+		It("List excludes unpublished objects", func() {
+			_, err := server.Create(ctx, publicv1.ComputeInstanceCatalogItemsCreateRequest_builder{
+				Object: publicv1.ComputeInstanceCatalogItem_builder{
+					Title:     "Published item",
+					Template:  "my-ci-template-id",
+					Published: true,
+				}.Build(),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+
+			_, err = server.Create(ctx, publicv1.ComputeInstanceCatalogItemsCreateRequest_builder{
+				Object: publicv1.ComputeInstanceCatalogItem_builder{
+					Title:    "Unpublished item",
+					Template: "my-ci-template-id",
+				}.Build(),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+
+			response, err := server.List(ctx, publicv1.ComputeInstanceCatalogItemsListRequest_builder{}.Build())
+			Expect(err).ToNot(HaveOccurred())
+			Expect(response.GetItems()).To(HaveLen(1))
+			Expect(response.GetItems()[0].GetTitle()).To(Equal("Published item"))
+		})
+
+		It("Get returns not found for unpublished object", func() {
+			createResponse, err := server.Create(ctx, publicv1.ComputeInstanceCatalogItemsCreateRequest_builder{
+				Object: publicv1.ComputeInstanceCatalogItem_builder{
+					Title:    "Unpublished item",
+					Template: "my-ci-template-id",
+				}.Build(),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+
+			_, err = server.Get(ctx, publicv1.ComputeInstanceCatalogItemsGetRequest_builder{
+				Id: createResponse.GetObject().GetId(),
+			}.Build())
+			Expect(err).To(HaveOccurred())
+			Expect(status.Code(err)).To(Equal(codes.NotFound))
+		})
+
 		It("Get object", func() {
 			createResponse, err := server.Create(ctx, publicv1.ComputeInstanceCatalogItemsCreateRequest_builder{
 				Object: publicv1.ComputeInstanceCatalogItem_builder{
 					Title:       "My CI catalog item",
 					Description: "My description.",
 					Template:    "my-ci-template-id",
+					Published:   true,
 				}.Build(),
 			}.Build())
 			Expect(err).ToNot(HaveOccurred())
@@ -205,6 +251,7 @@ var _ = Describe("Compute instance catalog items server", func() {
 					Title:       "Original title",
 					Description: "Original description.",
 					Template:    "my-ci-template-id",
+					Published:   true,
 				}.Build(),
 			}.Build())
 			Expect(err).ToNot(HaveOccurred())
@@ -216,6 +263,7 @@ var _ = Describe("Compute instance catalog items server", func() {
 					Title:       "Updated title",
 					Description: "Updated description.",
 					Template:    "my-ci-template-id",
+					Published:   true,
 				}.Build(),
 			}.Build())
 			Expect(err).ToNot(HaveOccurred())
@@ -233,8 +281,9 @@ var _ = Describe("Compute instance catalog items server", func() {
 		It("Delete object", func() {
 			createResponse, err := server.Create(ctx, publicv1.ComputeInstanceCatalogItemsCreateRequest_builder{
 				Object: publicv1.ComputeInstanceCatalogItem_builder{
-					Title:    "My CI catalog item",
-					Template: "my-ci-template-id",
+					Title:     "My CI catalog item",
+					Template:  "my-ci-template-id",
+					Published: true,
 				}.Build(),
 			}.Build())
 			Expect(err).ToNot(HaveOccurred())

--- a/internal/servers/compute_instance_catalog_items_server_test.go
+++ b/internal/servers/compute_instance_catalog_items_server_test.go
@@ -24,6 +24,8 @@ import (
 	"google.golang.org/protobuf/proto"
 
 	publicv1 "github.com/osac-project/fulfillment-service/internal/api/osac/public/v1"
+	"github.com/osac-project/fulfillment-service/internal/auth"
+	"github.com/osac-project/fulfillment-service/internal/collections"
 	"github.com/osac-project/fulfillment-service/internal/database"
 )
 
@@ -36,7 +38,10 @@ var _ = Describe("Compute instance catalog items server", func() {
 	BeforeEach(func() {
 		var err error
 
-		ctx = context.Background()
+		ctx = auth.ContextWithSubject(context.Background(), &auth.Subject{
+			User:    "system",
+			Tenants: collections.NewUniversalSet[string](),
+		})
 
 		db, err := server.NewInstance().Build()
 		Expect(err).ToNot(HaveOccurred())
@@ -187,7 +192,36 @@ var _ = Describe("Compute instance catalog items server", func() {
 			}
 		})
 
-		It("List excludes unpublished objects", func() {
+		It("List excludes unpublished objects from other creators", func() {
+			_, err := server.Create(ctx, publicv1.ComputeInstanceCatalogItemsCreateRequest_builder{
+				Object: publicv1.ComputeInstanceCatalogItem_builder{
+					Title:     "Published item",
+					Template:  "my-ci-template-id",
+					Published: true,
+				}.Build(),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+
+			_, err = server.Create(ctx, publicv1.ComputeInstanceCatalogItemsCreateRequest_builder{
+				Object: publicv1.ComputeInstanceCatalogItem_builder{
+					Title:     "Unpublished item",
+					Template:  "my-ci-template-id",
+					Published: false,
+				}.Build(),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+
+			otherUserCtx := auth.ContextWithSubject(ctx, &auth.Subject{
+				User:    "other-user",
+				Tenants: collections.NewUniversalSet[string](),
+			})
+			response, err := server.List(otherUserCtx, publicv1.ComputeInstanceCatalogItemsListRequest_builder{}.Build())
+			Expect(err).ToNot(HaveOccurred())
+			Expect(response.GetItems()).To(HaveLen(1))
+			Expect(response.GetItems()[0].GetTitle()).To(Equal("Published item"))
+		})
+
+		It("List shows unpublished objects to their creator", func() {
 			_, err := server.Create(ctx, publicv1.ComputeInstanceCatalogItemsCreateRequest_builder{
 				Object: publicv1.ComputeInstanceCatalogItem_builder{
 					Title:     "Published item",
@@ -208,11 +242,10 @@ var _ = Describe("Compute instance catalog items server", func() {
 
 			response, err := server.List(ctx, publicv1.ComputeInstanceCatalogItemsListRequest_builder{}.Build())
 			Expect(err).ToNot(HaveOccurred())
-			Expect(response.GetItems()).To(HaveLen(1))
-			Expect(response.GetItems()[0].GetTitle()).To(Equal("Published item"))
+			Expect(response.GetItems()).To(HaveLen(2))
 		})
 
-		It("List with user filter excludes unpublished objects", func() {
+		It("List with user filter excludes unpublished objects from other creators", func() {
 			publishedResponse, err := server.Create(ctx, publicv1.ComputeInstanceCatalogItemsCreateRequest_builder{
 				Object: publicv1.ComputeInstanceCatalogItem_builder{
 					Title:     "Target published",
@@ -243,7 +276,11 @@ var _ = Describe("Compute instance catalog items server", func() {
 			targetID := publishedResponse.GetObject().GetId()
 			unpublishedID := unpublishedResponse.GetObject().GetId()
 			filter := fmt.Sprintf("this.id == '%s' || this.id == '%s'", targetID, unpublishedID)
-			response, err := server.List(ctx, publicv1.ComputeInstanceCatalogItemsListRequest_builder{
+			otherUserCtx := auth.ContextWithSubject(ctx, &auth.Subject{
+				User:    "other-user",
+				Tenants: collections.NewUniversalSet[string](),
+			})
+			response, err := server.List(otherUserCtx, publicv1.ComputeInstanceCatalogItemsListRequest_builder{
 				Filter: proto.String(filter),
 			}.Build())
 			Expect(err).ToNot(HaveOccurred())
@@ -251,7 +288,7 @@ var _ = Describe("Compute instance catalog items server", func() {
 			Expect(response.GetItems()[0].GetId()).To(Equal(targetID))
 		})
 
-		It("Get returns not found for unpublished object", func() {
+		It("Get returns not found for unpublished object from other creator", func() {
 			createResponse, err := server.Create(ctx, publicv1.ComputeInstanceCatalogItemsCreateRequest_builder{
 				Object: publicv1.ComputeInstanceCatalogItem_builder{
 					Title:     "Unpublished item",
@@ -261,11 +298,32 @@ var _ = Describe("Compute instance catalog items server", func() {
 			}.Build())
 			Expect(err).ToNot(HaveOccurred())
 
-			_, err = server.Get(ctx, publicv1.ComputeInstanceCatalogItemsGetRequest_builder{
+			otherUserCtx := auth.ContextWithSubject(ctx, &auth.Subject{
+				User:    "other-user",
+				Tenants: collections.NewUniversalSet[string](),
+			})
+			_, err = server.Get(otherUserCtx, publicv1.ComputeInstanceCatalogItemsGetRequest_builder{
 				Id: createResponse.GetObject().GetId(),
 			}.Build())
 			Expect(err).To(HaveOccurred())
 			Expect(status.Code(err)).To(Equal(codes.NotFound))
+		})
+
+		It("Get returns unpublished object to its creator", func() {
+			createResponse, err := server.Create(ctx, publicv1.ComputeInstanceCatalogItemsCreateRequest_builder{
+				Object: publicv1.ComputeInstanceCatalogItem_builder{
+					Title:     "Unpublished item",
+					Template:  "my-ci-template-id",
+					Published: false,
+				}.Build(),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+
+			getResponse, err := server.Get(ctx, publicv1.ComputeInstanceCatalogItemsGetRequest_builder{
+				Id: createResponse.GetObject().GetId(),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+			Expect(getResponse.GetObject().GetTitle()).To(Equal("Unpublished item"))
 		})
 
 		It("Get object", func() {

--- a/internal/servers/compute_instance_catalog_items_server_test.go
+++ b/internal/servers/compute_instance_catalog_items_server_test.go
@@ -254,8 +254,9 @@ var _ = Describe("Compute instance catalog items server", func() {
 		It("Get returns not found for unpublished object", func() {
 			createResponse, err := server.Create(ctx, publicv1.ComputeInstanceCatalogItemsCreateRequest_builder{
 				Object: publicv1.ComputeInstanceCatalogItem_builder{
-					Title:    "Unpublished item",
-					Template: "my-ci-template-id",
+					Title:     "Unpublished item",
+					Template:  "my-ci-template-id",
+					Published: false,
 				}.Build(),
 			}.Build())
 			Expect(err).ToNot(HaveOccurred())

--- a/internal/servers/compute_instance_catalog_items_server_test.go
+++ b/internal/servers/compute_instance_catalog_items_server_test.go
@@ -24,8 +24,6 @@ import (
 	"google.golang.org/protobuf/proto"
 
 	publicv1 "github.com/osac-project/fulfillment-service/internal/api/osac/public/v1"
-	"github.com/osac-project/fulfillment-service/internal/auth"
-	"github.com/osac-project/fulfillment-service/internal/collections"
 	"github.com/osac-project/fulfillment-service/internal/database"
 )
 
@@ -38,10 +36,7 @@ var _ = Describe("Compute instance catalog items server", func() {
 	BeforeEach(func() {
 		var err error
 
-		ctx = auth.ContextWithSubject(context.Background(), &auth.Subject{
-			User:    "system",
-			Tenants: collections.NewUniversalSet[string](),
-		})
+		ctx = context.Background()
 
 		db, err := server.NewInstance().Build()
 		Expect(err).ToNot(HaveOccurred())
@@ -192,36 +187,7 @@ var _ = Describe("Compute instance catalog items server", func() {
 			}
 		})
 
-		It("List excludes unpublished objects from other creators", func() {
-			_, err := server.Create(ctx, publicv1.ComputeInstanceCatalogItemsCreateRequest_builder{
-				Object: publicv1.ComputeInstanceCatalogItem_builder{
-					Title:     "Published item",
-					Template:  "my-ci-template-id",
-					Published: true,
-				}.Build(),
-			}.Build())
-			Expect(err).ToNot(HaveOccurred())
-
-			_, err = server.Create(ctx, publicv1.ComputeInstanceCatalogItemsCreateRequest_builder{
-				Object: publicv1.ComputeInstanceCatalogItem_builder{
-					Title:     "Unpublished item",
-					Template:  "my-ci-template-id",
-					Published: false,
-				}.Build(),
-			}.Build())
-			Expect(err).ToNot(HaveOccurred())
-
-			otherUserCtx := auth.ContextWithSubject(ctx, &auth.Subject{
-				User:    "other-user",
-				Tenants: collections.NewUniversalSet[string](),
-			})
-			response, err := server.List(otherUserCtx, publicv1.ComputeInstanceCatalogItemsListRequest_builder{}.Build())
-			Expect(err).ToNot(HaveOccurred())
-			Expect(response.GetItems()).To(HaveLen(1))
-			Expect(response.GetItems()[0].GetTitle()).To(Equal("Published item"))
-		})
-
-		It("List shows unpublished objects to their creator", func() {
+		It("List excludes unpublished objects", func() {
 			_, err := server.Create(ctx, publicv1.ComputeInstanceCatalogItemsCreateRequest_builder{
 				Object: publicv1.ComputeInstanceCatalogItem_builder{
 					Title:     "Published item",
@@ -242,10 +208,11 @@ var _ = Describe("Compute instance catalog items server", func() {
 
 			response, err := server.List(ctx, publicv1.ComputeInstanceCatalogItemsListRequest_builder{}.Build())
 			Expect(err).ToNot(HaveOccurred())
-			Expect(response.GetItems()).To(HaveLen(2))
+			Expect(response.GetItems()).To(HaveLen(1))
+			Expect(response.GetItems()[0].GetTitle()).To(Equal("Published item"))
 		})
 
-		It("List with user filter excludes unpublished objects from other creators", func() {
+		It("List with user filter excludes unpublished objects", func() {
 			publishedResponse, err := server.Create(ctx, publicv1.ComputeInstanceCatalogItemsCreateRequest_builder{
 				Object: publicv1.ComputeInstanceCatalogItem_builder{
 					Title:     "Target published",
@@ -276,11 +243,7 @@ var _ = Describe("Compute instance catalog items server", func() {
 			targetID := publishedResponse.GetObject().GetId()
 			unpublishedID := unpublishedResponse.GetObject().GetId()
 			filter := fmt.Sprintf("this.id == '%s' || this.id == '%s'", targetID, unpublishedID)
-			otherUserCtx := auth.ContextWithSubject(ctx, &auth.Subject{
-				User:    "other-user",
-				Tenants: collections.NewUniversalSet[string](),
-			})
-			response, err := server.List(otherUserCtx, publicv1.ComputeInstanceCatalogItemsListRequest_builder{
+			response, err := server.List(ctx, publicv1.ComputeInstanceCatalogItemsListRequest_builder{
 				Filter: proto.String(filter),
 			}.Build())
 			Expect(err).ToNot(HaveOccurred())
@@ -288,7 +251,7 @@ var _ = Describe("Compute instance catalog items server", func() {
 			Expect(response.GetItems()[0].GetId()).To(Equal(targetID))
 		})
 
-		It("Get returns not found for unpublished object from other creator", func() {
+		It("Get returns not found for unpublished object", func() {
 			createResponse, err := server.Create(ctx, publicv1.ComputeInstanceCatalogItemsCreateRequest_builder{
 				Object: publicv1.ComputeInstanceCatalogItem_builder{
 					Title:     "Unpublished item",
@@ -298,32 +261,11 @@ var _ = Describe("Compute instance catalog items server", func() {
 			}.Build())
 			Expect(err).ToNot(HaveOccurred())
 
-			otherUserCtx := auth.ContextWithSubject(ctx, &auth.Subject{
-				User:    "other-user",
-				Tenants: collections.NewUniversalSet[string](),
-			})
-			_, err = server.Get(otherUserCtx, publicv1.ComputeInstanceCatalogItemsGetRequest_builder{
+			_, err = server.Get(ctx, publicv1.ComputeInstanceCatalogItemsGetRequest_builder{
 				Id: createResponse.GetObject().GetId(),
 			}.Build())
 			Expect(err).To(HaveOccurred())
 			Expect(status.Code(err)).To(Equal(codes.NotFound))
-		})
-
-		It("Get returns unpublished object to its creator", func() {
-			createResponse, err := server.Create(ctx, publicv1.ComputeInstanceCatalogItemsCreateRequest_builder{
-				Object: publicv1.ComputeInstanceCatalogItem_builder{
-					Title:     "Unpublished item",
-					Template:  "my-ci-template-id",
-					Published: false,
-				}.Build(),
-			}.Build())
-			Expect(err).ToNot(HaveOccurred())
-
-			getResponse, err := server.Get(ctx, publicv1.ComputeInstanceCatalogItemsGetRequest_builder{
-				Id: createResponse.GetObject().GetId(),
-			}.Build())
-			Expect(err).ToNot(HaveOccurred())
-			Expect(getResponse.GetObject().GetTitle()).To(Equal("Unpublished item"))
 		})
 
 		It("Get object", func() {


### PR DESCRIPTION
## Summary
- Public `List` endpoints for cluster and compute instance catalog items now inject a `this.published == true` CEL filter, excluding unpublished items from results
- Public `Get` endpoints return `NotFound` for unpublished catalog items
- Private API endpoints are unaffected - admins can still see all items

## Changes
- `catalog_item_validation.go`: add `addPublishedFilter` helper that appends the published CEL clause to user-provided filters
- `cluster_catalog_items_server.go`: apply filter in `List`, add published check in `Get`
- `compute_instance_catalog_items_server.go`: same changes
- New `catalog_item_validation_test.go`: table-driven tests for `addPublishedFilter`
- Updated existing tests to set `Published: true` explicitly
- Added tests: list excludes unpublished, list with user filter excludes unpublished, get returns not found for unpublished

## Test plan
- [x] All 800 server unit tests pass (60 catalog-related)
- [x] `addPublishedFilter` table-driven tests cover empty, simple, and compound filter inputs
- [x] Unpublished items excluded from List (with and without user-provided filter)
- [x] Unpublished items return NotFound from Get
- [x] Published items unaffected in List, Get, Update, Delete
- [ ] E2E: `test_unpublished_catalog_item_not_visible_in_public_api` (blocked on deployment)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Public List/Get now enforce published-only visibility; non-published items are hidden from other users.
  * Incoming filter expressions are syntax-validated; malformed filters are rejected with an error.

* **Behavior Changes**
  * Retrieving an unpublished item owned by another user returns "not found"; creators can still access their unpublished items.

* **Tests**
  * Added and updated tests covering publication visibility, filter validation, and NotFound behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/osac-project/fulfillment-service/pull/595?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->