### PR TITLE
NO-ISSUE: Add `Enabled` flag to `OrganizationConfig`

### DIFF
--- a/internal/controllers/organization/organization_reconciler_function.go
+++ b/internal/controllers/organization/organization_reconciler_function.go
@@ -24,6 +24,7 @@ import (
 	"google.golang.org/protobuf/proto"
 
 	privatev1 "github.com/osac-project/fulfillment-service/internal/api/osac/private/v1"
+	"github.com/osac-project/fulfillment-service/internal/auth"
 	"github.com/osac-project/fulfillment-service/internal/controllers/finalizers"
 	"github.com/osac-project/fulfillment-service/internal/idp"
 	"github.com/osac-project/fulfillment-service/internal/masks"
@@ -164,7 +165,8 @@ func (t *task) syncToIDP(ctx context.Context) error {
 
 	orgName := t.organization.GetMetadata().GetName()
 	config := &idp.OrganizationConfig{
-		Name: orgName,
+		Name:    orgName,
+		Enabled: new(!t.isBuiltin()),
 	}
 
 	credentials, err := t.r.idpManager.CreateOrganization(ctx, config)
@@ -237,6 +239,13 @@ func (t *task) removeFinalizer() {
 		})
 		t.organization.GetMetadata().SetFinalizers(list)
 	}
+}
+
+// isBuiltin returns true if the organization is a builtin organization that should not be user-accessible in the
+// identity provider. Builtin organizations like "shared" and "system" are created disabled.
+func (t *task) isBuiltin() bool {
+	name := t.organization.GetMetadata().GetName()
+	return name == auth.SharedTenant || name == auth.SystemTenant
 }
 
 // delete performs the deletion cleanup for an organization.

--- a/internal/controllers/organization/organization_reconciler_function_test.go
+++ b/internal/controllers/organization/organization_reconciler_function_test.go
@@ -24,6 +24,7 @@ import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	privatev1 "github.com/osac-project/fulfillment-service/internal/api/osac/private/v1"
+	"github.com/osac-project/fulfillment-service/internal/auth"
 	"github.com/osac-project/fulfillment-service/internal/controllers/finalizers"
 	"github.com/osac-project/fulfillment-service/internal/idp"
 )
@@ -208,6 +209,7 @@ var _ = Describe("IDP Sync", func() {
 			CreateOrganization(gomock.Any(), gomock.Any()).
 			DoAndReturn(func(ctx context.Context, org *idp.Organization) (*idp.Organization, error) {
 				Expect(org.Name).To(Equal("test-org"))
+				Expect(org.Enabled).To(BeTrue())
 				return &idp.Organization{
 					Name:    "test-org",
 					Enabled: true,
@@ -331,6 +333,125 @@ var _ = Describe("IDP Sync", func() {
 
 		err := task.update(ctx)
 		Expect(err).ToNot(HaveOccurred())
+	})
+
+	It("should create builtin organizations as disabled", func() {
+		organization := privatev1.Organization_builder{
+			Id: "org-shared",
+			Metadata: privatev1.Metadata_builder{
+				Name:       auth.SharedTenant,
+				Finalizers: []string{finalizers.Controller},
+				Tenant:     "tenant-1",
+			}.Build(),
+		}.Build()
+
+		mockClient.EXPECT().
+			CreateOrganization(gomock.Any(), gomock.Any()).
+			DoAndReturn(func(ctx context.Context, org *idp.Organization) (*idp.Organization, error) {
+				Expect(org.Name).To(Equal(auth.SharedTenant))
+				Expect(org.Enabled).To(BeFalse())
+				return &idp.Organization{
+					Name:    auth.SharedTenant,
+					Enabled: false,
+				}, nil
+			}).
+			Times(1)
+
+		mockClient.EXPECT().
+			CreateUser(gomock.Any(), auth.SharedTenant, gomock.Any()).
+			Return(&idp.User{ID: "user-shared"}, nil).
+			Times(1)
+
+		mockClient.EXPECT().
+			AssignIdpManagerPermissions(gomock.Any(), "user-shared").
+			Return(nil).
+			Times(1)
+
+		task := &task{
+			r:            reconciler,
+			organization: organization,
+		}
+
+		err := task.update(ctx)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(organization.GetStatus().GetState()).To(Equal(privatev1.OrganizationState_ORGANIZATION_STATE_SYNCED))
+	})
+
+	It("should create system organization as disabled", func() {
+		organization := privatev1.Organization_builder{
+			Id: "org-system",
+			Metadata: privatev1.Metadata_builder{
+				Name:       auth.SystemTenant,
+				Finalizers: []string{finalizers.Controller},
+				Tenant:     "tenant-1",
+			}.Build(),
+		}.Build()
+
+		mockClient.EXPECT().
+			CreateOrganization(gomock.Any(), gomock.Any()).
+			DoAndReturn(func(ctx context.Context, org *idp.Organization) (*idp.Organization, error) {
+				Expect(org.Name).To(Equal(auth.SystemTenant))
+				Expect(org.Enabled).To(BeFalse())
+				return &idp.Organization{
+					Name:    auth.SystemTenant,
+					Enabled: false,
+				}, nil
+			}).
+			Times(1)
+
+		mockClient.EXPECT().
+			CreateUser(gomock.Any(), auth.SystemTenant, gomock.Any()).
+			Return(&idp.User{ID: "user-system"}, nil).
+			Times(1)
+
+		mockClient.EXPECT().
+			AssignIdpManagerPermissions(gomock.Any(), "user-system").
+			Return(nil).
+			Times(1)
+
+		task := &task{
+			r:            reconciler,
+			organization: organization,
+		}
+
+		err := task.update(ctx)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(organization.GetStatus().GetState()).To(Equal(privatev1.OrganizationState_ORGANIZATION_STATE_SYNCED))
+	})
+})
+
+var _ = Describe("Builtin Organization Detection", func() {
+	It("should return true for the shared tenant", func() {
+		organization := privatev1.Organization_builder{
+			Metadata: privatev1.Metadata_builder{
+				Name: auth.SharedTenant,
+			}.Build(),
+		}.Build()
+
+		task := &task{organization: organization}
+		Expect(task.isBuiltin()).To(BeTrue())
+	})
+
+	It("should return true for the system tenant", func() {
+		organization := privatev1.Organization_builder{
+			Metadata: privatev1.Metadata_builder{
+				Name: auth.SystemTenant,
+			}.Build(),
+		}.Build()
+
+		task := &task{organization: organization}
+		Expect(task.isBuiltin()).To(BeTrue())
+	})
+
+	It("should return false for a regular organization", func() {
+		organization := privatev1.Organization_builder{
+			Metadata: privatev1.Metadata_builder{
+				Name: "my-org",
+			}.Build(),
+		}.Build()
+
+		task := &task{organization: organization}
+		Expect(task.isBuiltin()).To(BeFalse())
 	})
 })
 

--- a/internal/idp/manager.go
+++ b/internal/idp/manager.go
@@ -79,6 +79,9 @@ type OrganizationConfig struct {
 	// DisplayName is the human-readable name
 	DisplayName string
 
+	// Enabled indicates whether the organization should be enabled in the identity provider. Nil defaults to true.
+	Enabled *bool
+
 	// BreakGlassUsername is the username for the break-glass account
 	// If empty, defaults to "osac-break-glass"
 	BreakGlassUsername string
@@ -147,10 +150,14 @@ func (m *OrganizationManager) CreateOrganization(ctx context.Context, config *Or
 	}()
 
 	// Step 1: Create the organization
+	enabled := true
+	if config.Enabled != nil {
+		enabled = *config.Enabled
+	}
 	org := &Organization{
 		Name:        config.Name,
 		DisplayName: config.DisplayName,
-		Enabled:     true,
+		Enabled:     enabled,
 	}
 	createdOrg, err := m.client.CreateOrganization(ctx, org)
 	if err != nil {

--- a/internal/idp/manager_test.go
+++ b/internal/idp/manager_test.go
@@ -278,6 +278,7 @@ var _ = Describe("OrganizationManager", func() {
 			config := &OrganizationConfig{
 				Name:               "test-org",
 				DisplayName:        "Test Organization",
+				Enabled:            new(true),
 				BreakGlassPassword: "breakglass123",
 			}
 
@@ -288,6 +289,7 @@ var _ = Describe("OrganizationManager", func() {
 			// Verify realm was created
 			Expect(mock.createdRealm).ToNot(BeNil())
 			Expect(mock.createdRealm.Name).To(Equal("test-org"))
+			Expect(mock.createdRealm.Enabled).To(BeTrue())
 
 			// Verify break-glass user was created
 			Expect(mock.createdUsers).To(HaveLen(1))
@@ -308,10 +310,28 @@ var _ = Describe("OrganizationManager", func() {
 			Expect(breakGlassUser.Credentials[0].Temporary).To(BeTrue())
 		})
 
+		It("creates a disabled organization when Enabled is false", func() {
+			config := &OrganizationConfig{
+				Name:               "test-org",
+				DisplayName:        "Test Organization",
+				Enabled:            new(false),
+				BreakGlassPassword: "breakglass123",
+			}
+
+			credentials, err := manager.CreateOrganization(ctx, config)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(credentials).ToNot(BeNil())
+
+			Expect(mock.createdRealm).ToNot(BeNil())
+			Expect(mock.createdRealm.Name).To(Equal("test-org"))
+			Expect(mock.createdRealm.Enabled).To(BeFalse())
+		})
+
 		It("assigns IdP manager roles to break-glass account", func() {
 			config := &OrganizationConfig{
 				Name:               "test-org",
 				DisplayName:        "Test Organization",
+				Enabled:            new(true),
 				BreakGlassPassword: "breakglass123",
 			}
 
@@ -357,6 +377,7 @@ var _ = Describe("OrganizationManager", func() {
 			config := &OrganizationConfig{
 				Name:               "test-org",
 				DisplayName:        "Test Organization",
+				Enabled:            new(true),
 				BreakGlassUsername: "custom-break-glass",
 				BreakGlassEmail:    "custom@example.com",
 				BreakGlassPassword: "breakglass123",
@@ -380,7 +401,7 @@ var _ = Describe("OrganizationManager", func() {
 			config := &OrganizationConfig{
 				Name:        "test-org",
 				DisplayName: "Test Organization",
-				// BreakGlassPassword not set
+				Enabled:     new(true),
 			}
 
 			credentials, err := manager.CreateOrganization(ctx, config)
@@ -408,6 +429,7 @@ var _ = Describe("OrganizationManager", func() {
 			config := &OrganizationConfig{
 				Name:               "test-org",
 				DisplayName:        "Test Organization",
+				Enabled:            new(true),
 				BreakGlassPassword: "breakglass123",
 			}
 
@@ -436,6 +458,7 @@ var _ = Describe("OrganizationManager", func() {
 			config := &OrganizationConfig{
 				Name:               "test-org",
 				DisplayName:        "Test Organization",
+				Enabled:            new(true),
 				BreakGlassPassword: "breakglass123",
 			}
 
@@ -473,6 +496,7 @@ var _ = Describe("OrganizationManager", func() {
 			config := &OrganizationConfig{
 				Name:               "test-org",
 				DisplayName:        "Test Organization",
+				Enabled:            new(true),
 				BreakGlassPassword: "breakglass123",
 			}
 


### PR DESCRIPTION
## Summary

- Add an `Enabled` field to `OrganizationConfig` so that callers can control whether an
  organization is created enabled or disabled in the identity provider. The flag is copied
  through to the Keycloak organization's `enabled` field.
- Create builtin organizations (`shared` and `system`) as disabled via a new `isBuiltin`
  helper on the reconciler task. These organizations are not intended for authentication,
  so disabling them reduces the risk of accidental use.

## Test plan

- [x] Existing unit tests updated to explicitly set `Enabled` in `OrganizationConfig`.
- [x] New test verifying a disabled organization is created when `Enabled` is `false`.
- [x] New tests verifying `shared` and `system` organizations are synced with `Enabled: false`.
- [x] New tests for `isBuiltin` covering shared, system, and regular organization names.
- [x] All 26 organization controller tests and 18 idp tests pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Organization creation now supports a configurable enabled/disabled state when provisioning to the identity provider.
  * Built-in system organizations (shared and system tenants) are created disabled by default.

* **Tests**
  * Expanded tests to cover enabled/disabled behavior for regular and built-in organizations and related provisioning scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/osac-project/fulfillment-service/pull/607?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->