### PR TITLE
NO-ISSUE: Add least-privilege permissions to CI workflow

### DIFF
--- a/.github/workflows/check-pull-request.yaml
+++ b/.github/workflows/check-pull-request.yaml
@@ -19,6 +19,9 @@ on:
     branches:
     - main
 
+permissions:
+  contents: read
+
 jobs:
 
   check-pre-commit:


### PR DESCRIPTION
## Summary

- Adds a top-level `permissions: contents: read` block to the `check-pull-request.yaml`
  workflow, restricting the `GITHUB_TOKEN` to the minimum scope needed for the CI jobs.
- All jobs in this workflow only read repository contents (checkout, build, test), so no
  per-job permission overrides are required.
- Addresses the `excessive-permissions` finding reported by zizmor (1.25.2).

Closes https://github.com/osac-project/fulfillment-service/issues/601

## Test plan

- Verify the PR CI jobs still pass (checkout, pre-commit, build, unit tests, integration
  tests all only require read access to contents).
- Confirm no job fails with a permissions error.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Pull request validation workflow now explicitly declares read access to repository contents at the workflow level, making required permissions explicit and recorded in the workflow configuration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/osac-project/fulfillment-service/pull/602?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->