### PR TITLE
NO-ISSUE: Use `new(expression)` syntax from Go 1.26

### DIFF
--- a/internal/cmd/cli/console/connect/resolve.go
+++ b/internal/cmd/cli/console/connect/resolve.go
@@ -30,7 +30,7 @@ func ResolveInstance(ctx context.Context, conn *grpc.ClientConn, key string) (st
 		key,
 	)
 	resp, err := client.List(ctx, publicv1.ComputeInstancesListRequest_builder{
-		Filter: proto.String(listFilter),
+		Filter: new(listFilter),
 		Limit:  proto.Int32(2),
 	}.Build())
 	if err != nil {

--- a/internal/cmd/cli/create/cluster/create_cluster_cmd.go
+++ b/internal/cmd/cli/create/cluster/create_cluster_cmd.go
@@ -359,7 +359,7 @@ func (c *runnerContext) findTemplate(ctx context.Context) (result *publicv1.Clus
 		c.args.template,
 	)
 	response, err := c.templatesClient.List(ctx, publicv1.ClusterTemplatesListRequest_builder{
-		Filter: proto.String(filter),
+		Filter: new(filter),
 		Limit:  proto.Int32(10),
 	}.Build())
 	if err != nil {

--- a/internal/cmd/cli/create/computeinstance/create_compute_instance_cmd.go
+++ b/internal/cmd/cli/create/computeinstance/create_compute_instance_cmd.go
@@ -343,7 +343,7 @@ func (c *runnerContext) findTemplate(ctx context.Context) (result *publicv1.Comp
 		c.args.template,
 	)
 	response, err := c.templatesClient.List(ctx, publicv1.ComputeInstanceTemplatesListRequest_builder{
-		Filter: proto.String(filter),
+		Filter: new(filter),
 		Limit:  proto.Int32(10),
 	}.Build())
 	if err != nil {
@@ -714,13 +714,13 @@ func (c *runnerContext) buildSpec(templateID string,
 		}.Build()
 	}
 	if c.args.cores > 0 {
-		spec.Cores = proto.Int32(c.args.cores)
+		spec.Cores = new(c.args.cores)
 	}
 	if c.args.memoryGiB > 0 {
-		spec.MemoryGib = proto.Int32(c.args.memoryGiB)
+		spec.MemoryGib = new(c.args.memoryGiB)
 	}
 	if c.args.sshKey != "" {
-		spec.SshKey = proto.String(c.args.sshKey)
+		spec.SshKey = new(c.args.sshKey)
 	}
 	if c.args.bootDiskSizeGiB > 0 {
 		spec.BootDisk = publicv1.ComputeInstanceDisk_builder{
@@ -735,10 +735,10 @@ func (c *runnerContext) buildSpec(templateID string,
 		spec.AdditionalDisks = disks
 	}
 	if c.args.runStrategy != "" {
-		spec.RunStrategy = proto.String(c.args.runStrategy)
+		spec.RunStrategy = new(c.args.runStrategy)
 	}
 	if c.args.userData != "" {
-		spec.UserData = proto.String(c.args.userData)
+		spec.UserData = new(c.args.userData)
 	}
 	if err := c.applyNetworkingFlags(&spec); err != nil {
 		return nil, err
@@ -766,7 +766,7 @@ func (c *runnerContext) applyNetworkingFlags(spec *publicv1.ComputeInstanceSpec_
 		return nil
 	}
 	if c.args.subnet != "" {
-		spec.Subnet = proto.String(c.args.subnet)
+		spec.Subnet = new(c.args.subnet)
 	}
 	if len(c.args.securityGroups) > 0 {
 		spec.SecurityGroups = append([]string(nil), c.args.securityGroups...)
@@ -870,13 +870,13 @@ func (c *runnerContext) buildSpecFromCatalogItem(catalogItemID string) (*publicv
 		}.Build()
 	}
 	if c.args.cores > 0 {
-		spec.Cores = proto.Int32(c.args.cores)
+		spec.Cores = new(c.args.cores)
 	}
 	if c.args.memoryGiB > 0 {
-		spec.MemoryGib = proto.Int32(c.args.memoryGiB)
+		spec.MemoryGib = new(c.args.memoryGiB)
 	}
 	if c.args.sshKey != "" {
-		spec.SshKey = proto.String(c.args.sshKey)
+		spec.SshKey = new(c.args.sshKey)
 	}
 	if c.args.bootDiskSizeGiB > 0 {
 		spec.BootDisk = publicv1.ComputeInstanceDisk_builder{
@@ -891,10 +891,10 @@ func (c *runnerContext) buildSpecFromCatalogItem(catalogItemID string) (*publicv
 		spec.AdditionalDisks = disks
 	}
 	if c.args.runStrategy != "" {
-		spec.RunStrategy = proto.String(c.args.runStrategy)
+		spec.RunStrategy = new(c.args.runStrategy)
 	}
 	if c.args.userData != "" {
-		spec.UserData = proto.String(c.args.userData)
+		spec.UserData = new(c.args.userData)
 	}
 	return spec.Build(), nil
 }

--- a/internal/cmd/cli/create/computeinstance/create_compute_instance_cmd_test.go
+++ b/internal/cmd/cli/create/computeinstance/create_compute_instance_cmd_test.go
@@ -83,7 +83,7 @@ var _ = Describe("buildSpec", func() {
 
 		want := publicv1.ComputeInstanceSpec_builder{
 			Template:       "tmpl",
-			Subnet:         proto.String("legacy-sub"),
+			Subnet:         new("legacy-sub"),
 			SecurityGroups: []string{"sg-a", "sg-b"},
 		}.Build()
 		Expect(proto.Equal(spec, want)).To(BeTrue(), "spec should equal expected spec")

--- a/internal/cmd/cli/describe/securitygroup/describe_securitygroup_test.go
+++ b/internal/cmd/cli/describe/securitygroup/describe_securitygroup_test.go
@@ -55,7 +55,7 @@ var _ = Describe("Describe Security Group", func() {
 							Protocol: publicv1.Protocol_PROTOCOL_TCP,
 							PortFrom: proto.Int32(80),
 							PortTo:   proto.Int32(80),
-							Ipv4Cidr: proto.String("0.0.0.0/0"),
+							Ipv4Cidr: new("0.0.0.0/0"),
 						}.Build(),
 					},
 				}.Build(),
@@ -75,7 +75,7 @@ var _ = Describe("Describe Security Group", func() {
 					Ingress: []*publicv1.SecurityRule{
 						publicv1.SecurityRule_builder{
 							Protocol: publicv1.Protocol_PROTOCOL_ICMP,
-							Ipv4Cidr: proto.String("10.0.0.0/8"),
+							Ipv4Cidr: new("10.0.0.0/8"),
 						}.Build(),
 					},
 				}.Build(),

--- a/internal/cmd/cli/describe/subnet/describe_subnet_test.go
+++ b/internal/cmd/cli/describe/subnet/describe_subnet_test.go
@@ -19,8 +19,6 @@ import (
 	. "github.com/onsi/ginkgo/v2/dsl/core"
 	. "github.com/onsi/gomega"
 
-	"google.golang.org/protobuf/proto"
-
 	publicv1 "github.com/osac-project/fulfillment-service/internal/api/osac/public/v1"
 )
 
@@ -41,8 +39,8 @@ var _ = Describe("Describe Subnet", func() {
 				}.Build(),
 				Spec: publicv1.SubnetSpec_builder{
 					VirtualNetwork: "vnet-abc123",
-					Ipv4Cidr:       proto.String("10.0.1.0/24"),
-					Ipv6Cidr:       proto.String("2001:db8::/64"),
+					Ipv4Cidr:       new("10.0.1.0/24"),
+					Ipv6Cidr:       new("2001:db8::/64"),
 				}.Build(),
 				Status: publicv1.SubnetStatus_builder{
 					State:   publicv1.SubnetState_SUBNET_STATE_READY,
@@ -79,7 +77,7 @@ var _ = Describe("Describe Subnet", func() {
 				Id: "subnet-003",
 				Spec: publicv1.SubnetSpec_builder{
 					VirtualNetwork: "vnet-abc123",
-					Ipv6Cidr:       proto.String("2001:db8::/64"),
+					Ipv6Cidr:       new("2001:db8::/64"),
 				}.Build(),
 			}.Build()
 
@@ -109,7 +107,7 @@ var _ = Describe("Describe Subnet", func() {
 				Id: "subnet-006",
 				Spec: publicv1.SubnetSpec_builder{
 					VirtualNetwork: "vnet-abc123",
-					Ipv4Cidr:       proto.String("10.0.1.0/24"),
+					Ipv4Cidr:       new("10.0.1.0/24"),
 				}.Build(),
 			}.Build()
 

--- a/internal/cmd/cli/describe/virtualnetwork/describe_virtualnetwork_test.go
+++ b/internal/cmd/cli/describe/virtualnetwork/describe_virtualnetwork_test.go
@@ -19,8 +19,6 @@ import (
 	. "github.com/onsi/ginkgo/v2/dsl/core"
 	. "github.com/onsi/gomega"
 
-	"google.golang.org/protobuf/proto"
-
 	publicv1 "github.com/osac-project/fulfillment-service/internal/api/osac/public/v1"
 )
 
@@ -41,8 +39,8 @@ var _ = Describe("Describe Virtual Network", func() {
 				}.Build(),
 				Spec: publicv1.VirtualNetworkSpec_builder{
 					NetworkClass: "udn-net",
-					Ipv4Cidr:     proto.String("10.0.0.0/16"),
-					Ipv6Cidr:     proto.String("2001:db8::/48"),
+					Ipv4Cidr:     new("10.0.0.0/16"),
+					Ipv6Cidr:     new("2001:db8::/48"),
 				}.Build(),
 				Status: publicv1.VirtualNetworkStatus_builder{
 					State:   publicv1.VirtualNetworkState_VIRTUAL_NETWORK_STATE_READY,
@@ -79,7 +77,7 @@ var _ = Describe("Describe Virtual Network", func() {
 				Id: "vnet-003",
 				Spec: publicv1.VirtualNetworkSpec_builder{
 					NetworkClass: "udn-net",
-					Ipv6Cidr:     proto.String("2001:db8::/48"),
+					Ipv6Cidr:     new("2001:db8::/48"),
 				}.Build(),
 			}.Build()
 
@@ -93,7 +91,7 @@ var _ = Describe("Describe Virtual Network", func() {
 				Id: "vnet-004",
 				Spec: publicv1.VirtualNetworkSpec_builder{
 					NetworkClass: "udn-net",
-					Ipv4Cidr:     proto.String("10.0.0.0/16"),
+					Ipv4Cidr:     new("10.0.0.0/16"),
 				}.Build(),
 			}.Build()
 

--- a/internal/cmd/cli/get/kubeconfig/get_kubeconfig_cmd.go
+++ b/internal/cmd/cli/get/kubeconfig/get_kubeconfig_cmd.go
@@ -117,7 +117,7 @@ func (c *runnerContext) run(cmd *cobra.Command, args []string) error {
 		key,
 	)
 	listResponse, err := client.List(ctx, publicv1.ClustersListRequest_builder{
-		Filter: proto.String(listFilter),
+		Filter: new(listFilter),
 		Limit:  proto.Int32(10),
 	}.Build())
 	if err != nil {

--- a/internal/cmd/cli/get/password/get_password_cmd.go
+++ b/internal/cmd/cli/get/password/get_password_cmd.go
@@ -117,7 +117,7 @@ func (c *runnerContext) run(cmd *cobra.Command, args []string) error {
 		key,
 	)
 	listResponse, err := client.List(ctx, publicv1.ClustersListRequest_builder{
-		Filter: proto.String(listFilter),
+		Filter: new(listFilter),
 		Limit:  proto.Int32(10),
 	}.Build())
 	if err != nil {

--- a/internal/cmd/service/dev/watch/dev_watch_cmd.go
+++ b/internal/cmd/service/dev/watch/dev_watch_cmd.go
@@ -24,7 +24,6 @@ import (
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
-	"google.golang.org/protobuf/proto"
 
 	publicv1 "github.com/osac-project/fulfillment-service/internal/api/osac/public/v1"
 	"github.com/osac-project/fulfillment-service/internal/auth"
@@ -136,7 +135,7 @@ func (c *runnerContext) run(cmd *cobra.Command, argv []string) error {
 	// Start watching events:
 	eventsClient := publicv1.NewEventsClient(grpcClient)
 	eventsStream, err := eventsClient.Watch(ctx, &publicv1.EventsWatchRequest{
-		Filter: proto.String(c.args.filter),
+		Filter: new(c.args.filter),
 	})
 	if err != nil {
 		return fmt.Errorf("failed to start stream: %w", err)

--- a/internal/computeinstancespec/effective_network_test.go
+++ b/internal/computeinstancespec/effective_network_test.go
@@ -17,7 +17,6 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/testing/protocmp"
 
 	privatev1 "github.com/osac-project/fulfillment-service/internal/api/osac/private/v1"
@@ -46,7 +45,7 @@ func TestEffectiveNetworkAttachments(t *testing.T) {
 		{
 			name: "legacy subnet empty string",
 			spec: privatev1.ComputeInstanceSpec_builder{
-				Subnet: proto.String(""),
+				Subnet: new(""),
 			}.Build(),
 			want:    nil,
 			wantErr: false, // treat as no networking specified
@@ -54,7 +53,7 @@ func TestEffectiveNetworkAttachments(t *testing.T) {
 		{
 			name: "legacy subnet only",
 			spec: privatev1.ComputeInstanceSpec_builder{
-				Subnet: proto.String("sn-1"),
+				Subnet: new("sn-1"),
 			}.Build(),
 			want: []*privatev1.NetworkAttachment{
 				privatev1.NetworkAttachment_builder{Subnet: "sn-1"}.Build(),
@@ -64,7 +63,7 @@ func TestEffectiveNetworkAttachments(t *testing.T) {
 		{
 			name: "legacy subnet and security groups",
 			spec: privatev1.ComputeInstanceSpec_builder{
-				Subnet:         proto.String("sn-1"),
+				Subnet:         new("sn-1"),
 				SecurityGroups: []string{"sg-1", "sg-2"},
 			}.Build(),
 			want: []*privatev1.NetworkAttachment{
@@ -100,7 +99,7 @@ func TestEffectiveNetworkAttachments(t *testing.T) {
 		{
 			name: "conflict legacy subnet with network_attachments",
 			spec: privatev1.ComputeInstanceSpec_builder{
-				Subnet: proto.String("sn-1"),
+				Subnet: new("sn-1"),
 				NetworkAttachments: []*privatev1.NetworkAttachment{
 					privatev1.NetworkAttachment_builder{Subnet: "a"}.Build(),
 				},
@@ -122,7 +121,7 @@ func TestEffectiveNetworkAttachments(t *testing.T) {
 		{
 			name: "conflict deprecated subnet present but empty string with network_attachments",
 			spec: privatev1.ComputeInstanceSpec_builder{
-				Subnet: proto.String(""),
+				Subnet: new(""),
 				NetworkAttachments: []*privatev1.NetworkAttachment{
 					privatev1.NetworkAttachment_builder{Subnet: "a"}.Build(),
 				},

--- a/internal/controllers/computeinstance/computeinstance_reconciler_function_test.go
+++ b/internal/controllers/computeinstance/computeinstance_reconciler_function_test.go
@@ -92,8 +92,8 @@ var _ = Describe("buildSpec", func() {
 						Template:    template,
 						Cores:       proto.Int32(4),
 						MemoryGib:   proto.Int32(8),
-						RunStrategy: proto.String("Always"),
-						SshKey:      proto.String("ssh-rsa AAAA..."),
+						RunStrategy: new("Always"),
+						SshKey:      new("ssh-rsa AAAA..."),
 						Image: privatev1.ComputeInstanceImage_builder{
 							SourceType: "registry",
 							SourceRef:  "quay.io/fedora/fedora:latest",
@@ -1099,7 +1099,7 @@ var _ = Describe("ensureUserDataSecret", func() {
 			computeInstance: privatev1.ComputeInstance_builder{
 				Id: ciID,
 				Spec: privatev1.ComputeInstanceSpec_builder{
-					UserData: proto.String("#cloud-config\npackages:\n  - vim"),
+					UserData: new("#cloud-config\npackages:\n  - vim"),
 				}.Build(),
 			}.Build(),
 			hubNamespace:       hubNamespace,
@@ -1149,7 +1149,7 @@ var _ = Describe("ensureUserDataSecret", func() {
 			computeInstance: privatev1.ComputeInstance_builder{
 				Id: ciID,
 				Spec: privatev1.ComputeInstanceSpec_builder{
-					UserData: proto.String("some-data"),
+					UserData: new("some-data"),
 				}.Build(),
 			}.Build(),
 			hubNamespace:       hubNamespace,
@@ -1179,7 +1179,7 @@ var _ = Describe("ensureUserDataSecret", func() {
 			computeInstance: privatev1.ComputeInstance_builder{
 				Id: ciID,
 				Spec: privatev1.ComputeInstanceSpec_builder{
-					UserData: proto.String("some-data"),
+					UserData: new("some-data"),
 				}.Build(),
 			}.Build(),
 			hubNamespace:       hubNamespace,

--- a/internal/controllers/project/project_reconciler_function.go
+++ b/internal/controllers/project/project_reconciler_function.go
@@ -275,7 +275,7 @@ func (t *task) delete(ctx context.Context) error {
 	// Check for child projects before deletion
 	listResp, err := t.r.projectsClient.List(ctx, &privatev1.ProjectsListRequest{
 		//TODO: Update to use metadata.project once OSAC-1064 is implemented
-		Filter: proto.String(fmt.Sprintf("this.spec.parent == '%s'", t.project.GetId())),
+		Filter: new(fmt.Sprintf("this.spec.parent == '%s'", t.project.GetId())),
 		Limit:  proto.Int32(1), // We only need to know if any exist
 	})
 	if err != nil {

--- a/internal/controllers/project/project_reconciler_function_test.go
+++ b/internal/controllers/project/project_reconciler_function_test.go
@@ -21,7 +21,6 @@ import (
 	"go.uber.org/mock/gomock"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
-	"google.golang.org/protobuf/proto"
 
 	privatev1 "github.com/osac-project/fulfillment-service/internal/api/osac/private/v1"
 	"github.com/osac-project/fulfillment-service/internal/controllers/finalizers"
@@ -279,7 +278,7 @@ var _ = Describe("Validation and Activation", func() {
 					Tenant: "acme",
 				}.Build(),
 				Spec: privatev1.ProjectSpec_builder{
-					Parent: strPtr("parent-1"),
+					Parent: new("parent-1"),
 					Title:  "Child Project",
 				}.Build(),
 				Status: privatev1.ProjectStatus_builder{
@@ -327,7 +326,7 @@ var _ = Describe("Validation and Activation", func() {
 					State: privatev1.ProjectState_PROJECT_STATE_ACTIVE,
 				}.Build(),
 				Spec: privatev1.ProjectSpec_builder{
-					Parent: strPtr("root"),
+					Parent: new("root"),
 					Title:  "Parent",
 				}.Build(),
 			}.Build()
@@ -339,7 +338,7 @@ var _ = Describe("Validation and Activation", func() {
 					Tenant: "acme",
 				}.Build(),
 				Spec: privatev1.ProjectSpec_builder{
-					Parent: strPtr("parent"),
+					Parent: new("parent"),
 					Title:  "Child",
 				}.Build(),
 				Status: privatev1.ProjectStatus_builder{
@@ -381,7 +380,7 @@ var _ = Describe("Validation and Activation", func() {
 			project := privatev1.Project_builder{
 				Id: "project-1",
 				Spec: privatev1.ProjectSpec_builder{
-					Parent: strPtr("project-1"),
+					Parent: new("project-1"),
 					Title:  "Self-referencing",
 				}.Build(),
 				Status: privatev1.ProjectStatus_builder{
@@ -406,7 +405,7 @@ var _ = Describe("Validation and Activation", func() {
 			project := privatev1.Project_builder{
 				Id: "project-1",
 				Spec: privatev1.ProjectSpec_builder{
-					Parent: strPtr("nonexistent-parent"),
+					Parent: new("nonexistent-parent"),
 					Title:  "Orphaned Project",
 				}.Build(),
 				Status: privatev1.ProjectStatus_builder{
@@ -445,7 +444,7 @@ var _ = Describe("Validation and Activation", func() {
 			project := privatev1.Project_builder{
 				Id: "project-1",
 				Spec: privatev1.ProjectSpec_builder{
-					Parent: strPtr("parent-1"),
+					Parent: new("parent-1"),
 					Title:  "Child",
 				}.Build(),
 				Status: privatev1.ProjectStatus_builder{
@@ -482,7 +481,7 @@ var _ = Describe("Validation and Activation", func() {
 			project := privatev1.Project_builder{
 				Id: "project-1",
 				Spec: privatev1.ProjectSpec_builder{
-					Parent: strPtr("parent-1"),
+					Parent: new("parent-1"),
 					Title:  "Child",
 				}.Build(),
 				Status: privatev1.ProjectStatus_builder{
@@ -514,7 +513,7 @@ var _ = Describe("Validation and Activation", func() {
 					State: privatev1.ProjectState_PROJECT_STATE_ACTIVE,
 				}.Build(),
 				Spec: privatev1.ProjectSpec_builder{
-					Parent: strPtr("project-b"),
+					Parent: new("project-b"),
 					Title:  "Project A",
 				}.Build(),
 			}.Build()
@@ -530,7 +529,7 @@ var _ = Describe("Validation and Activation", func() {
 				project: privatev1.Project_builder{
 					Id: "project-b",
 					Spec: privatev1.ProjectSpec_builder{
-						Parent: strPtr("project-a"),
+						Parent: new("project-a"),
 						Title:  "Project B",
 					}.Build(),
 					Status: privatev1.ProjectStatus_builder{
@@ -552,7 +551,7 @@ var _ = Describe("Validation and Activation", func() {
 					State: privatev1.ProjectState_PROJECT_STATE_ACTIVE,
 				}.Build(),
 				Spec: privatev1.ProjectSpec_builder{
-					Parent: strPtr("project-c"),
+					Parent: new("project-c"),
 					Title:  "Project A",
 				}.Build(),
 			}.Build()
@@ -563,7 +562,7 @@ var _ = Describe("Validation and Activation", func() {
 					State: privatev1.ProjectState_PROJECT_STATE_ACTIVE,
 				}.Build(),
 				Spec: privatev1.ProjectSpec_builder{
-					Parent: strPtr("project-a"),
+					Parent: new("project-a"),
 					Title:  "Project B",
 				}.Build(),
 			}.Build()
@@ -583,7 +582,7 @@ var _ = Describe("Validation and Activation", func() {
 				project: privatev1.Project_builder{
 					Id: "project-c",
 					Spec: privatev1.ProjectSpec_builder{
-						Parent: strPtr("project-b"),
+						Parent: new("project-b"),
 						Title:  "Project C",
 					}.Build(),
 					Status: privatev1.ProjectStatus_builder{
@@ -633,7 +632,7 @@ var _ = Describe("Validation and Activation", func() {
 				}.Build(),
 				Status: privatev1.ProjectStatus_builder{
 					State:   privatev1.ProjectState_PROJECT_STATE_FAILED,
-					Message: strPtr("Some error"),
+					Message: new("Some error"),
 				}.Build(),
 				Spec: privatev1.ProjectSpec_builder{
 					Title: "Failed Project",
@@ -724,7 +723,7 @@ var _ = Describe("Deletion Cleanup", func() {
 				Finalizers: []string{finalizers.Controller},
 			}.Build(),
 			Status: privatev1.ProjectStatus_builder{
-				KeycloakResourceId: proto.String("resource-123"),
+				KeycloakResourceId: new("resource-123"),
 			}.Build(),
 		}.Build()
 
@@ -757,7 +756,7 @@ var _ = Describe("Deletion Cleanup", func() {
 				Finalizers: []string{finalizers.Controller},
 			}.Build(),
 			Status: privatev1.ProjectStatus_builder{
-				KeycloakResourceId: proto.String("resource-456"),
+				KeycloakResourceId: new("resource-456"),
 			}.Build(),
 		}.Build()
 
@@ -876,7 +875,3 @@ var _ = Describe("Deletion Cleanup", func() {
 		Expect(project.GetMetadata().GetFinalizers()).To(ContainElement(finalizers.Controller))
 	})
 })
-
-func strPtr(s string) *string {
-	return &s
-}

--- a/internal/servers/cluster_catalog_items_server_test.go
+++ b/internal/servers/cluster_catalog_items_server_test.go
@@ -174,7 +174,7 @@ var _ = Describe("Cluster catalog items server", func() {
 
 			for _, object := range objects {
 				response, err := server.List(ctx, publicv1.ClusterCatalogItemsListRequest_builder{
-					Filter: proto.String(fmt.Sprintf("this.id == '%s'", object.GetId())),
+					Filter: new(fmt.Sprintf("this.id == '%s'", object.GetId())),
 				}.Build())
 				Expect(err).ToNot(HaveOccurred())
 				Expect(response.GetSize()).To(BeNumerically("==", 1))

--- a/internal/servers/cluster_templates_server_test.go
+++ b/internal/servers/cluster_templates_server_test.go
@@ -148,7 +148,7 @@ var _ = Describe("Cluster templates server", func() {
 
 			// List the objects:
 			response, err := server.List(ctx, publicv1.ClusterTemplatesListRequest_builder{
-				Filter: proto.String("this.id.startsWith('my_template_')"),
+				Filter: new("this.id.startsWith('my_template_')"),
 			}.Build())
 			Expect(err).ToNot(HaveOccurred())
 			Expect(response).ToNot(BeNil())
@@ -194,7 +194,7 @@ var _ = Describe("Cluster templates server", func() {
 
 			// List the objects:
 			response, err := server.List(ctx, publicv1.ClusterTemplatesListRequest_builder{
-				Filter: proto.String("this.id.startsWith('my_template_')"),
+				Filter: new("this.id.startsWith('my_template_')"),
 				Offset: proto.Int32(1),
 			}.Build())
 			Expect(err).ToNot(HaveOccurred())
@@ -220,7 +220,7 @@ var _ = Describe("Cluster templates server", func() {
 			// List the objects:
 			for _, object := range objects {
 				response, err := server.List(ctx, publicv1.ClusterTemplatesListRequest_builder{
-					Filter: proto.String(fmt.Sprintf("this.id == '%s'", object.GetId())),
+					Filter: new(fmt.Sprintf("this.id == '%s'", object.GetId())),
 				}.Build())
 				Expect(err).ToNot(HaveOccurred())
 				Expect(response.GetSize()).To(BeNumerically("==", 1))

--- a/internal/servers/clusters_server_test.go
+++ b/internal/servers/clusters_server_test.go
@@ -747,7 +747,7 @@ var _ = Describe("Clusters server", func() {
 			// List the objects:
 			for _, object := range objects {
 				response, err := server.List(ctx, publicv1.ClustersListRequest_builder{
-					Filter: proto.String(fmt.Sprintf("this.id == '%s'", object.GetId())),
+					Filter: new(fmt.Sprintf("this.id == '%s'", object.GetId())),
 				}.Build())
 				Expect(err).ToNot(HaveOccurred())
 				Expect(response.GetSize()).To(BeNumerically("==", 1))

--- a/internal/servers/compute_instance_catalog_items_server_test.go
+++ b/internal/servers/compute_instance_catalog_items_server_test.go
@@ -174,7 +174,7 @@ var _ = Describe("Compute instance catalog items server", func() {
 
 			for _, object := range objects {
 				response, err := server.List(ctx, publicv1.ComputeInstanceCatalogItemsListRequest_builder{
-					Filter: proto.String(fmt.Sprintf("this.id == '%s'", object.GetId())),
+					Filter: new(fmt.Sprintf("this.id == '%s'", object.GetId())),
 				}.Build())
 				Expect(err).ToNot(HaveOccurred())
 				Expect(response.GetSize()).To(BeNumerically("==", 1))

--- a/internal/servers/compute_instances_server_test.go
+++ b/internal/servers/compute_instances_server_test.go
@@ -177,7 +177,7 @@ var _ = Describe("Compute instances server", func() {
 					BootDisk: privatev1.ComputeInstanceDisk_builder{
 						SizeGib: 10,
 					}.Build(),
-					RunStrategy: proto.String("Always"),
+					RunStrategy: new("Always"),
 				}.Build(),
 			}.Build()
 
@@ -353,7 +353,7 @@ var _ = Describe("Compute instances server", func() {
 						Template:    "general.small",
 						Cores:       proto.Int32(4),
 						MemoryGib:   proto.Int32(8),
-						RunStrategy: proto.String("Always"),
+						RunStrategy: new("Always"),
 						Image: publicv1.ComputeInstanceImage_builder{
 							SourceType: "registry",
 							SourceRef:  "quay.io/test:latest",
@@ -498,7 +498,7 @@ var _ = Describe("Compute instances server", func() {
 						Template:    "mapping-template",
 						Cores:       proto.Int32(8),
 						MemoryGib:   proto.Int32(16),
-						RunStrategy: proto.String("Halted"),
+						RunStrategy: new("Halted"),
 					}.Build(),
 				}.Build(),
 			}.Build())

--- a/internal/servers/generic_mapper_test.go
+++ b/internal/servers/generic_mapper_test.go
@@ -23,7 +23,6 @@ import (
 	privatev1 "github.com/osac-project/fulfillment-service/internal/api/osac/private/v1"
 	publicv1 "github.com/osac-project/fulfillment-service/internal/api/osac/public/v1"
 	"google.golang.org/protobuf/encoding/protojson"
-	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
@@ -184,8 +183,8 @@ var _ = Describe("Generic mapper", func() {
 							Type:               privatev1.ClusterConditionType_CLUSTER_CONDITION_TYPE_READY,
 							Status:             privatev1.ConditionStatus_CONDITION_STATUS_TRUE,
 							LastTransitionTime: parseDate("2025-06-02T14:53:00Z"),
-							Reason:             proto.String("MyReason"),
-							Message:            proto.String("My message."),
+							Reason:             new("MyReason"),
+							Message:            new("My message."),
 						}.Build(),
 					},
 				}.Build(),
@@ -198,8 +197,8 @@ var _ = Describe("Generic mapper", func() {
 							Type:               publicv1.ClusterConditionType_CLUSTER_CONDITION_TYPE_READY,
 							Status:             publicv1.ConditionStatus_CONDITION_STATUS_TRUE,
 							LastTransitionTime: parseDate("2025-06-02T14:53:00Z"),
-							Reason:             proto.String("MyReason"),
-							Message:            proto.String("My message."),
+							Reason:             new("MyReason"),
+							Message:            new("My message."),
 						}.Build(),
 					},
 				}.Build(),
@@ -214,15 +213,15 @@ var _ = Describe("Generic mapper", func() {
 							Type:               privatev1.ClusterConditionType_CLUSTER_CONDITION_TYPE_READY,
 							Status:             privatev1.ConditionStatus_CONDITION_STATUS_TRUE,
 							LastTransitionTime: parseDate("2025-06-02T14:53:00Z"),
-							Reason:             proto.String("MyReason"),
-							Message:            proto.String("My message."),
+							Reason:             new("MyReason"),
+							Message:            new("My message."),
 						}.Build(),
 						privatev1.ClusterCondition_builder{
 							Type:               privatev1.ClusterConditionType_CLUSTER_CONDITION_TYPE_FAILED,
 							Status:             privatev1.ConditionStatus_CONDITION_STATUS_FALSE,
 							LastTransitionTime: parseDate("2025-06-03T14:53:00Z"),
-							Reason:             proto.String("YourReason"),
-							Message:            proto.String("Your message."),
+							Reason:             new("YourReason"),
+							Message:            new("Your message."),
 						}.Build(),
 					},
 				}.Build(),
@@ -235,15 +234,15 @@ var _ = Describe("Generic mapper", func() {
 							Type:               publicv1.ClusterConditionType_CLUSTER_CONDITION_TYPE_READY,
 							Status:             publicv1.ConditionStatus_CONDITION_STATUS_TRUE,
 							LastTransitionTime: parseDate("2025-06-02T14:53:00Z"),
-							Reason:             proto.String("MyReason"),
-							Message:            proto.String("My message."),
+							Reason:             new("MyReason"),
+							Message:            new("My message."),
 						}.Build(),
 						publicv1.ClusterCondition_builder{
 							Type:               publicv1.ClusterConditionType_CLUSTER_CONDITION_TYPE_FAILED,
 							Status:             publicv1.ConditionStatus_CONDITION_STATUS_FALSE,
 							LastTransitionTime: parseDate("2025-06-03T14:53:00Z"),
-							Reason:             proto.String("YourReason"),
-							Message:            proto.String("Your message."),
+							Reason:             new("YourReason"),
+							Message:            new("Your message."),
 						}.Build(),
 					},
 				}.Build(),

--- a/internal/servers/host_types_server_test.go
+++ b/internal/servers/host_types_server_test.go
@@ -197,7 +197,7 @@ var _ = Describe("Host types server", func() {
 			// List the objects:
 			for _, object := range objects {
 				response, err := server.List(ctx, publicv1.HostTypesListRequest_builder{
-					Filter: proto.String(fmt.Sprintf("this.id == '%s'", object.GetId())),
+					Filter: new(fmt.Sprintf("this.id == '%s'", object.GetId())),
 				}.Build())
 				Expect(err).ToNot(HaveOccurred())
 				Expect(response.GetSize()).To(BeNumerically("==", 1))

--- a/internal/servers/network_classes_server_test.go
+++ b/internal/servers/network_classes_server_test.go
@@ -153,7 +153,7 @@ var _ = Describe("Network classes server", func() {
 				Object: privatev1.NetworkClass_builder{
 					Title:                  "Default Network Class",
 					ImplementationStrategy: "ovn-kubernetes",
-					IsDefault:              proto.Bool(true),
+					IsDefault:              new(true),
 				}.Build(),
 			}.Build())
 			Expect(err).ToNot(HaveOccurred())
@@ -217,7 +217,7 @@ var _ = Describe("Network classes server", func() {
 			// List the objects via public server:
 			for _, id := range ids {
 				response, err := publicServer.List(ctx, publicv1.NetworkClassesListRequest_builder{
-					Filter: proto.String(fmt.Sprintf("this.id == '%s'", id)),
+					Filter: new(fmt.Sprintf("this.id == '%s'", id)),
 				}.Build())
 				Expect(err).ToNot(HaveOccurred())
 				Expect(response.GetSize()).To(BeNumerically("==", 1))
@@ -359,7 +359,7 @@ var _ = Describe("Network classes server", func() {
 				updateResponse, err := privateServer.Update(ctx, privatev1.NetworkClassesUpdateRequest_builder{
 					Object: privatev1.NetworkClass_builder{
 						Id:        ncB.GetId(),
-						IsDefault: proto.Bool(true),
+						IsDefault: new(true),
 					}.Build(),
 					UpdateMask: &fieldmaskpb.FieldMask{Paths: []string{"is_default"}},
 				}.Build())
@@ -388,7 +388,7 @@ var _ = Describe("Network classes server", func() {
 				_, err := privateServer.Update(ctx, privatev1.NetworkClassesUpdateRequest_builder{
 					Object: privatev1.NetworkClass_builder{
 						Id:        ncB.GetId(),
-						IsDefault: proto.Bool(false),
+						IsDefault: new(false),
 					}.Build(),
 					UpdateMask: &fieldmaskpb.FieldMask{Paths: []string{"is_default"}},
 				}.Build())
@@ -411,7 +411,7 @@ var _ = Describe("Network classes server", func() {
 				updateResponse, err := privateServer.Update(ctx, privatev1.NetworkClassesUpdateRequest_builder{
 					Object: privatev1.NetworkClass_builder{
 						Id:        ncA.GetId(),
-						IsDefault: proto.Bool(false),
+						IsDefault: new(false),
 					}.Build(),
 					UpdateMask: &fieldmaskpb.FieldMask{Paths: []string{"is_default"}},
 				}.Build())
@@ -420,7 +420,7 @@ var _ = Describe("Network classes server", func() {
 
 				// Verify no defaults remain by listing:
 				listResponse, err := privateServer.List(ctx, privatev1.NetworkClassesListRequest_builder{
-					Filter: proto.String("this.is_default == true"),
+					Filter: new("this.is_default == true"),
 				}.Build())
 				Expect(err).ToNot(HaveOccurred())
 				Expect(listResponse.GetItems()).To(BeEmpty())
@@ -435,7 +435,7 @@ var _ = Describe("Network classes server", func() {
 				updateResponse, err := privateServer.Update(ctx, privatev1.NetworkClassesUpdateRequest_builder{
 					Object: privatev1.NetworkClass_builder{
 						Id:        ncA.GetId(),
-						IsDefault: proto.Bool(true),
+						IsDefault: new(true),
 					}.Build(),
 					UpdateMask: &fieldmaskpb.FieldMask{Paths: []string{"is_default"}},
 				}.Build())
@@ -483,7 +483,7 @@ var _ = Describe("Network classes server", func() {
 					Object: publicv1.NetworkClass_builder{
 						Id:        ncA.GetId(),
 						Title:     ncA.GetTitle(),
-						IsDefault: proto.Bool(false),
+						IsDefault: new(false),
 					}.Build(),
 				}.Build())
 				Expect(err).ToNot(HaveOccurred())
@@ -513,7 +513,7 @@ var _ = Describe("Network classes server", func() {
 					SetObject(privatev1.NetworkClass_builder{
 						Title:                  "NC-A",
 						ImplementationStrategy: "ovn-kubernetes",
-						IsDefault:              proto.Bool(true),
+						IsDefault:              new(true),
 						Metadata: privatev1.Metadata_builder{
 							Tenant: auth.SharedTenant,
 						}.Build(),
@@ -529,7 +529,7 @@ var _ = Describe("Network classes server", func() {
 					privatev1.NetworkClass_builder{
 						Title:                  "NC-B",
 						ImplementationStrategy: "ovn-kubernetes",
-						IsDefault:              proto.Bool(true),
+						IsDefault:              new(true),
 						Metadata: privatev1.Metadata_builder{
 							Tenant: auth.SharedTenant,
 						}.Build(),
@@ -543,7 +543,7 @@ var _ = Describe("Network classes server", func() {
 
 				// Verify: both NCs have is_default=true (invariant violation):
 				listResponse, err := privateServer.List(ctx, privatev1.NetworkClassesListRequest_builder{
-					Filter: proto.String("this.is_default == true"),
+					Filter: new("this.is_default == true"),
 				}.Build())
 				Expect(err).ToNot(HaveOccurred())
 				Expect(listResponse.GetItems()).To(HaveLen(2))
@@ -584,7 +584,7 @@ var _ = Describe("Network classes server", func() {
 					Object: privatev1.NetworkClass_builder{
 						Id:        ncA.GetId(),
 						Title:     ncA.GetTitle(),
-						IsDefault: proto.Bool(true),
+						IsDefault: new(true),
 					}.Build(),
 					// No UpdateMask — triggers proto.Merge branch in applyNetworkClassUpdate
 				}.Build())
@@ -654,7 +654,7 @@ var _ = Describe("Network classes server", func() {
 				ncA := privatev1.NetworkClass_builder{
 					Title:                  "NC-A",
 					ImplementationStrategy: "ovn-kubernetes",
-					IsDefault:              proto.Bool(true),
+					IsDefault:              new(true),
 					Metadata: privatev1.Metadata_builder{
 						Tenant: auth.SharedTenant,
 					}.Build(),
@@ -698,7 +698,7 @@ var _ = Describe("Network classes server", func() {
 				ncA := privatev1.NetworkClass_builder{
 					Title:                  "NC-A",
 					ImplementationStrategy: "ovn-kubernetes",
-					IsDefault:              proto.Bool(true),
+					IsDefault:              new(true),
 					Metadata: privatev1.Metadata_builder{
 						Tenant: auth.SharedTenant,
 					}.Build(),
@@ -713,7 +713,7 @@ var _ = Describe("Network classes server", func() {
 				ncB := privatev1.NetworkClass_builder{
 					Title:                  "NC-B",
 					ImplementationStrategy: "ovn-kubernetes",
-					IsDefault:              proto.Bool(true),
+					IsDefault:              new(true),
 					Metadata: privatev1.Metadata_builder{
 						Tenant: auth.SharedTenant,
 					}.Build(),
@@ -741,7 +741,7 @@ var _ = Describe("Network classes server", func() {
 					SetObject(privatev1.NetworkClass_builder{
 						Title:                  "Deleted Default",
 						ImplementationStrategy: "ovn-kubernetes",
-						IsDefault:              proto.Bool(true),
+						IsDefault:              new(true),
 						Metadata: privatev1.Metadata_builder{
 							Finalizers: []string{"a"},
 							Tenant:     auth.SharedTenant,
@@ -762,7 +762,7 @@ var _ = Describe("Network classes server", func() {
 					SetObject(privatev1.NetworkClass_builder{
 						Title:                  "Active Default",
 						ImplementationStrategy: "ovn-kubernetes",
-						IsDefault:              proto.Bool(true),
+						IsDefault:              new(true),
 						Metadata: privatev1.Metadata_builder{
 							Tenant: auth.SharedTenant,
 						}.Build(),
@@ -795,7 +795,7 @@ var _ = Describe("Network classes server", func() {
 
 				// Verify no defaults remain in List:
 				listResponse, err := privateServer.List(ctx, privatev1.NetworkClassesListRequest_builder{
-					Filter: proto.String("this.is_default == true"),
+					Filter: new("this.is_default == true"),
 				}.Build())
 				Expect(err).ToNot(HaveOccurred())
 				Expect(listResponse.GetItems()).To(BeEmpty())

--- a/internal/servers/organizations_server_test.go
+++ b/internal/servers/organizations_server_test.go
@@ -20,7 +20,6 @@ import (
 	. "github.com/onsi/gomega"
 	grpccodes "google.golang.org/grpc/codes"
 	grpcstatus "google.golang.org/grpc/status"
-	"google.golang.org/protobuf/proto"
 
 	privatev1 "github.com/osac-project/fulfillment-service/internal/api/osac/private/v1"
 	publicv1 "github.com/osac-project/fulfillment-service/internal/api/osac/public/v1"
@@ -127,7 +126,7 @@ var _ = Describe("Public organizations server", func() {
 			// List tenants via the public server. It is important to use a filter to skip the builtin
 			// tenants.
 			listResponse, err := publicServer.List(ctx, publicv1.OrganizationsListRequest_builder{
-				Filter: proto.String("this.metadata.name == 'my-tenant'"),
+				Filter: new("this.metadata.name == 'my-tenant'"),
 			}.Build())
 			Expect(err).ToNot(HaveOccurred())
 			Expect(listResponse.Size).To(Equal(int32(1)))

--- a/internal/servers/private_cluster_catalog_items_server_test.go
+++ b/internal/servers/private_cluster_catalog_items_server_test.go
@@ -202,7 +202,7 @@ var _ = Describe("Private cluster catalog items server", func() {
 
 			for _, object := range objects {
 				getResponse, err := server.List(ctx, privatev1.ClusterCatalogItemsListRequest_builder{
-					Filter: proto.String(fmt.Sprintf("this.id == '%s'", object.GetId())),
+					Filter: new(fmt.Sprintf("this.id == '%s'", object.GetId())),
 				}.Build())
 				Expect(err).ToNot(HaveOccurred())
 				Expect(getResponse.GetSize()).To(BeNumerically("==", 1))

--- a/internal/servers/private_cluster_templates_server_test.go
+++ b/internal/servers/private_cluster_templates_server_test.go
@@ -150,7 +150,7 @@ var _ = Describe("Private cluster templates server", func() {
 
 			// List the objects:
 			response, err := server.List(ctx, privatev1.ClusterTemplatesListRequest_builder{
-				Filter: proto.String("this.metadata.name.startsWith('my-template-')"),
+				Filter: new("this.metadata.name.startsWith('my-template-')"),
 			}.Build())
 			Expect(err).ToNot(HaveOccurred())
 			Expect(response).ToNot(BeNil())
@@ -176,7 +176,7 @@ var _ = Describe("Private cluster templates server", func() {
 
 			// List the objects:
 			response, err := server.List(ctx, privatev1.ClusterTemplatesListRequest_builder{
-				Filter: proto.String("this.metadata.name.startsWith('my-template-')"),
+				Filter: new("this.metadata.name.startsWith('my-template-')"),
 				Limit:  proto.Int32(1),
 			}.Build())
 			Expect(err).ToNot(HaveOccurred())
@@ -211,7 +211,7 @@ var _ = Describe("Private cluster templates server", func() {
 
 			// List the objects:
 			response, err := server.List(ctx, privatev1.ClusterTemplatesListRequest_builder{
-				Filter: proto.String("this.metadata.name.startsWith('my-template-')"),
+				Filter: new("this.metadata.name.startsWith('my-template-')"),
 				Offset: proto.Int32(1),
 			}.Build())
 			Expect(err).ToNot(HaveOccurred())
@@ -244,7 +244,7 @@ var _ = Describe("Private cluster templates server", func() {
 			// List the objects:
 			for _, object := range objects {
 				getResponse, err := server.List(ctx, privatev1.ClusterTemplatesListRequest_builder{
-					Filter: proto.String(fmt.Sprintf("this.id == '%s'", object.GetId())),
+					Filter: new(fmt.Sprintf("this.id == '%s'", object.GetId())),
 				}.Build())
 				Expect(err).ToNot(HaveOccurred())
 				Expect(getResponse.GetSize()).To(BeNumerically("==", 1))

--- a/internal/servers/private_clusters_server_test.go
+++ b/internal/servers/private_clusters_server_test.go
@@ -584,7 +584,7 @@ var _ = Describe("Private clusters server", func() {
 			// List the objects:
 			for _, object := range objects {
 				response, err := server.List(ctx, privatev1.ClustersListRequest_builder{
-					Filter: proto.String(fmt.Sprintf("this.id == '%s'", object.GetId())),
+					Filter: new(fmt.Sprintf("this.id == '%s'", object.GetId())),
 				}.Build())
 				Expect(err).ToNot(HaveOccurred())
 				Expect(response.GetSize()).To(BeNumerically("==", 1))
@@ -1184,7 +1184,7 @@ var _ = Describe("Private clusters server", func() {
 					Object: privatev1.Cluster_builder{
 						Spec: privatev1.ClusterSpec_builder{
 							CatalogItem: "cat-noneditable",
-							PullSecret:  proto.String("user-secret"),
+							PullSecret:  new("user-secret"),
 						}.Build(),
 						Status: privatev1.ClusterStatus_builder{
 							Hub: "my-hub-id",
@@ -1210,7 +1210,7 @@ var _ = Describe("Private clusters server", func() {
 						Object: privatev1.Cluster_builder{
 							Spec: privatev1.ClusterSpec_builder{
 								CatalogItem: catID,
-								PullSecret:  proto.String(value),
+								PullSecret:  new(value),
 							}.Build(),
 							Status: privatev1.ClusterStatus_builder{
 								Hub: "my-hub-id",
@@ -1329,7 +1329,7 @@ var _ = Describe("Private clusters server", func() {
 				object := createCluster()
 				id := object.GetId()
 				listResponse, err := server.List(ctx, privatev1.ClustersListRequest_builder{
-					Filter: proto.String(fmt.Sprintf("this.id == %q", id)),
+					Filter: new(fmt.Sprintf("this.id == %q", id)),
 				}.Build())
 				Expect(err).ToNot(HaveOccurred())
 				items := listResponse.GetItems()

--- a/internal/servers/private_compute_instance_catalog_items_server_test.go
+++ b/internal/servers/private_compute_instance_catalog_items_server_test.go
@@ -201,7 +201,7 @@ var _ = Describe("Private compute instance catalog items server", func() {
 
 			for _, object := range objects {
 				getResponse, err := server.List(ctx, privatev1.ComputeInstanceCatalogItemsListRequest_builder{
-					Filter: proto.String(fmt.Sprintf("this.id == '%s'", object.GetId())),
+					Filter: new(fmt.Sprintf("this.id == '%s'", object.GetId())),
 				}.Build())
 				Expect(err).ToNot(HaveOccurred())
 				Expect(getResponse.GetSize()).To(BeNumerically("==", 1))

--- a/internal/servers/private_compute_instances_server_test.go
+++ b/internal/servers/private_compute_instances_server_test.go
@@ -112,7 +112,7 @@ var _ = Describe("Private compute instances server", func() {
 				Tenant: auth.SharedTenant,
 			}.Build(),
 			Spec: privatev1.VirtualNetworkSpec_builder{
-				Ipv4Cidr:     proto.String("10.0.0.0/16"),
+				Ipv4Cidr:     new("10.0.0.0/16"),
 				NetworkClass: networkClassID,
 			}.Build(),
 			Status: privatev1.VirtualNetworkStatus_builder{
@@ -139,7 +139,7 @@ var _ = Describe("Private compute instances server", func() {
 			}.Build(),
 			Spec: privatev1.SubnetSpec_builder{
 				VirtualNetwork: vnID,
-				Ipv4Cidr:       proto.String("10.0.1.0/24"),
+				Ipv4Cidr:       new("10.0.1.0/24"),
 			}.Build(),
 			Status: privatev1.SubnetStatus_builder{
 				State: state,
@@ -280,7 +280,7 @@ var _ = Describe("Private compute instances server", func() {
 					BootDisk: privatev1.ComputeInstanceDisk_builder{
 						SizeGib: 10,
 					}.Build(),
-					RunStrategy: proto.String("Always"),
+					RunStrategy: new("Always"),
 				}.Build(),
 			}.Build()
 
@@ -752,7 +752,7 @@ var _ = Describe("Private compute instances server", func() {
 						Template:    "override-template",
 						Cores:       proto.Int32(8),
 						MemoryGib:   proto.Int32(16),
-						RunStrategy: proto.String("Halted"),
+						RunStrategy: new("Halted"),
 					}.Build(),
 				}.Build(),
 			}.Build())
@@ -843,7 +843,7 @@ var _ = Describe("Private compute instances server", func() {
 						BootDisk: privatev1.ComputeInstanceDisk_builder{
 							SizeGib: 20,
 						}.Build(),
-						RunStrategy: proto.String("Always"),
+						RunStrategy: new("Always"),
 					}.Build(),
 				}.Build(),
 			}.Build())
@@ -870,7 +870,7 @@ var _ = Describe("Private compute instances server", func() {
 				SpecDefaults: privatev1.ComputeInstanceTemplateSpecDefaults_builder{
 					Cores:       proto.Int32(2),
 					MemoryGib:   proto.Int32(4),
-					RunStrategy: proto.String("Always"),
+					RunStrategy: new("Always"),
 				}.Build(),
 			}.Build()
 			_, err = templatesDao.Create().SetObject(template).Do(ctx)
@@ -1034,7 +1034,7 @@ var _ = Describe("Private compute instances server", func() {
 					Object: privatev1.ComputeInstance_builder{
 						Spec: privatev1.ComputeInstanceSpec_builder{
 							CatalogItem: "ci-cat-nonedit",
-							SshKey:      proto.String("user-key"),
+							SshKey:      new("user-key"),
 						}.Build(),
 					}.Build(),
 				}.Build())
@@ -1057,7 +1057,7 @@ var _ = Describe("Private compute instances server", func() {
 						Object: privatev1.ComputeInstance_builder{
 							Spec: privatev1.ComputeInstanceSpec_builder{
 								CatalogItem: catID,
-								SshKey:      proto.String(value),
+								SshKey:      new(value),
 							}.Build(),
 						}.Build(),
 					}.Build())
@@ -1194,7 +1194,7 @@ var _ = Describe("Private compute instances server", func() {
 					BootDisk: privatev1.ComputeInstanceDisk_builder{
 						SizeGib: 10,
 					}.Build(),
-					RunStrategy: proto.String("Always"),
+					RunStrategy: new("Always"),
 				}.Build(),
 			}.Build()
 
@@ -1217,7 +1217,7 @@ var _ = Describe("Private compute instances server", func() {
 				vm := privatev1.ComputeInstance_builder{
 					Spec: privatev1.ComputeInstanceSpec_builder{
 						Template: template.GetId(),
-						Subnet:   proto.String(subnet.GetId()),
+						Subnet:   new(subnet.GetId()),
 					}.Build(),
 				}.Build()
 
@@ -1234,7 +1234,7 @@ var _ = Describe("Private compute instances server", func() {
 				vm := privatev1.ComputeInstance_builder{
 					Spec: privatev1.ComputeInstanceSpec_builder{
 						Template: template.GetId(),
-						Subnet:   proto.String("non-existent-subnet-id"),
+						Subnet:   new("non-existent-subnet-id"),
 					}.Build(),
 				}.Build()
 
@@ -1258,7 +1258,7 @@ var _ = Describe("Private compute instances server", func() {
 				vm := privatev1.ComputeInstance_builder{
 					Spec: privatev1.ComputeInstanceSpec_builder{
 						Template: template.GetId(),
-						Subnet:   proto.String(subnet.GetId()),
+						Subnet:   new(subnet.GetId()),
 					}.Build(),
 				}.Build()
 
@@ -1290,7 +1290,7 @@ var _ = Describe("Private compute instances server", func() {
 				vm := privatev1.ComputeInstance_builder{
 					Spec: privatev1.ComputeInstanceSpec_builder{
 						Template:       template.GetId(),
-						Subnet:         proto.String(subnet.GetId()),
+						Subnet:         new(subnet.GetId()),
 						SecurityGroups: []string{sg1.GetId(), sg2.GetId()},
 					}.Build(),
 				}.Build()
@@ -1308,7 +1308,7 @@ var _ = Describe("Private compute instances server", func() {
 				vm := privatev1.ComputeInstance_builder{
 					Spec: privatev1.ComputeInstanceSpec_builder{
 						Template:       template.GetId(),
-						Subnet:         proto.String(subnet.GetId()),
+						Subnet:         new(subnet.GetId()),
 						SecurityGroups: []string{"non-existent-sg-id"},
 					}.Build(),
 				}.Build()
@@ -1333,7 +1333,7 @@ var _ = Describe("Private compute instances server", func() {
 				vm := privatev1.ComputeInstance_builder{
 					Spec: privatev1.ComputeInstanceSpec_builder{
 						Template:       template.GetId(),
-						Subnet:         proto.String(subnet.GetId()),
+						Subnet:         new(subnet.GetId()),
 						SecurityGroups: []string{sg.GetId()},
 					}.Build(),
 				}.Build()
@@ -1360,7 +1360,7 @@ var _ = Describe("Private compute instances server", func() {
 				vm := privatev1.ComputeInstance_builder{
 					Spec: privatev1.ComputeInstanceSpec_builder{
 						Template:       template.GetId(),
-						Subnet:         proto.String(subnet.GetId()),
+						Subnet:         new(subnet.GetId()),
 						SecurityGroups: []string{sgFromOtherVN.GetId()},
 					}.Build(),
 				}.Build()
@@ -1387,7 +1387,7 @@ var _ = Describe("Private compute instances server", func() {
 				vm := privatev1.ComputeInstance_builder{
 					Spec: privatev1.ComputeInstanceSpec_builder{
 						Template: template.GetId(),
-						Subnet:   proto.String(subnet.GetId()),
+						Subnet:   new(subnet.GetId()),
 						NetworkAttachments: []*privatev1.NetworkAttachment{
 							privatev1.NetworkAttachment_builder{Subnet: subnet.GetId()}.Build(),
 						},

--- a/internal/servers/private_host_types_server_test.go
+++ b/internal/servers/private_host_types_server_test.go
@@ -214,7 +214,7 @@ var _ = Describe("Private host types server", func() {
 			// List the objects:
 			for _, object := range objects {
 				response, err := server.List(ctx, privatev1.HostTypesListRequest_builder{
-					Filter: proto.String(fmt.Sprintf("this.id == '%s'", object.GetId())),
+					Filter: new(fmt.Sprintf("this.id == '%s'", object.GetId())),
 				}.Build())
 				Expect(err).ToNot(HaveOccurred())
 				Expect(response.GetSize()).To(BeNumerically("==", 1))

--- a/internal/servers/private_hubs_server_test.go
+++ b/internal/servers/private_hubs_server_test.go
@@ -231,7 +231,7 @@ var _ = Describe("Private hubs server", func() {
 			// List the objects:
 			for _, object := range objects {
 				response, err := server.List(ctx, privatev1.HubsListRequest_builder{
-					Filter: proto.String(fmt.Sprintf("this.id == '%s'", object.GetId())),
+					Filter: new(fmt.Sprintf("this.id == '%s'", object.GetId())),
 				}.Build())
 				Expect(err).ToNot(HaveOccurred())
 				Expect(response.GetSize()).To(BeNumerically("==", 1))

--- a/internal/servers/private_organizations_server_test.go
+++ b/internal/servers/private_organizations_server_test.go
@@ -20,7 +20,6 @@ import (
 	. "github.com/onsi/gomega"
 	grpccodes "google.golang.org/grpc/codes"
 	grpcstatus "google.golang.org/grpc/status"
-	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/fieldmaskpb"
 
 	privatev1 "github.com/osac-project/fulfillment-service/internal/api/osac/private/v1"
@@ -106,7 +105,7 @@ var _ = Describe("Private tenants server", func() {
 
 		// List tenants:
 		listResp, err := privateServer.List(ctx, &privatev1.OrganizationsListRequest{
-			Filter: proto.String("this.metadata.name == 'my-tenant'"),
+			Filter: new("this.metadata.name == 'my-tenant'"),
 		})
 		Expect(err).ToNot(HaveOccurred())
 		Expect(listResp.Size).To(Equal(int32(1)))

--- a/internal/servers/private_projects_server_test.go
+++ b/internal/servers/private_projects_server_test.go
@@ -18,7 +18,6 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/fieldmaskpb"
 
 	privatev1 "github.com/osac-project/fulfillment-service/internal/api/osac/private/v1"
@@ -81,7 +80,7 @@ var _ = Describe("Private projects server", func() {
 				}.Build(),
 				Spec: privatev1.ProjectSpec_builder{
 					Title:       "My Project",
-					Description: proto.String("Test project"),
+					Description: new("Test project"),
 				}.Build(),
 			}.Build(),
 		}.Build()
@@ -122,7 +121,7 @@ var _ = Describe("Private projects server", func() {
 				}.Build(),
 				Spec: privatev1.ProjectSpec_builder{
 					Title:  "Child Project",
-					Parent: proto.String(parentResp.Object.Id),
+					Parent: new(parentResp.Object.Id),
 				}.Build(),
 			}.Build(),
 		}.Build()
@@ -149,7 +148,7 @@ var _ = Describe("Private projects server", func() {
 
 		// List projects:
 		listResp, err := privateServer.List(ctx, &privatev1.ProjectsListRequest{
-			Filter: proto.String("this.metadata.name == 'my-project'"),
+			Filter: new("this.metadata.name == 'my-project'"),
 		})
 		Expect(err).ToNot(HaveOccurred())
 		Expect(listResp.Size).To(Equal(int32(1)))
@@ -177,7 +176,7 @@ var _ = Describe("Private projects server", func() {
 
 		// List projects for org-1:
 		listResp, err := privateServer.List(ctx, &privatev1.ProjectsListRequest{
-			Filter: proto.String("this.metadata.tenant == 'org-1'"),
+			Filter: new("this.metadata.tenant == 'org-1'"),
 		})
 		Expect(err).ToNot(HaveOccurred())
 		Expect(listResp.Size).To(Equal(int32(1)))
@@ -208,7 +207,7 @@ var _ = Describe("Private projects server", func() {
 				}.Build(),
 				Spec: privatev1.ProjectSpec_builder{
 					Title:  "Child",
-					Parent: proto.String(parentResp.Object.Id),
+					Parent: new(parentResp.Object.Id),
 				}.Build(),
 			}.Build(),
 		}.Build()
@@ -217,7 +216,7 @@ var _ = Describe("Private projects server", func() {
 
 		// List only top-level projects:
 		listResp, err := privateServer.List(ctx, &privatev1.ProjectsListRequest{
-			Filter: proto.String("this.metadata.tenant == 'my-org' && !has(this.spec.parent)"),
+			Filter: new("this.metadata.tenant == 'my-org' && !has(this.spec.parent)"),
 		})
 		Expect(err).ToNot(HaveOccurred())
 		Expect(listResp.Size).To(Equal(int32(1)))
@@ -328,7 +327,7 @@ var _ = Describe("Private projects server", func() {
 			Object: privatev1.Project_builder{
 				Id: createResp.Object.Id,
 				Spec: privatev1.ProjectSpec_builder{
-					Description: proto.String("Updated description"),
+					Description: new("Updated description"),
 				}.Build(),
 			}.Build(),
 			UpdateMask: &fieldmaskpb.FieldMask{

--- a/internal/servers/private_public_ip_attachments_server_test.go
+++ b/internal/servers/private_public_ip_attachments_server_test.go
@@ -21,7 +21,6 @@ import (
 	"go.uber.org/mock/gomock"
 	grpccodes "google.golang.org/grpc/codes"
 	grpcstatus "google.golang.org/grpc/status"
-	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/fieldmaskpb"
 
 	privatev1 "github.com/osac-project/fulfillment-service/internal/api/osac/private/v1"
@@ -155,7 +154,7 @@ var _ = Describe("Private public IP attachments server", func() {
 					}.Build(),
 					Spec: privatev1.PublicIPAttachmentSpec_builder{
 						PublicIp:        pip.GetId(),
-						ComputeInstance: proto.String(ci.GetId()),
+						ComputeInstance: new(ci.GetId()),
 					}.Build(),
 				}.Build(),
 			}.Build())
@@ -181,7 +180,7 @@ var _ = Describe("Private public IP attachments server", func() {
 					}.Build(),
 					Spec: privatev1.PublicIPAttachmentSpec_builder{
 						PublicIp:        pip1.GetId(),
-						ComputeInstance: proto.String(ci1.GetId()),
+						ComputeInstance: new(ci1.GetId()),
 					}.Build(),
 				}.Build(),
 			}.Build())
@@ -194,7 +193,7 @@ var _ = Describe("Private public IP attachments server", func() {
 					}.Build(),
 					Spec: privatev1.PublicIPAttachmentSpec_builder{
 						PublicIp:        pip2.GetId(),
-						ComputeInstance: proto.String(ci2.GetId()),
+						ComputeInstance: new(ci2.GetId()),
 					}.Build(),
 				}.Build(),
 			}.Build())
@@ -217,7 +216,7 @@ var _ = Describe("Private public IP attachments server", func() {
 					}.Build(),
 					Spec: privatev1.PublicIPAttachmentSpec_builder{
 						PublicIp:        pip.GetId(),
-						ComputeInstance: proto.String(ci.GetId()),
+						ComputeInstance: new(ci.GetId()),
 					}.Build(),
 				}.Build(),
 			}.Build())
@@ -244,7 +243,7 @@ var _ = Describe("Private public IP attachments server", func() {
 					}.Build(),
 					Spec: privatev1.PublicIPAttachmentSpec_builder{
 						PublicIp:        pip.GetId(),
-						ComputeInstance: proto.String(ci.GetId()),
+						ComputeInstance: new(ci.GetId()),
 					}.Build(),
 				}.Build(),
 			}.Build())
@@ -280,7 +279,7 @@ var _ = Describe("Private public IP attachments server", func() {
 					}.Build(),
 					Spec: privatev1.PublicIPAttachmentSpec_builder{
 						PublicIp:        pip.GetId(),
-						ComputeInstance: proto.String(ci.GetId()),
+						ComputeInstance: new(ci.GetId()),
 					}.Build(),
 				}.Build(),
 			}.Build())
@@ -319,7 +318,7 @@ var _ = Describe("Private public IP attachments server", func() {
 					}.Build(),
 					Spec: privatev1.PublicIPAttachmentSpec_builder{
 						PublicIp:        pip.GetId(),
-						ComputeInstance: proto.String(ci.GetId()),
+						ComputeInstance: new(ci.GetId()),
 					}.Build(),
 				}.Build(),
 			}.Build())
@@ -331,7 +330,7 @@ var _ = Describe("Private public IP attachments server", func() {
 					Id: createResponse.GetObject().GetId(),
 					Spec: privatev1.PublicIPAttachmentSpec_builder{
 						PublicIp:        pip.GetId(),
-						ComputeInstance: proto.String(ci2.GetId()),
+						ComputeInstance: new(ci2.GetId()),
 					}.Build(),
 				}.Build(),
 				UpdateMask: &fieldmaskpb.FieldMask{
@@ -359,7 +358,7 @@ var _ = Describe("Private public IP attachments server", func() {
 					}.Build(),
 					Spec: privatev1.PublicIPAttachmentSpec_builder{
 						PublicIp:        pip.GetId(),
-						ComputeInstance: proto.String(ci.GetId()),
+						ComputeInstance: new(ci.GetId()),
 					}.Build(),
 				}.Build(),
 			}.Build())
@@ -373,7 +372,7 @@ var _ = Describe("Private public IP attachments server", func() {
 					}.Build(),
 					Spec: privatev1.PublicIPAttachmentSpec_builder{
 						PublicIp:        pip.GetId(),
-						ComputeInstance: proto.String(ci.GetId()),
+						ComputeInstance: new(ci.GetId()),
 					}.Build(),
 				}.Build(),
 				UpdateMask: &fieldmaskpb.FieldMask{
@@ -401,7 +400,7 @@ var _ = Describe("Private public IP attachments server", func() {
 					}.Build(),
 					Spec: privatev1.PublicIPAttachmentSpec_builder{
 						PublicIp:        pip.GetId(),
-						ComputeInstance: proto.String(ci.GetId()),
+						ComputeInstance: new(ci.GetId()),
 					}.Build(),
 				}.Build(),
 			}.Build())
@@ -413,7 +412,7 @@ var _ = Describe("Private public IP attachments server", func() {
 					Id: createResponse.GetObject().GetId(),
 					Spec: privatev1.PublicIPAttachmentSpec_builder{
 						PublicIp:        pip2.GetId(),
-						ComputeInstance: proto.String(ci.GetId()),
+						ComputeInstance: new(ci.GetId()),
 					}.Build(),
 				}.Build(),
 			}.Build())
@@ -435,7 +434,7 @@ var _ = Describe("Private public IP attachments server", func() {
 					}.Build(),
 					Spec: privatev1.PublicIPAttachmentSpec_builder{
 						PublicIp:        pip.GetId(),
-						ComputeInstance: proto.String(ci.GetId()),
+						ComputeInstance: new(ci.GetId()),
 					}.Build(),
 				}.Build(),
 			}.Build())
@@ -458,7 +457,7 @@ var _ = Describe("Private public IP attachments server", func() {
 					}.Build(),
 					Spec: privatev1.PublicIPAttachmentSpec_builder{
 						PublicIp:        pip.GetId(),
-						ComputeInstance: proto.String(ci.GetId()),
+						ComputeInstance: new(ci.GetId()),
 					}.Build(),
 				}.Build(),
 			}.Build())
@@ -500,7 +499,7 @@ var _ = Describe("Private public IP attachments server", func() {
 			_, err := publicIPAttachmentsServer.Create(ctx, privatev1.PublicIPAttachmentsCreateRequest_builder{
 				Object: privatev1.PublicIPAttachment_builder{
 					Spec: privatev1.PublicIPAttachmentSpec_builder{
-						ComputeInstance: proto.String("some-ci"),
+						ComputeInstance: new("some-ci"),
 					}.Build(),
 				}.Build(),
 			}.Build())
@@ -535,7 +534,7 @@ var _ = Describe("Private public IP attachments server", func() {
 				Object: privatev1.PublicIPAttachment_builder{
 					Spec: privatev1.PublicIPAttachmentSpec_builder{
 						PublicIp:        "nonexistent-public-ip-id",
-						ComputeInstance: proto.String(ci.GetId()),
+						ComputeInstance: new(ci.GetId()),
 					}.Build(),
 				}.Build(),
 			}.Build())
@@ -554,7 +553,7 @@ var _ = Describe("Private public IP attachments server", func() {
 				Object: privatev1.PublicIPAttachment_builder{
 					Spec: privatev1.PublicIPAttachmentSpec_builder{
 						PublicIp:        pip.GetId(),
-						ComputeInstance: proto.String(ci.GetId()),
+						ComputeInstance: new(ci.GetId()),
 					}.Build(),
 				}.Build(),
 			}.Build())
@@ -575,7 +574,7 @@ var _ = Describe("Private public IP attachments server", func() {
 				Object: privatev1.PublicIPAttachment_builder{
 					Spec: privatev1.PublicIPAttachmentSpec_builder{
 						PublicIp:        pip.GetId(),
-						ComputeInstance: proto.String("nonexistent-ci-id"),
+						ComputeInstance: new("nonexistent-ci-id"),
 					}.Build(),
 				}.Build(),
 			}.Build())
@@ -594,7 +593,7 @@ var _ = Describe("Private public IP attachments server", func() {
 				Object: privatev1.PublicIPAttachment_builder{
 					Spec: privatev1.PublicIPAttachmentSpec_builder{
 						PublicIp:        pip.GetId(),
-						ComputeInstance: proto.String(ci.GetId()),
+						ComputeInstance: new(ci.GetId()),
 					}.Build(),
 				}.Build(),
 			}.Build())
@@ -652,7 +651,7 @@ var _ = Describe("Private public IP attachments server", func() {
 				Object: privatev1.PublicIPAttachment_builder{
 					Spec: privatev1.PublicIPAttachmentSpec_builder{
 						PublicIp:        otherTenantIP.GetObject().GetId(),
-						ComputeInstance: proto.String(ci.GetId()),
+						ComputeInstance: new(ci.GetId()),
 					}.Build(),
 				}.Build(),
 			}.Build())
@@ -706,7 +705,7 @@ var _ = Describe("Private public IP attachments server", func() {
 				Object: privatev1.PublicIPAttachment_builder{
 					Spec: privatev1.PublicIPAttachmentSpec_builder{
 						PublicIp:        pip.GetId(),
-						ComputeInstance: proto.String(otherTenantCI.GetObject().GetId()),
+						ComputeInstance: new(otherTenantCI.GetObject().GetId()),
 					}.Build(),
 				}.Build(),
 			}.Build())
@@ -728,7 +727,7 @@ var _ = Describe("Private public IP attachments server", func() {
 				Object: privatev1.PublicIPAttachment_builder{
 					Spec: privatev1.PublicIPAttachmentSpec_builder{
 						PublicIp:        pip.GetId(),
-						ComputeInstance: proto.String(ci1.GetId()),
+						ComputeInstance: new(ci1.GetId()),
 					}.Build(),
 				}.Build(),
 			}.Build())
@@ -738,7 +737,7 @@ var _ = Describe("Private public IP attachments server", func() {
 				Object: privatev1.PublicIPAttachment_builder{
 					Spec: privatev1.PublicIPAttachmentSpec_builder{
 						PublicIp:        pip.GetId(),
-						ComputeInstance: proto.String(ci2.GetId()),
+						ComputeInstance: new(ci2.GetId()),
 					}.Build(),
 				}.Build(),
 			}.Build())
@@ -758,7 +757,7 @@ var _ = Describe("Private public IP attachments server", func() {
 				Object: privatev1.PublicIPAttachment_builder{
 					Spec: privatev1.PublicIPAttachmentSpec_builder{
 						PublicIp:        pip1.GetId(),
-						ComputeInstance: proto.String(ci.GetId()),
+						ComputeInstance: new(ci.GetId()),
 					}.Build(),
 				}.Build(),
 			}.Build())
@@ -768,7 +767,7 @@ var _ = Describe("Private public IP attachments server", func() {
 				Object: privatev1.PublicIPAttachment_builder{
 					Spec: privatev1.PublicIPAttachmentSpec_builder{
 						PublicIp:        pip2.GetId(),
-						ComputeInstance: proto.String(ci.GetId()),
+						ComputeInstance: new(ci.GetId()),
 					}.Build(),
 				}.Build(),
 			}.Build())
@@ -789,7 +788,7 @@ var _ = Describe("Private public IP attachments server", func() {
 				Object: privatev1.PublicIPAttachment_builder{
 					Spec: privatev1.PublicIPAttachmentSpec_builder{
 						PublicIp:        pip.GetId(),
-						ComputeInstance: proto.String(ci.GetId()),
+						ComputeInstance: new(ci.GetId()),
 					}.Build(),
 				}.Build(),
 			}.Build())
@@ -808,7 +807,7 @@ var _ = Describe("Private public IP attachments server", func() {
 				Object: privatev1.PublicIPAttachment_builder{
 					Spec: privatev1.PublicIPAttachmentSpec_builder{
 						PublicIp:        pip.GetId(),
-						ComputeInstance: proto.String(ci.GetId()),
+						ComputeInstance: new(ci.GetId()),
 					}.Build(),
 				}.Build(),
 			}.Build())

--- a/internal/servers/private_public_ip_pools_server_test.go
+++ b/internal/servers/private_public_ip_pools_server_test.go
@@ -205,7 +205,7 @@ var _ = Describe("Private public IP pools server", func() {
 			id := createResponse.GetObject().GetId()
 
 			response, err := poolsServer.List(ctx, privatev1.PublicIPPoolsListRequest_builder{
-				Filter: proto.String(fmt.Sprintf("this.id == '%s'", id)),
+				Filter: new(fmt.Sprintf("this.id == '%s'", id)),
 			}.Build())
 			Expect(err).ToNot(HaveOccurred())
 			Expect(response.GetSize()).To(BeNumerically("==", 1))

--- a/internal/servers/private_roles_server_test.go
+++ b/internal/servers/private_roles_server_test.go
@@ -18,7 +18,6 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/fieldmaskpb"
 
 	privatev1 "github.com/osac-project/fulfillment-service/internal/api/osac/private/v1"
@@ -132,7 +131,7 @@ var _ = Describe("Private roles server", func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			listResponse, err := rolesServer.List(ctx, privatev1.RolesListRequest_builder{
-				Filter: proto.String("this.metadata.name in ['role-a', 'role-b']"),
+				Filter: new("this.metadata.name in ['role-a', 'role-b']"),
 			}.Build())
 			Expect(err).ToNot(HaveOccurred())
 			Expect(listResponse.GetSize()).To(Equal(int32(2)))

--- a/internal/servers/private_subnets_server_test.go
+++ b/internal/servers/private_subnets_server_test.go
@@ -133,12 +133,12 @@ var _ = Describe("Private subnets server", func() {
 
 		// Add IPv4 CIDR if provided
 		if ipv4Cidr != "" {
-			builder.Spec.Ipv4Cidr = proto.String(ipv4Cidr)
+			builder.Spec.Ipv4Cidr = new(ipv4Cidr)
 		}
 
 		// Add IPv6 CIDR if provided
 		if ipv6Cidr != "" {
-			builder.Spec.Ipv6Cidr = proto.String(ipv6Cidr)
+			builder.Spec.Ipv6Cidr = new(ipv6Cidr)
 		}
 
 		vn := builder.Build()
@@ -202,7 +202,7 @@ var _ = Describe("Private subnets server", func() {
 
 				subnet := privatev1.Subnet_builder{
 					Spec: privatev1.SubnetSpec_builder{
-						Ipv4Cidr:       proto.String("10.0.1.0/24"),
+						Ipv4Cidr:       new("10.0.1.0/24"),
 						VirtualNetwork: vn.GetId(),
 					}.Build(),
 				}.Build()
@@ -216,7 +216,7 @@ var _ = Describe("Private subnets server", func() {
 
 				subnet := privatev1.Subnet_builder{
 					Spec: privatev1.SubnetSpec_builder{
-						Ipv4Cidr:       proto.String("not-a-cidr"),
+						Ipv4Cidr:       new("not-a-cidr"),
 						VirtualNetwork: vn.GetId(),
 					}.Build(),
 				}.Build()
@@ -231,7 +231,7 @@ var _ = Describe("Private subnets server", func() {
 
 				subnet := privatev1.Subnet_builder{
 					Spec: privatev1.SubnetSpec_builder{
-						Ipv4Cidr:       proto.String("10.0.1.0/33"),
+						Ipv4Cidr:       new("10.0.1.0/33"),
 						VirtualNetwork: vn.GetId(),
 					}.Build(),
 				}.Build()
@@ -246,7 +246,7 @@ var _ = Describe("Private subnets server", func() {
 
 				subnet := privatev1.Subnet_builder{
 					Spec: privatev1.SubnetSpec_builder{
-						Ipv4Cidr:       proto.String("2001:db8::/32"),
+						Ipv4Cidr:       new("2001:db8::/32"),
 						VirtualNetwork: vn.GetId(),
 					}.Build(),
 				}.Build()
@@ -263,7 +263,7 @@ var _ = Describe("Private subnets server", func() {
 
 				subnet := privatev1.Subnet_builder{
 					Spec: privatev1.SubnetSpec_builder{
-						Ipv6Cidr:       proto.String("2001:db8:1::/64"),
+						Ipv6Cidr:       new("2001:db8:1::/64"),
 						VirtualNetwork: vn.GetId(),
 					}.Build(),
 				}.Build()
@@ -277,7 +277,7 @@ var _ = Describe("Private subnets server", func() {
 
 				subnet := privatev1.Subnet_builder{
 					Spec: privatev1.SubnetSpec_builder{
-						Ipv6Cidr:       proto.String("not-ipv6"),
+						Ipv6Cidr:       new("not-ipv6"),
 						VirtualNetwork: vn.GetId(),
 					}.Build(),
 				}.Build()
@@ -292,7 +292,7 @@ var _ = Describe("Private subnets server", func() {
 
 				subnet := privatev1.Subnet_builder{
 					Spec: privatev1.SubnetSpec_builder{
-						Ipv6Cidr:       proto.String("2001:db8::/129"),
+						Ipv6Cidr:       new("2001:db8::/129"),
 						VirtualNetwork: vn.GetId(),
 					}.Build(),
 				}.Build()
@@ -307,7 +307,7 @@ var _ = Describe("Private subnets server", func() {
 
 				subnet := privatev1.Subnet_builder{
 					Spec: privatev1.SubnetSpec_builder{
-						Ipv6Cidr:       proto.String("10.0.1.0/24"),
+						Ipv6Cidr:       new("10.0.1.0/24"),
 						VirtualNetwork: vn.GetId(),
 					}.Build(),
 				}.Build()
@@ -338,7 +338,7 @@ var _ = Describe("Private subnets server", func() {
 
 				subnet := privatev1.Subnet_builder{
 					Spec: privatev1.SubnetSpec_builder{
-						Ipv4Cidr:       proto.String("10.0.1.0/24"),
+						Ipv4Cidr:       new("10.0.1.0/24"),
 						VirtualNetwork: vn.GetId(),
 					}.Build(),
 				}.Build()
@@ -352,7 +352,7 @@ var _ = Describe("Private subnets server", func() {
 
 				subnet := privatev1.Subnet_builder{
 					Spec: privatev1.SubnetSpec_builder{
-						Ipv6Cidr:       proto.String("2001:db8:1::/64"),
+						Ipv6Cidr:       new("2001:db8:1::/64"),
 						VirtualNetwork: vn.GetId(),
 					}.Build(),
 				}.Build()
@@ -366,8 +366,8 @@ var _ = Describe("Private subnets server", func() {
 
 				subnet := privatev1.Subnet_builder{
 					Spec: privatev1.SubnetSpec_builder{
-						Ipv4Cidr:       proto.String("10.0.1.0/24"),
-						Ipv6Cidr:       proto.String("2001:db8:1::/64"),
+						Ipv4Cidr:       new("10.0.1.0/24"),
+						Ipv6Cidr:       new("2001:db8:1::/64"),
 						VirtualNetwork: vn.GetId(),
 					}.Build(),
 				}.Build()
@@ -383,7 +383,7 @@ var _ = Describe("Private subnets server", func() {
 
 				subnet := privatev1.Subnet_builder{
 					Spec: privatev1.SubnetSpec_builder{
-						Ipv4Cidr:       proto.String("10.0.1.0/24"),
+						Ipv4Cidr:       new("10.0.1.0/24"),
 						VirtualNetwork: vn.GetId(),
 					}.Build(),
 				}.Build()
@@ -395,7 +395,7 @@ var _ = Describe("Private subnets server", func() {
 			It("rejects non-existent parent VirtualNetwork", func() {
 				subnet := privatev1.Subnet_builder{
 					Spec: privatev1.SubnetSpec_builder{
-						Ipv4Cidr:       proto.String("10.0.1.0/24"),
+						Ipv4Cidr:       new("10.0.1.0/24"),
 						VirtualNetwork: "non-existent-id",
 					}.Build(),
 				}.Build()
@@ -412,7 +412,7 @@ var _ = Describe("Private subnets server", func() {
 
 				subnet := privatev1.Subnet_builder{
 					Spec: privatev1.SubnetSpec_builder{
-						Ipv4Cidr:       proto.String("10.0.1.0/24"),
+						Ipv4Cidr:       new("10.0.1.0/24"),
 						VirtualNetwork: vn.GetId(),
 					}.Build(),
 				}.Build()
@@ -436,7 +436,7 @@ var _ = Describe("Private subnets server", func() {
 						Tenant: auth.SharedTenant,
 					}.Build(),
 					Spec: privatev1.VirtualNetworkSpec_builder{
-						Ipv4Cidr:     proto.String("10.0.0.0/16"),
+						Ipv4Cidr:     new("10.0.0.0/16"),
 						NetworkClass: nc.GetImplementationStrategy(),
 						Region:       "us-west-1",
 					}.Build(),
@@ -453,7 +453,7 @@ var _ = Describe("Private subnets server", func() {
 
 				subnet := privatev1.Subnet_builder{
 					Spec: privatev1.SubnetSpec_builder{
-						Ipv4Cidr:       proto.String("10.0.1.0/24"),
+						Ipv4Cidr:       new("10.0.1.0/24"),
 						VirtualNetwork: vn.GetId(),
 					}.Build(),
 				}.Build()
@@ -481,7 +481,7 @@ var _ = Describe("Private subnets server", func() {
 						Tenant: auth.SharedTenant,
 					}.Build(),
 					Spec: privatev1.VirtualNetworkSpec_builder{
-						Ipv4Cidr:     proto.String("10.0.0.0/16"),
+						Ipv4Cidr:     new("10.0.0.0/16"),
 						NetworkClass: nc.GetImplementationStrategy(),
 						Region:       "us-west-1",
 					}.Build(),
@@ -498,7 +498,7 @@ var _ = Describe("Private subnets server", func() {
 
 				subnet := privatev1.Subnet_builder{
 					Spec: privatev1.SubnetSpec_builder{
-						Ipv4Cidr:       proto.String("10.0.1.0/24"),
+						Ipv4Cidr:       new("10.0.1.0/24"),
 						VirtualNetwork: vn.GetId(),
 					}.Build(),
 				}.Build()
@@ -518,7 +518,7 @@ var _ = Describe("Private subnets server", func() {
 
 				subnet := privatev1.Subnet_builder{
 					Spec: privatev1.SubnetSpec_builder{
-						Ipv4Cidr:       proto.String("10.0.1.0/24"),
+						Ipv4Cidr:       new("10.0.1.0/24"),
 						VirtualNetwork: vn.GetId(),
 					}.Build(),
 				}.Build()
@@ -532,7 +532,7 @@ var _ = Describe("Private subnets server", func() {
 
 				subnet := privatev1.Subnet_builder{
 					Spec: privatev1.SubnetSpec_builder{
-						Ipv4Cidr:       proto.String("192.168.1.0/24"),
+						Ipv4Cidr:       new("192.168.1.0/24"),
 						VirtualNetwork: vn.GetId(),
 					}.Build(),
 				}.Build()
@@ -547,7 +547,7 @@ var _ = Describe("Private subnets server", func() {
 
 				subnet := privatev1.Subnet_builder{
 					Spec: privatev1.SubnetSpec_builder{
-						Ipv4Cidr:       proto.String("10.0.0.0/16"),
+						Ipv4Cidr:       new("10.0.0.0/16"),
 						VirtualNetwork: vn.GetId(),
 					}.Build(),
 				}.Build()
@@ -562,7 +562,7 @@ var _ = Describe("Private subnets server", func() {
 
 				subnet := privatev1.Subnet_builder{
 					Spec: privatev1.SubnetSpec_builder{
-						Ipv4Cidr:       proto.String("10.0.1.0/24"),
+						Ipv4Cidr:       new("10.0.1.0/24"),
 						VirtualNetwork: vn.GetId(),
 					}.Build(),
 				}.Build()
@@ -578,7 +578,7 @@ var _ = Describe("Private subnets server", func() {
 
 				subnet := privatev1.Subnet_builder{
 					Spec: privatev1.SubnetSpec_builder{
-						Ipv4Cidr:       proto.String("10.0.1.0/24"),
+						Ipv4Cidr:       new("10.0.1.0/24"),
 						VirtualNetwork: vn.GetId(),
 					}.Build(),
 				}.Build()
@@ -592,7 +592,7 @@ var _ = Describe("Private subnets server", func() {
 
 				subnet := privatev1.Subnet_builder{
 					Spec: privatev1.SubnetSpec_builder{
-						Ipv4Cidr:       proto.String("10.0.1.0/24"),
+						Ipv4Cidr:       new("10.0.1.0/24"),
 						VirtualNetwork: vn.GetId(),
 					}.Build(),
 				}.Build()
@@ -609,7 +609,7 @@ var _ = Describe("Private subnets server", func() {
 
 				subnet := privatev1.Subnet_builder{
 					Spec: privatev1.SubnetSpec_builder{
-						Ipv6Cidr:       proto.String("2001:db8:1::/64"),
+						Ipv6Cidr:       new("2001:db8:1::/64"),
 						VirtualNetwork: vn.GetId(),
 					}.Build(),
 				}.Build()
@@ -623,7 +623,7 @@ var _ = Describe("Private subnets server", func() {
 
 				subnet := privatev1.Subnet_builder{
 					Spec: privatev1.SubnetSpec_builder{
-						Ipv6Cidr:       proto.String("2001:db8:1::/64"),
+						Ipv6Cidr:       new("2001:db8:1::/64"),
 						VirtualNetwork: vn.GetId(),
 					}.Build(),
 				}.Build()
@@ -650,7 +650,7 @@ var _ = Describe("Private subnets server", func() {
 						Tenant: "tenant-a",
 					}.Build(),
 					Spec: privatev1.VirtualNetworkSpec_builder{
-						Ipv4Cidr:     proto.String("10.0.0.0/16"),
+						Ipv4Cidr:     new("10.0.0.0/16"),
 						NetworkClass: nc.GetImplementationStrategy(),
 						Region:       "us-west-1",
 					}.Build(),
@@ -670,7 +670,7 @@ var _ = Describe("Private subnets server", func() {
 						Tenant: "tenant-a",
 					}.Build(),
 					Spec: privatev1.SubnetSpec_builder{
-						Ipv4Cidr:       proto.String("10.0.1.0/24"),
+						Ipv4Cidr:       new("10.0.1.0/24"),
 						VirtualNetwork: vn.GetId(),
 					}.Build(),
 				}.Build()
@@ -696,7 +696,7 @@ var _ = Describe("Private subnets server", func() {
 						Tenant: auth.SharedTenant,
 					}.Build(),
 					Spec: privatev1.SubnetSpec_builder{
-						Ipv4Cidr:       proto.String("10.0.1.0/24"),
+						Ipv4Cidr:       new("10.0.1.0/24"),
 						VirtualNetwork: vn.GetId(),
 					}.Build(),
 				}.Build()
@@ -734,14 +734,14 @@ var _ = Describe("Private subnets server", func() {
 
 				existing := privatev1.Subnet_builder{
 					Spec: privatev1.SubnetSpec_builder{
-						Ipv4Cidr:       proto.String("10.0.1.0/24"),
+						Ipv4Cidr:       new("10.0.1.0/24"),
 						VirtualNetwork: vn1.GetId(),
 					}.Build(),
 				}.Build()
 
 				updated := privatev1.Subnet_builder{
 					Spec: privatev1.SubnetSpec_builder{
-						Ipv4Cidr:       proto.String("192.168.1.0/24"),
+						Ipv4Cidr:       new("192.168.1.0/24"),
 						VirtualNetwork: vn2.GetId(),
 					}.Build(),
 				}.Build()
@@ -760,14 +760,14 @@ var _ = Describe("Private subnets server", func() {
 
 				existing := privatev1.Subnet_builder{
 					Spec: privatev1.SubnetSpec_builder{
-						Ipv4Cidr:       proto.String("10.0.1.0/24"),
+						Ipv4Cidr:       new("10.0.1.0/24"),
 						VirtualNetwork: vn.GetId(),
 					}.Build(),
 				}.Build()
 
 				updated := privatev1.Subnet_builder{
 					Spec: privatev1.SubnetSpec_builder{
-						Ipv4Cidr:       proto.String("10.0.1.0/24"),
+						Ipv4Cidr:       new("10.0.1.0/24"),
 						VirtualNetwork: vn.GetId(),
 					}.Build(),
 				}.Build()
@@ -785,14 +785,14 @@ var _ = Describe("Private subnets server", func() {
 				// skips the VN reference lookup entirely. Rejection tests don't need a real VN.
 				existing := privatev1.Subnet_builder{
 					Spec: privatev1.SubnetSpec_builder{
-						Ipv4Cidr:       proto.String("10.0.1.0/24"),
+						Ipv4Cidr:       new("10.0.1.0/24"),
 						VirtualNetwork: fakeVNID,
 					}.Build(),
 				}.Build()
 
 				updated := privatev1.Subnet_builder{
 					Spec: privatev1.SubnetSpec_builder{
-						Ipv4Cidr:       proto.String("10.0.2.0/24"),
+						Ipv4Cidr:       new("10.0.2.0/24"),
 						VirtualNetwork: fakeVNID,
 					}.Build(),
 				}.Build()
@@ -810,14 +810,14 @@ var _ = Describe("Private subnets server", func() {
 				// Same VN ID, same CIDR: immutability passes, VN lookup skipped.
 				existing := privatev1.Subnet_builder{
 					Spec: privatev1.SubnetSpec_builder{
-						Ipv4Cidr:       proto.String("10.0.1.0/24"),
+						Ipv4Cidr:       new("10.0.1.0/24"),
 						VirtualNetwork: fakeVNID,
 					}.Build(),
 				}.Build()
 
 				updated := privatev1.Subnet_builder{
 					Spec: privatev1.SubnetSpec_builder{
-						Ipv4Cidr:       proto.String("10.0.1.0/24"),
+						Ipv4Cidr:       new("10.0.1.0/24"),
 						VirtualNetwork: fakeVNID,
 					}.Build(),
 				}.Build()
@@ -832,15 +832,15 @@ var _ = Describe("Private subnets server", func() {
 				// existing.GetIpv4Cidr() == "" != new value → reject.
 				existing := privatev1.Subnet_builder{
 					Spec: privatev1.SubnetSpec_builder{
-						Ipv6Cidr:       proto.String("2001:db8::/64"),
+						Ipv6Cidr:       new("2001:db8::/64"),
 						VirtualNetwork: fakeVNID,
 					}.Build(),
 				}.Build()
 
 				updated := privatev1.Subnet_builder{
 					Spec: privatev1.SubnetSpec_builder{
-						Ipv4Cidr:       proto.String("10.0.1.0/24"),
-						Ipv6Cidr:       proto.String("2001:db8::/64"),
+						Ipv4Cidr:       new("10.0.1.0/24"),
+						Ipv6Cidr:       new("2001:db8::/64"),
 						VirtualNetwork: fakeVNID,
 					}.Build(),
 				}.Build()
@@ -859,15 +859,15 @@ var _ = Describe("Private subnets server", func() {
 				// Immutability fires first: HasIpv4Cidr() true and "" != existing → rejected.
 				existing := privatev1.Subnet_builder{
 					Spec: privatev1.SubnetSpec_builder{
-						Ipv4Cidr:       proto.String("10.0.1.0/24"),
+						Ipv4Cidr:       new("10.0.1.0/24"),
 						VirtualNetwork: fakeVNID,
 					}.Build(),
 				}.Build()
 
 				updated := privatev1.Subnet_builder{
 					Spec: privatev1.SubnetSpec_builder{
-						Ipv4Cidr:       proto.String(""),
-						Ipv6Cidr:       proto.String("2001:db8::/64"),
+						Ipv4Cidr:       new(""),
+						Ipv6Cidr:       new("2001:db8::/64"),
 						VirtualNetwork: fakeVNID,
 					}.Build(),
 				}.Build()
@@ -888,14 +888,14 @@ var _ = Describe("Private subnets server", func() {
 			It("prevents ipv6_cidr field modification", func() {
 				existing := privatev1.Subnet_builder{
 					Spec: privatev1.SubnetSpec_builder{
-						Ipv6Cidr:       proto.String("2001:db8::/64"),
+						Ipv6Cidr:       new("2001:db8::/64"),
 						VirtualNetwork: fakeVNID,
 					}.Build(),
 				}.Build()
 
 				updated := privatev1.Subnet_builder{
 					Spec: privatev1.SubnetSpec_builder{
-						Ipv6Cidr:       proto.String("fd00:1234::/64"),
+						Ipv6Cidr:       new("fd00:1234::/64"),
 						VirtualNetwork: fakeVNID,
 					}.Build(),
 				}.Build()
@@ -912,14 +912,14 @@ var _ = Describe("Private subnets server", func() {
 			It("allows ipv6_cidr to stay same on Update", func() {
 				existing := privatev1.Subnet_builder{
 					Spec: privatev1.SubnetSpec_builder{
-						Ipv6Cidr:       proto.String("2001:db8::/64"),
+						Ipv6Cidr:       new("2001:db8::/64"),
 						VirtualNetwork: fakeVNID,
 					}.Build(),
 				}.Build()
 
 				updated := privatev1.Subnet_builder{
 					Spec: privatev1.SubnetSpec_builder{
-						Ipv6Cidr:       proto.String("2001:db8::/64"),
+						Ipv6Cidr:       new("2001:db8::/64"),
 						VirtualNetwork: fakeVNID,
 					}.Build(),
 				}.Build()
@@ -935,15 +935,15 @@ var _ = Describe("Private subnets server", func() {
 				// ipv4_cidr is identical so the ipv4 check does not fire first.
 				existing := privatev1.Subnet_builder{
 					Spec: privatev1.SubnetSpec_builder{
-						Ipv4Cidr:       proto.String("10.0.1.0/24"),
+						Ipv4Cidr:       new("10.0.1.0/24"),
 						VirtualNetwork: fakeVNID,
 					}.Build(),
 				}.Build()
 
 				updated := privatev1.Subnet_builder{
 					Spec: privatev1.SubnetSpec_builder{
-						Ipv4Cidr:       proto.String("10.0.1.0/24"),
-						Ipv6Cidr:       proto.String("2001:db8::/64"),
+						Ipv4Cidr:       new("10.0.1.0/24"),
+						Ipv6Cidr:       new("2001:db8::/64"),
 						VirtualNetwork: fakeVNID,
 					}.Build(),
 				}.Build()
@@ -963,16 +963,16 @@ var _ = Describe("Private subnets server", func() {
 				// (so SUB-VAL-14 doesn't fire), sets ipv6_cidr to "" explicitly.
 				existing := privatev1.Subnet_builder{
 					Spec: privatev1.SubnetSpec_builder{
-						Ipv4Cidr:       proto.String("10.0.1.0/24"),
-						Ipv6Cidr:       proto.String("2001:db8::/64"),
+						Ipv4Cidr:       new("10.0.1.0/24"),
+						Ipv6Cidr:       new("2001:db8::/64"),
 						VirtualNetwork: fakeVNID,
 					}.Build(),
 				}.Build()
 
 				updated := privatev1.Subnet_builder{
 					Spec: privatev1.SubnetSpec_builder{
-						Ipv4Cidr:       proto.String("10.0.1.0/24"),
-						Ipv6Cidr:       proto.String(""),
+						Ipv4Cidr:       new("10.0.1.0/24"),
+						Ipv6Cidr:       new(""),
 						VirtualNetwork: fakeVNID,
 					}.Build(),
 				}.Build()
@@ -995,8 +995,8 @@ var _ = Describe("Private subnets server", func() {
 						Name: "original-name",
 					}.Build(),
 					Spec: privatev1.SubnetSpec_builder{
-						Ipv4Cidr:       proto.String("10.0.1.0/24"),
-						Ipv6Cidr:       proto.String("2001:db8::/64"),
+						Ipv4Cidr:       new("10.0.1.0/24"),
+						Ipv6Cidr:       new("2001:db8::/64"),
 						VirtualNetwork: fakeVNID,
 					}.Build(),
 				}.Build()
@@ -1006,8 +1006,8 @@ var _ = Describe("Private subnets server", func() {
 						Name: "renamed-subnet",
 					}.Build(),
 					Spec: privatev1.SubnetSpec_builder{
-						Ipv4Cidr:       proto.String("10.0.1.0/24"),
-						Ipv6Cidr:       proto.String("2001:db8::/64"),
+						Ipv4Cidr:       new("10.0.1.0/24"),
+						Ipv6Cidr:       new("2001:db8::/64"),
 						VirtualNetwork: fakeVNID,
 					}.Build(),
 				}.Build()
@@ -1028,7 +1028,7 @@ var _ = Describe("Private subnets server", func() {
 							Tenant: auth.SharedTenant,
 						}.Build(),
 						Spec: privatev1.SubnetSpec_builder{
-							Ipv4Cidr:       proto.String("10.0.1.0/24"),
+							Ipv4Cidr:       new("10.0.1.0/24"),
 							VirtualNetwork: vn.GetId(),
 						}.Build(),
 					}.Build(),
@@ -1063,10 +1063,10 @@ var _ = Describe("Private subnets server", func() {
 					VirtualNetwork: virtualNetworkID,
 				}
 				if ipv4Cidr != "" {
-					builder.Ipv4Cidr = proto.String(ipv4Cidr)
+					builder.Ipv4Cidr = new(ipv4Cidr)
 				}
 				if ipv6Cidr != "" {
-					builder.Ipv6Cidr = proto.String(ipv6Cidr)
+					builder.Ipv6Cidr = new(ipv6Cidr)
 				}
 
 				subnet := privatev1.Subnet_builder{
@@ -1089,7 +1089,7 @@ var _ = Describe("Private subnets server", func() {
 
 				newSubnet := privatev1.Subnet_builder{
 					Spec: privatev1.SubnetSpec_builder{
-						Ipv4Cidr:       proto.String("10.0.1.0/24"),
+						Ipv4Cidr:       new("10.0.1.0/24"),
 						VirtualNetwork: vn.GetId(),
 					}.Build(),
 				}.Build()
@@ -1109,7 +1109,7 @@ var _ = Describe("Private subnets server", func() {
 
 				newSubnet := privatev1.Subnet_builder{
 					Spec: privatev1.SubnetSpec_builder{
-						Ipv4Cidr:       proto.String("10.0.1.0/24"),
+						Ipv4Cidr:       new("10.0.1.0/24"),
 						VirtualNetwork: vn.GetId(),
 					}.Build(),
 				}.Build()
@@ -1127,7 +1127,7 @@ var _ = Describe("Private subnets server", func() {
 
 				newSubnet := privatev1.Subnet_builder{
 					Spec: privatev1.SubnetSpec_builder{
-						Ipv4Cidr:       proto.String("10.0.0.0/20"),
+						Ipv4Cidr:       new("10.0.0.0/20"),
 						VirtualNetwork: vn.GetId(),
 					}.Build(),
 				}.Build()
@@ -1145,7 +1145,7 @@ var _ = Describe("Private subnets server", func() {
 
 				newSubnet := privatev1.Subnet_builder{
 					Spec: privatev1.SubnetSpec_builder{
-						Ipv4Cidr:       proto.String("10.0.2.0/24"),
+						Ipv4Cidr:       new("10.0.2.0/24"),
 						VirtualNetwork: vn.GetId(),
 					}.Build(),
 				}.Build()
@@ -1161,7 +1161,7 @@ var _ = Describe("Private subnets server", func() {
 
 				newSubnet := privatev1.Subnet_builder{
 					Spec: privatev1.SubnetSpec_builder{
-						Ipv4Cidr:       proto.String("10.0.1.0/24"),
+						Ipv4Cidr:       new("10.0.1.0/24"),
 						VirtualNetwork: vn2.GetId(),
 					}.Build(),
 				}.Build()
@@ -1176,7 +1176,7 @@ var _ = Describe("Private subnets server", func() {
 
 				newSubnet := privatev1.Subnet_builder{
 					Spec: privatev1.SubnetSpec_builder{
-						Ipv6Cidr:       proto.String("2001:db8:1::/48"),
+						Ipv6Cidr:       new("2001:db8:1::/48"),
 						VirtualNetwork: vn.GetId(),
 					}.Build(),
 				}.Build()
@@ -1215,7 +1215,7 @@ var _ = Describe("Private subnets server", func() {
 					Tenant: auth.SharedTenant,
 				}.Build(),
 				Spec: privatev1.SubnetSpec_builder{
-					Ipv4Cidr:       proto.String("10.0.1.0/24"),
+					Ipv4Cidr:       new("10.0.1.0/24"),
 					VirtualNetwork: vn.GetId(),
 				}.Build(),
 			}.Build()
@@ -1238,7 +1238,7 @@ var _ = Describe("Private subnets server", func() {
 					Tenant: auth.SharedTenant,
 				}.Build(),
 				Spec: privatev1.SubnetSpec_builder{
-					Ipv4Cidr:       proto.String("10.0.1.0/24"),
+					Ipv4Cidr:       new("10.0.1.0/24"),
 					VirtualNetwork: vn.GetId(),
 				}.Build(),
 			}.Build()
@@ -1269,7 +1269,7 @@ var _ = Describe("Private subnets server", func() {
 						Tenant: auth.SharedTenant,
 					}.Build(),
 					Spec: privatev1.SubnetSpec_builder{
-						Ipv4Cidr:       proto.String(fmt.Sprintf("10.%d.0.0/16", i)),
+						Ipv4Cidr:       new(fmt.Sprintf("10.%d.0.0/16", i)),
 						VirtualNetwork: vn.GetId(),
 					}.Build(),
 				}.Build()
@@ -1301,7 +1301,7 @@ var _ = Describe("Private subnets server", func() {
 						Tenant: auth.SharedTenant,
 					}.Build(),
 					Spec: privatev1.SubnetSpec_builder{
-						Ipv4Cidr:       proto.String(fmt.Sprintf("10.0.%d.0/24", i)),
+						Ipv4Cidr:       new(fmt.Sprintf("10.0.%d.0/24", i)),
 						VirtualNetwork: vn1.GetId(),
 					}.Build(),
 				}.Build()
@@ -1320,7 +1320,7 @@ var _ = Describe("Private subnets server", func() {
 						Tenant: auth.SharedTenant,
 					}.Build(),
 					Spec: privatev1.SubnetSpec_builder{
-						Ipv4Cidr:       proto.String(fmt.Sprintf("192.168.%d.0/24", i)),
+						Ipv4Cidr:       new(fmt.Sprintf("192.168.%d.0/24", i)),
 						VirtualNetwork: vn2.GetId(),
 					}.Build(),
 				}.Build()
@@ -1351,7 +1351,7 @@ var _ = Describe("Private subnets server", func() {
 					Tenant: auth.SharedTenant,
 				}.Build(),
 				Spec: privatev1.SubnetSpec_builder{
-					Ipv4Cidr:       proto.String("10.0.1.0/24"),
+					Ipv4Cidr:       new("10.0.1.0/24"),
 					VirtualNetwork: vn.GetId(),
 				}.Build(),
 			}.Build()
@@ -1388,7 +1388,7 @@ var _ = Describe("Private subnets server", func() {
 					Tenant:     auth.SharedTenant,
 				}.Build(),
 				Spec: privatev1.SubnetSpec_builder{
-					Ipv4Cidr:       proto.String("10.0.1.0/24"),
+					Ipv4Cidr:       new("10.0.1.0/24"),
 					VirtualNetwork: vn.GetId(),
 				}.Build(),
 			}.Build()
@@ -1425,7 +1425,7 @@ var _ = Describe("Private subnets server", func() {
 					Tenant: "tenant-a",
 				}.Build(),
 				Spec: privatev1.SubnetSpec_builder{
-					Ipv4Cidr:       proto.String("10.0.1.0/24"),
+					Ipv4Cidr:       new("10.0.1.0/24"),
 					VirtualNetwork: vn1.GetId(),
 				}.Build(),
 			}.Build()
@@ -1442,7 +1442,7 @@ var _ = Describe("Private subnets server", func() {
 					Tenant: "tenant-b",
 				}.Build(),
 				Spec: privatev1.SubnetSpec_builder{
-					Ipv4Cidr:       proto.String("192.168.1.0/24"),
+					Ipv4Cidr:       new("192.168.1.0/24"),
 					VirtualNetwork: vn2.GetId(),
 				}.Build(),
 			}.Build()

--- a/internal/servers/private_virtual_networks_server_test.go
+++ b/internal/servers/private_virtual_networks_server_test.go
@@ -107,7 +107,7 @@ var _ = Describe("Private virtual networks server", func() {
 
 		nc := privatev1.NetworkClass_builder{
 			ImplementationStrategy: "test-strategy",
-			IsDefault:              proto.Bool(true),
+			IsDefault:              new(true),
 			Metadata: privatev1.Metadata_builder{
 				Tenant: "shared",
 			}.Build(),
@@ -180,7 +180,7 @@ var _ = Describe("Private virtual networks server", func() {
 
 				vn := privatev1.VirtualNetwork_builder{
 					Spec: privatev1.VirtualNetworkSpec_builder{
-						Ipv4Cidr:     proto.String("192.168.0.0/16"),
+						Ipv4Cidr:     new("192.168.0.0/16"),
 						NetworkClass: nc.GetId(),
 						Region:       "us-west-1",
 					}.Build(),
@@ -193,7 +193,7 @@ var _ = Describe("Private virtual networks server", func() {
 			It("rejects invalid IPv4 CIDR format", func() {
 				vn := privatev1.VirtualNetwork_builder{
 					Spec: privatev1.VirtualNetworkSpec_builder{
-						Ipv4Cidr: proto.String("not-a-cidr"),
+						Ipv4Cidr: new("not-a-cidr"),
 						Region:   "us-west-1",
 					}.Build(),
 				}.Build()
@@ -206,7 +206,7 @@ var _ = Describe("Private virtual networks server", func() {
 			It("rejects IPv4 with invalid mask", func() {
 				vn := privatev1.VirtualNetwork_builder{
 					Spec: privatev1.VirtualNetworkSpec_builder{
-						Ipv4Cidr: proto.String("192.168.0.0/33"),
+						Ipv4Cidr: new("192.168.0.0/33"),
 						Region:   "us-west-1",
 					}.Build(),
 				}.Build()
@@ -219,7 +219,7 @@ var _ = Describe("Private virtual networks server", func() {
 			It("rejects IPv6 address in IPv4 field", func() {
 				vn := privatev1.VirtualNetwork_builder{
 					Spec: privatev1.VirtualNetworkSpec_builder{
-						Ipv4Cidr: proto.String("2001:db8::/32"),
+						Ipv4Cidr: new("2001:db8::/32"),
 						Region:   "us-west-1",
 					}.Build(),
 				}.Build()
@@ -236,7 +236,7 @@ var _ = Describe("Private virtual networks server", func() {
 
 				vn := privatev1.VirtualNetwork_builder{
 					Spec: privatev1.VirtualNetworkSpec_builder{
-						Ipv6Cidr:     proto.String("2001:db8::/32"),
+						Ipv6Cidr:     new("2001:db8::/32"),
 						NetworkClass: nc.GetId(),
 						Region:       "us-west-1",
 					}.Build(),
@@ -249,7 +249,7 @@ var _ = Describe("Private virtual networks server", func() {
 			It("rejects invalid IPv6 CIDR format", func() {
 				vn := privatev1.VirtualNetwork_builder{
 					Spec: privatev1.VirtualNetworkSpec_builder{
-						Ipv6Cidr: proto.String("not-ipv6"),
+						Ipv6Cidr: new("not-ipv6"),
 						Region:   "us-west-1",
 					}.Build(),
 				}.Build()
@@ -262,7 +262,7 @@ var _ = Describe("Private virtual networks server", func() {
 			It("rejects IPv6 with invalid mask", func() {
 				vn := privatev1.VirtualNetwork_builder{
 					Spec: privatev1.VirtualNetworkSpec_builder{
-						Ipv6Cidr: proto.String("2001:db8::/129"),
+						Ipv6Cidr: new("2001:db8::/129"),
 						Region:   "us-west-1",
 					}.Build(),
 				}.Build()
@@ -275,7 +275,7 @@ var _ = Describe("Private virtual networks server", func() {
 			It("rejects IPv4 address in IPv6 field", func() {
 				vn := privatev1.VirtualNetwork_builder{
 					Spec: privatev1.VirtualNetworkSpec_builder{
-						Ipv6Cidr: proto.String("192.168.0.0/16"),
+						Ipv6Cidr: new("192.168.0.0/16"),
 						Region:   "us-west-1",
 					}.Build(),
 				}.Build()
@@ -304,7 +304,7 @@ var _ = Describe("Private virtual networks server", func() {
 
 				vn := privatev1.VirtualNetwork_builder{
 					Spec: privatev1.VirtualNetworkSpec_builder{
-						Ipv4Cidr:     proto.String("10.0.0.0/16"),
+						Ipv4Cidr:     new("10.0.0.0/16"),
 						NetworkClass: nc.GetId(),
 						Region:       "us-west-1",
 					}.Build(),
@@ -319,7 +319,7 @@ var _ = Describe("Private virtual networks server", func() {
 
 				vn := privatev1.VirtualNetwork_builder{
 					Spec: privatev1.VirtualNetworkSpec_builder{
-						Ipv6Cidr:     proto.String("2001:db8::/32"),
+						Ipv6Cidr:     new("2001:db8::/32"),
 						NetworkClass: nc.GetId(),
 						Region:       "us-west-1",
 					}.Build(),
@@ -334,8 +334,8 @@ var _ = Describe("Private virtual networks server", func() {
 
 				vn := privatev1.VirtualNetwork_builder{
 					Spec: privatev1.VirtualNetworkSpec_builder{
-						Ipv4Cidr:     proto.String("10.0.0.0/16"),
-						Ipv6Cidr:     proto.String("2001:db8::/32"),
+						Ipv4Cidr:     new("10.0.0.0/16"),
+						Ipv6Cidr:     new("2001:db8::/32"),
 						NetworkClass: nc.GetId(),
 						Region:       "us-west-1",
 					}.Build(),
@@ -352,7 +352,7 @@ var _ = Describe("Private virtual networks server", func() {
 
 				vn := privatev1.VirtualNetwork_builder{
 					Spec: privatev1.VirtualNetworkSpec_builder{
-						Ipv4Cidr:     proto.String("10.0.0.0/16"),
+						Ipv4Cidr:     new("10.0.0.0/16"),
 						NetworkClass: nc.GetId(),
 						Region:       "us-west-1",
 					}.Build(),
@@ -365,7 +365,7 @@ var _ = Describe("Private virtual networks server", func() {
 			It("rejects non-existent NetworkClass", func() {
 				vn := privatev1.VirtualNetwork_builder{
 					Spec: privatev1.VirtualNetworkSpec_builder{
-						Ipv4Cidr:     proto.String("10.0.0.0/16"),
+						Ipv4Cidr:     new("10.0.0.0/16"),
 						NetworkClass: "non-existent-class",
 						Region:       "us-west-1",
 					}.Build(),
@@ -379,7 +379,7 @@ var _ = Describe("Private virtual networks server", func() {
 			It("rejects empty NetworkClass when no default exists", func() {
 				vn := privatev1.VirtualNetwork_builder{
 					Spec: privatev1.VirtualNetworkSpec_builder{
-						Ipv4Cidr: proto.String("10.0.0.0/16"),
+						Ipv4Cidr: new("10.0.0.0/16"),
 						Region:   "us-west-1",
 					}.Build(),
 				}.Build()
@@ -396,7 +396,7 @@ var _ = Describe("Private virtual networks server", func() {
 
 				vn := privatev1.VirtualNetwork_builder{
 					Spec: privatev1.VirtualNetworkSpec_builder{
-						Ipv4Cidr:     proto.String("10.0.0.0/16"),
+						Ipv4Cidr:     new("10.0.0.0/16"),
 						NetworkClass: nc.GetId(),
 						Region:       "us-west-1",
 					}.Build(),
@@ -411,7 +411,7 @@ var _ = Describe("Private virtual networks server", func() {
 
 				vn := privatev1.VirtualNetwork_builder{
 					Spec: privatev1.VirtualNetworkSpec_builder{
-						Ipv4Cidr:     proto.String("10.0.0.0/16"),
+						Ipv4Cidr:     new("10.0.0.0/16"),
 						NetworkClass: nc.GetId(),
 						Region:       "us-west-1",
 					}.Build(),
@@ -430,7 +430,7 @@ var _ = Describe("Private virtual networks server", func() {
 
 				vn := privatev1.VirtualNetwork_builder{
 					Spec: privatev1.VirtualNetworkSpec_builder{
-						Ipv4Cidr:     proto.String("10.0.0.0/16"),
+						Ipv4Cidr:     new("10.0.0.0/16"),
 						NetworkClass: nc.GetId(),
 						Region:       "us-west-1",
 					}.Build(),
@@ -451,7 +451,7 @@ var _ = Describe("Private virtual networks server", func() {
 
 				vn := privatev1.VirtualNetwork_builder{
 					Spec: privatev1.VirtualNetworkSpec_builder{
-						Ipv4Cidr:     proto.String("10.0.0.0/16"),
+						Ipv4Cidr:     new("10.0.0.0/16"),
 						NetworkClass: nc.GetId(),
 						Region:       "us-west-1",
 						Capabilities: privatev1.VirtualNetworkCapabilities_builder{
@@ -496,7 +496,7 @@ var _ = Describe("Private virtual networks server", func() {
 						Tenant: "shared",
 					}.Build(),
 					Spec: privatev1.VirtualNetworkSpec_builder{
-						Ipv4Cidr:     proto.String("10.0.0.0/16"),
+						Ipv4Cidr:     new("10.0.0.0/16"),
 						NetworkClass: nc.GetId(),
 						Region:       "us-west-1",
 						Capabilities: privatev1.VirtualNetworkCapabilities_builder{
@@ -515,7 +515,7 @@ var _ = Describe("Private virtual networks server", func() {
 			It("rejects empty region", func() {
 				vn := privatev1.VirtualNetwork_builder{
 					Spec: privatev1.VirtualNetworkSpec_builder{
-						Ipv4Cidr: proto.String("10.0.0.0/16"),
+						Ipv4Cidr: new("10.0.0.0/16"),
 					}.Build(),
 				}.Build()
 
@@ -530,7 +530,7 @@ var _ = Describe("Private virtual networks server", func() {
 
 				vn := privatev1.VirtualNetwork_builder{
 					Spec: privatev1.VirtualNetworkSpec_builder{
-						Ipv4Cidr:     proto.String("10.0.0.0/16"),
+						Ipv4Cidr:     new("10.0.0.0/16"),
 						NetworkClass: nc.GetId(),
 						Region:       "us-west-1",
 					}.Build(),
@@ -546,7 +546,7 @@ var _ = Describe("Private virtual networks server", func() {
 				existing := privatev1.VirtualNetwork_builder{
 					Spec: privatev1.VirtualNetworkSpec_builder{
 						Region:       "us-west-1",
-						Ipv4Cidr:     proto.String("10.0.0.0/16"),
+						Ipv4Cidr:     new("10.0.0.0/16"),
 						NetworkClass: "test-class",
 					}.Build(),
 				}.Build()
@@ -554,7 +554,7 @@ var _ = Describe("Private virtual networks server", func() {
 				updated := privatev1.VirtualNetwork_builder{
 					Spec: privatev1.VirtualNetworkSpec_builder{
 						Region:       "us-east-1",
-						Ipv4Cidr:     proto.String("10.0.0.0/16"),
+						Ipv4Cidr:     new("10.0.0.0/16"),
 						NetworkClass: "test-class",
 					}.Build(),
 				}.Build()
@@ -574,7 +574,7 @@ var _ = Describe("Private virtual networks server", func() {
 				existing := privatev1.VirtualNetwork_builder{
 					Spec: privatev1.VirtualNetworkSpec_builder{
 						Region:       "us-west-1",
-						Ipv4Cidr:     proto.String("10.0.0.0/16"),
+						Ipv4Cidr:     new("10.0.0.0/16"),
 						NetworkClass: nc.GetId(),
 					}.Build(),
 				}.Build()
@@ -582,7 +582,7 @@ var _ = Describe("Private virtual networks server", func() {
 				updated := privatev1.VirtualNetwork_builder{
 					Spec: privatev1.VirtualNetworkSpec_builder{
 						Region:       "us-west-1",
-						Ipv4Cidr:     proto.String("10.0.0.0/16"),
+						Ipv4Cidr:     new("10.0.0.0/16"),
 						NetworkClass: nc.GetId(),
 					}.Build(),
 				}.Build()
@@ -597,7 +597,7 @@ var _ = Describe("Private virtual networks server", func() {
 				existing := privatev1.VirtualNetwork_builder{
 					Spec: privatev1.VirtualNetworkSpec_builder{
 						Region:       "us-west-1",
-						Ipv4Cidr:     proto.String("10.0.0.0/16"),
+						Ipv4Cidr:     new("10.0.0.0/16"),
 						NetworkClass: "class-1",
 					}.Build(),
 				}.Build()
@@ -605,7 +605,7 @@ var _ = Describe("Private virtual networks server", func() {
 				updated := privatev1.VirtualNetwork_builder{
 					Spec: privatev1.VirtualNetworkSpec_builder{
 						Region:       "us-west-1",
-						Ipv4Cidr:     proto.String("10.0.0.0/16"),
+						Ipv4Cidr:     new("10.0.0.0/16"),
 						NetworkClass: "class-2",
 					}.Build(),
 				}.Build()
@@ -625,7 +625,7 @@ var _ = Describe("Private virtual networks server", func() {
 				existing := privatev1.VirtualNetwork_builder{
 					Spec: privatev1.VirtualNetworkSpec_builder{
 						Region:       "us-west-1",
-						Ipv4Cidr:     proto.String("10.0.0.0/16"),
+						Ipv4Cidr:     new("10.0.0.0/16"),
 						NetworkClass: nc.GetId(),
 					}.Build(),
 				}.Build()
@@ -633,7 +633,7 @@ var _ = Describe("Private virtual networks server", func() {
 				updated := privatev1.VirtualNetwork_builder{
 					Spec: privatev1.VirtualNetworkSpec_builder{
 						Region:       "us-west-1",
-						Ipv4Cidr:     proto.String("10.0.0.0/16"),
+						Ipv4Cidr:     new("10.0.0.0/16"),
 						NetworkClass: nc.GetId(),
 					}.Build(),
 				}.Build()
@@ -652,7 +652,7 @@ var _ = Describe("Private virtual networks server", func() {
 					Spec: privatev1.VirtualNetworkSpec_builder{
 						Region:       "us-west-1",
 						NetworkClass: "test-class",
-						Ipv4Cidr:     proto.String("10.0.0.0/16"),
+						Ipv4Cidr:     new("10.0.0.0/16"),
 					}.Build(),
 				}.Build()
 
@@ -660,7 +660,7 @@ var _ = Describe("Private virtual networks server", func() {
 					Spec: privatev1.VirtualNetworkSpec_builder{
 						Region:       "us-west-1",
 						NetworkClass: "test-class",
-						Ipv4Cidr:     proto.String("192.168.0.0/16"),
+						Ipv4Cidr:     new("192.168.0.0/16"),
 					}.Build(),
 				}.Build()
 
@@ -682,7 +682,7 @@ var _ = Describe("Private virtual networks server", func() {
 					Spec: privatev1.VirtualNetworkSpec_builder{
 						Region:       "us-west-1",
 						NetworkClass: nc.GetId(),
-						Ipv4Cidr:     proto.String("10.0.0.0/16"),
+						Ipv4Cidr:     new("10.0.0.0/16"),
 					}.Build(),
 				}.Build()
 
@@ -690,7 +690,7 @@ var _ = Describe("Private virtual networks server", func() {
 					Spec: privatev1.VirtualNetworkSpec_builder{
 						Region:       "us-west-1",
 						NetworkClass: nc.GetId(),
-						Ipv4Cidr:     proto.String("10.0.0.0/16"),
+						Ipv4Cidr:     new("10.0.0.0/16"),
 					}.Build(),
 				}.Build()
 
@@ -706,7 +706,7 @@ var _ = Describe("Private virtual networks server", func() {
 					Spec: privatev1.VirtualNetworkSpec_builder{
 						Region:       "us-west-1",
 						NetworkClass: "test-class",
-						Ipv6Cidr:     proto.String("2001:db8::/32"),
+						Ipv6Cidr:     new("2001:db8::/32"),
 					}.Build(),
 				}.Build()
 
@@ -714,8 +714,8 @@ var _ = Describe("Private virtual networks server", func() {
 					Spec: privatev1.VirtualNetworkSpec_builder{
 						Region:       "us-west-1",
 						NetworkClass: "test-class",
-						Ipv4Cidr:     proto.String("10.0.0.0/16"),
-						Ipv6Cidr:     proto.String("2001:db8::/32"),
+						Ipv4Cidr:     new("10.0.0.0/16"),
+						Ipv6Cidr:     new("2001:db8::/32"),
 					}.Build(),
 				}.Build()
 
@@ -735,7 +735,7 @@ var _ = Describe("Private virtual networks server", func() {
 					Spec: privatev1.VirtualNetworkSpec_builder{
 						Region:       "us-west-1",
 						NetworkClass: "test-class",
-						Ipv4Cidr:     proto.String("10.0.0.0/16"),
+						Ipv4Cidr:     new("10.0.0.0/16"),
 					}.Build(),
 				}.Build()
 
@@ -743,8 +743,8 @@ var _ = Describe("Private virtual networks server", func() {
 					Spec: privatev1.VirtualNetworkSpec_builder{
 						Region:       "us-west-1",
 						NetworkClass: "test-class",
-						Ipv4Cidr:     proto.String(""),
-						Ipv6Cidr:     proto.String("2001:db8::/32"),
+						Ipv4Cidr:     new(""),
+						Ipv6Cidr:     new("2001:db8::/32"),
 					}.Build(),
 				}.Build()
 
@@ -764,7 +764,7 @@ var _ = Describe("Private virtual networks server", func() {
 					Spec: privatev1.VirtualNetworkSpec_builder{
 						Region:       "us-west-1",
 						NetworkClass: "test-class",
-						Ipv6Cidr:     proto.String("2001:db8::/32"),
+						Ipv6Cidr:     new("2001:db8::/32"),
 					}.Build(),
 				}.Build()
 
@@ -772,7 +772,7 @@ var _ = Describe("Private virtual networks server", func() {
 					Spec: privatev1.VirtualNetworkSpec_builder{
 						Region:       "us-west-1",
 						NetworkClass: "test-class",
-						Ipv6Cidr:     proto.String("fd00:1234::/32"),
+						Ipv6Cidr:     new("fd00:1234::/32"),
 					}.Build(),
 				}.Build()
 
@@ -792,7 +792,7 @@ var _ = Describe("Private virtual networks server", func() {
 					Spec: privatev1.VirtualNetworkSpec_builder{
 						Region:       "us-west-1",
 						NetworkClass: nc.GetId(),
-						Ipv6Cidr:     proto.String("2001:db8::/32"),
+						Ipv6Cidr:     new("2001:db8::/32"),
 					}.Build(),
 				}.Build()
 
@@ -800,7 +800,7 @@ var _ = Describe("Private virtual networks server", func() {
 					Spec: privatev1.VirtualNetworkSpec_builder{
 						Region:       "us-west-1",
 						NetworkClass: nc.GetId(),
-						Ipv6Cidr:     proto.String("2001:db8::/32"),
+						Ipv6Cidr:     new("2001:db8::/32"),
 					}.Build(),
 				}.Build()
 
@@ -817,7 +817,7 @@ var _ = Describe("Private virtual networks server", func() {
 					Spec: privatev1.VirtualNetworkSpec_builder{
 						Region:       "us-west-1",
 						NetworkClass: "test-class",
-						Ipv4Cidr:     proto.String("10.0.0.0/16"),
+						Ipv4Cidr:     new("10.0.0.0/16"),
 					}.Build(),
 				}.Build()
 
@@ -825,8 +825,8 @@ var _ = Describe("Private virtual networks server", func() {
 					Spec: privatev1.VirtualNetworkSpec_builder{
 						Region:       "us-west-1",
 						NetworkClass: "test-class",
-						Ipv4Cidr:     proto.String("10.0.0.0/16"),
-						Ipv6Cidr:     proto.String("2001:db8::/32"),
+						Ipv4Cidr:     new("10.0.0.0/16"),
+						Ipv6Cidr:     new("2001:db8::/32"),
 					}.Build(),
 				}.Build()
 
@@ -847,8 +847,8 @@ var _ = Describe("Private virtual networks server", func() {
 					Spec: privatev1.VirtualNetworkSpec_builder{
 						Region:       "us-west-1",
 						NetworkClass: "test-class",
-						Ipv4Cidr:     proto.String("10.0.0.0/16"),
-						Ipv6Cidr:     proto.String("2001:db8::/32"),
+						Ipv4Cidr:     new("10.0.0.0/16"),
+						Ipv6Cidr:     new("2001:db8::/32"),
 					}.Build(),
 				}.Build()
 
@@ -856,8 +856,8 @@ var _ = Describe("Private virtual networks server", func() {
 					Spec: privatev1.VirtualNetworkSpec_builder{
 						Region:       "us-west-1",
 						NetworkClass: "test-class",
-						Ipv4Cidr:     proto.String("10.0.0.0/16"),
-						Ipv6Cidr:     proto.String(""),
+						Ipv4Cidr:     new("10.0.0.0/16"),
+						Ipv6Cidr:     new(""),
 					}.Build(),
 				}.Build()
 
@@ -882,7 +882,7 @@ var _ = Describe("Private virtual networks server", func() {
 							Tenant: "shared",
 						}.Build(),
 						Spec: privatev1.VirtualNetworkSpec_builder{
-							Ipv4Cidr:     proto.String("10.0.0.0/16"),
+							Ipv4Cidr:     new("10.0.0.0/16"),
 							NetworkClass: nc.GetId(),
 							Region:       "us-west-1",
 						}.Build(),
@@ -933,7 +933,7 @@ var _ = Describe("Private virtual networks server", func() {
 					Tenant: "shared",
 				}.Build(),
 				Spec: privatev1.VirtualNetworkSpec_builder{
-					Ipv4Cidr:     proto.String("10.0.0.0/16"),
+					Ipv4Cidr:     new("10.0.0.0/16"),
 					Region:       "us-west-1",
 					NetworkClass: "class-id",
 				}.Build(),
@@ -955,7 +955,7 @@ var _ = Describe("Private virtual networks server", func() {
 					Tenant: "shared",
 				}.Build(),
 				Spec: privatev1.VirtualNetworkSpec_builder{
-					Ipv4Cidr:     proto.String("10.0.0.0/16"),
+					Ipv4Cidr:     new("10.0.0.0/16"),
 					Region:       "us-west-1",
 					NetworkClass: "class-id",
 				}.Build(),
@@ -985,7 +985,7 @@ var _ = Describe("Private virtual networks server", func() {
 						Tenant: "shared",
 					}.Build(),
 					Spec: privatev1.VirtualNetworkSpec_builder{
-						Ipv4Cidr:     proto.String(fmt.Sprintf("10.%d.0.0/16", i)),
+						Ipv4Cidr:     new(fmt.Sprintf("10.%d.0.0/16", i)),
 						Region:       "us-west-1",
 						NetworkClass: "class-id",
 					}.Build(),
@@ -1015,7 +1015,7 @@ var _ = Describe("Private virtual networks server", func() {
 						Tenant: "shared",
 					}.Build(),
 					Spec: privatev1.VirtualNetworkSpec_builder{
-						Ipv4Cidr:     proto.String(fmt.Sprintf("10.%d.0.0/16", i)),
+						Ipv4Cidr:     new(fmt.Sprintf("10.%d.0.0/16", i)),
 						Region:       "us-west-1",
 						NetworkClass: "class-id",
 					}.Build(),
@@ -1043,7 +1043,7 @@ var _ = Describe("Private virtual networks server", func() {
 					Tenant: "shared",
 				}.Build(),
 				Spec: privatev1.VirtualNetworkSpec_builder{
-					Ipv4Cidr:     proto.String("10.0.0.0/16"),
+					Ipv4Cidr:     new("10.0.0.0/16"),
 					Region:       "us-west-1",
 					NetworkClass: "class-id",
 				}.Build(),
@@ -1079,7 +1079,7 @@ var _ = Describe("Private virtual networks server", func() {
 					Tenant:     "shared",
 				}.Build(),
 				Spec: privatev1.VirtualNetworkSpec_builder{
-					Ipv4Cidr:     proto.String("10.0.0.0/16"),
+					Ipv4Cidr:     new("10.0.0.0/16"),
 					Region:       "us-west-1",
 					NetworkClass: "class-id",
 				}.Build(),
@@ -1114,7 +1114,7 @@ var _ = Describe("Private virtual networks server", func() {
 					Tenant: "tenant-a",
 				}.Build(),
 				Spec: privatev1.VirtualNetworkSpec_builder{
-					Ipv4Cidr:     proto.String("10.1.0.0/16"),
+					Ipv4Cidr:     new("10.1.0.0/16"),
 					Region:       "us-west-1",
 					NetworkClass: "class-id",
 				}.Build(),
@@ -1132,7 +1132,7 @@ var _ = Describe("Private virtual networks server", func() {
 					Tenant: "tenant-b",
 				}.Build(),
 				Spec: privatev1.VirtualNetworkSpec_builder{
-					Ipv4Cidr:     proto.String("10.2.0.0/16"),
+					Ipv4Cidr:     new("10.2.0.0/16"),
 					Region:       "us-west-1",
 					NetworkClass: "class-id",
 				}.Build(),
@@ -1171,7 +1171,7 @@ var _ = Describe("Private virtual networks server", func() {
 			createResponse, err := vnServer.Create(ctx, privatev1.VirtualNetworksCreateRequest_builder{
 				Object: privatev1.VirtualNetwork_builder{
 					Spec: privatev1.VirtualNetworkSpec_builder{
-						Ipv4Cidr: proto.String("10.0.0.0/16"),
+						Ipv4Cidr: new("10.0.0.0/16"),
 						Region:   "us-west-1",
 					}.Build(),
 				}.Build(),
@@ -1188,7 +1188,7 @@ var _ = Describe("Private virtual networks server", func() {
 			_, err := vnServer.Create(ctx, privatev1.VirtualNetworksCreateRequest_builder{
 				Object: privatev1.VirtualNetwork_builder{
 					Spec: privatev1.VirtualNetworkSpec_builder{
-						Ipv4Cidr: proto.String("10.0.0.0/16"),
+						Ipv4Cidr: new("10.0.0.0/16"),
 						Region:   "us-west-1",
 					}.Build(),
 				}.Build(),
@@ -1208,7 +1208,7 @@ var _ = Describe("Private virtual networks server", func() {
 			createResponse, err := vnServer.Create(ctx, privatev1.VirtualNetworksCreateRequest_builder{
 				Object: privatev1.VirtualNetwork_builder{
 					Spec: privatev1.VirtualNetworkSpec_builder{
-						Ipv4Cidr:     proto.String("10.0.0.0/16"),
+						Ipv4Cidr:     new("10.0.0.0/16"),
 						Region:       "us-west-1",
 						NetworkClass: ncB.GetId(),
 					}.Build(),
@@ -1226,7 +1226,7 @@ var _ = Describe("Private virtual networks server", func() {
 			_, err := vnServer.Create(ctx, privatev1.VirtualNetworksCreateRequest_builder{
 				Object: privatev1.VirtualNetwork_builder{
 					Spec: privatev1.VirtualNetworkSpec_builder{
-						Ipv4Cidr: proto.String("10.0.0.0/16"),
+						Ipv4Cidr: new("10.0.0.0/16"),
 						Region:   "us-west-1",
 					}.Build(),
 				}.Build(),
@@ -1248,7 +1248,7 @@ var _ = Describe("Private virtual networks server", func() {
 
 			nc := privatev1.NetworkClass_builder{
 				ImplementationStrategy: "test-strategy",
-				IsDefault:              proto.Bool(true),
+				IsDefault:              new(true),
 				Metadata: privatev1.Metadata_builder{
 					Tenant: "shared",
 				}.Build(),
@@ -1268,7 +1268,7 @@ var _ = Describe("Private virtual networks server", func() {
 			_, err = vnServer.Create(ctx, privatev1.VirtualNetworksCreateRequest_builder{
 				Object: privatev1.VirtualNetwork_builder{
 					Spec: privatev1.VirtualNetworkSpec_builder{
-						Ipv6Cidr: proto.String("2001:db8::/32"),
+						Ipv6Cidr: new("2001:db8::/32"),
 						Region:   "us-west-1",
 						Capabilities: privatev1.VirtualNetworkCapabilities_builder{
 							EnableIpv6: true,
@@ -1298,7 +1298,7 @@ var _ = Describe("Private virtual networks server", func() {
 			_, err := vnServer.Create(ctx, privatev1.VirtualNetworksCreateRequest_builder{
 				Object: privatev1.VirtualNetwork_builder{
 					Spec: privatev1.VirtualNetworkSpec_builder{
-						Ipv4Cidr: proto.String("10.0.0.0/16"),
+						Ipv4Cidr: new("10.0.0.0/16"),
 						Region:   "us-west-1",
 					}.Build(),
 				}.Build(),
@@ -1323,7 +1323,7 @@ var _ = Describe("Private virtual networks server", func() {
 			_, err := vnServer.Create(ctx, privatev1.VirtualNetworksCreateRequest_builder{
 				Object: privatev1.VirtualNetwork_builder{
 					Spec: privatev1.VirtualNetworkSpec_builder{
-						Ipv4Cidr: proto.String("10.0.0.0/16"),
+						Ipv4Cidr: new("10.0.0.0/16"),
 						Region:   "us-west-1",
 					}.Build(),
 				}.Build(),
@@ -1340,7 +1340,7 @@ var _ = Describe("Private virtual networks server", func() {
 			createResponse, err := vnServer.Create(ctx, privatev1.VirtualNetworksCreateRequest_builder{
 				Object: privatev1.VirtualNetwork_builder{
 					Spec: privatev1.VirtualNetworkSpec_builder{
-						Ipv4Cidr: proto.String("10.0.0.0/16"),
+						Ipv4Cidr: new("10.0.0.0/16"),
 						Region:   "us-west-1",
 					}.Build(),
 				}.Build(),
@@ -1357,7 +1357,7 @@ var _ = Describe("Private virtual networks server", func() {
 				Object: privatev1.VirtualNetwork_builder{
 					Id: vn.GetId(),
 					Spec: privatev1.VirtualNetworkSpec_builder{
-						Ipv4Cidr:     proto.String("10.0.0.0/16"),
+						Ipv4Cidr:     new("10.0.0.0/16"),
 						Region:       "us-west-1",
 						NetworkClass: ncB.GetId(),
 					}.Build(),

--- a/internal/servers/projects_server_test.go
+++ b/internal/servers/projects_server_test.go
@@ -18,7 +18,6 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/fieldmaskpb"
 
 	publicv1 "github.com/osac-project/fulfillment-service/internal/api/osac/public/v1"
@@ -119,7 +118,7 @@ var _ = Describe("Public projects server", func() {
 
 			// List projects:
 			listResponse, err := publicServer.List(ctx, publicv1.ProjectsListRequest_builder{
-				Filter: proto.String("this.metadata.name == 'my-project'"),
+				Filter: new("this.metadata.name == 'my-project'"),
 			}.Build())
 			Expect(err).ToNot(HaveOccurred())
 			Expect(listResponse.Size).To(Equal(int32(1)))
@@ -162,7 +161,7 @@ var _ = Describe("Public projects server", func() {
 					}.Build(),
 					Spec: publicv1.ProjectSpec_builder{
 						Title:       "New Project",
-						Description: proto.String("Test project"),
+						Description: new("Test project"),
 					}.Build(),
 				}.Build(),
 			}.Build())
@@ -195,7 +194,7 @@ var _ = Describe("Public projects server", func() {
 				Object: publicv1.Project_builder{
 					Id: createResponse.Object.Id,
 					Spec: publicv1.ProjectSpec_builder{
-						Description: proto.String("Updated description"),
+						Description: new("Updated description"),
 					}.Build(),
 				}.Build(),
 				UpdateMask: &fieldmaskpb.FieldMask{
@@ -254,7 +253,7 @@ var _ = Describe("Public projects server", func() {
 					}.Build(),
 					Spec: publicv1.ProjectSpec_builder{
 						Title:  "Child",
-						Parent: proto.String(parentResp.Object.Id),
+						Parent: new(parentResp.Object.Id),
 					}.Build(),
 				}.Build(),
 			}.Build())
@@ -262,7 +261,7 @@ var _ = Describe("Public projects server", func() {
 
 			// List child projects:
 			listResp, err := publicServer.List(ctx, publicv1.ProjectsListRequest_builder{
-				Filter: proto.String("this.spec.parent == '" + parentResp.Object.Id + "'"),
+				Filter: new("this.spec.parent == '" + parentResp.Object.Id + "'"),
 			}.Build())
 			Expect(err).ToNot(HaveOccurred())
 			Expect(listResp.Size).To(Equal(int32(1)))

--- a/internal/servers/public_ip_attachments_server_test.go
+++ b/internal/servers/public_ip_attachments_server_test.go
@@ -214,7 +214,7 @@ var _ = Describe("Public IP attachments server", func() {
 				Object: publicv1.PublicIPAttachment_builder{
 					Spec: publicv1.PublicIPAttachmentSpec_builder{
 						PublicIp:        pip.GetId(),
-						ComputeInstance: proto.String(ci.GetId()),
+						ComputeInstance: new(ci.GetId()),
 					}.Build(),
 				}.Build(),
 			}.Build())
@@ -279,7 +279,7 @@ var _ = Describe("Public IP attachments server", func() {
 
 			for _, object := range objects {
 				response, err := publicIPAttachmentsServer.List(ctx, publicv1.PublicIPAttachmentsListRequest_builder{
-					Filter: proto.String(fmt.Sprintf("this.id == '%s'", object.GetId())),
+					Filter: new(fmt.Sprintf("this.id == '%s'", object.GetId())),
 				}.Build())
 				Expect(err).ToNot(HaveOccurred())
 				Expect(response.GetSize()).To(BeNumerically("==", 1))

--- a/internal/servers/public_ips_server_test.go
+++ b/internal/servers/public_ips_server_test.go
@@ -255,7 +255,7 @@ var _ = Describe("Public IPs server", func() {
 			// List the objects:
 			for _, object := range objects {
 				response, err := publicIPsServer.List(ctx, publicv1.PublicIPsListRequest_builder{
-					Filter: proto.String(fmt.Sprintf("this.id == '%s'", object.GetId())),
+					Filter: new(fmt.Sprintf("this.id == '%s'", object.GetId())),
 				}.Build())
 				Expect(err).ToNot(HaveOccurred())
 				Expect(response.GetSize()).To(BeNumerically("==", 1))

--- a/internal/servers/roles_server_test.go
+++ b/internal/servers/roles_server_test.go
@@ -18,7 +18,6 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/fieldmaskpb"
 
 	publicv1 "github.com/osac-project/fulfillment-service/internal/api/osac/public/v1"
@@ -125,7 +124,7 @@ var _ = Describe("Public roles server", func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			listResponse, err := rolesServer.List(ctx, publicv1.RolesListRequest_builder{
-				Filter: proto.String("this.metadata.name == 'test-role'"),
+				Filter: new("this.metadata.name == 'test-role'"),
 			}.Build())
 			Expect(err).ToNot(HaveOccurred())
 			Expect(listResponse.GetSize()).To(Equal(int32(1)))

--- a/internal/servers/security_groups_server_test.go
+++ b/internal/servers/security_groups_server_test.go
@@ -108,7 +108,7 @@ var _ = Describe("SecurityGroups server", func() {
 			Spec: privatev1.VirtualNetworkSpec_builder{
 				Region:       "us-east-1",
 				NetworkClass: "default",
-				Ipv4Cidr:     proto.String("10.0.0.0/16"),
+				Ipv4Cidr:     new("10.0.0.0/16"),
 				Capabilities: privatev1.VirtualNetworkCapabilities_builder{
 					EnableIpv4: true,
 				}.Build(),
@@ -181,13 +181,13 @@ var _ = Describe("SecurityGroups server", func() {
 								Protocol: publicv1.Protocol_PROTOCOL_TCP,
 								PortFrom: proto.Int32(80),
 								PortTo:   proto.Int32(80),
-								Ipv4Cidr: proto.String("0.0.0.0/0"),
+								Ipv4Cidr: new("0.0.0.0/0"),
 							},
 						},
 						Egress: []*publicv1.SecurityRule{
 							{
 								Protocol: publicv1.Protocol_PROTOCOL_ALL,
-								Ipv4Cidr: proto.String("0.0.0.0/0"),
+								Ipv4Cidr: new("0.0.0.0/0"),
 							},
 						},
 					}.Build(),
@@ -218,7 +218,7 @@ var _ = Describe("SecurityGroups server", func() {
 									Protocol: publicv1.Protocol_PROTOCOL_TCP,
 									PortFrom: proto.Int32(443),
 									PortTo:   proto.Int32(443),
-									Ipv4Cidr: proto.String("0.0.0.0/0"),
+									Ipv4Cidr: new("0.0.0.0/0"),
 								},
 							},
 						}.Build(),
@@ -298,7 +298,7 @@ var _ = Describe("SecurityGroups server", func() {
 			// List the objects:
 			for _, object := range objects {
 				response, err := server.List(ctx, publicv1.SecurityGroupsListRequest_builder{
-					Filter: proto.String(fmt.Sprintf("this.id == '%s'", object.GetId())),
+					Filter: new(fmt.Sprintf("this.id == '%s'", object.GetId())),
 				}.Build())
 				Expect(err).ToNot(HaveOccurred())
 				Expect(response.GetSize()).To(BeNumerically("==", 1))
@@ -317,7 +317,7 @@ var _ = Describe("SecurityGroups server", func() {
 								Protocol: publicv1.Protocol_PROTOCOL_TCP,
 								PortFrom: proto.Int32(22),
 								PortTo:   proto.Int32(22),
-								Ipv4Cidr: proto.String("10.0.0.0/8"),
+								Ipv4Cidr: new("10.0.0.0/8"),
 							},
 						},
 					}.Build(),
@@ -362,7 +362,7 @@ var _ = Describe("SecurityGroups server", func() {
 								Protocol: publicv1.Protocol_PROTOCOL_UDP,
 								PortFrom: proto.Int32(53),
 								PortTo:   proto.Int32(53),
-								Ipv4Cidr: proto.String("0.0.0.0/0"),
+								Ipv4Cidr: new("0.0.0.0/0"),
 							},
 						},
 					}.Build(),

--- a/internal/servers/subnets_server_test.go
+++ b/internal/servers/subnets_server_test.go
@@ -119,7 +119,7 @@ var _ = Describe("Subnets server", func() {
 			Spec: privatev1.VirtualNetworkSpec_builder{
 				Region:       "us-east-1",
 				NetworkClass: "default",
-				Ipv4Cidr:     proto.String("10.0.0.0/16"),
+				Ipv4Cidr:     new("10.0.0.0/16"),
 				Capabilities: privatev1.VirtualNetworkCapabilities_builder{
 					EnableIpv4: true,
 				}.Build(),
@@ -197,7 +197,7 @@ var _ = Describe("Subnets server", func() {
 				Object: publicv1.Subnet_builder{
 					Spec: publicv1.SubnetSpec_builder{
 						VirtualNetwork: virtualNetworkID,
-						Ipv4Cidr:       proto.String("10.0.1.0/24"),
+						Ipv4Cidr:       new("10.0.1.0/24"),
 					}.Build(),
 				}.Build(),
 			}.Build())
@@ -216,7 +216,7 @@ var _ = Describe("Subnets server", func() {
 					Object: publicv1.Subnet_builder{
 						Spec: publicv1.SubnetSpec_builder{
 							VirtualNetwork: virtualNetworkID,
-							Ipv4Cidr:       proto.String(fmt.Sprintf("10.0.%d.0/24", i+1)),
+							Ipv4Cidr:       new(fmt.Sprintf("10.0.%d.0/24", i+1)),
 						}.Build(),
 					}.Build(),
 				}.Build())
@@ -239,7 +239,7 @@ var _ = Describe("Subnets server", func() {
 					Object: publicv1.Subnet_builder{
 						Spec: publicv1.SubnetSpec_builder{
 							VirtualNetwork: virtualNetworkID,
-							Ipv4Cidr:       proto.String(fmt.Sprintf("10.0.%d.0/24", i+1)),
+							Ipv4Cidr:       new(fmt.Sprintf("10.0.%d.0/24", i+1)),
 						}.Build(),
 					}.Build(),
 				}.Build())
@@ -262,7 +262,7 @@ var _ = Describe("Subnets server", func() {
 					Object: publicv1.Subnet_builder{
 						Spec: publicv1.SubnetSpec_builder{
 							VirtualNetwork: virtualNetworkID,
-							Ipv4Cidr:       proto.String(fmt.Sprintf("10.0.%d.0/24", i+1)),
+							Ipv4Cidr:       new(fmt.Sprintf("10.0.%d.0/24", i+1)),
 						}.Build(),
 					}.Build(),
 				}.Build())
@@ -286,7 +286,7 @@ var _ = Describe("Subnets server", func() {
 					Object: publicv1.Subnet_builder{
 						Spec: publicv1.SubnetSpec_builder{
 							VirtualNetwork: virtualNetworkID,
-							Ipv4Cidr:       proto.String(fmt.Sprintf("10.0.%d.0/24", i+1)),
+							Ipv4Cidr:       new(fmt.Sprintf("10.0.%d.0/24", i+1)),
 						}.Build(),
 					}.Build(),
 				}.Build())
@@ -297,7 +297,7 @@ var _ = Describe("Subnets server", func() {
 			// List the objects:
 			for _, object := range objects {
 				response, err := server.List(ctx, publicv1.SubnetsListRequest_builder{
-					Filter: proto.String(fmt.Sprintf("this.id == '%s'", object.GetId())),
+					Filter: new(fmt.Sprintf("this.id == '%s'", object.GetId())),
 				}.Build())
 				Expect(err).ToNot(HaveOccurred())
 				Expect(response.GetSize()).To(BeNumerically("==", 1))
@@ -311,7 +311,7 @@ var _ = Describe("Subnets server", func() {
 				Object: publicv1.Subnet_builder{
 					Spec: publicv1.SubnetSpec_builder{
 						VirtualNetwork: virtualNetworkID,
-						Ipv4Cidr:       proto.String("10.0.1.0/24"),
+						Ipv4Cidr:       new("10.0.1.0/24"),
 					}.Build(),
 				}.Build(),
 			}.Build())
@@ -334,7 +334,7 @@ var _ = Describe("Subnets server", func() {
 					}.Build(),
 					Spec: publicv1.SubnetSpec_builder{
 						VirtualNetwork: virtualNetworkID,
-						Ipv4Cidr:       proto.String("10.0.1.0/24"),
+						Ipv4Cidr:       new("10.0.1.0/24"),
 					}.Build(),
 				}.Build(),
 			}.Build())
@@ -350,7 +350,7 @@ var _ = Describe("Subnets server", func() {
 					}.Build(),
 					Spec: publicv1.SubnetSpec_builder{
 						VirtualNetwork: virtualNetworkID,
-						Ipv4Cidr:       proto.String("10.0.1.0/24"),
+						Ipv4Cidr:       new("10.0.1.0/24"),
 					}.Build(),
 				}.Build(),
 			}.Build())
@@ -371,7 +371,7 @@ var _ = Describe("Subnets server", func() {
 				Object: publicv1.Subnet_builder{
 					Spec: publicv1.SubnetSpec_builder{
 						VirtualNetwork: virtualNetworkID,
-						Ipv4Cidr:       proto.String("10.0.1.0/24"),
+						Ipv4Cidr:       new("10.0.1.0/24"),
 					}.Build(),
 				}.Build(),
 			}.Build())
@@ -387,7 +387,7 @@ var _ = Describe("Subnets server", func() {
 					}.Build(),
 					Spec: publicv1.SubnetSpec_builder{
 						VirtualNetwork: virtualNetworkID,
-						Ipv4Cidr:       proto.String("10.0.1.0/24"),
+						Ipv4Cidr:       new("10.0.1.0/24"),
 					}.Build(),
 				}.Build(),
 			}.Build())
@@ -401,7 +401,7 @@ var _ = Describe("Subnets server", func() {
 				Object: publicv1.Subnet_builder{
 					Spec: publicv1.SubnetSpec_builder{
 						VirtualNetwork: virtualNetworkID,
-						Ipv4Cidr:       proto.String("10.0.2.0/24"),
+						Ipv4Cidr:       new("10.0.2.0/24"),
 					}.Build(),
 				}.Build(),
 			}.Build())
@@ -431,7 +431,7 @@ var _ = Describe("Subnets server", func() {
 				Object: publicv1.Subnet_builder{
 					Spec: publicv1.SubnetSpec_builder{
 						VirtualNetwork: virtualNetworkID,
-						Ipv4Cidr:       proto.String("10.0.3.0/24"),
+						Ipv4Cidr:       new("10.0.3.0/24"),
 					}.Build(),
 				}.Build(),
 			}.Build())
@@ -444,7 +444,7 @@ var _ = Describe("Subnets server", func() {
 					Id: object.GetId(),
 					Spec: publicv1.SubnetSpec_builder{
 						VirtualNetwork: virtualNetworkID,
-						Ipv4Cidr:       proto.String("10.0.4.0/24"),
+						Ipv4Cidr:       new("10.0.4.0/24"),
 					}.Build(),
 				}.Build(),
 			}.Build())
@@ -461,7 +461,7 @@ var _ = Describe("Subnets server", func() {
 				Object: publicv1.Subnet_builder{
 					Spec: publicv1.SubnetSpec_builder{
 						VirtualNetwork: virtualNetworkID,
-						Ipv4Cidr:       proto.String("10.0.5.0/24"),
+						Ipv4Cidr:       new("10.0.5.0/24"),
 					}.Build(),
 				}.Build(),
 			}.Build())
@@ -478,7 +478,7 @@ var _ = Describe("Subnets server", func() {
 					}.Build(),
 					Spec: publicv1.SubnetSpec_builder{
 						VirtualNetwork: virtualNetworkID,
-						Ipv4Cidr:       proto.String("10.0.5.0/24"),
+						Ipv4Cidr:       new("10.0.5.0/24"),
 					}.Build(),
 				}.Build(),
 				Lock: true,
@@ -495,7 +495,7 @@ var _ = Describe("Subnets server", func() {
 				Object: publicv1.Subnet_builder{
 					Spec: publicv1.SubnetSpec_builder{
 						VirtualNetwork: virtualNetworkID,
-						Ipv4Cidr:       proto.String("10.0.1.0/24"),
+						Ipv4Cidr:       new("10.0.1.0/24"),
 					}.Build(),
 				}.Build(),
 			}.Build())

--- a/internal/servers/users_server_test.go
+++ b/internal/servers/users_server_test.go
@@ -19,7 +19,6 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"google.golang.org/protobuf/proto"
 
 	publicv1 "github.com/osac-project/fulfillment-service/internal/api/osac/public/v1"
 	"github.com/osac-project/fulfillment-service/internal/database"
@@ -343,7 +342,7 @@ var _ = Describe("Public Users Server", func() {
 
 		// List users filtering by organization "org-a":
 		listResp, err := publicServer.List(ctx, publicv1.UsersListRequest_builder{
-			Filter: proto.String("this.spec.organization == 'org-a'"),
+			Filter: new("this.spec.organization == 'org-a'"),
 		}.Build())
 		Expect(err).ToNot(HaveOccurred())
 		Expect(listResp.GetSize()).To(Equal(int32(2)))
@@ -354,7 +353,7 @@ var _ = Describe("Public Users Server", func() {
 
 		// List users filtering by organization "org-b":
 		listResp, err = publicServer.List(ctx, publicv1.UsersListRequest_builder{
-			Filter: proto.String("this.spec.organization == 'org-b'"),
+			Filter: new("this.spec.organization == 'org-b'"),
 		}.Build())
 		Expect(err).ToNot(HaveOccurred())
 		Expect(listResp.GetSize()).To(Equal(int32(3)))

--- a/internal/servers/virtual_networks_server_test.go
+++ b/internal/servers/virtual_networks_server_test.go
@@ -88,7 +88,7 @@ var _ = Describe("Virtual networks server", func() {
 			Metadata: privatev1.Metadata_builder{
 				Tenant: auth.SharedTenant,
 			}.Build(),
-			IsDefault: proto.Bool(true),
+			IsDefault: new(true),
 			Capabilities: privatev1.NetworkClassCapabilities_builder{
 				SupportsIpv4:      true,
 				SupportsIpv6:      true,
@@ -182,7 +182,7 @@ var _ = Describe("Virtual networks server", func() {
 						Region:                 "us-east-1",
 						NetworkClass:           "default",
 						ImplementationStrategy: "ovn-kubernetes",
-						Ipv4Cidr:               proto.String("10.0.0.0/16"),
+						Ipv4Cidr:               new("10.0.0.0/16"),
 						Capabilities: privatev1.VirtualNetworkCapabilities_builder{
 							EnableIpv4: true,
 						}.Build(),
@@ -250,7 +250,7 @@ var _ = Describe("Virtual networks server", func() {
 			// List the objects via public server:
 			for _, id := range ids {
 				response, err := publicServer.List(ctx, publicv1.VirtualNetworksListRequest_builder{
-					Filter: proto.String(fmt.Sprintf("this.id == '%s'", id)),
+					Filter: new(fmt.Sprintf("this.id == '%s'", id)),
 				}.Build())
 				Expect(err).ToNot(HaveOccurred())
 				Expect(response.GetSize()).To(BeNumerically("==", 1))
@@ -285,7 +285,7 @@ var _ = Describe("Virtual networks server", func() {
 					}.Build(),
 					Spec: publicv1.VirtualNetworkSpec_builder{
 						NetworkClass: "default",
-						Ipv4Cidr:     proto.String("10.0.0.0/16"),
+						Ipv4Cidr:     new("10.0.0.0/16"),
 						Capabilities: publicv1.VirtualNetworkCapabilities_builder{
 							EnableIpv4: true,
 						}.Build(),
@@ -316,7 +316,7 @@ var _ = Describe("Virtual networks server", func() {
 					}.Build(),
 					Spec: publicv1.VirtualNetworkSpec_builder{
 						NetworkClass: "default",
-						Ipv4Cidr:     proto.String("10.0.0.0/16"),
+						Ipv4Cidr:     new("10.0.0.0/16"),
 					}.Build(),
 				}.Build(),
 			}.Build())
@@ -355,7 +355,7 @@ var _ = Describe("Virtual networks server", func() {
 					Id: privateObj.GetId(),
 					Spec: publicv1.VirtualNetworkSpec_builder{
 						NetworkClass: "default",
-						Ipv4Cidr:     proto.String("192.168.0.0/16"),
+						Ipv4Cidr:     new("192.168.0.0/16"),
 					}.Build(),
 				}.Build(),
 			}.Build())
@@ -380,7 +380,7 @@ var _ = Describe("Virtual networks server", func() {
 					}.Build(),
 					Spec: publicv1.VirtualNetworkSpec_builder{
 						NetworkClass: "default",
-						Ipv4Cidr:     proto.String("10.0.0.0/16"),
+						Ipv4Cidr:     new("10.0.0.0/16"),
 					}.Build(),
 				}.Build(),
 				Lock: true,
@@ -400,7 +400,7 @@ var _ = Describe("Virtual networks server", func() {
 					}.Build(),
 					Spec: publicv1.VirtualNetworkSpec_builder{
 						NetworkClass: "default",
-						Ipv4Cidr:     proto.String("10.0.0.0/16"),
+						Ipv4Cidr:     new("10.0.0.0/16"),
 					}.Build(),
 				}.Build(),
 			}.Build())
@@ -452,7 +452,7 @@ var _ = Describe("Virtual networks server", func() {
 						Name: "default-nc-vn",
 					}.Build(),
 					Spec: publicv1.VirtualNetworkSpec_builder{
-						Ipv4Cidr: proto.String("10.2.0.0/16"),
+						Ipv4Cidr: new("10.2.0.0/16"),
 						Capabilities: publicv1.VirtualNetworkCapabilities_builder{
 							EnableIpv4: true,
 						}.Build(),
@@ -497,7 +497,7 @@ var _ = Describe("Virtual networks server", func() {
 					}.Build(),
 					Spec: publicv1.VirtualNetworkSpec_builder{
 						NetworkClass: altNCId,
-						Ipv4Cidr:     proto.String("10.1.0.0/16"),
+						Ipv4Cidr:     new("10.1.0.0/16"),
 						Capabilities: publicv1.VirtualNetworkCapabilities_builder{
 							EnableIpv4: true,
 						}.Build(),
@@ -523,7 +523,7 @@ var _ = Describe("Virtual networks server", func() {
 						Name: "renamed-vn",
 					}.Build(),
 					Spec: publicv1.VirtualNetworkSpec_builder{
-						Ipv4Cidr: proto.String("10.0.0.0/16"),
+						Ipv4Cidr: new("10.0.0.0/16"),
 						Capabilities: publicv1.VirtualNetworkCapabilities_builder{
 							EnableIpv4: true,
 						}.Build(),
@@ -547,7 +547,7 @@ var _ = Describe("Virtual networks server", func() {
 					Id: privateObj.GetId(),
 					Spec: publicv1.VirtualNetworkSpec_builder{
 						NetworkClass: "different-nc",
-						Ipv4Cidr:     proto.String("10.0.0.0/16"),
+						Ipv4Cidr:     new("10.0.0.0/16"),
 						Capabilities: publicv1.VirtualNetworkCapabilities_builder{
 							EnableIpv4: true,
 						}.Build(),
@@ -579,7 +579,7 @@ var _ = Describe("Virtual networks server", func() {
 						Name: "no-default-nc-vn",
 					}.Build(),
 					Spec: publicv1.VirtualNetworkSpec_builder{
-						Ipv4Cidr: proto.String("10.3.0.0/16"),
+						Ipv4Cidr: new("10.3.0.0/16"),
 					}.Build(),
 				}.Build(),
 			}.Build())

--- a/internal/utils/spec_defaults_test.go
+++ b/internal/utils/spec_defaults_test.go
@@ -58,7 +58,7 @@ var _ = Describe("ApplySpecDefaults", func() {
 			BootDisk: privatev1.ComputeInstanceDisk_builder{
 				SizeGib: 10,
 			}.Build(),
-			RunStrategy: proto.String("Always"),
+			RunStrategy: new("Always"),
 		}.Build()
 
 		ApplySpecDefaults(spec, defaults)
@@ -76,7 +76,7 @@ var _ = Describe("ApplySpecDefaults", func() {
 			Template:    "test.template",
 			Cores:       proto.Int32(8),
 			MemoryGib:   proto.Int32(16),
-			RunStrategy: proto.String("Halted"),
+			RunStrategy: new("Halted"),
 		}.Build()
 
 		defaults := privatev1.ComputeInstanceTemplateSpecDefaults_builder{
@@ -89,7 +89,7 @@ var _ = Describe("ApplySpecDefaults", func() {
 			BootDisk: privatev1.ComputeInstanceDisk_builder{
 				SizeGib: 10,
 			}.Build(),
-			RunStrategy: proto.String("Always"),
+			RunStrategy: new("Always"),
 		}.Build()
 
 		ApplySpecDefaults(spec, defaults)
@@ -110,7 +110,7 @@ var _ = Describe("ApplySpecDefaults", func() {
 
 		defaults := privatev1.ComputeInstanceTemplateSpecDefaults_builder{
 			Cores:       proto.Int32(2),
-			RunStrategy: proto.String("Always"),
+			RunStrategy: new("Always"),
 		}.Build()
 
 		ApplySpecDefaults(spec, defaults)
@@ -252,7 +252,7 @@ var _ = Describe("ValidateRequiredSpecFields", func() {
 			Template:    "test.template",
 			Cores:       proto.Int32(4),
 			MemoryGib:   proto.Int32(8),
-			RunStrategy: proto.String("Always"),
+			RunStrategy: new("Always"),
 		}.Build()
 
 		err := ValidateRequiredSpecFields(spec)
@@ -277,7 +277,7 @@ var _ = Describe("ValidateRequiredSpecFields", func() {
 			BootDisk: privatev1.ComputeInstanceDisk_builder{
 				SizeGib: 20,
 			}.Build(),
-			RunStrategy: proto.String("Always"),
+			RunStrategy: new("Always"),
 		}.Build()
 
 		err := ValidateRequiredSpecFields(spec)
@@ -296,7 +296,7 @@ var _ = Describe("ValidateRequiredSpecFields", func() {
 			BootDisk: privatev1.ComputeInstanceDisk_builder{
 				SizeGib: 20,
 			}.Build(),
-			RunStrategy: proto.String("always"),
+			RunStrategy: new("always"),
 		}.Build()
 
 		err := ValidateRequiredSpecFields(spec)
@@ -316,7 +316,7 @@ var _ = Describe("ValidateRequiredSpecFields", func() {
 			BootDisk: privatev1.ComputeInstanceDisk_builder{
 				SizeGib: 20,
 			}.Build(),
-			RunStrategy: proto.String("Always"),
+			RunStrategy: new("Always"),
 		}.Build()
 
 		err := ValidateRequiredSpecFields(spec)
@@ -337,7 +337,7 @@ var _ = Describe("ValidateRequiredSpecFields", func() {
 			BootDisk: privatev1.ComputeInstanceDisk_builder{
 				SizeGib: 20,
 			}.Build(),
-			RunStrategy: proto.String("Always"),
+			RunStrategy: new("Always"),
 		}.Build()
 
 		err := ValidateRequiredSpecFields(spec)
@@ -357,7 +357,7 @@ var _ = Describe("ValidateRequiredSpecFields", func() {
 				SourceRef:  "quay.io/containerdisks/fedora:latest",
 			}.Build(),
 			BootDisk:    privatev1.ComputeInstanceDisk_builder{}.Build(),
-			RunStrategy: proto.String("Always"),
+			RunStrategy: new("Always"),
 		}.Build()
 
 		err := ValidateRequiredSpecFields(spec)

--- a/it/it_compute_subnet_test.go
+++ b/it/it_compute_subnet_test.go
@@ -82,7 +82,7 @@ var _ = Describe("ComputeInstance with Subnet attachment", func() {
 				Spec: privatev1.VirtualNetworkSpec_builder{
 					NetworkClass: networkClassId,
 					Region:       "us-east-1",
-					Ipv4Cidr:     proto.String("10.100.0.0/16"),
+					Ipv4Cidr:     new("10.100.0.0/16"),
 				}.Build(),
 			}.Build(),
 		}.Build())
@@ -111,7 +111,7 @@ var _ = Describe("ComputeInstance with Subnet attachment", func() {
 				Id: subnetId,
 				Spec: privatev1.SubnetSpec_builder{
 					VirtualNetwork: virtualNetworkId,
-					Ipv4Cidr:       proto.String("10.100.1.0/24"),
+					Ipv4Cidr:       new("10.100.1.0/24"),
 				}.Build(),
 			}.Build(),
 		}.Build())
@@ -180,7 +180,7 @@ var _ = Describe("ComputeInstance with Subnet attachment", func() {
 					Template:    computeInstanceTemplateId,
 					Cores:       proto.Int32(2),
 					MemoryGib:   proto.Int32(4),
-					RunStrategy: proto.String("Always"),
+					RunStrategy: new("Always"),
 					BootDisk: publicv1.ComputeInstanceDisk_builder{
 						SizeGib: 20,
 					}.Build(),
@@ -188,7 +188,7 @@ var _ = Describe("ComputeInstance with Subnet attachment", func() {
 						SourceType: "registry",
 						SourceRef:  "quay.io/containerdisks/fedora:latest",
 					}.Build(),
-					Subnet: proto.String(subnetId),
+					Subnet: new(subnetId),
 				}.Build(),
 			}.Build(),
 		}.Build())
@@ -213,7 +213,7 @@ var _ = Describe("ComputeInstance with Subnet attachment", func() {
 					Template:    computeInstanceTemplateId,
 					Cores:       proto.Int32(2),
 					MemoryGib:   proto.Int32(4),
-					RunStrategy: proto.String("Always"),
+					RunStrategy: new("Always"),
 					BootDisk: publicv1.ComputeInstanceDisk_builder{
 						SizeGib: 20,
 					}.Build(),
@@ -221,7 +221,7 @@ var _ = Describe("ComputeInstance with Subnet attachment", func() {
 						SourceType: "registry",
 						SourceRef:  "quay.io/containerdisks/fedora:latest",
 					}.Build(),
-					Subnet: proto.String("non-existent-subnet"),
+					Subnet: new("non-existent-subnet"),
 				}.Build(),
 			}.Build(),
 		}.Build())

--- a/it/it_roles_test.go
+++ b/it/it_roles_test.go
@@ -18,7 +18,6 @@ import (
 
 	. "github.com/onsi/ginkgo/v2/dsl/core"
 	. "github.com/onsi/gomega"
-	"google.golang.org/protobuf/proto"
 
 	privatev1 "github.com/osac-project/fulfillment-service/internal/api/osac/private/v1"
 	publicv1 "github.com/osac-project/fulfillment-service/internal/api/osac/public/v1"
@@ -40,7 +39,7 @@ var _ = Describe("Roles", func() {
 	Describe("Private API", func() {
 		It("Can list built-in roles", func() {
 			listResponse, err := privateClient.List(ctx, privatev1.RolesListRequest_builder{
-				Filter: proto.String(`
+				Filter: new(`
 					this.metadata.name in [
 						'cloud-provider-admin',
 						'cloud-provider-reader',
@@ -70,7 +69,7 @@ var _ = Describe("Roles", func() {
 
 		It("Can get a specific built-in role", func() {
 			listResponse, err := privateClient.List(ctx, privatev1.RolesListRequest_builder{
-				Filter: proto.String("this.metadata.name == 'tenant-admin'"),
+				Filter: new("this.metadata.name == 'tenant-admin'"),
 			}.Build())
 			Expect(err).ToNot(HaveOccurred())
 			Expect(listResponse).ToNot(BeNil())
@@ -96,7 +95,7 @@ var _ = Describe("Roles", func() {
 	Describe("Public API", func() {
 		It("Can list built-in roles", func() {
 			listResponse, err := publicClient.List(ctx, publicv1.RolesListRequest_builder{
-				Filter: proto.String(`
+				Filter: new(`
 					this.metadata.name in [
 						'cloud-provider-admin',
 						'cloud-provider-reader',
@@ -126,7 +125,7 @@ var _ = Describe("Roles", func() {
 
 		It("Can get a specific built-in role", func() {
 			listResponse, err := publicClient.List(ctx, publicv1.RolesListRequest_builder{
-				Filter: proto.String("this.metadata.name == 'tenant-reader'"),
+				Filter: new("this.metadata.name == 'tenant-reader'"),
 			}.Build())
 			Expect(err).ToNot(HaveOccurred())
 			Expect(listResponse).ToNot(BeNil())

--- a/it/it_tool.go
+++ b/it/it_tool.go
@@ -52,7 +52,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
-	"k8s.io/utils/ptr"
 	crclient "sigs.k8s.io/controller-runtime/pkg/client"
 
 	privatev1 "github.com/osac-project/fulfillment-service/internal/api/osac/private/v1"
@@ -1761,7 +1760,7 @@ func (t *Tool) makeKubernetesTokenSource(ctx context.Context, sa, namespace stri
 		sa,
 		&authenticationv1.TokenRequest{
 			Spec: authenticationv1.TokenRequestSpec{
-				ExpirationSeconds: ptr.To(int64(3600)),
+				ExpirationSeconds: new(int64(3600)),
 			},
 		},
 		metav1.CreateOptions{},

--- a/it/it_version_test.go
+++ b/it/it_version_test.go
@@ -23,7 +23,6 @@ import (
 	. "github.com/onsi/gomega"
 	grpccodes "google.golang.org/grpc/codes"
 	grpcstatus "google.golang.org/grpc/status"
-	"google.golang.org/protobuf/proto"
 
 	privatev1 "github.com/osac-project/fulfillment-service/internal/api/osac/private/v1"
 	publicv1 "github.com/osac-project/fulfillment-service/internal/api/osac/public/v1"
@@ -123,7 +122,7 @@ var _ = Describe("Version", func() {
 		object := createCluster()
 		id := object.GetId()
 		listResponse, err := clustersClient.List(ctx, publicv1.ClustersListRequest_builder{
-			Filter: proto.String(fmt.Sprintf("this.id == %q", id)),
+			Filter: new(fmt.Sprintf("this.id == %q", id)),
 		}.Build())
 		Expect(err).ToNot(HaveOccurred())
 		items := listResponse.GetItems()


### PR DESCRIPTION
## Summary

- Apply the `go fix -newexpr ./...` transformation to replace calls to pointer-helper
  functions like `proto.String`, `proto.Int32`, and `proto.Bool` with the `new(expression)`
  built-in syntax introduced in Go 1.26.
- Remove now-unused `proto` imports where they are no longer needed.

## Test plan

- [x] Verify the project builds: `go build ./cmd/fulfillment-service && go build ./cmd/osac`
- [x] Run unit tests: `ginkgo run -r internal`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Replaced protobuf helper pointer constructors with native pointer allocations across CLI, service, controller, and test code. Removed unused protobuf helper imports where applicable. No changes to behavior, APIs, or user-facing functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/osac-project/fulfillment-service/pull/610?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->