### PR TITLE
NO-ISSUE: Fix boolean filter for protobuf zero values

### DIFF
--- a/internal/database/dao/filter_translator.go
+++ b/internal/database/dao/filter_translator.go
@@ -871,7 +871,7 @@ func (t *FilterTranslator[O]) translateSelectJsonField(operandSql string, msgDes
 	fieldKind := fieldDesc.Kind()
 	switch fieldKind {
 	case protoreflect.BoolKind:
-		result.sql = fmt.Sprintf("cast(%s->>'%s' as bool)", operandSql, fieldName)
+		result.sql = fmt.Sprintf("coalesce(cast(%s->>'%s' as bool), false)", operandSql, fieldName)
 		result.kind = filterTranslatorBooleanKind
 	case protoreflect.Int32Kind:
 		result.sql = fmt.Sprintf("cast(%s->>'%s' as integer)", operandSql, fieldName)

--- a/internal/database/dao/filter_translator_test.go
+++ b/internal/database/dao/filter_translator_test.go
@@ -158,14 +158,24 @@ var _ = Describe("Filter translator", func() {
 			`deletion_timestamp != '1970-01-01 00:00:00Z'`,
 		),
 		Entry(
+			"Boolean true check",
+			`this.my_bool`,
+			`coalesce(cast(data->>'my_bool' as bool), false)`,
+		),
+		Entry(
+			"Boolean false check",
+			`!this.my_bool`,
+			`not coalesce(cast(data->>'my_bool' as bool), false)`,
+		),
+		Entry(
 			"Boolean equality true",
 			`this.my_bool == true`,
-			`cast(data->>'my_bool' as bool) = true`,
+			`coalesce(cast(data->>'my_bool' as bool), false) = true`,
 		),
 		Entry(
 			"Boolean equality false",
 			`this.my_bool == false`,
-			`cast(data->>'my_bool' as bool) = false`,
+			`coalesce(cast(data->>'my_bool' as bool), false) = false`,
 		),
 		Entry(
 			"Check presence of boolean field",

--- a/internal/database/dao/generic_dao_test.go
+++ b/internal/database/dao/generic_dao_test.go
@@ -2223,6 +2223,56 @@ var _ = Describe("Generic DAO", func() {
 				Expect(items).To(HaveLen(1))
 				Expect(items[0].GetId()).To(Equal("object_without_label"))
 			})
+
+			It("Filters by boolean field", func() {
+				// Create two objects, one with the boolean set to 'true' and one with the boolean set to 'false':
+				_, err := generic.Create().
+					SetObject(
+						testsv1.Object_builder{
+							Metadata: testsv1.Metadata_builder{
+								Name:   "my-true",
+								Tenant: "my-tenant",
+							}.Build(),
+							Spec: testsv1.Spec_builder{
+								SpecBool: true,
+							}.Build(),
+						}.Build(),
+					).
+					Do(ctx)
+				Expect(err).ToNot(HaveOccurred())
+				_, err = generic.Create().
+					SetObject(
+						testsv1.Object_builder{
+							Metadata: testsv1.Metadata_builder{
+								Name:   "my-false",
+								Tenant: "my-tenant",
+							}.Build(),
+							Spec: testsv1.Spec_builder{
+								SpecBool: false,
+							}.Build(),
+						}.Build(),
+					).
+					Do(ctx)
+				Expect(err).ToNot(HaveOccurred())
+
+				// Check that we can get only the object with the boolean set to 'true':
+				response, err := generic.List().
+					SetFilter("this.spec.spec_bool").
+					Do(ctx)
+				Expect(err).ToNot(HaveOccurred())
+				items := response.GetItems()
+				Expect(items).To(HaveLen(1))
+				Expect(items[0].GetMetadata().GetName()).To(Equal("my-true"))
+
+				// Check that we can get only the object with the boolean set to 'false':
+				response, err = generic.List().
+					SetFilter("!this.spec.spec_bool").
+					Do(ctx)
+				Expect(err).ToNot(HaveOccurred())
+				items = response.GetItems()
+				Expect(items).To(HaveLen(1))
+				Expect(items[0].GetMetadata().GetName()).To(Equal("my-false"))
+			})
 		})
 	})
 })


### PR DESCRIPTION
## Summary

- Protobuf JSON serialization omits boolean fields set to `false` (the zero value), so the
  stored JSON has no key at all. The filter translator's `cast(data->>'field' as bool)` then
  evaluates to `NULL` instead of `false`, and `not NULL` stays `NULL`, silently dropping
  matching rows from query results.
- Wrap the boolean cast in `coalesce(..., false)` so that absent fields default to `false`,
  matching protobuf semantics and making negated boolean filters work correctly.

## Test plan

- [x] Existing filter translator unit tests updated to expect the new `coalesce` SQL output.
- [x] New integration-level test in `generic_dao_test.go` that creates objects with `true` and
  `false` boolean fields and verifies both `this.spec.spec_bool` and `!this.spec.spec_bool`
  return the correct results.
- [x] Full DAO test suite passes (194 specs).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Boolean field filters now correctly handle missing or null values by defaulting to false, ensuring consistent query results.

* **Tests**
  * Enhanced test coverage for boolean field filtering to validate truthiness evaluation, negation, and correct behavior with missing values.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/osac-project/fulfillment-service/pull/598?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->