### PR TITLE
OSAC-843: Update the OSAC CLI to include Projects

### DIFF
--- a/internal/rendering/tables/osac.private.v1.Project.yaml
+++ b/internal/rendering/tables/osac.private.v1.Project.yaml
@@ -1,0 +1,30 @@
+#
+# Copyright (c) 2026 Red Hat Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+# the License. You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+columns:
+
+- header: ID
+  value: this.id
+
+- header: NAME
+  value: "has(this.metadata.name)? this.metadata.name: '-'"
+
+- header: TITLE
+  value: "has(this.spec.title)? this.spec.title: '-'"
+
+- header: TENANT
+  value: "has(this.metadata.tenant)? this.metadata.tenant: '-'"
+
+- header: STATE
+  value: this.status.state
+  type: osac.private.v1.ProjectState

--- a/internal/rendering/tables/osac.public.v1.Project.yaml
+++ b/internal/rendering/tables/osac.public.v1.Project.yaml
@@ -1,0 +1,30 @@
+#
+# Copyright (c) 2026 Red Hat Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+# the License. You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+columns:
+
+- header: ID
+  value: this.id
+
+- header: NAME
+  value: "has(this.metadata.name)? this.metadata.name: '-'"
+
+- header: TITLE
+  value: "has(this.spec.title)? this.spec.title: '-'"
+
+- header: TENANT
+  value: "has(this.metadata.tenant)? this.metadata.tenant: '-'"
+
+- header: STATE
+  value: this.status.state
+  type: osac.public.v1.ProjectState


### PR DESCRIPTION
# Testing

- [x] `go build ./cmd/osac` passes
- [x] Using `./osac get project` works
- [x] All unit tests pass `ginkgo run -r ./internal`

Assisted-by: Claude Code <noreply@anthropic.com>

/cc @jhernand 