### PR TITLE
OSAC-843: Add projects server

### DIFF
--- a/internal/cmd/service/start/grpcserver/start_grpc_server_cmd.go
+++ b/internal/cmd/service/start/grpcserver/start_grpc_server_cmd.go
@@ -892,6 +892,34 @@ func (c *runnerContext) run(cmd *cobra.Command, argv []string) error {
 	}
 	privatev1.RegisterOrganizationsServer(grpcServer, privateOrganizationsServer)
 
+	// Create the public projects server:
+	c.logger.InfoContext(ctx, "Creating public projects server")
+	publicProjectsServer, err := servers.NewProjectsServer().
+		SetLogger(c.logger).
+		SetNotifier(notifier).
+		SetAttributionLogic(publicAttributionLogic).
+		SetTenancyLogic(tenancyLogic).
+		SetMetricsRegisterer(metricsRegisterer).
+		Build()
+	if err != nil {
+		return fmt.Errorf("failed to create public projects server: %w", err)
+	}
+	publicv1.RegisterProjectsServer(grpcServer, publicProjectsServer)
+
+	// Create the private projects server:
+	c.logger.InfoContext(ctx, "Creating private projects server")
+	privateProjectsServer, err := servers.NewPrivateProjectsServer().
+		SetLogger(c.logger).
+		SetNotifier(notifier).
+		SetAttributionLogic(privateAttributionLogic).
+		SetTenancyLogic(tenancyLogic).
+		SetMetricsRegisterer(metricsRegisterer).
+		Build()
+	if err != nil {
+		return fmt.Errorf("failed to create private projects server: %w", err)
+	}
+	privatev1.RegisterProjectsServer(grpcServer, privateProjectsServer)
+
 	// Create the public users server:
 	c.logger.InfoContext(ctx, "Creating public users server")
 	publicUsersServer, err := servers.NewUsersServer().

--- a/internal/database/migrations/47_create_projects_tables.up.sql
+++ b/internal/database/migrations/47_create_projects_tables.up.sql
@@ -1,0 +1,47 @@
+--
+-- Copyright (c) 2026 Red Hat Inc.
+--
+-- Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+-- the License. You may obtain a copy of the License at
+--
+--   http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+-- "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+-- specific language governing permissions and limitations under the License.
+--
+
+-- Create the projects tables following the generic schema pattern.
+
+create table projects (
+  id text not null primary key,
+  name text not null default '',
+  creation_timestamp timestamp with time zone not null default now(),
+  deletion_timestamp timestamp with time zone not null default 'epoch',
+  finalizers text[] not null default '{}',
+  creator text not null default '',
+  tenant text not null default '',
+  labels jsonb not null default '{}'::jsonb,
+  annotations jsonb not null default '{}'::jsonb,
+  data jsonb not null,
+  version integer not null default 0
+);
+
+create table archived_projects (
+  id text not null,
+  name text not null default '',
+  creation_timestamp timestamp with time zone not null,
+  deletion_timestamp timestamp with time zone not null,
+  archival_timestamp timestamp with time zone not null default now(),
+  creator text not null default '',
+  tenant text not null default '',
+  labels jsonb not null default '{}'::jsonb,
+  annotations jsonb not null default '{}'::jsonb,
+  data jsonb not null,
+  version integer not null default 0
+);
+
+create index projects_by_name on projects (name);
+create index projects_by_creator on projects (creator);
+create index projects_by_tenant on projects (tenant);
+create index projects_by_label on projects using gin (labels);

--- a/internal/database/migrations/47_create_projects_tables_test.go
+++ b/internal/database/migrations/47_create_projects_tables_test.go
@@ -1,0 +1,78 @@
+/*
+Copyright (c) 2026 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package migrations
+
+import (
+	. "github.com/onsi/ginkgo/v2/dsl/core"
+	. "github.com/onsi/gomega"
+)
+
+var _ = DescribeMigration("Create projects tables", func() {
+	It("Creates the projects table", func() {
+		// Run the migration:
+		err := tool.Migrate(ctx, 47)
+		Expect(err).ToNot(HaveOccurred())
+
+		// Verify the projects table exists:
+		var exists bool
+		row := conn.QueryRow(
+			ctx,
+			`select exists (
+				select from information_schema.tables
+				where table_name = 'projects'
+			)`,
+		)
+		err = row.Scan(&exists)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(exists).To(BeTrue())
+
+		// Verify the archived_projects table exists:
+		row = conn.QueryRow(
+			ctx,
+			`select exists (
+				select from information_schema.tables
+				where table_name = 'archived_projects'
+			)`,
+		)
+		err = row.Scan(&exists)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(exists).To(BeTrue())
+	})
+
+	It("Can insert and query a project", func() {
+		// Run the migration:
+		err := tool.Migrate(ctx, 47)
+		Expect(err).ToNot(HaveOccurred())
+
+		// Insert a test project:
+		_, err = conn.Exec(
+			ctx,
+			`insert into projects (id, name, creator, tenant, data)
+			 values ('test-id', 'test-project', 'test-creator', 'test-tenant', '{}')`,
+		)
+		Expect(err).ToNot(HaveOccurred())
+
+		// Query it back:
+		var name, creator, tenant string
+		row := conn.QueryRow(
+			ctx,
+			`select name, creator, tenant from projects where id = 'test-id'`,
+		)
+		err = row.Scan(&name, &creator, &tenant)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(name).To(Equal("test-project"))
+		Expect(creator).To(Equal("test-creator"))
+		Expect(tenant).To(Equal("test-tenant"))
+	})
+})

--- a/internal/servers/private_projects_server.go
+++ b/internal/servers/private_projects_server.go
@@ -1,0 +1,152 @@
+/*
+Copyright (c) 2026 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package servers
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+
+	"github.com/prometheus/client_golang/prometheus"
+
+	privatev1 "github.com/osac-project/fulfillment-service/internal/api/osac/private/v1"
+	"github.com/osac-project/fulfillment-service/internal/auth"
+	"github.com/osac-project/fulfillment-service/internal/database/dao"
+	"github.com/osac-project/fulfillment-service/internal/events"
+)
+
+type PrivateProjectsServerBuilder struct {
+	logger            *slog.Logger
+	notifier          events.Notifier
+	attributionLogic  auth.AttributionLogic
+	tenancyLogic      auth.TenancyLogic
+	metricsRegisterer prometheus.Registerer
+}
+
+var _ privatev1.ProjectsServer = (*PrivateProjectsServer)(nil)
+
+type PrivateProjectsServer struct {
+	privatev1.UnimplementedProjectsServer
+	logger  *slog.Logger
+	generic *GenericServer[*privatev1.Project]
+	dao     *dao.GenericDAO[*privatev1.Project]
+}
+
+func NewPrivateProjectsServer() *PrivateProjectsServerBuilder {
+	return &PrivateProjectsServerBuilder{}
+}
+
+func (b *PrivateProjectsServerBuilder) SetLogger(value *slog.Logger) *PrivateProjectsServerBuilder {
+	b.logger = value
+	return b
+}
+
+func (b *PrivateProjectsServerBuilder) SetNotifier(value events.Notifier) *PrivateProjectsServerBuilder {
+	b.notifier = value
+	return b
+}
+
+func (b *PrivateProjectsServerBuilder) SetAttributionLogic(value auth.AttributionLogic) *PrivateProjectsServerBuilder {
+	b.attributionLogic = value
+	return b
+}
+
+func (b *PrivateProjectsServerBuilder) SetTenancyLogic(value auth.TenancyLogic) *PrivateProjectsServerBuilder {
+	b.tenancyLogic = value
+	return b
+}
+
+func (b *PrivateProjectsServerBuilder) SetMetricsRegisterer(value prometheus.Registerer) *PrivateProjectsServerBuilder {
+	b.metricsRegisterer = value
+	return b
+}
+
+func (b *PrivateProjectsServerBuilder) Build() (result *PrivateProjectsServer, err error) {
+	// Check parameters:
+	if b.logger == nil {
+		err = errors.New("logger is mandatory")
+		return
+	}
+	if b.tenancyLogic == nil {
+		err = errors.New("tenancy logic is mandatory")
+		return
+	}
+
+	// Create the generic server:
+	generic, err := NewGenericServer[*privatev1.Project]().
+		SetLogger(b.logger).
+		SetService(privatev1.Projects_ServiceDesc.ServiceName).
+		SetNotifier(b.notifier).
+		SetAttributionLogic(b.attributionLogic).
+		SetTenancyLogic(b.tenancyLogic).
+		SetMetricsRegisterer(b.metricsRegisterer).
+		Build()
+	if err != nil {
+		return
+	}
+
+	// Create the DAO:
+	dao, err := dao.NewGenericDAO[*privatev1.Project]().
+		SetLogger(b.logger).
+		SetTenancyLogic(b.tenancyLogic).
+		SetMetricsRegisterer(b.metricsRegisterer).
+		Build()
+	if err != nil {
+		return
+	}
+
+	// Create and populate the object:
+	result = &PrivateProjectsServer{
+		logger:  b.logger,
+		generic: generic,
+		dao:     dao,
+	}
+	return
+}
+
+func (s *PrivateProjectsServer) List(ctx context.Context,
+	request *privatev1.ProjectsListRequest) (response *privatev1.ProjectsListResponse, err error) {
+	err = s.generic.List(ctx, request, &response)
+	return
+}
+
+func (s *PrivateProjectsServer) Get(ctx context.Context,
+	request *privatev1.ProjectsGetRequest) (response *privatev1.ProjectsGetResponse, err error) {
+	err = s.generic.Get(ctx, request, &response)
+	return
+}
+
+func (s *PrivateProjectsServer) Create(ctx context.Context,
+	request *privatev1.ProjectsCreateRequest) (response *privatev1.ProjectsCreateResponse, err error) {
+	err = s.generic.Create(ctx, request, &response)
+	return
+}
+
+func (s *PrivateProjectsServer) Update(ctx context.Context,
+	request *privatev1.ProjectsUpdateRequest) (response *privatev1.ProjectsUpdateResponse, err error) {
+	err = s.generic.Update(ctx, request, &response)
+	return
+}
+
+func (s *PrivateProjectsServer) Delete(ctx context.Context,
+	request *privatev1.ProjectsDeleteRequest) (response *privatev1.ProjectsDeleteResponse, err error) {
+	err = s.generic.Delete(ctx, request, &response)
+	return
+}
+
+func (s *PrivateProjectsServer) Signal(ctx context.Context,
+	request *privatev1.ProjectsSignalRequest) (response *privatev1.ProjectsSignalResponse, err error) {
+	err = s.generic.Signal(ctx, request, &response)
+	return
+}

--- a/internal/servers/private_projects_server_test.go
+++ b/internal/servers/private_projects_server_test.go
@@ -1,0 +1,344 @@
+/*
+Copyright (c) 2026 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package servers
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/fieldmaskpb"
+
+	privatev1 "github.com/osac-project/fulfillment-service/internal/api/osac/private/v1"
+	"github.com/osac-project/fulfillment-service/internal/database"
+)
+
+var _ = Describe("Private projects server", func() {
+	var (
+		ctx           context.Context
+		tx            database.Tx
+		privateServer *PrivateProjectsServer
+	)
+
+	BeforeEach(func() {
+		var err error
+
+		// Create context:
+		ctx = context.Background()
+
+		// Prepare the database pool:
+		db, err := server.NewInstance().Build()
+		Expect(err).ToNot(HaveOccurred())
+		DeferCleanup(db.Close)
+		pool, err := db.Pool(ctx)
+		Expect(err).ToNot(HaveOccurred())
+		DeferCleanup(pool.Close)
+
+		// Create the transaction manager:
+		tm, err := database.NewTxManager().
+			SetLogger(logger).
+			SetPool(pool).
+			Build()
+		Expect(err).ToNot(HaveOccurred())
+
+		// Start a transaction and add it to the context:
+		tx, err = tm.Begin(ctx)
+		Expect(err).ToNot(HaveOccurred())
+		DeferCleanup(func() {
+			err := tm.End(ctx, tx)
+			Expect(err).ToNot(HaveOccurred())
+		})
+		ctx = database.TxIntoContext(ctx, tx)
+
+		// Create server (without notifier for testing):
+		privateServer, err = NewPrivateProjectsServer().
+			SetLogger(logger).
+			SetAttributionLogic(attribution).
+			SetTenancyLogic(tenancy).
+			Build()
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	It("Creates a project", func() {
+		// Create request:
+		request := privatev1.ProjectsCreateRequest_builder{
+			Object: privatev1.Project_builder{
+				Metadata: privatev1.Metadata_builder{
+					Name:   "my-project",
+					Tenant: "my-org",
+				}.Build(),
+				Spec: privatev1.ProjectSpec_builder{
+					Title:       "My Project",
+					Description: proto.String("Test project"),
+				}.Build(),
+			}.Build(),
+		}.Build()
+
+		// Create project:
+		response, err := privateServer.Create(ctx, request)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(response).ToNot(BeNil())
+		Expect(response.Object).ToNot(BeNil())
+		Expect(response.Object.Id).ToNot(BeEmpty())
+		Expect(response.Object.Metadata.Name).To(Equal("my-project"))
+		Expect(response.Object.Spec.Title).To(Equal("My Project"))
+		Expect(response.Object.Spec.Description).To(HaveValue(Equal("Test project")))
+	})
+
+	It("Creates a nested project with parent", func() {
+		// Create parent project:
+		parentReq := privatev1.ProjectsCreateRequest_builder{
+			Object: privatev1.Project_builder{
+				Metadata: privatev1.Metadata_builder{
+					Name:   "parent-project",
+					Tenant: "my-org",
+				}.Build(),
+				Spec: privatev1.ProjectSpec_builder{
+					Title: "Parent Project",
+				}.Build(),
+			}.Build(),
+		}.Build()
+		parentResp, err := privateServer.Create(ctx, parentReq)
+		Expect(err).ToNot(HaveOccurred())
+
+		// Create child project:
+		childReq := privatev1.ProjectsCreateRequest_builder{
+			Object: privatev1.Project_builder{
+				Metadata: privatev1.Metadata_builder{
+					Name:   "child-project",
+					Tenant: "my-org",
+				}.Build(),
+				Spec: privatev1.ProjectSpec_builder{
+					Title:  "Child Project",
+					Parent: proto.String(parentResp.Object.Id),
+				}.Build(),
+			}.Build(),
+		}.Build()
+		childResp, err := privateServer.Create(ctx, childReq)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(childResp.Object.Spec.Parent).To(HaveValue(Equal(parentResp.Object.Id)))
+	})
+
+	It("Lists projects", func() {
+		// Create a project first:
+		createReq := privatev1.ProjectsCreateRequest_builder{
+			Object: privatev1.Project_builder{
+				Metadata: privatev1.Metadata_builder{
+					Name:   "my-project",
+					Tenant: "my-org",
+				}.Build(),
+				Spec: privatev1.ProjectSpec_builder{
+					Title: "My Project",
+				}.Build(),
+			}.Build(),
+		}.Build()
+		_, err := privateServer.Create(ctx, createReq)
+		Expect(err).ToNot(HaveOccurred())
+
+		// List projects:
+		listResp, err := privateServer.List(ctx, &privatev1.ProjectsListRequest{
+			Filter: proto.String("this.metadata.name == 'my-project'"),
+		})
+		Expect(err).ToNot(HaveOccurred())
+		Expect(listResp.Size).To(Equal(int32(1)))
+		Expect(listResp.Items).To(HaveLen(1))
+		Expect(listResp.Items[0].Metadata.Name).To(Equal("my-project"))
+	})
+
+	It("Lists projects by tenant", func() {
+		// Create projects in different tenants:
+		for _, tenant := range []string{"org-1", "org-2"} {
+			createReq := privatev1.ProjectsCreateRequest_builder{
+				Object: privatev1.Project_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name:   "project-" + tenant,
+						Tenant: tenant,
+					}.Build(),
+					Spec: privatev1.ProjectSpec_builder{
+						Title: "Project " + tenant,
+					}.Build(),
+				}.Build(),
+			}.Build()
+			_, err := privateServer.Create(ctx, createReq)
+			Expect(err).ToNot(HaveOccurred())
+		}
+
+		// List projects for org-1:
+		listResp, err := privateServer.List(ctx, &privatev1.ProjectsListRequest{
+			Filter: proto.String("this.metadata.tenant == 'org-1'"),
+		})
+		Expect(err).ToNot(HaveOccurred())
+		Expect(listResp.Size).To(Equal(int32(1)))
+		Expect(listResp.Items[0].Metadata.Tenant).To(Equal("org-1"))
+	})
+
+	It("Lists top-level projects (no parent)", func() {
+		// Create parent and child:
+		parentReq := privatev1.ProjectsCreateRequest_builder{
+			Object: privatev1.Project_builder{
+				Metadata: privatev1.Metadata_builder{
+					Name:   "parent",
+					Tenant: "my-org",
+				}.Build(),
+				Spec: privatev1.ProjectSpec_builder{
+					Title: "Parent",
+				}.Build(),
+			}.Build(),
+		}.Build()
+		parentResp, err := privateServer.Create(ctx, parentReq)
+		Expect(err).ToNot(HaveOccurred())
+
+		childReq := privatev1.ProjectsCreateRequest_builder{
+			Object: privatev1.Project_builder{
+				Metadata: privatev1.Metadata_builder{
+					Name:   "child",
+					Tenant: "my-org",
+				}.Build(),
+				Spec: privatev1.ProjectSpec_builder{
+					Title:  "Child",
+					Parent: proto.String(parentResp.Object.Id),
+				}.Build(),
+			}.Build(),
+		}.Build()
+		_, err = privateServer.Create(ctx, childReq)
+		Expect(err).ToNot(HaveOccurred())
+
+		// List only top-level projects:
+		listResp, err := privateServer.List(ctx, &privatev1.ProjectsListRequest{
+			Filter: proto.String("this.metadata.tenant == 'my-org' && !has(this.spec.parent)"),
+		})
+		Expect(err).ToNot(HaveOccurred())
+		Expect(listResp.Size).To(Equal(int32(1)))
+		Expect(listResp.Items[0].Metadata.Name).To(Equal("parent"))
+	})
+
+	It("Gets a project by ID", func() {
+		// Create a project:
+		createReq := privatev1.ProjectsCreateRequest_builder{
+			Object: privatev1.Project_builder{
+				Metadata: privatev1.Metadata_builder{
+					Name:   "my-project",
+					Tenant: "my-org",
+				}.Build(),
+				Spec: privatev1.ProjectSpec_builder{
+					Title: "My Project",
+				}.Build(),
+			}.Build(),
+		}.Build()
+		createResp, err := privateServer.Create(ctx, createReq)
+		Expect(err).ToNot(HaveOccurred())
+
+		// Get the project:
+		getResp, err := privateServer.Get(ctx, privatev1.ProjectsGetRequest_builder{
+			Id: createResp.Object.Id,
+		}.Build())
+		Expect(err).ToNot(HaveOccurred())
+		Expect(getResp.Object.Id).To(Equal(createResp.Object.Id))
+		Expect(getResp.Object.Metadata.Name).To(Equal("my-project"))
+	})
+
+	It("Deletes a project", func() {
+		// Create a project:
+		createReq := privatev1.ProjectsCreateRequest_builder{
+			Object: privatev1.Project_builder{
+				Metadata: privatev1.Metadata_builder{
+					Name:   "my-project",
+					Tenant: "my-org",
+				}.Build(),
+				Spec: privatev1.ProjectSpec_builder{
+					Title: "My Project",
+				}.Build(),
+			}.Build(),
+		}.Build()
+		createResp, err := privateServer.Create(ctx, createReq)
+		Expect(err).ToNot(HaveOccurred())
+
+		// Delete the project:
+		_, err = privateServer.Delete(ctx, privatev1.ProjectsDeleteRequest_builder{
+			Id: createResp.Object.Id,
+		}.Build())
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	It("Updates a project", func() {
+		// Create a project:
+		createReq := privatev1.ProjectsCreateRequest_builder{
+			Object: privatev1.Project_builder{
+				Metadata: privatev1.Metadata_builder{
+					Name:   "my-project",
+					Tenant: "my-org",
+				}.Build(),
+				Spec: privatev1.ProjectSpec_builder{
+					Title: "My Project",
+				}.Build(),
+			}.Build(),
+		}.Build()
+		createResp, err := privateServer.Create(ctx, createReq)
+		Expect(err).ToNot(HaveOccurred())
+
+		// Update the project status:
+		updateReq := privatev1.ProjectsUpdateRequest_builder{
+			Object: privatev1.Project_builder{
+				Id: createResp.Object.Id,
+				Status: privatev1.ProjectStatus_builder{
+					State: privatev1.ProjectState_PROJECT_STATE_ACTIVE,
+				}.Build(),
+			}.Build(),
+			UpdateMask: &fieldmaskpb.FieldMask{
+				Paths: []string{
+					"status.state",
+				},
+			},
+		}.Build()
+		updateResp, err := privateServer.Update(ctx, updateReq)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(updateResp.Object.Status.State).To(Equal(privatev1.ProjectState_PROJECT_STATE_ACTIVE))
+	})
+
+	It("Updates project description", func() {
+		// Create a project:
+		createReq := privatev1.ProjectsCreateRequest_builder{
+			Object: privatev1.Project_builder{
+				Metadata: privatev1.Metadata_builder{
+					Name:   "my-project",
+					Tenant: "my-org",
+				}.Build(),
+				Spec: privatev1.ProjectSpec_builder{
+					Title: "My Project",
+				}.Build(),
+			}.Build(),
+		}.Build()
+		createResp, err := privateServer.Create(ctx, createReq)
+		Expect(err).ToNot(HaveOccurred())
+
+		// Update description:
+		updateReq := privatev1.ProjectsUpdateRequest_builder{
+			Object: privatev1.Project_builder{
+				Id: createResp.Object.Id,
+				Spec: privatev1.ProjectSpec_builder{
+					Description: proto.String("Updated description"),
+				}.Build(),
+			}.Build(),
+			UpdateMask: &fieldmaskpb.FieldMask{
+				Paths: []string{
+					"spec.description",
+				},
+			},
+		}.Build()
+		updateResp, err := privateServer.Update(ctx, updateReq)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(updateResp.Object.Spec.Description).To(HaveValue(Equal("Updated description")))
+	})
+})

--- a/internal/servers/projects_server.go
+++ b/internal/servers/projects_server.go
@@ -1,0 +1,296 @@
+/*
+Copyright (c) 2026 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package servers
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+
+	"github.com/prometheus/client_golang/prometheus"
+
+	privatev1 "github.com/osac-project/fulfillment-service/internal/api/osac/private/v1"
+	publicv1 "github.com/osac-project/fulfillment-service/internal/api/osac/public/v1"
+	"github.com/osac-project/fulfillment-service/internal/auth"
+	"github.com/osac-project/fulfillment-service/internal/events"
+)
+
+type ProjectsServerBuilder struct {
+	logger            *slog.Logger
+	notifier          events.Notifier
+	attributionLogic  auth.AttributionLogic
+	tenancyLogic      auth.TenancyLogic
+	metricsRegisterer prometheus.Registerer
+}
+
+var _ publicv1.ProjectsServer = (*ProjectsServer)(nil)
+
+type ProjectsServer struct {
+	publicv1.UnimplementedProjectsServer
+
+	logger    *slog.Logger
+	private   privatev1.ProjectsServer
+	inMapper  *GenericMapper[*publicv1.Project, *privatev1.Project]
+	outMapper *GenericMapper[*privatev1.Project, *publicv1.Project]
+}
+
+func NewProjectsServer() *ProjectsServerBuilder {
+	return &ProjectsServerBuilder{}
+}
+
+func (b *ProjectsServerBuilder) SetLogger(value *slog.Logger) *ProjectsServerBuilder {
+	b.logger = value
+	return b
+}
+
+func (b *ProjectsServerBuilder) SetNotifier(value events.Notifier) *ProjectsServerBuilder {
+	b.notifier = value
+	return b
+}
+
+func (b *ProjectsServerBuilder) SetAttributionLogic(value auth.AttributionLogic) *ProjectsServerBuilder {
+	b.attributionLogic = value
+	return b
+}
+
+func (b *ProjectsServerBuilder) SetTenancyLogic(value auth.TenancyLogic) *ProjectsServerBuilder {
+	b.tenancyLogic = value
+	return b
+}
+
+func (b *ProjectsServerBuilder) SetMetricsRegisterer(value prometheus.Registerer) *ProjectsServerBuilder {
+	b.metricsRegisterer = value
+	return b
+}
+
+func (b *ProjectsServerBuilder) Build() (result *ProjectsServer, err error) {
+	// Check parameters:
+	if b.logger == nil {
+		err = errors.New("logger is mandatory")
+		return
+	}
+	if b.tenancyLogic == nil {
+		err = errors.New("tenancy logic is mandatory")
+		return
+	}
+
+	// Create the mappers:
+	inMapper, err := NewGenericMapper[*publicv1.Project, *privatev1.Project]().
+		SetLogger(b.logger).
+		SetStrict(true).
+		Build()
+	if err != nil {
+		return
+	}
+	outMapper, err := NewGenericMapper[*privatev1.Project, *publicv1.Project]().
+		SetLogger(b.logger).
+		SetStrict(false).
+		Build()
+	if err != nil {
+		return
+	}
+
+	// Create the private server to delegate to:
+	delegate, err := NewPrivateProjectsServer().
+		SetLogger(b.logger).
+		SetNotifier(b.notifier).
+		SetAttributionLogic(b.attributionLogic).
+		SetTenancyLogic(b.tenancyLogic).
+		SetMetricsRegisterer(b.metricsRegisterer).
+		Build()
+	if err != nil {
+		return
+	}
+
+	// Create and populate the object:
+	result = &ProjectsServer{
+		logger:    b.logger,
+		private:   delegate,
+		inMapper:  inMapper,
+		outMapper: outMapper,
+	}
+	return
+}
+
+func (s *ProjectsServer) List(ctx context.Context,
+	request *publicv1.ProjectsListRequest) (response *publicv1.ProjectsListResponse, err error) {
+	// Create private request with same parameters:
+	privateRequest := &privatev1.ProjectsListRequest{}
+	privateRequest.SetOffset(request.GetOffset())
+	privateRequest.SetLimit(request.GetLimit())
+	privateRequest.SetFilter(request.GetFilter())
+	privateRequest.SetOrder(request.GetOrder())
+
+	// Delegate to private server:
+	privateResponse, err := s.private.List(ctx, privateRequest)
+	if err != nil {
+		return nil, err
+	}
+
+	// Map private response to public format:
+	privateItems := privateResponse.GetItems()
+	publicItems := make([]*publicv1.Project, len(privateItems))
+	for i, privateItem := range privateItems {
+		publicItem := &publicv1.Project{}
+		err = s.outMapper.Copy(ctx, privateItem, publicItem)
+		if err != nil {
+			s.logger.ErrorContext(
+				ctx,
+				"Failed to map private project to public",
+				slog.Any("error", err),
+			)
+			return nil, err
+		}
+		publicItems[i] = publicItem
+	}
+
+	// Build and return the response:
+	response = &publicv1.ProjectsListResponse{}
+	response.SetSize(privateResponse.GetSize())
+	response.SetTotal(privateResponse.GetTotal())
+	response.SetItems(publicItems)
+	return
+}
+
+func (s *ProjectsServer) Get(ctx context.Context,
+	request *publicv1.ProjectsGetRequest) (response *publicv1.ProjectsGetResponse, err error) {
+	// Create private request:
+	privateRequest := &privatev1.ProjectsGetRequest{}
+	privateRequest.SetId(request.GetId())
+
+	// Delegate to private server:
+	privateResponse, err := s.private.Get(ctx, privateRequest)
+	if err != nil {
+		return nil, err
+	}
+
+	// Map private response to public format:
+	publicObject := &publicv1.Project{}
+	err = s.outMapper.Copy(ctx, privateResponse.GetObject(), publicObject)
+	if err != nil {
+		s.logger.ErrorContext(
+			ctx,
+			"Failed to map private project to public",
+			slog.Any("error", err),
+		)
+		return nil, err
+	}
+
+	// Build and return the response:
+	response = &publicv1.ProjectsGetResponse{}
+	response.SetObject(publicObject)
+	return
+}
+
+func (s *ProjectsServer) Create(ctx context.Context,
+	request *publicv1.ProjectsCreateRequest) (response *publicv1.ProjectsCreateResponse, err error) {
+	// Map public request to private format:
+	privateObject := &privatev1.Project{}
+	err = s.inMapper.Copy(ctx, request.GetObject(), privateObject)
+	if err != nil {
+		s.logger.ErrorContext(
+			ctx,
+			"Failed to map public project to private",
+			slog.Any("error", err),
+		)
+		return nil, err
+	}
+
+	// Create private request:
+	privateRequest := &privatev1.ProjectsCreateRequest{}
+	privateRequest.SetObject(privateObject)
+
+	// Delegate to private server:
+	privateResponse, err := s.private.Create(ctx, privateRequest)
+	if err != nil {
+		return nil, err
+	}
+
+	// Map private response to public format:
+	publicObject := &publicv1.Project{}
+	err = s.outMapper.Copy(ctx, privateResponse.GetObject(), publicObject)
+	if err != nil {
+		s.logger.ErrorContext(
+			ctx,
+			"Failed to map private project to public",
+			slog.Any("error", err),
+		)
+		return nil, err
+	}
+
+	// Build and return the response:
+	response = &publicv1.ProjectsCreateResponse{}
+	response.SetObject(publicObject)
+	return
+}
+
+func (s *ProjectsServer) Update(ctx context.Context,
+	request *publicv1.ProjectsUpdateRequest) (response *publicv1.ProjectsUpdateResponse, err error) {
+	// Map public request to private format:
+	privateObject := &privatev1.Project{}
+	err = s.inMapper.Copy(ctx, request.GetObject(), privateObject)
+	if err != nil {
+		s.logger.ErrorContext(
+			ctx,
+			"Failed to map public project to private",
+			slog.Any("error", err),
+		)
+		return nil, err
+	}
+
+	// Create private request:
+	privateRequest := &privatev1.ProjectsUpdateRequest{}
+	privateRequest.SetObject(privateObject)
+	privateRequest.SetUpdateMask(request.GetUpdateMask())
+
+	// Delegate to private server:
+	privateResponse, err := s.private.Update(ctx, privateRequest)
+	if err != nil {
+		return nil, err
+	}
+
+	// Map private response to public format:
+	publicObject := &publicv1.Project{}
+	err = s.outMapper.Copy(ctx, privateResponse.GetObject(), publicObject)
+	if err != nil {
+		s.logger.ErrorContext(
+			ctx,
+			"Failed to map private project to public",
+			slog.Any("error", err),
+		)
+		return nil, err
+	}
+
+	// Build and return the response:
+	response = &publicv1.ProjectsUpdateResponse{}
+	response.SetObject(publicObject)
+	return
+}
+
+func (s *ProjectsServer) Delete(ctx context.Context,
+	request *publicv1.ProjectsDeleteRequest) (response *publicv1.ProjectsDeleteResponse, err error) {
+	// Create private request:
+	privateRequest := &privatev1.ProjectsDeleteRequest{}
+	privateRequest.SetId(request.GetId())
+
+	// Delegate to private server:
+	_, err = s.private.Delete(ctx, privateRequest)
+	if err != nil {
+		return nil, err
+	}
+
+	// Build and return the response:
+	response = &publicv1.ProjectsDeleteResponse{}
+	return
+}

--- a/internal/servers/projects_server_test.go
+++ b/internal/servers/projects_server_test.go
@@ -1,0 +1,272 @@
+/*
+Copyright (c) 2026 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package servers
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/fieldmaskpb"
+
+	publicv1 "github.com/osac-project/fulfillment-service/internal/api/osac/public/v1"
+	"github.com/osac-project/fulfillment-service/internal/database"
+)
+
+var _ = Describe("Public projects server", func() {
+	var (
+		ctx          context.Context
+		tx           database.Tx
+		publicServer *ProjectsServer
+	)
+
+	BeforeEach(func() {
+		var err error
+
+		// Create context:
+		ctx = context.Background()
+
+		// Prepare the database pool:
+		db, err := server.NewInstance().Build()
+		Expect(err).ToNot(HaveOccurred())
+		DeferCleanup(db.Close)
+		pool, err := db.Pool(ctx)
+		Expect(err).ToNot(HaveOccurred())
+		DeferCleanup(pool.Close)
+
+		// Create the transaction manager:
+		tm, err := database.NewTxManager().
+			SetLogger(logger).
+			SetPool(pool).
+			Build()
+		Expect(err).ToNot(HaveOccurred())
+
+		// Start a transaction and add it to the context:
+		tx, err = tm.Begin(ctx)
+		Expect(err).ToNot(HaveOccurred())
+		DeferCleanup(func() {
+			err := tm.End(ctx, tx)
+			Expect(err).ToNot(HaveOccurred())
+		})
+		ctx = database.TxIntoContext(ctx, tx)
+
+		// Create public server:
+		publicServer, err = NewProjectsServer().
+			SetLogger(logger).
+			SetAttributionLogic(attribution).
+			SetTenancyLogic(tenancy).
+			Build()
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	Describe("Creation", func() {
+		It("Can be built if all required parameters are set", func() {
+			srv, err := NewProjectsServer().
+				SetLogger(logger).
+				SetAttributionLogic(attribution).
+				SetTenancyLogic(tenancy).
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(srv).ToNot(BeNil())
+		})
+
+		It("Fails if logger is not set", func() {
+			srv, err := NewProjectsServer().
+				SetAttributionLogic(attribution).
+				SetTenancyLogic(tenancy).
+				Build()
+			Expect(err).To(MatchError("logger is mandatory"))
+			Expect(srv).To(BeNil())
+		})
+
+		It("Fails if tenancy logic is not set", func() {
+			srv, err := NewProjectsServer().
+				SetLogger(logger).
+				SetAttributionLogic(attribution).
+				Build()
+			Expect(err).To(MatchError("tenancy logic is mandatory"))
+			Expect(srv).To(BeNil())
+		})
+	})
+
+	Describe("Behaviour", func() {
+		It("Lists projects", func() {
+			// Create the project:
+			_, err := publicServer.Create(ctx, publicv1.ProjectsCreateRequest_builder{
+				Object: publicv1.Project_builder{
+					Metadata: publicv1.Metadata_builder{
+						Name:   "my-project",
+						Tenant: "my-org",
+					}.Build(),
+					Spec: publicv1.ProjectSpec_builder{
+						Title: "My Project",
+					}.Build(),
+				}.Build(),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+
+			// List projects:
+			listResponse, err := publicServer.List(ctx, publicv1.ProjectsListRequest_builder{
+				Filter: proto.String("this.metadata.name == 'my-project'"),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+			Expect(listResponse.Size).To(Equal(int32(1)))
+			Expect(listResponse.Items).To(HaveLen(1))
+			Expect(listResponse.Items[0].Metadata.Name).To(Equal("my-project"))
+		})
+
+		It("Gets a project by identifier", func() {
+			// Create the project:
+			createResponse, err := publicServer.Create(ctx, publicv1.ProjectsCreateRequest_builder{
+				Object: publicv1.Project_builder{
+					Metadata: publicv1.Metadata_builder{
+						Name:   "my-project",
+						Tenant: "my-org",
+					}.Build(),
+					Spec: publicv1.ProjectSpec_builder{
+						Title: "My Project",
+					}.Build(),
+				}.Build(),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+			object := createResponse.GetObject()
+			id := object.GetId()
+
+			// Get the project:
+			getResponse, err := publicServer.Get(ctx, publicv1.ProjectsGetRequest_builder{
+				Id: id,
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+			Expect(getResponse.Object.Id).To(Equal(id))
+			Expect(getResponse.Object.Metadata.Name).To(Equal("my-project"))
+		})
+
+		It("Creates a project", func() {
+			response, err := publicServer.Create(ctx, publicv1.ProjectsCreateRequest_builder{
+				Object: publicv1.Project_builder{
+					Metadata: publicv1.Metadata_builder{
+						Name:   "new-project",
+						Tenant: "my-org",
+					}.Build(),
+					Spec: publicv1.ProjectSpec_builder{
+						Title:       "New Project",
+						Description: proto.String("Test project"),
+					}.Build(),
+				}.Build(),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+			Expect(response).ToNot(BeNil())
+			Expect(response.Object).ToNot(BeNil())
+			Expect(response.Object.Id).ToNot(BeEmpty())
+			Expect(response.Object.Metadata.Name).To(Equal("new-project"))
+			Expect(response.Object.Spec.Title).To(Equal("New Project"))
+			Expect(response.Object.Spec.Description).To(HaveValue(Equal("Test project")))
+		})
+
+		It("Updates a project", func() {
+			// Create the project:
+			createResponse, err := publicServer.Create(ctx, publicv1.ProjectsCreateRequest_builder{
+				Object: publicv1.Project_builder{
+					Metadata: publicv1.Metadata_builder{
+						Name:   "my-project",
+						Tenant: "my-org",
+					}.Build(),
+					Spec: publicv1.ProjectSpec_builder{
+						Title: "My Project",
+					}.Build(),
+				}.Build(),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+
+			// Update the project:
+			updateResponse, err := publicServer.Update(ctx, publicv1.ProjectsUpdateRequest_builder{
+				Object: publicv1.Project_builder{
+					Id: createResponse.Object.Id,
+					Spec: publicv1.ProjectSpec_builder{
+						Description: proto.String("Updated description"),
+					}.Build(),
+				}.Build(),
+				UpdateMask: &fieldmaskpb.FieldMask{
+					Paths: []string{
+						"spec.description",
+					},
+				},
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+			Expect(updateResponse.Object.Spec.Description).To(HaveValue(Equal("Updated description")))
+		})
+
+		It("Deletes a project", func() {
+			// Create the project:
+			createResponse, err := publicServer.Create(ctx, publicv1.ProjectsCreateRequest_builder{
+				Object: publicv1.Project_builder{
+					Metadata: publicv1.Metadata_builder{
+						Name:   "my-project",
+						Tenant: "my-org",
+					}.Build(),
+					Spec: publicv1.ProjectSpec_builder{
+						Title: "My Project",
+					}.Build(),
+				}.Build(),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+
+			// Delete the project:
+			_, err = publicServer.Delete(ctx, publicv1.ProjectsDeleteRequest_builder{
+				Id: createResponse.Object.Id,
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("Filters projects by parent", func() {
+			// Create parent:
+			parentResp, err := publicServer.Create(ctx, publicv1.ProjectsCreateRequest_builder{
+				Object: publicv1.Project_builder{
+					Metadata: publicv1.Metadata_builder{
+						Name:   "parent",
+						Tenant: "my-org",
+					}.Build(),
+					Spec: publicv1.ProjectSpec_builder{
+						Title: "Parent",
+					}.Build(),
+				}.Build(),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+
+			// Create child:
+			_, err = publicServer.Create(ctx, publicv1.ProjectsCreateRequest_builder{
+				Object: publicv1.Project_builder{
+					Metadata: publicv1.Metadata_builder{
+						Name:   "child",
+						Tenant: "my-org",
+					}.Build(),
+					Spec: publicv1.ProjectSpec_builder{
+						Title:  "Child",
+						Parent: proto.String(parentResp.Object.Id),
+					}.Build(),
+				}.Build(),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+
+			// List child projects:
+			listResp, err := publicServer.List(ctx, publicv1.ProjectsListRequest_builder{
+				Filter: proto.String("this.spec.parent == '" + parentResp.Object.Id + "'"),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+			Expect(listResp.Size).To(Equal(int32(1)))
+			Expect(listResp.Items[0].Metadata.Name).To(Equal("child"))
+		})
+	})
+})


### PR DESCRIPTION
# Description

Implement Projects server to allow users to CRUD Projects from the fulfillment-service 

# Testing

- [x] go build passes
- [x] All unit tests pass `ginkgo run -r ./internal`


Assisted-by: Claude Code <noreply@anthropic.com>

/cc @jhernand 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Launched Projects service with complete CRUD (Create, Read, Update, Delete) capabilities
  * Enabled hierarchical project organization through parent-child relationships
  * Added archival support for managing inactive projects
  * Implemented filtering and querying of projects by multiple criteria

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/osac-project/fulfillment-service/pull/599?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->