### PR TITLE
NO-ISSUE: Support pre-generated CA key and certificate for integration tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,13 +269,61 @@ want to use the secret. You can get it like this:
 $ kubectl get secret -n default random -o json | jq -r '.data["secret"] | @base64d'
 ```
 
+### Custom CA certificate
+
+By default, each integration test run generates a fresh CA private key and certificate. This means
+that the CA changes every time the cluster is recreated, which forces you to either re-extract the
+CA bundle and pass it to `osac login --ca-file`, or use `--insecure` to skip verification.
+
+To avoid this, you can provide your own pre-generated CA files via the `IT_CA_KEY` and `IT_CA_CRT`
+environment variables. Both must be set together and must point to PEM-encoded files. When provided,
+the integration tests will use them instead of generating a new CA. This allows you to configure the
+CA once in your browser or pass it to `osac login --ca-file` without having to update it after every
+run.
+
+To generate a CA key and certificate with `openssl`:
+
+```bash
+openssl req \
+-x509 \
+-newkey rsa:2048 \
+-nodes \
+-keyout ca.key \
+-out ca.crt \
+-days 365 \
+-subj "/CN=Default CA" \
+-addext "keyUsage=critical,keyCertSign,cRLSign" \
+-addext "basicConstraints=critical,CA:TRUE"
+```
+
+Then run the integration tests pointing to those files:
+
+```bash
+export IT_KEEP_KIND=true
+export IT_CA_KEY=ca.key
+export IT_CA_CRT=ca.crt
+ginkgo run -v it
+```
+
+Note that `-nodes` flag in the `openssl` command above means `ca.key` (referenced by `IT_CA_KEY`) is
+not passphrase-protected. This is fine for local development, but as a good habit consider setting
+restrictive permissions (`chmod 600 ca.key`) and avoiding committing it to version control. If the
+key is ever shared accidentally, simply regenerate both files and recreate the cluster.
+
+As long as you reuse the same files across runs, the CA will remain stable and you can use the
+certificate directly with the CLI:
+
+```bash
+osac login --ca-file ca.crt ...
+```
+
 ### Login to the integration tests environment
 
 Once the cluster is running, you can log in using the credentials flow:
 
 ```bash
-$ osac login \
---ca-file bundle.pem \
+osac login \
+--ca-file ca.crt \
 --flow credentials \
 --client-id osac-admin \
 --client-secret my-secret \
@@ -285,12 +333,12 @@ https://fulfillment-internal-api.osac.svc.cluster.local:8000
 
 The same secret is shared by all service accounts and users.
 
-The `--ca-file` flag should point to a file containing the trusted CA certificates. In the default
-installation, the CA bundle is stored in the `ca-bundle` ConfigMap created by _trust-manager_. You
-can extract it with:
+The `--ca-file` flag should point to a file containing the trusted CA certificates. If you used the
+`IT_CA_CRT` environment variable, you can point directly to that file. Otherwise, the CA bundle is
+stored in the `ca-bundle` ConfigMap created by _trust-manager_. You can extract it with:
 
 ```bash
-$ kubectl get configmap ca-bundle -n osac -o jsonpath='{.data.bundle\.pem}' > bundle.pem
+kubectl get configmap ca-bundle -n osac -o json | jq -r '.data["bundle.pem"]' > ca.crt
 ```
 
 ### Debugging in the integration tests environment

--- a/internal/testing/kind.go
+++ b/internal/testing/kind.go
@@ -17,6 +17,7 @@ import (
 	"context"
 	"crypto/rand"
 	"crypto/rsa"
+	"crypto/tls"
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"embed"
@@ -55,6 +56,8 @@ type KindBuilder struct {
 	name         string
 	home         string
 	quiet        bool
+	caKeyFile    string
+	caCrtFile    string
 	crdFiles     []string
 	portMappings []kindPortMapping
 }
@@ -66,6 +69,8 @@ type Kind struct {
 	name            string
 	home            string
 	quiet           bool
+	caKeyFile       string
+	caCrtFile       string
 	crdFiles        []string
 	portMappings    []kindPortMapping
 	kubeconfigBytes []byte
@@ -133,6 +138,14 @@ func (b *KindBuilder) AddPortMapping(listenAddress string, hostPort int, contain
 	return b
 }
 
+// SetCaFiles sets the paths to PEM files containing a pre-generated CA private key and certificate. When set, the
+// cluster will use these files instead of generating a new CA. This is optional.
+func (b *KindBuilder) SetCaFiles(keyFile, crtFile string) *KindBuilder {
+	b.caKeyFile = keyFile
+	b.caCrtFile = crtFile
+	return b
+}
+
 // Build uses the configuration stored in the builder to create a new Kind cluster
 func (b *KindBuilder) Build() (result *Kind, err error) {
 	// Check parameters:
@@ -143,6 +156,30 @@ func (b *KindBuilder) Build() (result *Kind, err error) {
 	if b.name == "" {
 		err = fmt.Errorf("name is mandatory")
 		return
+	}
+	if (b.caKeyFile == "") != (b.caCrtFile == "") {
+		err = fmt.Errorf("key file and certificate file must both be provided or both be omitted")
+		return
+	}
+
+	// If a custom CA key pair is provided, verify that it is valid:
+	if b.caKeyFile != "" && b.caCrtFile != "" {
+		var caKeyData, caCrtData []byte
+		caKeyData, err = os.ReadFile(b.caKeyFile)
+		if err != nil {
+			err = fmt.Errorf("failed to load key file '%s': %w", b.caKeyFile, err)
+			return
+		}
+		caCrtData, err = os.ReadFile(b.caCrtFile)
+		if err != nil {
+			err = fmt.Errorf("failed to load certificate file '%s': %w", b.caCrtFile, err)
+			return
+		}
+		_, err = tls.X509KeyPair(caCrtData, caKeyData)
+		if err != nil {
+			err = fmt.Errorf("key and certificate files don't contain a valid key pair: %w", err)
+			return
+		}
 	}
 
 	// Add the name to the logger:
@@ -174,6 +211,8 @@ func (b *KindBuilder) Build() (result *Kind, err error) {
 		name:         b.name,
 		home:         b.home,
 		quiet:        b.quiet,
+		caKeyFile:    b.caKeyFile,
+		caCrtFile:    b.caCrtFile,
 		crdFiles:     slices.Clone(b.crdFiles),
 		portMappings: slices.Clone(b.portMappings),
 	}
@@ -740,42 +779,29 @@ func (k *Kind) installTrustManager(ctx context.Context) (err error) {
 }
 
 func (k *Kind) installCa(ctx context.Context) (err error) {
-	// Generate private key and certificate:
-	k.logger.DebugContext(ctx, "Generating CA private key and certificate")
-	key, err := rsa.GenerateKey(rand.Reader, 2048)
-	if err != nil {
-		return err
+	var keyPem, crtPem []byte
+	if k.caKeyFile != "" && k.caCrtFile != "" {
+		k.logger.DebugContext(
+			ctx,
+			"Loading CA private key and certificate from files",
+			slog.Bool("ca_key_set", k.caKeyFile != ""),
+			slog.Bool("ca_crt_set", k.caCrtFile != ""),
+		)
+		keyPem, err = os.ReadFile(k.caKeyFile)
+		if err != nil {
+			return fmt.Errorf("failed to read CA key file '%s': %w", k.caKeyFile, err)
+		}
+		crtPem, err = os.ReadFile(k.caCrtFile)
+		if err != nil {
+			return fmt.Errorf("failed to read CA certificate file '%s': %w", k.caCrtFile, err)
+		}
+	} else {
+		k.logger.DebugContext(ctx, "Generating CA private key and certificate")
+		keyPem, crtPem, err = k.generateCa()
+		if err != nil {
+			return fmt.Errorf("failed to generate CA: %w", err)
+		}
 	}
-	now := time.Now()
-	crt := x509.Certificate{
-		SerialNumber: big.NewInt(1),
-		Subject: pkix.Name{
-			CommonName: defaultCaCommonName,
-		},
-		NotBefore:             now,
-		NotAfter:              now.AddDate(1, 0, 0),
-		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
-		BasicConstraintsValid: true,
-		IsCA:                  true,
-	}
-
-	// Create the PEM encoding of the private key and the certificate:
-	keyBytes, err := x509.MarshalPKCS8PrivateKey(key)
-	if err != nil {
-		return err
-	}
-	keyPem := pem.EncodeToMemory(&pem.Block{
-		Type:  "PRIVATE KEY",
-		Bytes: keyBytes,
-	})
-	crtBytes, err := x509.CreateCertificate(rand.Reader, &crt, &crt, &key.PublicKey, key)
-	if err != nil {
-		return err
-	}
-	crtPem := pem.EncodeToMemory(&pem.Block{
-		Type:  "CERTIFICATE",
-		Bytes: crtBytes,
-	})
 
 	// Create or update the secret:
 	k.logger.DebugContext(ctx, "Creating or updating CA secret")
@@ -865,6 +891,43 @@ func (k *Kind) installCa(ctx context.Context) (err error) {
 		return err
 	}
 	return nil
+}
+
+// generateCa generates a new CA private key and self-signed certificate, returning them as PEM-encoded bytes.
+func (k *Kind) generateCa() (keyPem, crtPem []byte, err error) {
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		return nil, nil, err
+	}
+	now := time.Now()
+	crt := x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject: pkix.Name{
+			CommonName: defaultCaCommonName,
+		},
+		NotBefore:             now,
+		NotAfter:              now.AddDate(1, 0, 0),
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+	}
+	keyBytes, err := x509.MarshalPKCS8PrivateKey(key)
+	if err != nil {
+		return nil, nil, err
+	}
+	keyPem = pem.EncodeToMemory(&pem.Block{
+		Type:  "PRIVATE KEY",
+		Bytes: keyBytes,
+	})
+	crtBytes, err := x509.CreateCertificate(rand.Reader, &crt, &crt, &key.PublicKey, key)
+	if err != nil {
+		return nil, nil, err
+	}
+	crtPem = pem.EncodeToMemory(&pem.Block{
+		Type:  "CERTIFICATE",
+		Bytes: crtBytes,
+	})
+	return keyPem, crtPem, nil
 }
 
 func (k *Kind) installAuthorino(ctx context.Context) (err error) {

--- a/it/it_suite_test.go
+++ b/it/it_suite_test.go
@@ -57,6 +57,14 @@ type Config struct {
 	// client secrets and user passwords. If the environment variable is set then that value will be used, otherwise
 	// a random one will be generated.
 	Secret string `json:"secret" envconfig:"secret" default:""`
+
+	// CaKey is the path to a PEM file containing a pre-generated CA private key. When both CaKey and CaCrt are
+	// set, the integration tests will use these files instead of generating a new CA each run.
+	CaKey string `json:"ca_key" envconfig:"ca_key" default:""`
+
+	// CaCrt is the path to a PEM file containing a pre-generated CA certificate. When both CaKey and CaCrt are
+	// set, the integration tests will use these files instead of generating a new CA each run.
+	CaCrt string `json:"ca_crt" envconfig:"ca_crt" default:""`
 }
 
 var (
@@ -99,6 +107,8 @@ var _ = BeforeSuite(func() {
 		slog.String("deploy_mode", config.DeployMode),
 		slog.Bool("debug", config.Debug),
 		slog.String("!secret", config.Secret),
+		slog.Bool("ca_key_set", config.CaKey != ""),
+		slog.Bool("ca_crt_set", config.CaCrt != ""),
 	)
 
 	// Debug mode isn't compatible with the Kustomize deployment mode:
@@ -117,6 +127,7 @@ var _ = BeforeSuite(func() {
 		SetDeployMode(config.DeployMode).
 		SetDebug(config.Debug).
 		SetSecret(config.Secret).
+		SetCaFiles(config.CaKey, config.CaCrt).
 		AddCrdFile(filepath.Join("crds", "clusterorders.osac.openshift.io.yaml")).
 		AddCrdFile(filepath.Join("crds", "hostedclusters.hypershift.openshift.io.yaml")).
 		Build()

--- a/it/it_tool.go
+++ b/it/it_tool.go
@@ -89,6 +89,8 @@ type ToolBuilder struct {
 	deployMode  string
 	debug       bool
 	secret      string
+	caKeyFile   string
+	caCrtFile   string
 }
 
 // Tool is an instance of the integration test tool that sets up the test environment. Don't create instances of this
@@ -101,6 +103,8 @@ type Tool struct {
 	keepService   bool
 	deployMode    string
 	debug         bool
+	caKeyFile     string
+	caCrtFile     string
 	tmpDir        string
 	cluster       *testing.Kind
 	kubeClient    crclient.Client
@@ -193,6 +197,14 @@ func (b *ToolBuilder) SetSecret(value string) *ToolBuilder {
 	return b
 }
 
+// SetCaFiles sets the paths to PEM files containing a pre-generated CA private key and certificate. When set, the
+// Kind cluster will use these files instead of generating a new CA each time. This is optional.
+func (b *ToolBuilder) SetCaFiles(keyFile, crtFile string) *ToolBuilder {
+	b.caKeyFile = keyFile
+	b.caCrtFile = crtFile
+	return b
+}
+
 // Build uses the data stored in the builder to create a new instance of the integration test tool.
 func (b *ToolBuilder) Build() (result *Tool, err error) {
 	// Check parameters:
@@ -205,6 +217,10 @@ func (b *ToolBuilder) Build() (result *Tool, err error) {
 			"invalid deploy mode '%s'i must be '%s' or '%s'",
 			b.deployMode, deployModeHelm, deployModeKustomize,
 		)
+		return
+	}
+	if (b.caKeyFile == "") != (b.caCrtFile == "") {
+		err = errors.New("key file and certificate file must both be provided or both be omitted")
 		return
 	}
 
@@ -235,6 +251,8 @@ func (b *ToolBuilder) Build() (result *Tool, err error) {
 		keepService: b.keepService,
 		deployMode:  b.deployMode,
 		debug:       b.debug,
+		caKeyFile:   b.caKeyFile,
+		caCrtFile:   b.caCrtFile,
 		secret:      b.secret,
 		jqTool:      jqTool,
 	}
@@ -538,6 +556,9 @@ func (t *Tool) startCluster(ctx context.Context) error {
 		builder.AddPortMapping("127.0.0.1", 30001, 30001) // gRPC server.
 		builder.AddPortMapping("127.0.0.1", 30002, 30002) // REST gateway.
 		builder.AddPortMapping("127.0.0.1", 30003, 30003) // Controller.
+	}
+	if t.caKeyFile != "" && t.caCrtFile != "" {
+		builder.SetCaFiles(t.caKeyFile, t.caCrtFile)
 	}
 	var err error
 	t.cluster, err = builder.Build()


### PR DESCRIPTION
## Summary

- Add `IT_CA_KEY` and `IT_CA_CRT` environment variables that allow developers to provide
  pre-generated PEM files for the CA private key and certificate used by the integration test
  Kind cluster. When both are set, the existing files are used instead of generating a fresh CA
  each run. This avoids having to re-extract the CA bundle or use `--insecure` after every
  cluster recreation.
- Thread the file paths through `Config`, `ToolBuilder`, and `KindBuilder`, with validation
  that both must be provided together or not at all.
- Extract the CA generation logic into a dedicated `generateCa` method in `Kind`.
- Update `README.md` with a new "Custom CA certificate" section documenting the variables,
  including an `openssl` command to generate compatible files.

## Test plan

- [x] Verify `go build ./...` succeeds.
- [x] Run `ginkgo run -r internal` to confirm existing unit tests pass.
- [x] Run integration tests without `IT_CA_KEY`/`IT_CA_CRT` to confirm the default generation
      path still works.
- [x] Generate CA files with the documented `openssl` command and run integration tests with
      `IT_CA_KEY` and `IT_CA_CRT` set to verify the pre-generated path.
- [x] Verify that setting only one of the two variables produces a clear error.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added "Custom CA certificate" section with steps to supply pre-generated CA key/certificate for integration tests, updated login example to use --ca-file ca.crt, and improved guidance for extracting the trusted CA bundle via kubectl+jq.

* **New Features**
  * Integration test tooling now supports optional pre-generated CA key/certificate files and validates that both key and cert are supplied together.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/osac-project/fulfillment-service/pull/612?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->