### PR TITLE
NO-ISSUE: Upgrade Keycloak to 26.6.2

### DIFF
--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -588,8 +588,8 @@ full reference.
 Install the Keycloak custom resource definitions:
 
 ```shell
-oc apply -f https://raw.githubusercontent.com/keycloak/keycloak-k8s-resources/26.6.0/kubernetes/keycloaks.k8s.keycloak.org-v1.yml
-oc apply -f https://raw.githubusercontent.com/keycloak/keycloak-k8s-resources/26.6.0/kubernetes/keycloakrealmimports.k8s.keycloak.org-v1.yml
+oc apply -f https://raw.githubusercontent.com/keycloak/keycloak-k8s-resources/26.6.2/kubernetes/keycloaks.k8s.keycloak.org-v1.yml
+oc apply -f https://raw.githubusercontent.com/keycloak/keycloak-k8s-resources/26.6.2/kubernetes/keycloakrealmimports.k8s.keycloak.org-v1.yml
 ```
 
 Install the operator deployment in the `keycloak` namespace. The operator watches the namespace
@@ -599,7 +599,7 @@ where it is installed, so the Keycloak instance will also be created there:
 oc new-project keycloak || true
 
 oc apply -n keycloak \
--f https://raw.githubusercontent.com/keycloak/keycloak-k8s-resources/26.6.0/kubernetes/kubernetes.yml
+-f https://raw.githubusercontent.com/keycloak/keycloak-k8s-resources/26.6.2/kubernetes/kubernetes.yml
 ```
 
 Wait for the operator to be ready:

--- a/it/charts/keycloak/values.yaml
+++ b/it/charts/keycloak/values.yaml
@@ -38,7 +38,7 @@ admin:
 
 # Image configuration:
 images:
-  keycloak: quay.io/keycloak/keycloak:26.3
+  keycloak: quay.io/keycloak/keycloak:26.6.2
 
 # Database connection configuration. Keycloak expects an external PostgreSQL database to be available. The database
 # should be created before installing this chart.


### PR DESCRIPTION
## Summary

- Upgrades the Keycloak image from 26.3 to 26.6.2 in the integration test
  Helm chart.
- Keycloak 26.6.0 introduced Organization Groups, which provide isolated
  hierarchical group management within each organization. We want to use this
  feature to map organization groups to projects.

See https://www.keycloak.org/2026/04/org-groups for details.

## Test plan

- [ ] Verify integration tests pass with the new Keycloak version.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated Keycloak authentication service to version 26.6.2.

* **Documentation**
  * Installation docs updated to reference Keycloak 26.6.2 manifests and deployment instructions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/osac-project/fulfillment-service/pull/604?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->