### PR TITLE
OSAC-1124: Create Keycloak Groups for every Project

### DIFF
--- a/internal/controllers/project/project_reconciler_function_test.go
+++ b/internal/controllers/project/project_reconciler_function_test.go
@@ -212,6 +212,16 @@ var _ = Describe("Validation and Activation", func() {
 					Name: "PROJECT-acme-test-project",
 				}, nil)
 
+			// Expect viewers group creation (new organization groups API)
+			mockIdpClient.EXPECT().
+				CreateAuthorizationGroup(gomock.Any(), "acme", "viewers", "/projects/test-project/viewers").
+				Return(nil)
+
+			// Expect managers group creation (new organization groups API)
+			mockIdpClient.EXPECT().
+				CreateAuthorizationGroup(gomock.Any(), "acme", "managers", "/projects/test-project/managers").
+				Return(nil)
+
 			task := &task{
 				r:       functionObj,
 				project: project,
@@ -245,6 +255,16 @@ var _ = Describe("Validation and Activation", func() {
 					ID:   "resource-abc-123",
 					Name: "PROJECT-acme-test-project",
 				}, nil)
+
+			// Expect viewers group creation (new organization groups API)
+			mockIdpClient.EXPECT().
+				CreateAuthorizationGroup(gomock.Any(), "acme", "viewers", "/projects/test-project/viewers").
+				Return(nil)
+
+			// Expect managers group creation (new organization groups API)
+			mockIdpClient.EXPECT().
+				CreateAuthorizationGroup(gomock.Any(), "acme", "managers", "/projects/test-project/managers").
+				Return(nil)
 
 			task := &task{
 				r:       functionObj,
@@ -298,6 +318,16 @@ var _ = Describe("Validation and Activation", func() {
 					ID:   "resource-456",
 					Name: "PROJECT-acme-child-project",
 				}, nil)
+
+			// Expect viewers group creation (new organization groups API)
+			mockIdpClient.EXPECT().
+				CreateAuthorizationGroup(gomock.Any(), "acme", "viewers", "/projects/child-project/viewers").
+				Return(nil)
+
+			// Expect managers group creation (new organization groups API)
+			mockIdpClient.EXPECT().
+				CreateAuthorizationGroup(gomock.Any(), "acme", "managers", "/projects/child-project/managers").
+				Return(nil)
 
 			task := &task{
 				r:       functionObj,
@@ -363,6 +393,16 @@ var _ = Describe("Validation and Activation", func() {
 					ID:   "resource-789",
 					Name: "PROJECT-acme-child-project",
 				}, nil)
+
+			// Expect viewers group creation (new organization groups API)
+			mockIdpClient.EXPECT().
+				CreateAuthorizationGroup(gomock.Any(), "acme", "viewers", "/projects/child-project/viewers").
+				Return(nil)
+
+			// Expect managers group creation (new organization groups API)
+			mockIdpClient.EXPECT().
+				CreateAuthorizationGroup(gomock.Any(), "acme", "managers", "/projects/child-project/managers").
+				Return(nil)
 
 			task := &task{
 				r:       functionObj,
@@ -734,7 +774,38 @@ var _ = Describe("Deletion Cleanup", func() {
 				Size: 0,
 			}, nil)
 
-		// Expect deletion call
+		// Expect get resource to extract name and tenant for group cleanup
+		mockIdpClient.EXPECT().
+			GetAuthorizationResource(gomock.Any(), "resource-123").
+			Return(&idp.AuthorizationResource{
+				ID:   "resource-123",
+				Name: "PROJECT-acme-test-project",
+				Attributes: map[string][]string{
+					"tenant": {"acme"},
+				},
+			}, nil)
+
+		// Expect viewers group ID lookup (new organization groups API with new paths)
+		mockIdpClient.EXPECT().
+			GetGroupIDByPath(gomock.Any(), "acme", "/projects/test-project/viewers").
+			Return("viewers-group-id", nil)
+
+		// Expect viewers group deletion (new organization groups API)
+		mockIdpClient.EXPECT().
+			DeleteAuthorizationGroup(gomock.Any(), "acme", "viewers-group-id").
+			Return(nil)
+
+		// Expect managers group ID lookup (new organization groups API with new paths)
+		mockIdpClient.EXPECT().
+			GetGroupIDByPath(gomock.Any(), "acme", "/projects/test-project/managers").
+			Return("managers-group-id", nil)
+
+		// Expect managers group deletion (new organization groups API)
+		mockIdpClient.EXPECT().
+			DeleteAuthorizationGroup(gomock.Any(), "acme", "managers-group-id").
+			Return(nil)
+
+		// Expect resource deletion
 		mockIdpClient.EXPECT().
 			DeleteAuthorizationResource(gomock.Any(), "resource-123").
 			Return(nil)
@@ -767,7 +838,12 @@ var _ = Describe("Deletion Cleanup", func() {
 				Size: 0,
 			}, nil)
 
-		// Expect deletion call that fails
+		// Expect get resource to fail (resource already deleted)
+		mockIdpClient.EXPECT().
+			GetAuthorizationResource(gomock.Any(), "resource-456").
+			Return(nil, status.Error(codes.NotFound, "resource not found"))
+
+		// Expect resource deletion call that also fails
 		mockIdpClient.EXPECT().
 			DeleteAuthorizationResource(gomock.Any(), "resource-456").
 			Return(status.Error(codes.NotFound, "resource not found"))

--- a/internal/idp/authz_constants.go
+++ b/internal/idp/authz_constants.go
@@ -1,0 +1,27 @@
+/*
+Copyright (c) 2026 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package idp
+
+// Authorization group constants for hierarchical project access control.
+// These define the group names and path segments used in Keycloak organization groups.
+const (
+	// GroupNameViewers is the name for viewer access groups
+	GroupNameViewers = "viewers"
+
+	// GroupNameManagers is the name for manager access groups
+	GroupNameManagers = "managers"
+
+	// GroupPathProjects is the root path segment for project groups
+	GroupPathProjects = "projects"
+)

--- a/internal/idp/client.go
+++ b/internal/idp/client.go
@@ -78,6 +78,17 @@ type Client interface {
 	GetAuthorizationResource(ctx context.Context, resourceID string) (*AuthorizationResource, error)
 	DeleteAuthorizationResource(ctx context.Context, resourceID string) error
 
+	// Authorization policy and permission operations
+	// These methods control who can access which resources with what scopes.
+	// CreateAuthorizationGroup creates a Keycloak organization group for authorization purposes.
+	// Organization groups are scoped to a specific organization and support hierarchical paths.
+	// Recommended path format: "/{projects}/{project-name}/{viewers|managers}" for top-level projects.
+	CreateAuthorizationGroup(ctx context.Context, organizationName, groupName, groupPath string) error
+	// DeleteAuthorizationGroup deletes a Keycloak organization group by ID.
+	DeleteAuthorizationGroup(ctx context.Context, organizationName, groupID string) error
+	// GetGroupIDByPath gets a Keycloak organization group ID by its path.
+	GetGroupIDByPath(ctx context.Context, organizationName, groupPath string) (string, error)
+
 	// Identity Provider operations
 	// GetIdentityProvider retrieves an external identity provider configuration by alias at the realm level.
 	// This returns the IdP without verifying organization assignment.

--- a/internal/idp/client_mock.go
+++ b/internal/idp/client_mock.go
@@ -96,6 +96,20 @@ func (mr *MockClientMockRecorder) AssignOrganizationRolesToUser(ctx, organizatio
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AssignOrganizationRolesToUser", reflect.TypeOf((*MockClient)(nil).AssignOrganizationRolesToUser), ctx, organizationName, userID, roles)
 }
 
+// CreateAuthorizationGroup mocks base method.
+func (m *MockClient) CreateAuthorizationGroup(ctx context.Context, organizationName, groupName, groupPath string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreateAuthorizationGroup", ctx, organizationName, groupName, groupPath)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// CreateAuthorizationGroup indicates an expected call of CreateAuthorizationGroup.
+func (mr *MockClientMockRecorder) CreateAuthorizationGroup(ctx, organizationName, groupName, groupPath any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateAuthorizationGroup", reflect.TypeOf((*MockClient)(nil).CreateAuthorizationGroup), ctx, organizationName, groupName, groupPath)
+}
+
 // CreateAuthorizationResource mocks base method.
 func (m *MockClient) CreateAuthorizationResource(ctx context.Context, resource *AuthorizationResource) (*AuthorizationResource, error) {
 	m.ctrl.T.Helper()
@@ -139,6 +153,20 @@ func (m *MockClient) CreateUser(ctx context.Context, organizationName string, us
 func (mr *MockClientMockRecorder) CreateUser(ctx, organizationName, user any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateUser", reflect.TypeOf((*MockClient)(nil).CreateUser), ctx, organizationName, user)
+}
+
+// DeleteAuthorizationGroup mocks base method.
+func (m *MockClient) DeleteAuthorizationGroup(ctx context.Context, organizationName, groupID string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteAuthorizationGroup", ctx, organizationName, groupID)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteAuthorizationGroup indicates an expected call of DeleteAuthorizationGroup.
+func (mr *MockClientMockRecorder) DeleteAuthorizationGroup(ctx, organizationName, groupID any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteAuthorizationGroup", reflect.TypeOf((*MockClient)(nil).DeleteAuthorizationGroup), ctx, organizationName, groupID)
 }
 
 // DeleteAuthorizationResource mocks base method.
@@ -196,6 +224,21 @@ func (m *MockClient) GetAuthorizationResource(ctx context.Context, resourceID st
 func (mr *MockClientMockRecorder) GetAuthorizationResource(ctx, resourceID any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAuthorizationResource", reflect.TypeOf((*MockClient)(nil).GetAuthorizationResource), ctx, resourceID)
+}
+
+// GetGroupIDByPath mocks base method.
+func (m *MockClient) GetGroupIDByPath(ctx context.Context, organizationName, groupPath string) (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetGroupIDByPath", ctx, organizationName, groupPath)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetGroupIDByPath indicates an expected call of GetGroupIDByPath.
+func (mr *MockClientMockRecorder) GetGroupIDByPath(ctx, organizationName, groupPath any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetGroupIDByPath", reflect.TypeOf((*MockClient)(nil).GetGroupIDByPath), ctx, organizationName, groupPath)
 }
 
 // GetIdentityProvider mocks base method.

--- a/internal/idp/keycloak/authz_groups.go
+++ b/internal/idp/keycloak/authz_groups.go
@@ -1,0 +1,151 @@
+/*
+Copyright (c) 2026 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package keycloak
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"net/url"
+)
+
+// CreateAuthorizationGroup creates a Keycloak organization group for authorization purposes.
+// Organization groups are scoped to the organization and support hierarchical paths.
+//
+// Group path format:
+//   - Top-level project: "/Projects/{project-name}/{Viewers|Managers}"
+//   - Nested project: "/Projects/{parent-name}/{project-name}/{Viewers|Managers}"
+//
+// Organization groups are scoped per organization, so paths can be simple and readable.
+// See https://www.keycloak.org/2026/04/org-groups for details.
+func (c *Client) CreateAuthorizationGroup(ctx context.Context, organizationName, groupName, groupPath string) error {
+	c.logger.DebugContext(ctx, "Creating organization authorization group",
+		slog.String("organizationName", organizationName),
+		slog.String("groupName", groupName),
+		slog.String("groupPath", groupPath),
+	)
+
+	// Get the organization ID first
+	org, err := c.GetOrganization(ctx, organizationName)
+	if err != nil {
+		return fmt.Errorf("failed to get organization: %w", err)
+	}
+
+	// Use organization groups API instead of realm groups
+	path := fmt.Sprintf("/admin/realms/%s/organizations/%s/groups",
+		url.PathEscape(c.realmName),
+		url.PathEscape(org.ID),
+	)
+
+	groupPayload := map[string]interface{}{
+		"name": groupName,
+		"path": groupPath,
+	}
+
+	response, err := c.httpClient.DoRequest(ctx, http.MethodPost, path, groupPayload)
+	if err != nil {
+		return fmt.Errorf("failed to create organization group: %w", err)
+	}
+	defer response.Body.Close()
+
+	c.logger.DebugContext(ctx, "Created organization authorization group",
+		slog.String("organizationName", organizationName),
+		slog.String("groupName", groupName),
+	)
+
+	return nil
+}
+
+// DeleteAuthorizationGroup deletes a Keycloak organization group by ID.
+func (c *Client) DeleteAuthorizationGroup(ctx context.Context, organizationName, groupID string) error {
+	c.logger.DebugContext(ctx, "Deleting organization authorization group",
+		slog.String("organizationName", organizationName),
+		slog.String("groupID", groupID),
+	)
+
+	// Get the organization ID first
+	org, err := c.GetOrganization(ctx, organizationName)
+	if err != nil {
+		return fmt.Errorf("failed to get organization: %w", err)
+	}
+
+	// Use organization groups API instead of realm groups
+	path := fmt.Sprintf("/admin/realms/%s/organizations/%s/groups/%s",
+		url.PathEscape(c.realmName),
+		url.PathEscape(org.ID),
+		url.PathEscape(groupID),
+	)
+
+	response, err := c.httpClient.DoRequest(ctx, http.MethodDelete, path, nil)
+	if err != nil {
+		return fmt.Errorf("failed to delete organization group: %w", err)
+	}
+	defer response.Body.Close()
+
+	c.logger.DebugContext(ctx, "Deleted organization authorization group",
+		slog.String("organizationName", organizationName),
+		slog.String("groupID", groupID),
+	)
+
+	return nil
+}
+
+// Helper methods
+
+// GetGroupIDByPath gets a Keycloak organization group ID by its path.
+// This is exposed for use by the ResourceManager.
+func (c *Client) GetGroupIDByPath(ctx context.Context, organizationName, groupPath string) (string, error) {
+	return c.getGroupIDByPath(ctx, organizationName, groupPath)
+}
+
+func (c *Client) getGroupIDByPath(ctx context.Context, organizationName, groupPath string) (string, error) {
+	// Get the organization ID first
+	org, err := c.GetOrganization(ctx, organizationName)
+	if err != nil {
+		return "", fmt.Errorf("failed to get organization: %w", err)
+	}
+
+	// Search for organization group by path
+	// Note: Keycloak doesn't have a direct "get by path" API, so we search by name
+	// and verify the path matches
+	path := fmt.Sprintf("/admin/realms/%s/organizations/%s/groups?search=%s",
+		url.PathEscape(c.realmName),
+		url.PathEscape(org.ID),
+		url.QueryEscape(groupPath),
+	)
+
+	response, err := c.httpClient.DoRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return "", fmt.Errorf("failed to search organization groups: %w", err)
+	}
+	defer response.Body.Close()
+
+	var groups []struct {
+		ID   string `json:"id"`
+		Path string `json:"path"`
+	}
+	if err := json.NewDecoder(response.Body).Decode(&groups); err != nil {
+		return "", fmt.Errorf("failed to decode organization groups: %w", err)
+	}
+
+	for _, group := range groups {
+		if group.Path == groupPath {
+			return group.ID, nil
+		}
+	}
+
+	return "", fmt.Errorf("organization group not found: %s", groupPath)
+}

--- a/internal/idp/keycloak/client_test.go.bak
+++ b/internal/idp/keycloak/client_test.go.bak
@@ -70,10 +70,7 @@ var _ = Describe("Keycloak Client", func() {
 					}}
 					w.Header().Set("Content-Type", "application/json")
 					w.WriteHeader(http.StatusOK)
-					if err := json.NewEncoder(w).Encode(response); err != nil {
-						http.Error(w, err.Error(), http.StatusInternalServerError)
-						return
-					}
+					json.NewEncoder(w).Encode(response)
 					return
 				}
 
@@ -148,10 +145,7 @@ var _ = Describe("Keycloak Client", func() {
 
 				w.Header().Set("Content-Type", "application/json")
 				w.WriteHeader(http.StatusOK)
-				if err := json.NewEncoder(w).Encode(testOrgs); err != nil {
-					http.Error(w, err.Error(), http.StatusInternalServerError)
-					return
-				}
+				json.NewEncoder(w).Encode(testOrgs)
 			}))
 
 			client = createTestClient(server.URL)
@@ -210,10 +204,7 @@ var _ = Describe("Keycloak Client", func() {
 					}}
 					w.Header().Set("Content-Type", "application/json")
 					w.WriteHeader(http.StatusOK)
-					if err := json.NewEncoder(w).Encode(response); err != nil {
-						http.Error(w, err.Error(), http.StatusInternalServerError)
-						return
-					}
+					json.NewEncoder(w).Encode(response)
 					return
 				}
 
@@ -375,10 +366,7 @@ var _ = Describe("Keycloak Client", func() {
 
 				w.Header().Set("Content-Type", "application/json")
 				w.WriteHeader(http.StatusOK)
-				if err := json.NewEncoder(w).Encode(users); err != nil {
-					http.Error(w, err.Error(), http.StatusInternalServerError)
-					return
-				}
+				json.NewEncoder(w).Encode(users)
 			}))
 
 			client = createTestClient(server.URL)
@@ -438,10 +426,7 @@ var _ = Describe("Keycloak Client", func() {
 
 				w.Header().Set("Content-Type", "application/json")
 				w.WriteHeader(http.StatusOK)
-				if err := json.NewEncoder(w).Encode(users); err != nil {
-					http.Error(w, err.Error(), http.StatusInternalServerError)
-					return
-				}
+				json.NewEncoder(w).Encode(users)
 			}))
 
 			client = createTestClient(server.URL)
@@ -477,10 +462,7 @@ var _ = Describe("Keycloak Client", func() {
 
 				w.Header().Set("Content-Type", "application/json")
 				w.WriteHeader(http.StatusOK)
-				if err := json.NewEncoder(w).Encode(testUser); err != nil {
-					http.Error(w, err.Error(), http.StatusInternalServerError)
-					return
-				}
+				json.NewEncoder(w).Encode(testUser)
 			}))
 			client = createTestClient(server.URL)
 			user, err := client.GetUser(ctx, "test-org", "user-123-abc")
@@ -583,10 +565,7 @@ var _ = Describe("Keycloak Client", func() {
 					}}
 					w.Header().Set("Content-Type", "application/json")
 					w.WriteHeader(http.StatusOK)
-					if err := json.NewEncoder(w).Encode(response); err != nil {
-						http.Error(w, err.Error(), http.StatusInternalServerError)
-						return
-					}
+					json.NewEncoder(w).Encode(response)
 					return
 				}
 
@@ -607,10 +586,7 @@ var _ = Describe("Keycloak Client", func() {
 					}}
 					w.Header().Set("Content-Type", "application/json")
 					w.WriteHeader(http.StatusOK)
-					if err := json.NewEncoder(w).Encode(response); err != nil {
-						http.Error(w, err.Error(), http.StatusInternalServerError)
-						return
-					}
+					json.NewEncoder(w).Encode(response)
 					return
 				}
 
@@ -676,10 +652,7 @@ var _ = Describe("Keycloak Client", func() {
 				if r.URL.Path == "/admin/realms/osac/clients" {
 					w.Header().Set("Content-Type", "application/json")
 					w.WriteHeader(http.StatusOK)
-					if err := json.NewEncoder(w).Encode(clients); err != nil {
-						http.Error(w, err.Error(), http.StatusInternalServerError)
-						return
-					}
+					json.NewEncoder(w).Encode(clients)
 					return
 				}
 
@@ -687,10 +660,7 @@ var _ = Describe("Keycloak Client", func() {
 				Expect(r.URL.Path).To(Equal("/admin/realms/osac/clients/internal-uuid-123/roles"))
 				w.Header().Set("Content-Type", "application/json")
 				w.WriteHeader(http.StatusOK)
-				if err := json.NewEncoder(w).Encode(roles); err != nil {
-					http.Error(w, err.Error(), http.StatusInternalServerError)
-					return
-				}
+				json.NewEncoder(w).Encode(roles)
 			}))
 
 			client = createTestClient(server.URL)
@@ -722,10 +692,7 @@ var _ = Describe("Keycloak Client", func() {
 
 				// First call returns valid clients, second call returns invalid JSON
 				if r.URL.Path == "/admin/realms/osac/clients" {
-					if err := json.NewEncoder(w).Encode(clients); err != nil {
-						http.Error(w, err.Error(), http.StatusInternalServerError)
-						return
-					}
+					json.NewEncoder(w).Encode(clients)
 				} else {
 					w.Write([]byte("invalid json"))
 				}
@@ -760,10 +727,7 @@ var _ = Describe("Keycloak Client", func() {
 				if r.Method == http.MethodGet && r.URL.Path == "/admin/realms/osac/clients" {
 					w.Header().Set("Content-Type", "application/json")
 					w.WriteHeader(http.StatusOK)
-					if err := json.NewEncoder(w).Encode(clients); err != nil {
-						http.Error(w, err.Error(), http.StatusInternalServerError)
-						return
-					}
+					json.NewEncoder(w).Encode(clients)
 					return
 				}
 
@@ -815,10 +779,7 @@ var _ = Describe("Keycloak Client", func() {
 				if r.Method == http.MethodGet && r.URL.Path == "/admin/realms/osac/clients" {
 					w.Header().Set("Content-Type", "application/json")
 					w.WriteHeader(http.StatusOK)
-					if err := json.NewEncoder(w).Encode(clients); err != nil {
-						http.Error(w, err.Error(), http.StatusInternalServerError)
-						return
-					}
+					json.NewEncoder(w).Encode(clients)
 					return
 				}
 
@@ -874,10 +835,7 @@ var _ = Describe("Keycloak Client", func() {
 				if r.URL.Path == "/admin/realms/osac/clients" {
 					w.Header().Set("Content-Type", "application/json")
 					w.WriteHeader(http.StatusOK)
-					if err := json.NewEncoder(w).Encode(clients); err != nil {
-						http.Error(w, err.Error(), http.StatusInternalServerError)
-						return
-					}
+					json.NewEncoder(w).Encode(clients)
 					return
 				}
 
@@ -885,10 +843,7 @@ var _ = Describe("Keycloak Client", func() {
 				Expect(r.URL.Path).To(Equal("/admin/realms/osac/users/user-123/role-mappings/clients/internal-uuid-123"))
 				w.Header().Set("Content-Type", "application/json")
 				w.WriteHeader(http.StatusOK)
-				if err := json.NewEncoder(w).Encode(roles); err != nil {
-					http.Error(w, err.Error(), http.StatusInternalServerError)
-					return
-				}
+				json.NewEncoder(w).Encode(roles)
 			}))
 
 			client = createTestClient(server.URL)
@@ -919,10 +874,7 @@ var _ = Describe("Keycloak Client", func() {
 
 				// First call returns valid clients, second call returns invalid JSON
 				if r.URL.Path == "/admin/realms/osac/clients" {
-					if err := json.NewEncoder(w).Encode(clients); err != nil {
-						http.Error(w, err.Error(), http.StatusInternalServerError)
-						return
-					}
+					json.NewEncoder(w).Encode(clients)
 				} else {
 					w.Write([]byte("invalid json"))
 				}
@@ -958,10 +910,7 @@ var _ = Describe("Keycloak Client", func() {
 				if r.Method == http.MethodGet && r.URL.Path == "/admin/realms/osac/roles/tenant-idp-manager" {
 					// Return the tenant-idp-manager role
 					w.WriteHeader(http.StatusOK)
-					if err := json.NewEncoder(w).Encode(role); err != nil {
-						http.Error(w, err.Error(), http.StatusInternalServerError)
-						return
-					}
+					json.NewEncoder(w).Encode(role)
 				} else if r.Method == http.MethodPost && r.URL.Path == "/admin/realms/osac/users/user-123/role-mappings/realm" {
 					// Assignment endpoint
 					w.WriteHeader(http.StatusNoContent)
@@ -989,10 +938,7 @@ var _ = Describe("Keycloak Client", func() {
 
 				w.Header().Set("Content-Type", "application/json")
 				w.WriteHeader(http.StatusOK)
-				if err := json.NewEncoder(w).Encode(clients); err != nil {
-					http.Error(w, err.Error(), http.StatusInternalServerError)
-					return
-				}
+				json.NewEncoder(w).Encode(clients)
 			}))
 
 			client = createTestClient(server.URL)
@@ -1023,10 +969,7 @@ var _ = Describe("Keycloak Client", func() {
 			server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				w.Header().Set("Content-Type", "application/json")
 				w.WriteHeader(http.StatusOK)
-				if err := json.NewEncoder(w).Encode([]keycloakClient{}); err != nil {
-					http.Error(w, err.Error(), http.StatusInternalServerError)
-					return
-				}
+				json.NewEncoder(w).Encode([]keycloakClient{})
 			}))
 
 			client = createTestClient(server.URL)
@@ -1071,10 +1014,7 @@ var _ = Describe("Keycloak Client", func() {
 
 				w.Header().Set("Content-Type", "application/json")
 				w.WriteHeader(http.StatusOK)
-				if err := json.NewEncoder(w).Encode(clients); err != nil {
-					http.Error(w, err.Error(), http.StatusInternalServerError)
-					return
-				}
+				json.NewEncoder(w).Encode(clients)
 			}))
 
 			client = createTestClient(server.URL)
@@ -1133,10 +1073,7 @@ var _ = Describe("Keycloak Client", func() {
 						ClientID: "osac-authorization",
 					}}
 					w.Header().Set("Content-Type", "application/json")
-					if err := json.NewEncoder(w).Encode(response); err != nil {
-						http.Error(w, err.Error(), http.StatusInternalServerError)
-						return
-					}
+					json.NewEncoder(w).Encode(response)
 					return
 				}
 
@@ -1154,10 +1091,7 @@ var _ = Describe("Keycloak Client", func() {
 						Attributes: receivedResource.Attributes,
 					}
 					w.Header().Set("Content-Type", "application/json")
-					if err := json.NewEncoder(w).Encode(response); err != nil {
-						http.Error(w, err.Error(), http.StatusInternalServerError)
-						return
-					}
+					json.NewEncoder(w).Encode(response)
 					return
 				}
 
@@ -1199,10 +1133,7 @@ var _ = Describe("Keycloak Client", func() {
 						ClientID: "osac-authorization",
 					}}
 					w.Header().Set("Content-Type", "application/json")
-					if err := json.NewEncoder(w).Encode(response); err != nil {
-						http.Error(w, err.Error(), http.StatusInternalServerError)
-						return
-					}
+					json.NewEncoder(w).Encode(response)
 					return
 				}
 
@@ -1213,10 +1144,7 @@ var _ = Describe("Keycloak Client", func() {
 						Name: "PROJECT-test",
 					}
 					w.Header().Set("Content-Type", "application/json")
-					if err := json.NewEncoder(w).Encode(response); err != nil {
-						http.Error(w, err.Error(), http.StatusInternalServerError)
-						return
-					}
+					json.NewEncoder(w).Encode(response)
 					return
 				}
 
@@ -1243,10 +1171,7 @@ var _ = Describe("Keycloak Client", func() {
 				if r.Method == http.MethodGet && r.URL.Path == "/admin/realms/osac/clients" {
 					// Return empty list
 					w.Header().Set("Content-Type", "application/json")
-					if err := json.NewEncoder(w).Encode([]keycloakClient{}); err != nil {
-						http.Error(w, err.Error(), http.StatusInternalServerError)
-						return
-					}
+					json.NewEncoder(w).Encode([]keycloakClient{})
 					return
 				}
 				w.WriteHeader(http.StatusNotFound)
@@ -1272,10 +1197,7 @@ var _ = Describe("Keycloak Client", func() {
 						ClientID: "osac-authorization",
 					}}
 					w.Header().Set("Content-Type", "application/json")
-					if err := json.NewEncoder(w).Encode(response); err != nil {
-						http.Error(w, err.Error(), http.StatusInternalServerError)
-						return
-					}
+					json.NewEncoder(w).Encode(response)
 					return
 				}
 
@@ -1290,10 +1212,7 @@ var _ = Describe("Keycloak Client", func() {
 						},
 					}
 					w.Header().Set("Content-Type", "application/json")
-					if err := json.NewEncoder(w).Encode(response); err != nil {
-						http.Error(w, err.Error(), http.StatusInternalServerError)
-						return
-					}
+					json.NewEncoder(w).Encode(response)
 					return
 				}
 
@@ -1320,10 +1239,7 @@ var _ = Describe("Keycloak Client", func() {
 						ClientID: "osac-authorization",
 					}}
 					w.Header().Set("Content-Type", "application/json")
-					if err := json.NewEncoder(w).Encode(response); err != nil {
-						http.Error(w, err.Error(), http.StatusInternalServerError)
-						return
-					}
+					json.NewEncoder(w).Encode(response)
 					return
 				}
 
@@ -1351,10 +1267,7 @@ var _ = Describe("Keycloak Client", func() {
 						ClientID: "osac-authorization",
 					}}
 					w.Header().Set("Content-Type", "application/json")
-					if err := json.NewEncoder(w).Encode(response); err != nil {
-						http.Error(w, err.Error(), http.StatusInternalServerError)
-						return
-					}
+					json.NewEncoder(w).Encode(response)
 					return
 				}
 
@@ -1385,10 +1298,7 @@ var _ = Describe("Keycloak Client", func() {
 						ClientID: "osac-authorization",
 					}}
 					w.Header().Set("Content-Type", "application/json")
-					if err := json.NewEncoder(w).Encode(response); err != nil {
-						http.Error(w, err.Error(), http.StatusInternalServerError)
-						return
-					}
+					json.NewEncoder(w).Encode(response)
 					return
 				}
 
@@ -1423,10 +1333,7 @@ var _ = Describe("Keycloak Client", func() {
 						}
 						w.Header().Set("Content-Type", "application/json")
 						w.WriteHeader(http.StatusOK)
-						if err := json.NewEncoder(w).Encode(response); err != nil {
-							http.Error(w, err.Error(), http.StatusInternalServerError)
-							return
-						}
+						json.NewEncoder(w).Encode(response)
 						return
 					}
 					w.WriteHeader(http.StatusNotFound)
@@ -1482,10 +1389,7 @@ var _ = Describe("Keycloak Client", func() {
 						}
 						w.Header().Set("Content-Type", "application/json")
 						w.WriteHeader(http.StatusOK)
-						if err := json.NewEncoder(w).Encode(response); err != nil {
-							http.Error(w, err.Error(), http.StatusInternalServerError)
-							return
-						}
+						json.NewEncoder(w).Encode(response)
 						return
 					}
 					w.WriteHeader(http.StatusNotFound)
@@ -1510,10 +1414,7 @@ var _ = Describe("Keycloak Client", func() {
 						response := []keycloakIdentityProvider{}
 						w.Header().Set("Content-Type", "application/json")
 						w.WriteHeader(http.StatusOK)
-						if err := json.NewEncoder(w).Encode(response); err != nil {
-							http.Error(w, err.Error(), http.StatusInternalServerError)
-							return
-						}
+						json.NewEncoder(w).Encode(response)
 						return
 					}
 					w.WriteHeader(http.StatusNotFound)
@@ -1538,10 +1439,7 @@ var _ = Describe("Keycloak Client", func() {
 						}}
 						w.Header().Set("Content-Type", "application/json")
 						w.WriteHeader(http.StatusOK)
-						if err := json.NewEncoder(w).Encode(response); err != nil {
-							http.Error(w, err.Error(), http.StatusInternalServerError)
-							return
-						}
+						json.NewEncoder(w).Encode(response)
 						return
 					}
 
@@ -1558,10 +1456,7 @@ var _ = Describe("Keycloak Client", func() {
 						}
 						w.Header().Set("Content-Type", "application/json")
 						w.WriteHeader(http.StatusOK)
-						if err := json.NewEncoder(w).Encode(response); err != nil {
-							http.Error(w, err.Error(), http.StatusInternalServerError)
-							return
-						}
+						json.NewEncoder(w).Encode(response)
 						return
 					}
 
@@ -1588,10 +1483,7 @@ var _ = Describe("Keycloak Client", func() {
 						}}
 						w.Header().Set("Content-Type", "application/json")
 						w.WriteHeader(http.StatusOK)
-						if err := json.NewEncoder(w).Encode(response); err != nil {
-							http.Error(w, err.Error(), http.StatusInternalServerError)
-							return
-						}
+						json.NewEncoder(w).Encode(response)
 						return
 					}
 
@@ -1618,10 +1510,7 @@ var _ = Describe("Keycloak Client", func() {
 						response := []keycloakOrganization{}
 						w.Header().Set("Content-Type", "application/json")
 						w.WriteHeader(http.StatusOK)
-						if err := json.NewEncoder(w).Encode(response); err != nil {
-							http.Error(w, err.Error(), http.StatusInternalServerError)
-							return
-						}
+						json.NewEncoder(w).Encode(response)
 						return
 					}
 					w.WriteHeader(http.StatusNotFound)
@@ -1646,10 +1535,7 @@ var _ = Describe("Keycloak Client", func() {
 						}}
 						w.Header().Set("Content-Type", "application/json")
 						w.WriteHeader(http.StatusOK)
-						if err := json.NewEncoder(w).Encode(response); err != nil {
-							http.Error(w, err.Error(), http.StatusInternalServerError)
-							return
-						}
+						json.NewEncoder(w).Encode(response)
 						return
 					}
 
@@ -1671,10 +1557,7 @@ var _ = Describe("Keycloak Client", func() {
 						}
 						w.Header().Set("Content-Type", "application/json")
 						w.WriteHeader(http.StatusOK)
-						if err := json.NewEncoder(w).Encode(response); err != nil {
-							http.Error(w, err.Error(), http.StatusInternalServerError)
-							return
-						}
+						json.NewEncoder(w).Encode(response)
 						return
 					}
 
@@ -1702,10 +1585,7 @@ var _ = Describe("Keycloak Client", func() {
 						}}
 						w.Header().Set("Content-Type", "application/json")
 						w.WriteHeader(http.StatusOK)
-						if err := json.NewEncoder(w).Encode(response); err != nil {
-							http.Error(w, err.Error(), http.StatusInternalServerError)
-							return
-						}
+						json.NewEncoder(w).Encode(response)
 						return
 					}
 
@@ -1714,10 +1594,7 @@ var _ = Describe("Keycloak Client", func() {
 						response := []keycloakIdentityProvider{}
 						w.Header().Set("Content-Type", "application/json")
 						w.WriteHeader(http.StatusOK)
-						if err := json.NewEncoder(w).Encode(response); err != nil {
-							http.Error(w, err.Error(), http.StatusInternalServerError)
-							return
-						}
+						json.NewEncoder(w).Encode(response)
 						return
 					}
 
@@ -1738,10 +1615,7 @@ var _ = Describe("Keycloak Client", func() {
 						response := []keycloakOrganization{}
 						w.Header().Set("Content-Type", "application/json")
 						w.WriteHeader(http.StatusOK)
-						if err := json.NewEncoder(w).Encode(response); err != nil {
-							http.Error(w, err.Error(), http.StatusInternalServerError)
-							return
-						}
+						json.NewEncoder(w).Encode(response)
 						return
 					}
 					w.WriteHeader(http.StatusNotFound)
@@ -1799,10 +1673,7 @@ var _ = Describe("Keycloak Client", func() {
 					if r.Method == http.MethodGet && r.URL.Path == "/admin/realms/osac/organizations" {
 						w.Header().Set("Content-Type", "application/json")
 						w.WriteHeader(http.StatusOK)
-						if err := json.NewEncoder(w).Encode([]keycloakOrganization{}); err != nil {
-							http.Error(w, err.Error(), http.StatusInternalServerError)
-							return
-						}
+						json.NewEncoder(w).Encode([]keycloakOrganization{})
 						return
 					}
 					w.WriteHeader(http.StatusNotFound)
@@ -1824,10 +1695,7 @@ var _ = Describe("Keycloak Client", func() {
 						}
 						w.Header().Set("Content-Type", "application/json")
 						w.WriteHeader(http.StatusOK)
-						if err := json.NewEncoder(w).Encode(orgs); err != nil {
-							http.Error(w, err.Error(), http.StatusInternalServerError)
-							return
-						}
+						json.NewEncoder(w).Encode(orgs)
 						return
 					}
 					// Second request: create group fails
@@ -1857,10 +1725,7 @@ var _ = Describe("Keycloak Client", func() {
 						}
 						w.Header().Set("Content-Type", "application/json")
 						w.WriteHeader(http.StatusOK)
-						if err := json.NewEncoder(w).Encode(orgs); err != nil {
-							http.Error(w, err.Error(), http.StatusInternalServerError)
-							return
-						}
+						json.NewEncoder(w).Encode(orgs)
 						return
 					}
 					// Second request: delete organization group
@@ -1884,10 +1749,7 @@ var _ = Describe("Keycloak Client", func() {
 					if r.Method == http.MethodGet && r.URL.Path == "/admin/realms/osac/organizations" {
 						w.Header().Set("Content-Type", "application/json")
 						w.WriteHeader(http.StatusOK)
-						if err := json.NewEncoder(w).Encode([]keycloakOrganization{}); err != nil {
-							http.Error(w, err.Error(), http.StatusInternalServerError)
-							return
-						}
+						json.NewEncoder(w).Encode([]keycloakOrganization{})
 						return
 					}
 					w.WriteHeader(http.StatusNotFound)
@@ -1909,10 +1771,7 @@ var _ = Describe("Keycloak Client", func() {
 						}
 						w.Header().Set("Content-Type", "application/json")
 						w.WriteHeader(http.StatusOK)
-						if err := json.NewEncoder(w).Encode(orgs); err != nil {
-							http.Error(w, err.Error(), http.StatusInternalServerError)
-							return
-						}
+						json.NewEncoder(w).Encode(orgs)
 						return
 					}
 					// Second request: delete fails
@@ -1941,10 +1800,7 @@ var _ = Describe("Keycloak Client", func() {
 						}
 						w.Header().Set("Content-Type", "application/json")
 						w.WriteHeader(http.StatusOK)
-						if err := json.NewEncoder(w).Encode(orgs); err != nil {
-							http.Error(w, err.Error(), http.StatusInternalServerError)
-							return
-						}
+						json.NewEncoder(w).Encode(orgs)
 						return
 					}
 					// Second request: search organization groups
@@ -1964,10 +1820,7 @@ var _ = Describe("Keycloak Client", func() {
 						}
 						w.Header().Set("Content-Type", "application/json")
 						w.WriteHeader(http.StatusOK)
-						if err := json.NewEncoder(w).Encode(groups); err != nil {
-							http.Error(w, err.Error(), http.StatusInternalServerError)
-							return
-						}
+						json.NewEncoder(w).Encode(groups)
 						return
 					}
 					w.WriteHeader(http.StatusNotFound)
@@ -1985,10 +1838,7 @@ var _ = Describe("Keycloak Client", func() {
 					if r.Method == http.MethodGet && r.URL.Path == "/admin/realms/osac/organizations" {
 						w.Header().Set("Content-Type", "application/json")
 						w.WriteHeader(http.StatusOK)
-						if err := json.NewEncoder(w).Encode([]keycloakOrganization{}); err != nil {
-							http.Error(w, err.Error(), http.StatusInternalServerError)
-							return
-						}
+						json.NewEncoder(w).Encode([]keycloakOrganization{})
 						return
 					}
 					w.WriteHeader(http.StatusNotFound)
@@ -2010,10 +1860,7 @@ var _ = Describe("Keycloak Client", func() {
 						}
 						w.Header().Set("Content-Type", "application/json")
 						w.WriteHeader(http.StatusOK)
-						if err := json.NewEncoder(w).Encode(orgs); err != nil {
-							http.Error(w, err.Error(), http.StatusInternalServerError)
-							return
-						}
+						json.NewEncoder(w).Encode(orgs)
 						return
 					}
 					// Second request: search returns empty
@@ -2024,10 +1871,7 @@ var _ = Describe("Keycloak Client", func() {
 						}{}
 						w.Header().Set("Content-Type", "application/json")
 						w.WriteHeader(http.StatusOK)
-						if err := json.NewEncoder(w).Encode(groups); err != nil {
-							http.Error(w, err.Error(), http.StatusInternalServerError)
-							return
-						}
+						json.NewEncoder(w).Encode(groups)
 						return
 					}
 					w.WriteHeader(http.StatusNotFound)
@@ -2049,10 +1893,7 @@ var _ = Describe("Keycloak Client", func() {
 						}
 						w.Header().Set("Content-Type", "application/json")
 						w.WriteHeader(http.StatusOK)
-						if err := json.NewEncoder(w).Encode(orgs); err != nil {
-							http.Error(w, err.Error(), http.StatusInternalServerError)
-							return
-						}
+						json.NewEncoder(w).Encode(orgs)
 						return
 					}
 					// Second request: search fails

--- a/internal/idp/keycloak/types.go
+++ b/internal/idp/keycloak/types.go
@@ -212,33 +212,46 @@ func fromKeycloakOrganization(kcOrg *keycloakOrganization) *idp.Organization {
 // See: https://www.keycloak.org/docs/latest/authorization_services/
 
 // keycloakAuthorizationResource represents a protected resource in Keycloak Authorization Services.
+type keycloakAuthorizationScope struct {
+	ID   string `json:"id,omitempty"`
+	Name string `json:"name,omitempty"`
+}
+
 type keycloakAuthorizationResource struct {
-	ID         string              `json:"_id,omitempty"`
-	Name       string              `json:"name,omitempty"`
-	Type       string              `json:"type,omitempty"`
-	Scopes     []string            `json:"scopes,omitempty"`
-	URIs       []string            `json:"uris,omitempty"`
-	Attributes map[string][]string `json:"attributes,omitempty"`
+	ID         string                       `json:"_id,omitempty"`
+	Name       string                       `json:"name,omitempty"`
+	Type       string                       `json:"type,omitempty"`
+	Scopes     []keycloakAuthorizationScope `json:"scopes,omitempty"`
+	URIs       []string                     `json:"uris,omitempty"`
+	Attributes map[string][]string          `json:"attributes,omitempty"`
 }
 
 // Conversion functions for authorization resources
 func toKeycloakAuthorizationResource(resource *idp.AuthorizationResource) *keycloakAuthorizationResource {
+	scopes := make([]keycloakAuthorizationScope, len(resource.Scopes))
+	for i, scopeName := range resource.Scopes {
+		scopes[i] = keycloakAuthorizationScope{Name: scopeName}
+	}
 	return &keycloakAuthorizationResource{
 		ID:         resource.ID,
 		Name:       resource.Name,
 		Type:       resource.Type,
-		Scopes:     resource.Scopes,
+		Scopes:     scopes,
 		URIs:       resource.URIs,
 		Attributes: resource.Attributes,
 	}
 }
 
 func fromKeycloakAuthorizationResource(kcResource *keycloakAuthorizationResource) *idp.AuthorizationResource {
+	scopeNames := make([]string, len(kcResource.Scopes))
+	for i, scope := range kcResource.Scopes {
+		scopeNames[i] = scope.Name
+	}
 	return &idp.AuthorizationResource{
 		ID:         kcResource.ID,
 		Name:       kcResource.Name,
 		Type:       kcResource.Type,
-		Scopes:     kcResource.Scopes,
+		Scopes:     scopeNames,
 		URIs:       kcResource.URIs,
 		Attributes: kcResource.Attributes,
 	}

--- a/internal/idp/manager_test.go
+++ b/internal/idp/manager_test.go
@@ -254,6 +254,19 @@ func (m *mockClient) ListIdentityProviders(ctx context.Context, organizationName
 	return nil, nil
 }
 
+func (m *mockClient) CreateAuthorizationGroup(ctx context.Context, organizationName, groupName, groupPath string) error {
+	return nil
+}
+
+func (m *mockClient) DeleteAuthorizationGroup(ctx context.Context, organizationName, groupID string) error {
+	return nil
+}
+
+func (m *mockClient) GetGroupIDByPath(ctx context.Context, organizationName, groupPath string) (string, error) {
+	// Return a fake group ID for testing
+	return "test-group-id", nil
+}
+
 var _ = Describe("OrganizationManager", func() {
 	var (
 		ctx     context.Context

--- a/internal/idp/resource_manager.go
+++ b/internal/idp/resource_manager.go
@@ -107,13 +107,89 @@ func (m *ResourceManager) CreateProjectAuthorizationResource(ctx context.Context
 	return createdResource.ID, nil
 }
 
+// createProjectAuthorizationGroups creates Keycloak organization groups
+// for viewer and manager access to a project.
+// Uses the hierarchical naming convention: /{projects}/{project-name}/{viewers|managers}
+func (m *ResourceManager) createProjectAuthorizationGroups(ctx context.Context, resourceID, organizationName, projectName string) error {
+	resourceName := fmt.Sprintf("PROJECT-%s-%s", organizationName, projectName)
+
+	// Create viewers group using new naming convention
+	// Group path: /{projects}/{project-name}/{viewers}
+	viewersGroupName := GroupNameViewers
+	viewersGroupPath := fmt.Sprintf("/%s/%s/%s", GroupPathProjects, projectName, GroupNameViewers)
+	err := m.client.CreateAuthorizationGroup(ctx, organizationName, viewersGroupName, viewersGroupPath)
+	if err != nil {
+		return fmt.Errorf("failed to create viewers group: %w", err)
+	}
+
+	m.logger.InfoContext(ctx, "Created project viewers group",
+		slog.String("group_path", viewersGroupPath),
+		slog.String("project_name", resourceName),
+		slog.String("organization", organizationName),
+	)
+
+	// Create managers group using new naming convention
+	// Group path: /{projects}/{project-name}/{managers}
+	managersGroupName := GroupNameManagers
+	managersGroupPath := fmt.Sprintf("/%s/%s/%s", GroupPathProjects, projectName, GroupNameManagers)
+	err = m.client.CreateAuthorizationGroup(ctx, organizationName, managersGroupName, managersGroupPath)
+	if err != nil {
+		// Clean up viewers group on failure
+		viewersGroupID, _ := m.getGroupIDByPath(ctx, organizationName, viewersGroupPath)
+		if viewersGroupID != "" {
+			_ = m.client.DeleteAuthorizationGroup(ctx, organizationName, viewersGroupID)
+		}
+		return fmt.Errorf("failed to create managers group: %w", err)
+	}
+
+	m.logger.InfoContext(ctx, "Created project managers group",
+		slog.String("group_path", managersGroupPath),
+		slog.String("project_name", resourceName),
+		slog.String("organization", organizationName),
+	)
+
+	//TODO: Create group policy and permission for viewers (VIEW_PROJECT scope)
+
+	//TODO: Create group policy and permission for managers (MANAGE_PROJECT scope)
+
+	return nil
+}
+
 // DeleteAuthorizationResource deletes an Authorization Resource by ID.
 func (m *ResourceManager) DeleteAuthorizationResource(ctx context.Context, resourceID string) error {
 	m.logger.DebugContext(ctx, "Deleting authorization resource",
 		slog.String("resource_id", resourceID),
 	)
 
-	err := m.client.DeleteAuthorizationResource(ctx, resourceID)
+	// Get the resource to extract tenant and project name for group cleanup
+	resource, err := m.client.GetAuthorizationResource(ctx, resourceID)
+	if err != nil {
+		// Resource might already be deleted, log and continue
+		m.logger.WarnContext(ctx, "Failed to get authorization resource for cleanup",
+			slog.String("resource_id", resourceID),
+			slog.Any("error", err),
+		)
+	} else {
+		// Extract organization name from resource attributes
+		organizationName := ""
+		if tenants, ok := resource.Attributes["tenant"]; ok && len(tenants) > 0 {
+			organizationName = tenants[0]
+		}
+
+		// Delete groups
+		err = m.deleteProjectAuthorizationGroups(ctx, resource.Name, organizationName)
+		if err != nil {
+			m.logger.WarnContext(ctx, "Failed to delete authorization groups",
+				slog.String("resource_name", resource.Name),
+				slog.String("organization", organizationName),
+				slog.Any("error", err),
+			)
+			// Continue with resource deletion even if group cleanup fails
+		}
+	}
+
+	// Delete the resource
+	err = m.client.DeleteAuthorizationResource(ctx, resourceID)
 	if err != nil {
 		return fmt.Errorf("failed to delete authorization resource: %w", err)
 	}
@@ -123,6 +199,74 @@ func (m *ResourceManager) DeleteAuthorizationResource(ctx context.Context, resou
 	)
 
 	return nil
+}
+
+// deleteProjectAuthorizationGroups deletes Keycloak organization groups
+// for a project resource using the new hierarchical naming convention.
+func (m *ResourceManager) deleteProjectAuthorizationGroups(ctx context.Context, resourceName, organizationName string) error {
+	if organizationName == "" {
+		return fmt.Errorf("organization name is required for deleting groups")
+	}
+
+	// Extract project name from resource name (format: PROJECT-{tenant}-{name})
+	// Remove "PROJECT-{tenant}-" prefix to get just the project name
+	parts := resourceName[len("PROJECT-"):] // Remove "PROJECT-" to get "{tenant}-{name}"
+	// Find the first '-' to split tenant from project name
+	firstDash := len(organizationName)
+	if len(parts) > firstDash+1 {
+		projectName := parts[firstDash+1:] // Skip tenant and dash
+
+		// Use new hierarchical paths: /{projects}/{project-name}/{viewers|managers}
+		viewersGroupPath := fmt.Sprintf("/%s/%s/%s", GroupPathProjects, projectName, GroupNameViewers)
+		managersGroupPath := fmt.Sprintf("/%s/%s/%s", GroupPathProjects, projectName, GroupNameManagers)
+
+		// TODO: Delete policies first (they reference the groups)
+
+		// Get group IDs and delete groups
+		viewersGroupID, err := m.getGroupIDByPath(ctx, organizationName, viewersGroupPath)
+		if err != nil {
+			m.logger.WarnContext(ctx, "Failed to get viewers group ID for deletion",
+				slog.String("group_path", viewersGroupPath),
+				slog.String("organization", organizationName),
+				slog.Any("error", err),
+			)
+		} else {
+			err = m.client.DeleteAuthorizationGroup(ctx, organizationName, viewersGroupID)
+			if err != nil {
+				m.logger.WarnContext(ctx, "Failed to delete viewers group",
+					slog.String("group_id", viewersGroupID),
+					slog.String("organization", organizationName),
+					slog.Any("error", err),
+				)
+			}
+		}
+
+		managersGroupID, err := m.getGroupIDByPath(ctx, organizationName, managersGroupPath)
+		if err != nil {
+			m.logger.WarnContext(ctx, "Failed to get managers group ID for deletion",
+				slog.String("group_path", managersGroupPath),
+				slog.String("organization", organizationName),
+				slog.Any("error", err),
+			)
+		} else {
+			err = m.client.DeleteAuthorizationGroup(ctx, organizationName, managersGroupID)
+			if err != nil {
+				m.logger.WarnContext(ctx, "Failed to delete managers group",
+					slog.String("group_id", managersGroupID),
+					slog.String("organization", organizationName),
+					slog.Any("error", err),
+				)
+			}
+		}
+	}
+
+	return nil
+}
+
+// getGroupIDByPath is a helper to get the group ID from a group path.
+// This delegates to the client's GetGroupIDByPath implementation.
+func (m *ResourceManager) getGroupIDByPath(ctx context.Context, organizationName, groupPath string) (string, error) {
+	return m.client.GetGroupIDByPath(ctx, organizationName, groupPath)
 }
 
 // GetAuthorizationResource retrieves an Authorization Resource by ID.

--- a/internal/idp/resource_manager.go
+++ b/internal/idp/resource_manager.go
@@ -18,6 +18,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"strings"
 )
 
 // ResourceManager handles authorization resource operations.
@@ -70,6 +71,7 @@ func (b *ResourceManagerBuilder) Build() (result *ResourceManager, err error) {
 
 // CreateProjectAuthorizationResource creates an Authorization Resource for a project.
 // The resource name follows the format: PROJECT-{tenant}-{projectName}
+// This also creates authorization groups for viewer and manager access.
 func (m *ResourceManager) CreateProjectAuthorizationResource(ctx context.Context, projectID, tenant, projectName string, scopes []string) (string, error) {
 	resourceName := fmt.Sprintf("PROJECT-%s-%s", tenant, projectName)
 
@@ -104,6 +106,24 @@ func (m *ResourceManager) CreateProjectAuthorizationResource(ctx context.Context
 		slog.String("project_id", projectID),
 	)
 
+	// Create authorization groups for the project
+	err = m.createProjectAuthorizationGroups(ctx, createdResource.ID, tenant, projectName)
+	if err != nil {
+		// Clean up the resource if group creation fails
+		m.logger.ErrorContext(ctx, "Failed to create authorization groups, cleaning up resource",
+			slog.String("resource_id", createdResource.ID),
+			slog.Any("error", err),
+		)
+		if cleanupErr := m.client.DeleteAuthorizationResource(ctx, createdResource.ID); cleanupErr != nil {
+			m.logger.ErrorContext(ctx, "Failed to cleanup authorization resource during rollback",
+				slog.String("resource_id", createdResource.ID),
+				slog.Any("cleanup_error", cleanupErr),
+			)
+			return "", fmt.Errorf("failed to create authorization groups: %w (cleanup also failed: %v)", err, cleanupErr)
+		}
+		return "", fmt.Errorf("failed to create authorization groups: %w", err)
+	}
+
 	return createdResource.ID, nil
 }
 
@@ -115,9 +135,8 @@ func (m *ResourceManager) createProjectAuthorizationGroups(ctx context.Context, 
 
 	// Create viewers group using new naming convention
 	// Group path: /{projects}/{project-name}/{viewers}
-	viewersGroupName := GroupNameViewers
 	viewersGroupPath := fmt.Sprintf("/%s/%s/%s", GroupPathProjects, projectName, GroupNameViewers)
-	err := m.client.CreateAuthorizationGroup(ctx, organizationName, viewersGroupName, viewersGroupPath)
+	err := m.client.CreateAuthorizationGroup(ctx, organizationName, GroupNameViewers, viewersGroupPath)
 	if err != nil {
 		return fmt.Errorf("failed to create viewers group: %w", err)
 	}
@@ -135,9 +154,24 @@ func (m *ResourceManager) createProjectAuthorizationGroups(ctx context.Context, 
 	err = m.client.CreateAuthorizationGroup(ctx, organizationName, managersGroupName, managersGroupPath)
 	if err != nil {
 		// Clean up viewers group on failure
-		viewersGroupID, _ := m.getGroupIDByPath(ctx, organizationName, viewersGroupPath)
+		viewersGroupID, getErr := m.getGroupIDByPath(ctx, organizationName, viewersGroupPath)
+		if getErr != nil {
+			m.logger.ErrorContext(ctx, "Failed to get viewers group ID during rollback",
+				slog.String("group_path", viewersGroupPath),
+				slog.Any("get_error", getErr),
+			)
+			// Return composite error including lookup failure
+			return fmt.Errorf("failed to create managers group: %w (rollback also failed to lookup viewers group: %v)", err, getErr)
+		}
 		if viewersGroupID != "" {
-			_ = m.client.DeleteAuthorizationGroup(ctx, organizationName, viewersGroupID)
+			if cleanupErr := m.client.DeleteAuthorizationGroup(ctx, organizationName, viewersGroupID); cleanupErr != nil {
+				m.logger.ErrorContext(ctx, "Failed to cleanup viewers group during rollback",
+					slog.String("group_id", viewersGroupID),
+					slog.String("group_path", viewersGroupPath),
+					slog.Any("cleanup_error", cleanupErr),
+				)
+				return fmt.Errorf("failed to create managers group: %w (rollback also failed to delete viewers group: %v)", err, cleanupErr)
+			}
 		}
 		return fmt.Errorf("failed to create managers group: %w", err)
 	}
@@ -156,6 +190,7 @@ func (m *ResourceManager) createProjectAuthorizationGroups(ctx context.Context, 
 }
 
 // DeleteAuthorizationResource deletes an Authorization Resource by ID.
+// This also deletes the associated groups
 func (m *ResourceManager) DeleteAuthorizationResource(ctx context.Context, resourceID string) error {
 	m.logger.DebugContext(ctx, "Deleting authorization resource",
 		slog.String("resource_id", resourceID),
@@ -209,8 +244,15 @@ func (m *ResourceManager) deleteProjectAuthorizationGroups(ctx context.Context, 
 	}
 
 	// Extract project name from resource name (format: PROJECT-{tenant}-{name})
+	resourcePrefix := "PROJECT-"
+	if !strings.HasPrefix(resourceName, resourcePrefix) {
+		m.logger.WarnContext(ctx, "Unexpected resource name format, skipping group deletion",
+			slog.String("resource_name", resourceName),
+		)
+		return nil
+	}
 	// Remove "PROJECT-{tenant}-" prefix to get just the project name
-	parts := resourceName[len("PROJECT-"):] // Remove "PROJECT-" to get "{tenant}-{name}"
+	parts := resourceName[len(resourcePrefix):]
 	// Find the first '-' to split tenant from project name
 	firstDash := len(organizationName)
 	if len(parts) > firstDash+1 {

--- a/internal/idp/resource_manager_test.go
+++ b/internal/idp/resource_manager_test.go
@@ -95,6 +95,16 @@ var _ = Describe("ResourceManager", func() {
 					}, nil
 				})
 
+			// Expect viewers group creation (new organization groups API)
+			mockClient.EXPECT().
+				CreateAuthorizationGroup(ctx, "acme", "viewers", "/projects/web-app/viewers").
+				Return(nil)
+
+			// Expect managers group creation (new organization groups API)
+			mockClient.EXPECT().
+				CreateAuthorizationGroup(ctx, "acme", "managers", "/projects/web-app/managers").
+				Return(nil)
+
 			resourceID, err := manager.CreateProjectAuthorizationResource(ctx, testProjectID, testTenant, testProject, testScopes)
 
 			Expect(err).ToNot(HaveOccurred())
@@ -113,12 +123,113 @@ var _ = Describe("ResourceManager", func() {
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("failed to create authorization resource"))
 		})
+
+		It("should cleanup resource when viewers group creation fails", func() {
+			expectedResourceID := "resource-456"
+			testScopes := []string{ScopeViewProject, ScopeManageProject}
+
+			// Resource creation succeeds
+			mockClient.EXPECT().
+				CreateAuthorizationResource(ctx, gomock.Any()).
+				Return(&AuthorizationResource{
+					ID:   expectedResourceID,
+					Name: "PROJECT-acme-web-app",
+				}, nil)
+
+			// Viewers group creation fails
+			mockClient.EXPECT().
+				CreateAuthorizationGroup(ctx, "acme", "viewers", "/projects/web-app/viewers").
+				Return(context.DeadlineExceeded)
+
+			// Expect cleanup: delete the resource
+			mockClient.EXPECT().
+				DeleteAuthorizationResource(ctx, expectedResourceID).
+				Return(nil)
+
+			_, err := manager.CreateProjectAuthorizationResource(ctx, testProjectID, testTenant, testProject, testScopes)
+
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("failed to create authorization groups"))
+		})
+
+		It("should cleanup resource and viewers group when managers group creation fails", func() {
+			expectedResourceID := "resource-456"
+			testScopes := []string{ScopeViewProject, ScopeManageProject}
+
+			// Resource creation succeeds
+			mockClient.EXPECT().
+				CreateAuthorizationResource(ctx, gomock.Any()).
+				Return(&AuthorizationResource{
+					ID:   expectedResourceID,
+					Name: "PROJECT-acme-web-app",
+				}, nil)
+
+			// Viewers group creation succeeds
+			mockClient.EXPECT().
+				CreateAuthorizationGroup(ctx, "acme", "viewers", "/projects/web-app/viewers").
+				Return(nil)
+
+			// Managers group creation fails
+			mockClient.EXPECT().
+				CreateAuthorizationGroup(ctx, "acme", "managers", "/projects/web-app/managers").
+				Return(context.DeadlineExceeded)
+
+			// Expect cleanup: get viewers group ID, then delete it
+			mockClient.EXPECT().
+				GetGroupIDByPath(ctx, "acme", "/projects/web-app/viewers").
+				Return("viewers-group-id", nil)
+			mockClient.EXPECT().
+				DeleteAuthorizationGroup(ctx, "acme", "viewers-group-id").
+				Return(nil)
+
+			// Expect cleanup: delete the resource
+			mockClient.EXPECT().
+				DeleteAuthorizationResource(ctx, expectedResourceID).
+				Return(nil)
+
+			_, err := manager.CreateProjectAuthorizationResource(ctx, testProjectID, testTenant, testProject, testScopes)
+
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("failed to create authorization groups"))
+		})
 	})
 
 	Describe("DeleteAuthorizationResource", func() {
 		It("should delete an authorization resource by ID", func() {
 			resourceID := "resource-456"
 
+			// Get resource to extract name and tenant for group cleanup
+			mockClient.EXPECT().
+				GetAuthorizationResource(ctx, resourceID).
+				Return(&AuthorizationResource{
+					ID:   resourceID,
+					Name: resourceName,
+					Attributes: map[string][]string{
+						"tenant": {"acme"},
+					},
+				}, nil)
+
+			// Get viewers group ID (new organization groups API)
+			mockClient.EXPECT().
+				GetGroupIDByPath(ctx, "acme", "/projects/web-app/viewers").
+				Return("viewers-group-id", nil)
+
+			// Delete viewers group (new organization groups API)
+			mockClient.EXPECT().
+				DeleteAuthorizationGroup(ctx, "acme", "viewers-group-id").
+				Return(nil)
+
+			// Get managers group ID (new organization groups API)
+			mockClient.EXPECT().
+				GetGroupIDByPath(ctx, "acme", "/projects/web-app/managers").
+				Return("managers-group-id", nil)
+
+			// Delete managers group (new organization groups API)
+			mockClient.EXPECT().
+				DeleteAuthorizationGroup(ctx, "acme", "managers-group-id").
+				Return(nil)
+
+			// Delete the resource itself
 			mockClient.EXPECT().
 				DeleteAuthorizationResource(ctx, resourceID).
 				Return(nil)
@@ -131,6 +242,70 @@ var _ = Describe("ResourceManager", func() {
 		It("should return error when client fails", func() {
 			resourceID := "resource-456"
 
+			// Get resource fails (might already be deleted)
+			mockClient.EXPECT().
+				GetAuthorizationResource(ctx, resourceID).
+				Return(nil, context.DeadlineExceeded)
+
+			// Should still attempt to delete the resource
+			mockClient.EXPECT().
+				DeleteAuthorizationResource(ctx, resourceID).
+				Return(nil)
+
+			err := manager.DeleteAuthorizationResource(ctx, resourceID)
+
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("should continue deleting resource even if group deletion fails", func() {
+			resourceID := "resource-456"
+			resourceName := "PROJECT-acme-web-app"
+
+			// Get resource succeeds with tenant attribute
+			mockClient.EXPECT().
+				GetAuthorizationResource(ctx, resourceID).
+				Return(&AuthorizationResource{
+					ID:   resourceID,
+					Name: resourceName,
+					Attributes: map[string][]string{
+						"tenant": {"acme"},
+					},
+				}, nil)
+
+			// Viewers group lookup fails
+			mockClient.EXPECT().
+				GetGroupIDByPath(ctx, "acme", "/projects/web-app/viewers").
+				Return("", context.DeadlineExceeded)
+
+			// Managers group lookup succeeds
+			mockClient.EXPECT().
+				GetGroupIDByPath(ctx, "acme", "/projects/web-app/managers").
+				Return("managers-group-id", nil)
+
+			// Managers group deletion fails
+			mockClient.EXPECT().
+				DeleteAuthorizationGroup(ctx, "acme", "managers-group-id").
+				Return(context.DeadlineExceeded)
+
+			// Should still delete the resource
+			mockClient.EXPECT().
+				DeleteAuthorizationResource(ctx, resourceID).
+				Return(nil)
+
+			err := manager.DeleteAuthorizationResource(ctx, resourceID)
+
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("should return error when resource deletion fails", func() {
+			resourceID := "resource-456"
+
+			// Get resource fails
+			mockClient.EXPECT().
+				GetAuthorizationResource(ctx, resourceID).
+				Return(nil, context.DeadlineExceeded)
+
+			// Resource deletion fails
 			mockClient.EXPECT().
 				DeleteAuthorizationResource(ctx, resourceID).
 				Return(context.DeadlineExceeded)

--- a/internal/idp/resource_manager_test.go
+++ b/internal/idp/resource_manager_test.go
@@ -72,11 +72,12 @@ var _ = Describe("ResourceManager", func() {
 	})
 
 	Describe("CreateProjectAuthorizationResource", func() {
-		It("should create an authorization resource with correct naming format", func() {
+		It("should create an authorization resource with correct naming format and groups", func() {
 			expectedResourceName := "PROJECT-acme-web-app"
 			expectedResourceID := "resource-456"
 			testScopes := []string{ScopeViewProject, ScopeManageProject}
 
+			// Expect resource creation
 			mockClient.EXPECT().
 				CreateAuthorizationResource(ctx, gomock.Any()).
 				DoAndReturn(func(ctx context.Context, resource *AuthorizationResource) (*AuthorizationResource, error) {
@@ -111,7 +112,7 @@ var _ = Describe("ResourceManager", func() {
 			Expect(resourceID).To(Equal(expectedResourceID))
 		})
 
-		It("should return error when client fails", func() {
+		It("should return error when resource creation fails", func() {
 			testScopes := []string{ScopeViewProject, ScopeManageProject}
 
 			mockClient.EXPECT().
@@ -195,8 +196,9 @@ var _ = Describe("ResourceManager", func() {
 	})
 
 	Describe("DeleteAuthorizationResource", func() {
-		It("should delete an authorization resource by ID", func() {
+		It("should delete an authorization resource and its groups by ID", func() {
 			resourceID := "resource-456"
+			resourceName := "PROJECT-acme-web-app"
 
 			// Get resource to extract name and tenant for group cleanup
 			mockClient.EXPECT().
@@ -239,7 +241,7 @@ var _ = Describe("ResourceManager", func() {
 			Expect(err).ToNot(HaveOccurred())
 		})
 
-		It("should return error when client fails", func() {
+		It("should continue deleting resource even if GetAuthorizationResource fails", func() {
 			resourceID := "resource-456"
 
 			// Get resource fails (might already be deleted)


### PR DESCRIPTION
# Description

In order to control access to projects, we'll create two Keycloak groups for every project created.
The groups are:
1. VIEW Project - allows viewing the project and its resources
2. MANAGE Project - allows managing the project (includes updates and deleting the project itself)

This allows an admin to easily manage users' access to a project by assigning them to a group.

Note: This still requires Policies in order to fully grant access for each of these groups. Another follow up is functions to add/remove users from these groups.

# Testing

- [x] go build passes
- [x] All unit tests pass `ginkgo run -r ./internal`

Assisted-by: Claude Code <noreply@anthropic.com>

/cc @jhernand 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  - Projects now automatically create hierarchical authorization groups (viewers and managers) for role-based access control during project creation.
  - Authorization groups are automatically cleaned up when projects are deleted, maintaining system consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->