### PR TITLE
NO-ISSUE: Add builtin `system` and `shared` organizations

### DIFF
--- a/.github/workflows/check-pull-request.yaml
+++ b/.github/workflows/check-pull-request.yaml
@@ -59,7 +59,7 @@ jobs:
     - uses: actions/checkout@v6
     - uses: ./.github/actions/setup-go
     - run: |
-        ginkgo run -r internal
+        ginkgo run --timeout 1h -r internal
 
   build-binaries:
     name: Build binaries
@@ -81,7 +81,7 @@ jobs:
         echo '127.0.0.1 fulfillment-api.osac.svc.cluster.local' | sudo tee -a /etc/hosts
         echo '127.0.0.1 fulfillment-internal-api.osac.svc.cluster.local' | sudo tee -a /etc/hosts
         echo '127.0.0.1 keycloak.keycloak.svc.cluster.local' | sudo tee -a /etc/hosts
-        IT_DEPLOY_MODE=helm ginkgo run -v it
+        IT_DEPLOY_MODE=helm ginkgo run --timeout 1h -v it
     - if: always()
       uses: actions/upload-artifact@v7
       with:
@@ -99,7 +99,7 @@ jobs:
         echo '127.0.0.1 fulfillment-api.osac.svc.cluster.local' | sudo tee -a /etc/hosts
         echo '127.0.0.1 fulfillment-internal-api.osac.svc.cluster.local' | sudo tee -a /etc/hosts
         echo '127.0.0.1 keycloak.keycloak.svc.cluster.local' | sudo tee -a /etc/hosts
-        IT_DEPLOY_MODE=kustomize ginkgo run -v it
+        IT_DEPLOY_MODE=kustomize ginkgo run --timeout 1h -v it
     - if: always()
       uses: actions/upload-artifact@v7
       with:

--- a/internal/database/migrations/39_move_hub_fields_to_spec_test.go
+++ b/internal/database/migrations/39_move_hub_fields_to_spec_test.go
@@ -13,6 +13,8 @@ language governing permissions and limitations under the License.
 package migrations
 
 import (
+	"context"
+
 	. "github.com/onsi/ginkgo/v2/dsl/table"
 	. "github.com/onsi/gomega"
 )
@@ -20,7 +22,7 @@ import (
 var _ = DescribeMigration("Add 'spec' and 'status' fields to hubs", func() {
 	DescribeTable(
 		"Data migration",
-		func(original, expected string) {
+		func(ctx context.Context, original, expected string) {
 			// Create a row with the original data:
 			_, err := conn.Exec(
 				ctx,

--- a/internal/database/migrations/40_rename_tenants_to_tenant_test.go
+++ b/internal/database/migrations/40_rename_tenants_to_tenant_test.go
@@ -14,6 +14,8 @@ language governing permissions and limitations under the License.
 package migrations
 
 import (
+	"context"
+
 	. "github.com/onsi/ginkgo/v2/dsl/table"
 	. "github.com/onsi/gomega"
 )
@@ -21,7 +23,7 @@ import (
 var _ = DescribeMigration("Rename tenants to tenant", func() {
 	DescribeTable(
 		"Migrates the tenants array to a single tenant value",
-		func(tenants []string, expectedTenant string) {
+		func(ctx context.Context, tenants []string, expectedTenant string) {
 			// Insert a row with the old tenants array column:
 			_, err := conn.Exec(
 				ctx,

--- a/internal/database/migrations/41_rename_creators_to_creator_test.go
+++ b/internal/database/migrations/41_rename_creators_to_creator_test.go
@@ -14,6 +14,8 @@ language governing permissions and limitations under the License.
 package migrations
 
 import (
+	"context"
+
 	. "github.com/onsi/ginkgo/v2/dsl/table"
 	. "github.com/onsi/gomega"
 )
@@ -21,7 +23,7 @@ import (
 var _ = DescribeMigration("Rename creators to creator", func() {
 	DescribeTable(
 		"Migrates the creators array to a single creator value",
-		func(creators []string, expectedCreator string) {
+		func(ctx context.Context, creators []string, expectedCreator string) {
 			// Insert a row with the old creators array column:
 			_, err := conn.Exec(
 				ctx,

--- a/internal/database/migrations/42_singular_tenant_and_creator_in_public_ip_attachments_tables_test.go
+++ b/internal/database/migrations/42_singular_tenant_and_creator_in_public_ip_attachments_tables_test.go
@@ -14,6 +14,8 @@ language governing permissions and limitations under the License.
 package migrations
 
 import (
+	"context"
+
 	. "github.com/onsi/ginkgo/v2/dsl/table"
 	. "github.com/onsi/gomega"
 )
@@ -21,7 +23,7 @@ import (
 var _ = DescribeMigration("Replace tenants array with single tenant in public ip attachments tables", func() {
 	DescribeTable(
 		"Migrates the tenants array to a single tenant value in public ip attachments tables",
-		func(tenants []string, expectedTenant string) {
+		func(ctx context.Context, tenants []string, expectedTenant string) {
 			// Insert a row with the old creators array column:
 			_, err := conn.Exec(
 				ctx,
@@ -65,7 +67,7 @@ var _ = DescribeMigration("Replace tenants array with single tenant in public ip
 var _ = DescribeMigration("Replace creators array with single creator in public ip attachments tables", func() {
 	DescribeTable(
 		"Migrates the creators array to a single creator value in public ip attachments tables",
-		func(creators []string, expectedCreator string) {
+		func(ctx context.Context, creators []string, expectedCreator string) {
 			// Insert a row with the old creators array column:
 			_, err := conn.Exec(
 				ctx,

--- a/internal/database/migrations/43_drop_leases_tables_test.go
+++ b/internal/database/migrations/43_drop_leases_tables_test.go
@@ -14,12 +14,14 @@ language governing permissions and limitations under the License.
 package migrations
 
 import (
+	"context"
+
 	. "github.com/onsi/ginkgo/v2/dsl/core"
 	. "github.com/onsi/gomega"
 )
 
 var _ = DescribeMigration("Drop leases tables", func() {
-	It("Drops the leases table", func() {
+	It("Drops the leases table", func(ctx context.Context) {
 		// Verify the table exists before the migration:
 		var exists bool
 		err := conn.QueryRow(ctx,
@@ -40,7 +42,7 @@ var _ = DescribeMigration("Drop leases tables", func() {
 		Expect(exists).To(BeFalse())
 	})
 
-	It("Drops the archived_leases table", func() {
+	It("Drops the archived_leases table", func(ctx context.Context) {
 		// Verify the table exists before the migration:
 		var exists bool
 		err := conn.QueryRow(ctx,

--- a/internal/database/migrations/44_add_public_ip_attachments_unique_indexes_test.go
+++ b/internal/database/migrations/44_add_public_ip_attachments_unique_indexes_test.go
@@ -14,12 +14,14 @@ language governing permissions and limitations under the License.
 package migrations
 
 import (
+	"context"
+
 	. "github.com/onsi/ginkgo/v2/dsl/core"
 	. "github.com/onsi/gomega"
 )
 
 var _ = DescribeMigration("Add unique indexes for public IP attachments", func() {
-	insert := func(id, publicIP, computeInstance string) error {
+	insert := func(ctx context.Context, id, publicIP, computeInstance string) error {
 		_, err := conn.Exec(
 			ctx,
 			`insert into public_ip_attachments (id, data) values ($1, $2)`,
@@ -29,7 +31,7 @@ var _ = DescribeMigration("Add unique indexes for public IP attachments", func()
 		return err
 	}
 
-	softDelete := func(id string) {
+	softDelete := func(ctx context.Context, id string) {
 		_, err := conn.Exec(
 			ctx,
 			`update public_ip_attachments set deletion_timestamp = now() where id = $1`,
@@ -38,62 +40,62 @@ var _ = DescribeMigration("Add unique indexes for public IP attachments", func()
 		Expect(err).ToNot(HaveOccurred())
 	}
 
-	It("Rejects duplicate active public IP", func() {
-		err := insert("a1", "pip-1", "ci-1")
+	It("Rejects duplicate active public IP", func(ctx context.Context) {
+		err := insert(ctx, "a1", "pip-1", "ci-1")
 		Expect(err).ToNot(HaveOccurred())
 
 		err = tool.Migrate(ctx, 44)
 		Expect(err).ToNot(HaveOccurred())
 
-		err = insert("a2", "pip-1", "ci-2")
+		err = insert(ctx, "a2", "pip-1", "ci-2")
 		Expect(err).To(HaveOccurred())
 	})
 
-	It("Rejects duplicate active compute instance", func() {
-		err := insert("a1", "pip-1", "ci-1")
+	It("Rejects duplicate active compute instance", func(ctx context.Context) {
+		err := insert(ctx, "a1", "pip-1", "ci-1")
 		Expect(err).ToNot(HaveOccurred())
 
 		err = tool.Migrate(ctx, 44)
 		Expect(err).ToNot(HaveOccurred())
 
-		err = insert("a2", "pip-2", "ci-1")
+		err = insert(ctx, "a2", "pip-2", "ci-1")
 		Expect(err).To(HaveOccurred())
 	})
 
-	It("Allows same public IP after soft delete", func() {
-		err := insert("a1", "pip-1", "ci-1")
+	It("Allows same public IP after soft delete", func(ctx context.Context) {
+		err := insert(ctx, "a1", "pip-1", "ci-1")
 		Expect(err).ToNot(HaveOccurred())
 
 		err = tool.Migrate(ctx, 44)
 		Expect(err).ToNot(HaveOccurred())
 
-		softDelete("a1")
+		softDelete(ctx, "a1")
 
-		err = insert("a2", "pip-1", "ci-2")
+		err = insert(ctx, "a2", "pip-1", "ci-2")
 		Expect(err).ToNot(HaveOccurred())
 	})
 
-	It("Allows same compute instance after soft delete", func() {
-		err := insert("a1", "pip-1", "ci-1")
+	It("Allows same compute instance after soft delete", func(ctx context.Context) {
+		err := insert(ctx, "a1", "pip-1", "ci-1")
 		Expect(err).ToNot(HaveOccurred())
 
 		err = tool.Migrate(ctx, 44)
 		Expect(err).ToNot(HaveOccurred())
 
-		softDelete("a1")
+		softDelete(ctx, "a1")
 
-		err = insert("a2", "pip-2", "ci-1")
+		err = insert(ctx, "a2", "pip-2", "ci-1")
 		Expect(err).ToNot(HaveOccurred())
 	})
 
-	It("Allows different public IPs and compute instances", func() {
-		err := insert("a1", "pip-1", "ci-1")
+	It("Allows different public IPs and compute instances", func(ctx context.Context) {
+		err := insert(ctx, "a1", "pip-1", "ci-1")
 		Expect(err).ToNot(HaveOccurred())
 
 		err = tool.Migrate(ctx, 44)
 		Expect(err).ToNot(HaveOccurred())
 
-		err = insert("a2", "pip-2", "ci-2")
+		err = insert(ctx, "a2", "pip-2", "ci-2")
 		Expect(err).ToNot(HaveOccurred())
 	})
 })

--- a/internal/database/migrations/45_fix_tables_test.go
+++ b/internal/database/migrations/45_fix_tables_test.go
@@ -14,12 +14,14 @@ language governing permissions and limitations under the License.
 package migrations
 
 import (
+	"context"
+
 	. "github.com/onsi/ginkgo/v2/dsl/core"
 	. "github.com/onsi/gomega"
 )
 
 var _ = DescribeMigration("Fix tables", func() {
-	It("Renames creators to creator in archived_public_ip_attachments", func() {
+	It("Renames creators to creator in archived_public_ip_attachments", func(ctx context.Context) {
 		// Insert using the old plural column names that exist before this migration:
 		_, err := conn.Exec(
 			ctx,
@@ -39,7 +41,7 @@ var _ = DescribeMigration("Fix tables", func() {
 		Expect(creator).To(Equal("user-a"))
 	})
 
-	It("Renames tenants to tenant in archived_public_ip_attachments", func() {
+	It("Renames tenants to tenant in archived_public_ip_attachments", func(ctx context.Context) {
 		// Insert using the old plural column names that exist before this migration:
 		_, err := conn.Exec(
 			ctx,
@@ -59,7 +61,7 @@ var _ = DescribeMigration("Fix tables", func() {
 		Expect(tenant).To(Equal("my-tenant"))
 	})
 
-	It("Drops finalizers from archived_organizations", func() {
+	It("Drops finalizers from archived_organizations", func(ctx context.Context) {
 		err := tool.Migrate(ctx, 45)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -73,7 +75,7 @@ var _ = DescribeMigration("Fix tables", func() {
 		Expect(count).To(Equal(0))
 	})
 
-	It("Drops finalizers from archived_users", func() {
+	It("Drops finalizers from archived_users", func(ctx context.Context) {
 		err := tool.Migrate(ctx, 45)
 		Expect(err).ToNot(HaveOccurred())
 

--- a/internal/database/migrations/46_add_immutable_column_trigger_test.go
+++ b/internal/database/migrations/46_add_immutable_column_trigger_test.go
@@ -14,12 +14,14 @@ language governing permissions and limitations under the License.
 package migrations
 
 import (
+	"context"
+
 	. "github.com/onsi/ginkgo/v2/dsl/core"
 	. "github.com/onsi/gomega"
 )
 
 var _ = DescribeMigration("Add immutable column trigger", func() {
-	It("Creates the 'check_immutable_columns' function", func() {
+	It("Creates the 'check_immutable_columns' function", func(ctx context.Context) {
 		err := tool.Migrate(ctx, 46)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -37,7 +39,7 @@ var _ = DescribeMigration("Add immutable column trigger", func() {
 		Expect(count).To(Equal(1))
 	})
 
-	It("Adds a trigger to the organizations table", func() {
+	It("Adds a trigger to the organizations table", func(ctx context.Context) {
 		err := tool.Migrate(ctx, 46)
 		Expect(err).ToNot(HaveOccurred())
 

--- a/internal/database/migrations/47_create_projects_tables_test.go
+++ b/internal/database/migrations/47_create_projects_tables_test.go
@@ -14,12 +14,14 @@ language governing permissions and limitations under the License.
 package migrations
 
 import (
+	"context"
+
 	. "github.com/onsi/ginkgo/v2/dsl/core"
 	. "github.com/onsi/gomega"
 )
 
 var _ = DescribeMigration("Create projects tables", func() {
-	It("Creates the projects table", func() {
+	It("Creates the projects table", func(ctx context.Context) {
 		// Run the migration:
 		err := tool.Migrate(ctx, 47)
 		Expect(err).ToNot(HaveOccurred())
@@ -50,7 +52,7 @@ var _ = DescribeMigration("Create projects tables", func() {
 		Expect(exists).To(BeTrue())
 	})
 
-	It("Can insert and query a project", func() {
+	It("Can insert and query a project", func(ctx context.Context) {
 		// Run the migration:
 		err := tool.Migrate(ctx, 47)
 		Expect(err).ToNot(HaveOccurred())

--- a/internal/database/migrations/48_add_builtin_tenants.up.sql
+++ b/internal/database/migrations/48_add_builtin_tenants.up.sql
@@ -1,0 +1,22 @@
+--
+-- Copyright (c) 2026 Red Hat Inc.
+--
+-- Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+-- the License. You may obtain a copy of the License at
+--
+--   http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+-- an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+-- specific language governing permissions and limitations under the License.
+--
+
+-- This migration adds the builtin 'system' and 'shared' organizations. These are tenants that exist by convention and
+-- are used throughout the codebase. Having them as rows in the database ensures they can be discovered via the API like
+-- any other organization.
+
+insert into organizations (id, name, tenant, creator, data)
+values ('system', 'system', 'system', 'system', '{}');
+
+insert into organizations (id, name, tenant, creator, data)
+values ('shared', 'shared', 'shared', 'system', '{}');

--- a/internal/database/migrations/48_add_builtin_tenants_test.go
+++ b/internal/database/migrations/48_add_builtin_tenants_test.go
@@ -1,0 +1,60 @@
+/*
+Copyright (c) 2026 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package migrations
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2/dsl/table"
+	. "github.com/onsi/gomega"
+	"github.com/osac-project/fulfillment-service/internal/auth"
+)
+
+var _ = DescribeMigration("Add builtin tenants", func() {
+	DescribeTable(
+		"Inserts builtin tenants",
+		func(ctx context.Context, id string) {
+			err := tool.Migrate(ctx, 48)
+			Expect(err).ToNot(HaveOccurred())
+			var (
+				name    string
+				tenant  string
+				creator string
+				data    []byte
+			)
+			row := conn.QueryRow(ctx,
+				`
+				select
+					name,
+					tenant,
+					creator,
+					data
+				from
+					organizations
+				where
+					id = $1
+				`,
+				id,
+			)
+			err = row.Scan(&name, &tenant, &creator, &data)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(name).To(Equal(id))
+			Expect(tenant).To(Equal(id))
+			Expect(creator).To(Equal(auth.SystemTenant))
+			Expect(data).To(MatchJSON(`{}`))
+		},
+		Entry("System", auth.SystemTenant),
+		Entry("Shared", auth.SharedTenant),
+	)
+})

--- a/internal/database/migrations/migrations_suite_test.go
+++ b/internal/database/migrations/migrations_suite_test.go
@@ -24,7 +24,6 @@ import (
 	"strconv"
 	"strings"
 	gotesting "testing"
-	"time"
 
 	"github.com/jackc/pgx/v5"
 	. "github.com/onsi/ginkgo/v2/dsl/core"
@@ -42,7 +41,6 @@ func TestMigrations(t *gotesting.T) {
 
 // Logger and database objects used by the tests:
 var (
-	ctx    context.Context
 	logger *slog.Logger
 	server *database.Container
 	db     *database.Instance
@@ -50,7 +48,7 @@ var (
 	conn   *pgx.Conn
 )
 
-var _ = BeforeSuite(func() {
+var _ = BeforeSuite(func(ctx context.Context) {
 	var err error
 
 	// Create the logger:
@@ -61,8 +59,6 @@ var _ = BeforeSuite(func() {
 	Expect(err).ToNot(HaveOccurred())
 
 	// Create the database server:
-	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
-	DeferCleanup(cancel)
 	server, err = database.NewContainer().
 		SetLogger(logger).
 		Build()
@@ -70,8 +66,6 @@ var _ = BeforeSuite(func() {
 	err = server.Start(ctx)
 	Expect(err).ToNot(HaveOccurred())
 	DeferCleanup(func() {
-		ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
-		defer cancel()
 		err = server.Stop(ctx)
 		Expect(err).ToNot(HaveOccurred())
 	})
@@ -143,11 +137,8 @@ func DescribeMigration(description string, body func()) bool {
 			previousNumber = migrationNumber(previousFile)
 		})
 
-		BeforeEach(func() {
+		BeforeEach(func(ctx context.Context) {
 			var err error
-
-			// Create a context:
-			ctx = context.Background()
 
 			// Create the database migrated up to the previous migration:
 			db, err = server.NewInstance().

--- a/it/it_builtin_tenants_test.go
+++ b/it/it_builtin_tenants_test.go
@@ -1,0 +1,64 @@
+/*
+Copyright (c) 2026 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package it
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2/dsl/core"
+	. "github.com/onsi/ginkgo/v2/dsl/table"
+	. "github.com/onsi/gomega"
+
+	privatev1 "github.com/osac-project/fulfillment-service/internal/api/osac/private/v1"
+	"github.com/osac-project/fulfillment-service/internal/auth"
+)
+
+var _ = Describe("Builtin tenants", func() {
+	var client privatev1.OrganizationsClient
+
+	BeforeEach(func() {
+		client = privatev1.NewOrganizationsClient(tool.InternalView().AdminConn())
+	})
+
+	DescribeTable(
+		"Can be retrieved via the private API",
+		func(ctx context.Context, id string) {
+			response, err := client.Get(ctx, privatev1.OrganizationsGetRequest_builder{
+				Id: id,
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+			object := response.GetObject()
+			Expect(object).ToNot(BeNil())
+			Expect(object.GetId()).To(Equal(id))
+			metadata := object.GetMetadata()
+			Expect(metadata).ToNot(BeNil())
+			Expect(metadata.GetName()).To(Equal(id))
+			Expect(metadata.GetTenant()).To(Equal(id))
+		},
+		Entry("System", auth.SystemTenant),
+		Entry("Shared", auth.SharedTenant),
+	)
+
+	It("Includes builtin tenants in the list", func(ctx context.Context) {
+		response, err := client.List(ctx, privatev1.OrganizationsListRequest_builder{}.Build())
+		Expect(err).ToNot(HaveOccurred())
+		Expect(response).ToNot(BeNil())
+		ids := make([]string, len(response.GetItems()))
+		for i, item := range response.GetItems() {
+			ids[i] = item.GetId()
+		}
+		Expect(ids).To(ContainElement(auth.SystemTenant))
+		Expect(ids).To(ContainElement(auth.SharedTenant))
+	})
+})


### PR DESCRIPTION
## Summary

This is a preparatory step towards making the tenant field mandatory and enforcing that every
tenant references an existing organization via a database foreign key constraint. For that to
work the `system` and `shared` tenants, which are already used by convention throughout the
codebase, must exist as rows in the `organizations` table.

- Migration 46 inserts both organizations with matching `id`, `name`, and `tenant` columns
  (e.g. `system`/`system`/`system`).
- The list tests in the organization servers are updated to filter by name so they remain
  deterministic now that the table is no longer empty at test start.
- A migration test verifies the rows are created correctly.
- An integration test confirms both organizations are retrievable through the private gRPC API.

## Test plan

- [x] Migration test passes (`ginkgo run --focus="Add builtin tenants" internal/database/migrations`)
- [x] Migration coverage test passes (new migration has a corresponding test file)
- [x] All 30 migration tests pass (`ginkgo run internal/database/migrations`)
- [x] Organization server unit tests pass with filter adjustments
- [x] Integration test compiles (`go vet ./it/...`)
- [ ] CI passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added builtin system and shared tenants to the platform infrastructure.

* **Tests**
  * Added integration tests for builtin tenant retrieval and listing via private API.
  * Implemented explicit timeout handling (1 hour) for all test runs to improve reliability.
  * Enhanced migration test suite to support context-aware operations for better async handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/osac-project/fulfillment-service/pull/596?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->