### PR TITLE
NO-ISSUE: Use `new(expression)` for remaining `proto.Int32` calls

### DIFF
--- a/internal/cmd/cli/console/connect/resolve.go
+++ b/internal/cmd/cli/console/connect/resolve.go
@@ -19,7 +19,6 @@ import (
 
 	publicv1 "github.com/osac-project/fulfillment-service/internal/api/osac/public/v1"
 	"google.golang.org/grpc"
-	"google.golang.org/protobuf/proto"
 )
 
 // ResolveInstance resolves a name or ID to a compute instance ID.
@@ -31,7 +30,7 @@ func ResolveInstance(ctx context.Context, conn *grpc.ClientConn, key string) (st
 	)
 	resp, err := client.List(ctx, publicv1.ComputeInstancesListRequest_builder{
 		Filter: new(listFilter),
-		Limit:  proto.Int32(2),
+		Limit:  new(int32(2)),
 	}.Build())
 	if err != nil {
 		return "", fmt.Errorf("failed to look up compute instance: %w", err)

--- a/internal/cmd/cli/create/cluster/create_cluster_cmd.go
+++ b/internal/cmd/cli/create/cluster/create_cluster_cmd.go
@@ -360,7 +360,7 @@ func (c *runnerContext) findTemplate(ctx context.Context) (result *publicv1.Clus
 	)
 	response, err := c.templatesClient.List(ctx, publicv1.ClusterTemplatesListRequest_builder{
 		Filter: new(filter),
-		Limit:  proto.Int32(10),
+		Limit:  new(int32(10)),
 	}.Build())
 	if err != nil {
 		return nil, fmt.Errorf("failed to list templates: %w", err)
@@ -387,7 +387,7 @@ func (c *runnerContext) findTemplate(ctx context.Context) (result *publicv1.Clus
 
 	// If we are here then no matches were found, we will show to the user some of the available templates:
 	response, err = c.templatesClient.List(ctx, publicv1.ClusterTemplatesListRequest_builder{
-		Limit: proto.Int32(10),
+		Limit: new(int32(10)),
 	}.Build())
 	if err != nil {
 		return nil, fmt.Errorf("failed to list templates: %w", err)

--- a/internal/cmd/cli/create/computeinstance/create_compute_instance_cmd.go
+++ b/internal/cmd/cli/create/computeinstance/create_compute_instance_cmd.go
@@ -344,7 +344,7 @@ func (c *runnerContext) findTemplate(ctx context.Context) (result *publicv1.Comp
 	)
 	response, err := c.templatesClient.List(ctx, publicv1.ComputeInstanceTemplatesListRequest_builder{
 		Filter: new(filter),
-		Limit:  proto.Int32(10),
+		Limit:  new(int32(10)),
 	}.Build())
 	if err != nil {
 		return nil, fmt.Errorf("failed to list templates: %w", err)
@@ -371,7 +371,7 @@ func (c *runnerContext) findTemplate(ctx context.Context) (result *publicv1.Comp
 
 	// If we are here then no matches were found, we will show to the user some of the available templates:
 	response, err = c.templatesClient.List(ctx, publicv1.ComputeInstanceTemplatesListRequest_builder{
-		Limit: proto.Int32(10),
+		Limit: new(int32(10)),
 	}.Build())
 	if err != nil {
 		return nil, fmt.Errorf("failed to list templates: %w", err)

--- a/internal/cmd/cli/describe/cluster/describe_cluster.go
+++ b/internal/cmd/cli/describe/cluster/describe_cluster.go
@@ -20,7 +20,6 @@ import (
 	"text/tabwriter"
 
 	"github.com/spf13/cobra"
-	"google.golang.org/protobuf/proto"
 
 	publicv1 "github.com/osac-project/fulfillment-service/internal/api/osac/public/v1"
 	"github.com/osac-project/fulfillment-service/internal/config"
@@ -69,7 +68,7 @@ func (c *runnerContext) run(cmd *cobra.Command, args []string) error {
 	filter := buildFilter(ref)
 	listResponse, err := client.List(ctx, publicv1.ClustersListRequest_builder{
 		Filter: &filter,
-		Limit:  proto.Int32(2),
+		Limit:  new(int32(2)),
 	}.Build())
 	if err != nil {
 		return fmt.Errorf("failed to describe cluster: %w", err)

--- a/internal/cmd/cli/describe/computeinstance/describe_computeinstance_cmd.go
+++ b/internal/cmd/cli/describe/computeinstance/describe_computeinstance_cmd.go
@@ -21,7 +21,6 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
-	"google.golang.org/protobuf/proto"
 
 	publicv1 "github.com/osac-project/fulfillment-service/internal/api/osac/public/v1"
 	"github.com/osac-project/fulfillment-service/internal/config"
@@ -70,7 +69,7 @@ func (c *runnerContext) run(cmd *cobra.Command, args []string) error {
 	filter := buildFilter(ref)
 	listResponse, err := client.List(ctx, publicv1.ComputeInstancesListRequest_builder{
 		Filter: &filter,
-		Limit:  proto.Int32(2),
+		Limit:  new(int32(2)),
 	}.Build())
 	if err != nil {
 		return fmt.Errorf("failed to describe compute instance: %w", err)

--- a/internal/cmd/cli/describe/securitygroup/describe_securitygroup_test.go
+++ b/internal/cmd/cli/describe/securitygroup/describe_securitygroup_test.go
@@ -19,8 +19,6 @@ import (
 	. "github.com/onsi/ginkgo/v2/dsl/core"
 	. "github.com/onsi/gomega"
 
-	"google.golang.org/protobuf/proto"
-
 	publicv1 "github.com/osac-project/fulfillment-service/internal/api/osac/public/v1"
 )
 
@@ -53,8 +51,8 @@ var _ = Describe("Describe Security Group", func() {
 					Ingress: []*publicv1.SecurityRule{
 						publicv1.SecurityRule_builder{
 							Protocol: publicv1.Protocol_PROTOCOL_TCP,
-							PortFrom: proto.Int32(80),
-							PortTo:   proto.Int32(80),
+							PortFrom: new(int32(80)),
+							PortTo:   new(int32(80)),
 							Ipv4Cidr: new("0.0.0.0/0"),
 						}.Build(),
 					},
@@ -111,8 +109,8 @@ var _ = Describe("Describe Security Group", func() {
 					Ingress: []*publicv1.SecurityRule{
 						publicv1.SecurityRule_builder{
 							Protocol: publicv1.Protocol_PROTOCOL_TCP,
-							PortFrom: proto.Int32(443),
-							PortTo:   proto.Int32(443),
+							PortFrom: new(int32(443)),
+							PortTo:   new(int32(443)),
 						}.Build(),
 					},
 				}.Build(),

--- a/internal/cmd/cli/get/kubeconfig/get_kubeconfig_cmd.go
+++ b/internal/cmd/cli/get/kubeconfig/get_kubeconfig_cmd.go
@@ -23,7 +23,6 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"google.golang.org/grpc"
-	"google.golang.org/protobuf/proto"
 	"gopkg.in/yaml.v3"
 
 	publicv1 "github.com/osac-project/fulfillment-service/internal/api/osac/public/v1"
@@ -118,7 +117,7 @@ func (c *runnerContext) run(cmd *cobra.Command, args []string) error {
 	)
 	listResponse, err := client.List(ctx, publicv1.ClustersListRequest_builder{
 		Filter: new(listFilter),
-		Limit:  proto.Int32(10),
+		Limit:  new(int32(10)),
 	}.Build())
 	if err != nil {
 		return fmt.Errorf("failed to list clusters: %w", err)

--- a/internal/cmd/cli/get/password/get_password_cmd.go
+++ b/internal/cmd/cli/get/password/get_password_cmd.go
@@ -23,7 +23,6 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"google.golang.org/grpc"
-	"google.golang.org/protobuf/proto"
 
 	publicv1 "github.com/osac-project/fulfillment-service/internal/api/osac/public/v1"
 	"github.com/osac-project/fulfillment-service/internal/config"
@@ -118,7 +117,7 @@ func (c *runnerContext) run(cmd *cobra.Command, args []string) error {
 	)
 	listResponse, err := client.List(ctx, publicv1.ClustersListRequest_builder{
 		Filter: new(listFilter),
-		Limit:  proto.Int32(10),
+		Limit:  new(int32(10)),
 	}.Build())
 	if err != nil {
 		return fmt.Errorf("failed to list clusters: %w", err)

--- a/internal/controllers/computeinstance/computeinstance_reconciler_function_test.go
+++ b/internal/controllers/computeinstance/computeinstance_reconciler_function_test.go
@@ -90,8 +90,8 @@ var _ = Describe("buildSpec", func() {
 					Id: "test-explicit-fields",
 					Spec: privatev1.ComputeInstanceSpec_builder{
 						Template:    template,
-						Cores:       proto.Int32(4),
-						MemoryGib:   proto.Int32(8),
+						Cores:       new(int32(4)),
+						MemoryGib:   new(int32(8)),
 						RunStrategy: new("Always"),
 						SshKey:      new("ssh-rsa AAAA..."),
 						Image: privatev1.ComputeInstanceImage_builder{

--- a/internal/controllers/project/project_reconciler_function.go
+++ b/internal/controllers/project/project_reconciler_function.go
@@ -276,7 +276,7 @@ func (t *task) delete(ctx context.Context) error {
 	listResp, err := t.r.projectsClient.List(ctx, &privatev1.ProjectsListRequest{
 		//TODO: Update to use metadata.project once OSAC-1064 is implemented
 		Filter: new(fmt.Sprintf("this.spec.parent == '%s'", t.project.GetId())),
-		Limit:  proto.Int32(1), // We only need to know if any exist
+		Limit:  new(int32(1)), // We only need to know if any exist
 	})
 	if err != nil {
 		// Transient error - retry later

--- a/internal/servers/cluster_catalog_items_server_test.go
+++ b/internal/servers/cluster_catalog_items_server_test.go
@@ -152,7 +152,7 @@ var _ = Describe("Cluster catalog items server", func() {
 			}
 
 			response, err := server.List(ctx, publicv1.ClusterCatalogItemsListRequest_builder{
-				Limit: proto.Int32(1),
+				Limit: new(int32(1)),
 			}.Build())
 			Expect(err).ToNot(HaveOccurred())
 			Expect(response.GetSize()).To(BeNumerically("==", 1))

--- a/internal/servers/cluster_templates_server_test.go
+++ b/internal/servers/cluster_templates_server_test.go
@@ -172,7 +172,7 @@ var _ = Describe("Cluster templates server", func() {
 
 			// List the objects:
 			response, err := server.List(ctx, publicv1.ClusterTemplatesListRequest_builder{
-				Limit: proto.Int32(1),
+				Limit: new(int32(1)),
 			}.Build())
 			Expect(err).ToNot(HaveOccurred())
 			Expect(response.GetSize()).To(BeNumerically("==", 1))
@@ -195,7 +195,7 @@ var _ = Describe("Cluster templates server", func() {
 			// List the objects:
 			response, err := server.List(ctx, publicv1.ClusterTemplatesListRequest_builder{
 				Filter: new("this.id.startsWith('my_template_')"),
-				Offset: proto.Int32(1),
+				Offset: new(int32(1)),
 			}.Build())
 			Expect(err).ToNot(HaveOccurred())
 			Expect(response.GetSize()).To(BeNumerically("==", count-1))

--- a/internal/servers/clusters_server_test.go
+++ b/internal/servers/clusters_server_test.go
@@ -700,7 +700,7 @@ var _ = Describe("Clusters server", func() {
 
 			// List the objects:
 			response, err := server.List(ctx, publicv1.ClustersListRequest_builder{
-				Limit: proto.Int32(1),
+				Limit: new(int32(1)),
 			}.Build())
 			Expect(err).ToNot(HaveOccurred())
 			Expect(response.GetSize()).To(BeNumerically("==", 1))
@@ -722,7 +722,7 @@ var _ = Describe("Clusters server", func() {
 
 			// List the objects:
 			response, err := server.List(ctx, publicv1.ClustersListRequest_builder{
-				Offset: proto.Int32(1),
+				Offset: new(int32(1)),
 			}.Build())
 			Expect(err).ToNot(HaveOccurred())
 			Expect(response.GetSize()).To(BeNumerically("==", count-1))

--- a/internal/servers/compute_instance_catalog_items_server_test.go
+++ b/internal/servers/compute_instance_catalog_items_server_test.go
@@ -152,7 +152,7 @@ var _ = Describe("Compute instance catalog items server", func() {
 			}
 
 			response, err := server.List(ctx, publicv1.ComputeInstanceCatalogItemsListRequest_builder{
-				Limit: proto.Int32(1),
+				Limit: new(int32(1)),
 			}.Build())
 			Expect(err).ToNot(HaveOccurred())
 			Expect(response.GetSize()).To(BeNumerically("==", 1))

--- a/internal/servers/compute_instance_templates_server_test.go
+++ b/internal/servers/compute_instance_templates_server_test.go
@@ -19,7 +19,6 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/fieldmaskpb"
 
 	publicv1 "github.com/osac-project/fulfillment-service/internal/api/osac/public/v1"
@@ -210,7 +209,7 @@ var _ = Describe("Compute instance templates server", func() {
 
 			// List the objects with limit:
 			response, err := server.List(ctx, publicv1.ComputeInstanceTemplatesListRequest_builder{
-				Limit: proto.Int32(5),
+				Limit: new(int32(5)),
 			}.Build())
 			Expect(err).ToNot(HaveOccurred())
 			Expect(response).ToNot(BeNil())
@@ -233,7 +232,7 @@ var _ = Describe("Compute instance templates server", func() {
 
 			// List the objects with offset:
 			response, err := server.List(ctx, publicv1.ComputeInstanceTemplatesListRequest_builder{
-				Offset: proto.Int32(5),
+				Offset: new(int32(5)),
 			}.Build())
 			Expect(err).ToNot(HaveOccurred())
 			Expect(response).ToNot(BeNil())

--- a/internal/servers/compute_instances_server_test.go
+++ b/internal/servers/compute_instances_server_test.go
@@ -19,7 +19,6 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/anypb"
 	"google.golang.org/protobuf/types/known/fieldmaskpb"
 	"google.golang.org/protobuf/types/known/timestamppb"
@@ -168,8 +167,8 @@ var _ = Describe("Compute instances server", func() {
 					},
 				},
 				SpecDefaults: privatev1.ComputeInstanceTemplateSpecDefaults_builder{
-					Cores:     proto.Int32(2),
-					MemoryGib: proto.Int32(2),
+					Cores:     new(int32(2)),
+					MemoryGib: new(int32(2)),
 					Image: privatev1.ComputeInstanceImage_builder{
 						SourceType: "registry",
 						SourceRef:  "quay.io/containerdisks/fedora:latest",
@@ -269,7 +268,7 @@ var _ = Describe("Compute instances server", func() {
 
 			// List the objects with limit:
 			response, err := server.List(ctx, publicv1.ComputeInstancesListRequest_builder{
-				Limit: proto.Int32(5),
+				Limit: new(int32(5)),
 			}.Build())
 			Expect(err).ToNot(HaveOccurred())
 			Expect(response).ToNot(BeNil())
@@ -299,7 +298,7 @@ var _ = Describe("Compute instances server", func() {
 
 			// List the objects with offset:
 			response, err := server.List(ctx, publicv1.ComputeInstancesListRequest_builder{
-				Offset: proto.Int32(5),
+				Offset: new(int32(5)),
 			}.Build())
 			Expect(err).ToNot(HaveOccurred())
 			Expect(response).ToNot(BeNil())
@@ -351,8 +350,8 @@ var _ = Describe("Compute instances server", func() {
 				Object: publicv1.ComputeInstance_builder{
 					Spec: publicv1.ComputeInstanceSpec_builder{
 						Template:    "general.small",
-						Cores:       proto.Int32(4),
-						MemoryGib:   proto.Int32(8),
+						Cores:       new(int32(4)),
+						MemoryGib:   new(int32(8)),
 						RunStrategy: new("Always"),
 						Image: publicv1.ComputeInstanceImage_builder{
 							SourceType: "registry",
@@ -496,8 +495,8 @@ var _ = Describe("Compute instances server", func() {
 				Object: publicv1.ComputeInstance_builder{
 					Spec: publicv1.ComputeInstanceSpec_builder{
 						Template:    "mapping-template",
-						Cores:       proto.Int32(8),
-						MemoryGib:   proto.Int32(16),
+						Cores:       new(int32(8)),
+						MemoryGib:   new(int32(16)),
 						RunStrategy: new("Halted"),
 					}.Build(),
 				}.Build(),

--- a/internal/servers/host_types_server_test.go
+++ b/internal/servers/host_types_server_test.go
@@ -158,7 +158,7 @@ var _ = Describe("Host types server", func() {
 
 			// List the objects:
 			response, err := server.List(ctx, publicv1.HostTypesListRequest_builder{
-				Limit: proto.Int32(1),
+				Limit: new(int32(1)),
 			}.Build())
 			Expect(err).ToNot(HaveOccurred())
 			Expect(response.GetSize()).To(BeNumerically("==", 1))
@@ -176,7 +176,7 @@ var _ = Describe("Host types server", func() {
 
 			// List the objects:
 			response, err := server.List(ctx, publicv1.HostTypesListRequest_builder{
-				Offset: proto.Int32(1),
+				Offset: new(int32(1)),
 			}.Build())
 			Expect(err).ToNot(HaveOccurred())
 			Expect(response.GetSize()).To(BeNumerically("==", count-1))

--- a/internal/servers/network_classes_server_test.go
+++ b/internal/servers/network_classes_server_test.go
@@ -20,7 +20,6 @@ import (
 	"github.com/google/uuid"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/fieldmaskpb"
 
 	privatev1 "github.com/osac-project/fulfillment-service/internal/api/osac/private/v1"
@@ -184,7 +183,7 @@ var _ = Describe("Network classes server", func() {
 
 			// List the objects via public server:
 			response, err := publicServer.List(ctx, publicv1.NetworkClassesListRequest_builder{
-				Limit: proto.Int32(1),
+				Limit: new(int32(1)),
 			}.Build())
 			Expect(err).ToNot(HaveOccurred())
 			Expect(response.GetSize()).To(BeNumerically("==", 1))
@@ -199,7 +198,7 @@ var _ = Describe("Network classes server", func() {
 
 			// List the objects via public server:
 			response, err := publicServer.List(ctx, publicv1.NetworkClassesListRequest_builder{
-				Offset: proto.Int32(1),
+				Offset: new(int32(1)),
 			}.Build())
 			Expect(err).ToNot(HaveOccurred())
 			Expect(response.GetSize()).To(BeNumerically("==", count-1))

--- a/internal/servers/private_cluster_catalog_items_server_test.go
+++ b/internal/servers/private_cluster_catalog_items_server_test.go
@@ -172,7 +172,7 @@ var _ = Describe("Private cluster catalog items server", func() {
 			}
 
 			response, err := server.List(ctx, privatev1.ClusterCatalogItemsListRequest_builder{
-				Limit: proto.Int32(1),
+				Limit: new(int32(1)),
 			}.Build())
 			Expect(err).ToNot(HaveOccurred())
 			Expect(response.GetSize()).To(BeNumerically("==", 1))

--- a/internal/servers/private_cluster_templates_server_test.go
+++ b/internal/servers/private_cluster_templates_server_test.go
@@ -177,7 +177,7 @@ var _ = Describe("Private cluster templates server", func() {
 			// List the objects:
 			response, err := server.List(ctx, privatev1.ClusterTemplatesListRequest_builder{
 				Filter: new("this.metadata.name.startsWith('my-template-')"),
-				Limit:  proto.Int32(1),
+				Limit:  new(int32(1)),
 			}.Build())
 			Expect(err).ToNot(HaveOccurred())
 			Expect(response.GetSize()).To(BeNumerically("==", 1))
@@ -212,7 +212,7 @@ var _ = Describe("Private cluster templates server", func() {
 			// List the objects:
 			response, err := server.List(ctx, privatev1.ClusterTemplatesListRequest_builder{
 				Filter: new("this.metadata.name.startsWith('my-template-')"),
-				Offset: proto.Int32(1),
+				Offset: new(int32(1)),
 			}.Build())
 			Expect(err).ToNot(HaveOccurred())
 			Expect(response.GetSize()).To(BeNumerically("==", count-1))

--- a/internal/servers/private_clusters_server_test.go
+++ b/internal/servers/private_clusters_server_test.go
@@ -531,7 +531,7 @@ var _ = Describe("Private clusters server", func() {
 
 			// List the objects:
 			response, err := server.List(ctx, privatev1.ClustersListRequest_builder{
-				Limit: proto.Int32(1),
+				Limit: new(int32(1)),
 			}.Build())
 			Expect(err).ToNot(HaveOccurred())
 			Expect(response.GetSize()).To(BeNumerically("==", 1))
@@ -556,7 +556,7 @@ var _ = Describe("Private clusters server", func() {
 
 			// List the objects:
 			response, err := server.List(ctx, privatev1.ClustersListRequest_builder{
-				Offset: proto.Int32(1),
+				Offset: new(int32(1)),
 			}.Build())
 			Expect(err).ToNot(HaveOccurred())
 			Expect(response.GetSize()).To(BeNumerically("==", count-1))

--- a/internal/servers/private_compute_instance_catalog_items_server_test.go
+++ b/internal/servers/private_compute_instance_catalog_items_server_test.go
@@ -171,7 +171,7 @@ var _ = Describe("Private compute instance catalog items server", func() {
 			}
 
 			response, err := server.List(ctx, privatev1.ComputeInstanceCatalogItemsListRequest_builder{
-				Limit: proto.Int32(1),
+				Limit: new(int32(1)),
 			}.Build())
 			Expect(err).ToNot(HaveOccurred())
 			Expect(response.GetSize()).To(BeNumerically("==", 1))

--- a/internal/servers/private_compute_instance_templates_server_test.go
+++ b/internal/servers/private_compute_instance_templates_server_test.go
@@ -19,7 +19,6 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/fieldmaskpb"
 
 	privatev1 "github.com/osac-project/fulfillment-service/internal/api/osac/private/v1"
@@ -208,7 +207,7 @@ var _ = Describe("Private compute instance templates server", func() {
 
 			// List the objects with limit:
 			response, err := server.List(ctx, privatev1.ComputeInstanceTemplatesListRequest_builder{
-				Limit: proto.Int32(5),
+				Limit: new(int32(5)),
 			}.Build())
 			Expect(err).ToNot(HaveOccurred())
 			Expect(response).ToNot(BeNil())
@@ -231,7 +230,7 @@ var _ = Describe("Private compute instance templates server", func() {
 
 			// List the objects with offset:
 			response, err := server.List(ctx, privatev1.ComputeInstanceTemplatesListRequest_builder{
-				Offset: proto.Int32(5),
+				Offset: new(int32(5)),
 			}.Build())
 			Expect(err).ToNot(HaveOccurred())
 			Expect(response).ToNot(BeNil())

--- a/internal/servers/private_compute_instances_server_test.go
+++ b/internal/servers/private_compute_instances_server_test.go
@@ -21,7 +21,6 @@ import (
 	. "github.com/onsi/gomega"
 	grpccodes "google.golang.org/grpc/codes"
 	grpcstatus "google.golang.org/grpc/status"
-	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/anypb"
 	"google.golang.org/protobuf/types/known/fieldmaskpb"
 	"google.golang.org/protobuf/types/known/structpb"
@@ -271,8 +270,8 @@ var _ = Describe("Private compute instances server", func() {
 					},
 				},
 				SpecDefaults: privatev1.ComputeInstanceTemplateSpecDefaults_builder{
-					Cores:     proto.Int32(2),
-					MemoryGib: proto.Int32(2),
+					Cores:     new(int32(2)),
+					MemoryGib: new(int32(2)),
 					Image: privatev1.ComputeInstanceImage_builder{
 						SourceType: "registry",
 						SourceRef:  "quay.io/containerdisks/fedora:latest",
@@ -372,7 +371,7 @@ var _ = Describe("Private compute instances server", func() {
 
 			// List the objects with limit:
 			response, err := server.List(ctx, privatev1.ComputeInstancesListRequest_builder{
-				Limit: proto.Int32(5),
+				Limit: new(int32(5)),
 			}.Build())
 			Expect(err).ToNot(HaveOccurred())
 			Expect(response).ToNot(BeNil())
@@ -402,7 +401,7 @@ var _ = Describe("Private compute instances server", func() {
 
 			// List the objects with offset:
 			response, err := server.List(ctx, privatev1.ComputeInstancesListRequest_builder{
-				Offset: proto.Int32(5),
+				Offset: new(int32(5)),
 			}.Build())
 			Expect(err).ToNot(HaveOccurred())
 			Expect(response).ToNot(BeNil())
@@ -750,8 +749,8 @@ var _ = Describe("Private compute instances server", func() {
 				Object: privatev1.ComputeInstance_builder{
 					Spec: privatev1.ComputeInstanceSpec_builder{
 						Template:    "override-template",
-						Cores:       proto.Int32(8),
-						MemoryGib:   proto.Int32(16),
+						Cores:       new(int32(8)),
+						MemoryGib:   new(int32(16)),
 						RunStrategy: new("Halted"),
 					}.Build(),
 				}.Build(),
@@ -834,8 +833,8 @@ var _ = Describe("Private compute instances server", func() {
 				Object: privatev1.ComputeInstance_builder{
 					Spec: privatev1.ComputeInstanceSpec_builder{
 						Template:  "bare-template",
-						Cores:     proto.Int32(4),
-						MemoryGib: proto.Int32(8),
+						Cores:     new(int32(4)),
+						MemoryGib: new(int32(8)),
 						Image: privatev1.ComputeInstanceImage_builder{
 							SourceType: "registry",
 							SourceRef:  "quay.io/containerdisks/fedora:latest",
@@ -868,8 +867,8 @@ var _ = Describe("Private compute instances server", func() {
 					Tenant: auth.SharedTenant,
 				}.Build(),
 				SpecDefaults: privatev1.ComputeInstanceTemplateSpecDefaults_builder{
-					Cores:       proto.Int32(2),
-					MemoryGib:   proto.Int32(4),
+					Cores:       new(int32(2)),
+					MemoryGib:   new(int32(4)),
 					RunStrategy: new("Always"),
 				}.Build(),
 			}.Build()
@@ -1185,8 +1184,8 @@ var _ = Describe("Private compute instances server", func() {
 					},
 				},
 				SpecDefaults: privatev1.ComputeInstanceTemplateSpecDefaults_builder{
-					Cores:     proto.Int32(2),
-					MemoryGib: proto.Int32(2),
+					Cores:     new(int32(2)),
+					MemoryGib: new(int32(2)),
 					Image: privatev1.ComputeInstanceImage_builder{
 						SourceType: "registry",
 						SourceRef:  "quay.io/containerdisks/fedora:latest",

--- a/internal/servers/private_host_types_server_test.go
+++ b/internal/servers/private_host_types_server_test.go
@@ -169,7 +169,7 @@ var _ = Describe("Private host types server", func() {
 
 			// List the objects:
 			response, err := server.List(ctx, privatev1.HostTypesListRequest_builder{
-				Limit: proto.Int32(1),
+				Limit: new(int32(1)),
 			}.Build())
 			Expect(err).ToNot(HaveOccurred())
 			Expect(response.GetSize()).To(BeNumerically("==", 1))
@@ -190,7 +190,7 @@ var _ = Describe("Private host types server", func() {
 
 			// List the objects:
 			response, err := server.List(ctx, privatev1.HostTypesListRequest_builder{
-				Offset: proto.Int32(1),
+				Offset: new(int32(1)),
 			}.Build())
 			Expect(err).ToNot(HaveOccurred())
 			Expect(response.GetSize()).To(BeNumerically("==", count-1))

--- a/internal/servers/private_hubs_server_test.go
+++ b/internal/servers/private_hubs_server_test.go
@@ -182,7 +182,7 @@ var _ = Describe("Private hubs server", func() {
 
 			// List the objects:
 			response, err := server.List(ctx, privatev1.HubsListRequest_builder{
-				Limit: proto.Int32(1),
+				Limit: new(int32(1)),
 			}.Build())
 			Expect(err).ToNot(HaveOccurred())
 			Expect(response.GetSize()).To(BeNumerically("==", 1))
@@ -205,7 +205,7 @@ var _ = Describe("Private hubs server", func() {
 
 			// List the objects:
 			response, err := server.List(ctx, privatev1.HubsListRequest_builder{
-				Offset: proto.Int32(1),
+				Offset: new(int32(1)),
 			}.Build())
 			Expect(err).ToNot(HaveOccurred())
 			Expect(response.GetSize()).To(BeNumerically("==", count-1))

--- a/internal/servers/private_public_ip_pools_server_test.go
+++ b/internal/servers/private_public_ip_pools_server_test.go
@@ -186,7 +186,7 @@ var _ = Describe("Private public IP pools server", func() {
 			}
 
 			response, err := poolsServer.List(ctx, privatev1.PublicIPPoolsListRequest_builder{
-				Limit: proto.Int32(2),
+				Limit: new(int32(2)),
 			}.Build())
 			Expect(err).ToNot(HaveOccurred())
 			Expect(response.GetSize()).To(BeNumerically("==", 2))

--- a/internal/servers/public_ip_attachments_server_test.go
+++ b/internal/servers/public_ip_attachments_server_test.go
@@ -251,7 +251,7 @@ var _ = Describe("Public IP attachments server", func() {
 			}
 
 			response, err := publicIPAttachmentsServer.List(ctx, publicv1.PublicIPAttachmentsListRequest_builder{
-				Limit: proto.Int32(1),
+				Limit: new(int32(1)),
 			}.Build())
 			Expect(err).ToNot(HaveOccurred())
 			Expect(response.GetSize()).To(BeNumerically("==", 1))
@@ -264,7 +264,7 @@ var _ = Describe("Public IP attachments server", func() {
 			}
 
 			response, err := publicIPAttachmentsServer.List(ctx, publicv1.PublicIPAttachmentsListRequest_builder{
-				Offset: proto.Int32(1),
+				Offset: new(int32(1)),
 			}.Build())
 			Expect(err).ToNot(HaveOccurred())
 			Expect(response.GetSize()).To(BeNumerically("==", count-1))

--- a/internal/servers/public_ips_server_test.go
+++ b/internal/servers/public_ips_server_test.go
@@ -208,7 +208,7 @@ var _ = Describe("Public IPs server", func() {
 
 			// List the objects:
 			response, err := publicIPsServer.List(ctx, publicv1.PublicIPsListRequest_builder{
-				Limit: proto.Int32(1),
+				Limit: new(int32(1)),
 			}.Build())
 			Expect(err).ToNot(HaveOccurred())
 			Expect(response.GetSize()).To(BeNumerically("==", 1))
@@ -230,7 +230,7 @@ var _ = Describe("Public IPs server", func() {
 
 			// List the objects:
 			response, err := publicIPsServer.List(ctx, publicv1.PublicIPsListRequest_builder{
-				Offset: proto.Int32(1),
+				Offset: new(int32(1)),
 			}.Build())
 			Expect(err).ToNot(HaveOccurred())
 			Expect(response.GetSize()).To(BeNumerically("==", count-1))

--- a/internal/servers/security_groups_server_test.go
+++ b/internal/servers/security_groups_server_test.go
@@ -179,8 +179,8 @@ var _ = Describe("SecurityGroups server", func() {
 						Ingress: []*publicv1.SecurityRule{
 							{
 								Protocol: publicv1.Protocol_PROTOCOL_TCP,
-								PortFrom: proto.Int32(80),
-								PortTo:   proto.Int32(80),
+								PortFrom: new(int32(80)),
+								PortTo:   new(int32(80)),
 								Ipv4Cidr: new("0.0.0.0/0"),
 							},
 						},
@@ -216,8 +216,8 @@ var _ = Describe("SecurityGroups server", func() {
 							Ingress: []*publicv1.SecurityRule{
 								{
 									Protocol: publicv1.Protocol_PROTOCOL_TCP,
-									PortFrom: proto.Int32(443),
-									PortTo:   proto.Int32(443),
+									PortFrom: new(int32(443)),
+									PortTo:   new(int32(443)),
 									Ipv4Cidr: new("0.0.0.0/0"),
 								},
 							},
@@ -251,7 +251,7 @@ var _ = Describe("SecurityGroups server", func() {
 
 			// List the objects:
 			response, err := server.List(ctx, publicv1.SecurityGroupsListRequest_builder{
-				Limit: proto.Int32(1),
+				Limit: new(int32(1)),
 			}.Build())
 			Expect(err).ToNot(HaveOccurred())
 			Expect(response.GetSize()).To(BeNumerically("==", 1))
@@ -273,7 +273,7 @@ var _ = Describe("SecurityGroups server", func() {
 
 			// List the objects:
 			response, err := server.List(ctx, publicv1.SecurityGroupsListRequest_builder{
-				Offset: proto.Int32(1),
+				Offset: new(int32(1)),
 			}.Build())
 			Expect(err).ToNot(HaveOccurred())
 			Expect(response.GetSize()).To(BeNumerically("==", count-1))
@@ -315,8 +315,8 @@ var _ = Describe("SecurityGroups server", func() {
 						Ingress: []*publicv1.SecurityRule{
 							{
 								Protocol: publicv1.Protocol_PROTOCOL_TCP,
-								PortFrom: proto.Int32(22),
-								PortTo:   proto.Int32(22),
+								PortFrom: new(int32(22)),
+								PortTo:   new(int32(22)),
 								Ipv4Cidr: new("10.0.0.0/8"),
 							},
 						},
@@ -360,8 +360,8 @@ var _ = Describe("SecurityGroups server", func() {
 						Ingress: []*publicv1.SecurityRule{
 							{
 								Protocol: publicv1.Protocol_PROTOCOL_UDP,
-								PortFrom: proto.Int32(53),
-								PortTo:   proto.Int32(53),
+								PortFrom: new(int32(53)),
+								PortTo:   new(int32(53)),
 								Ipv4Cidr: new("0.0.0.0/0"),
 							},
 						},

--- a/internal/servers/subnets_server_test.go
+++ b/internal/servers/subnets_server_test.go
@@ -248,7 +248,7 @@ var _ = Describe("Subnets server", func() {
 
 			// List the objects:
 			response, err := server.List(ctx, publicv1.SubnetsListRequest_builder{
-				Limit: proto.Int32(1),
+				Limit: new(int32(1)),
 			}.Build())
 			Expect(err).ToNot(HaveOccurred())
 			Expect(response.GetSize()).To(BeNumerically("==", 1))
@@ -271,7 +271,7 @@ var _ = Describe("Subnets server", func() {
 
 			// List the objects:
 			response, err := server.List(ctx, publicv1.SubnetsListRequest_builder{
-				Offset: proto.Int32(1),
+				Offset: new(int32(1)),
 			}.Build())
 			Expect(err).ToNot(HaveOccurred())
 			Expect(response.GetSize()).To(BeNumerically("==", count-1))

--- a/internal/servers/virtual_networks_server_test.go
+++ b/internal/servers/virtual_networks_server_test.go
@@ -22,7 +22,6 @@ import (
 	. "github.com/onsi/gomega"
 	grpccodes "google.golang.org/grpc/codes"
 	grpcstatus "google.golang.org/grpc/status"
-	"google.golang.org/protobuf/proto"
 
 	privatev1 "github.com/osac-project/fulfillment-service/internal/api/osac/private/v1"
 	publicv1 "github.com/osac-project/fulfillment-service/internal/api/osac/public/v1"
@@ -217,7 +216,7 @@ var _ = Describe("Virtual networks server", func() {
 
 			// List the objects via public server:
 			response, err := publicServer.List(ctx, publicv1.VirtualNetworksListRequest_builder{
-				Limit: proto.Int32(1),
+				Limit: new(int32(1)),
 			}.Build())
 			Expect(err).ToNot(HaveOccurred())
 			Expect(response.GetSize()).To(BeNumerically("==", 1))
@@ -232,7 +231,7 @@ var _ = Describe("Virtual networks server", func() {
 
 			// List the objects via public server:
 			response, err := publicServer.List(ctx, publicv1.VirtualNetworksListRequest_builder{
-				Offset: proto.Int32(1),
+				Offset: new(int32(1)),
 			}.Build())
 			Expect(err).ToNot(HaveOccurred())
 			Expect(response.GetSize()).To(BeNumerically("==", count-1))

--- a/internal/utils/spec_defaults_test.go
+++ b/internal/utils/spec_defaults_test.go
@@ -18,7 +18,6 @@ import (
 	. "github.com/onsi/gomega"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
-	"google.golang.org/protobuf/proto"
 
 	privatev1 "github.com/osac-project/fulfillment-service/internal/api/osac/private/v1"
 )
@@ -37,7 +36,7 @@ var _ = Describe("ApplySpecDefaults", func() {
 
 	It("Does nothing when spec is nil", func() {
 		defaults := privatev1.ComputeInstanceTemplateSpecDefaults_builder{
-			Cores: proto.Int32(4),
+			Cores: new(int32(4)),
 		}.Build()
 
 		ApplySpecDefaults(nil, defaults)
@@ -49,8 +48,8 @@ var _ = Describe("ApplySpecDefaults", func() {
 		}.Build()
 
 		defaults := privatev1.ComputeInstanceTemplateSpecDefaults_builder{
-			Cores:     proto.Int32(2),
-			MemoryGib: proto.Int32(4),
+			Cores:     new(int32(2)),
+			MemoryGib: new(int32(4)),
 			Image: privatev1.ComputeInstanceImage_builder{
 				SourceType: "registry",
 				SourceRef:  "quay.io/containerdisks/fedora:latest",
@@ -74,14 +73,14 @@ var _ = Describe("ApplySpecDefaults", func() {
 	It("Does not override user-provided values", func() {
 		spec := privatev1.ComputeInstanceSpec_builder{
 			Template:    "test.template",
-			Cores:       proto.Int32(8),
-			MemoryGib:   proto.Int32(16),
+			Cores:       new(int32(8)),
+			MemoryGib:   new(int32(16)),
 			RunStrategy: new("Halted"),
 		}.Build()
 
 		defaults := privatev1.ComputeInstanceTemplateSpecDefaults_builder{
-			Cores:     proto.Int32(2),
-			MemoryGib: proto.Int32(4),
+			Cores:     new(int32(2)),
+			MemoryGib: new(int32(4)),
 			Image: privatev1.ComputeInstanceImage_builder{
 				SourceType: "registry",
 				SourceRef:  "quay.io/containerdisks/fedora:latest",
@@ -109,7 +108,7 @@ var _ = Describe("ApplySpecDefaults", func() {
 		}.Build()
 
 		defaults := privatev1.ComputeInstanceTemplateSpecDefaults_builder{
-			Cores:       proto.Int32(2),
+			Cores:       new(int32(2)),
 			RunStrategy: new("Always"),
 		}.Build()
 
@@ -250,8 +249,8 @@ var _ = Describe("ValidateRequiredSpecFields", func() {
 	It("Returns error for partially missing fields", func() {
 		spec := privatev1.ComputeInstanceSpec_builder{
 			Template:    "test.template",
-			Cores:       proto.Int32(4),
-			MemoryGib:   proto.Int32(8),
+			Cores:       new(int32(4)),
+			MemoryGib:   new(int32(8)),
 			RunStrategy: new("Always"),
 		}.Build()
 
@@ -268,8 +267,8 @@ var _ = Describe("ValidateRequiredSpecFields", func() {
 	It("Passes when all required fields are set", func() {
 		spec := privatev1.ComputeInstanceSpec_builder{
 			Template:  "test.template",
-			Cores:     proto.Int32(4),
-			MemoryGib: proto.Int32(8),
+			Cores:     new(int32(4)),
+			MemoryGib: new(int32(8)),
 			Image: privatev1.ComputeInstanceImage_builder{
 				SourceType: "registry",
 				SourceRef:  "quay.io/containerdisks/fedora:latest",
@@ -287,8 +286,8 @@ var _ = Describe("ValidateRequiredSpecFields", func() {
 	It("Rejects invalid run_strategy value", func() {
 		spec := privatev1.ComputeInstanceSpec_builder{
 			Template:  "test.template",
-			Cores:     proto.Int32(4),
-			MemoryGib: proto.Int32(8),
+			Cores:     new(int32(4)),
+			MemoryGib: new(int32(8)),
 			Image: privatev1.ComputeInstanceImage_builder{
 				SourceType: "registry",
 				SourceRef:  "quay.io/containerdisks/fedora:latest",
@@ -310,8 +309,8 @@ var _ = Describe("ValidateRequiredSpecFields", func() {
 	It("Rejects empty image fields", func() {
 		spec := privatev1.ComputeInstanceSpec_builder{
 			Template:  "test.template",
-			Cores:     proto.Int32(4),
-			MemoryGib: proto.Int32(8),
+			Cores:     new(int32(4)),
+			MemoryGib: new(int32(8)),
 			Image:     privatev1.ComputeInstanceImage_builder{}.Build(),
 			BootDisk: privatev1.ComputeInstanceDisk_builder{
 				SizeGib: 20,
@@ -329,8 +328,8 @@ var _ = Describe("ValidateRequiredSpecFields", func() {
 	It("Rejects image with partial fields", func() {
 		spec := privatev1.ComputeInstanceSpec_builder{
 			Template:  "test.template",
-			Cores:     proto.Int32(4),
-			MemoryGib: proto.Int32(8),
+			Cores:     new(int32(4)),
+			MemoryGib: new(int32(8)),
 			Image: privatev1.ComputeInstanceImage_builder{
 				SourceType: "registry",
 			}.Build(),
@@ -350,8 +349,8 @@ var _ = Describe("ValidateRequiredSpecFields", func() {
 	It("Rejects boot_disk with zero size", func() {
 		spec := privatev1.ComputeInstanceSpec_builder{
 			Template:  "test.template",
-			Cores:     proto.Int32(4),
-			MemoryGib: proto.Int32(8),
+			Cores:     new(int32(4)),
+			MemoryGib: new(int32(8)),
 			Image: privatev1.ComputeInstanceImage_builder{
 				SourceType: "registry",
 				SourceRef:  "quay.io/containerdisks/fedora:latest",

--- a/it/it_compute_subnet_test.go
+++ b/it/it_compute_subnet_test.go
@@ -19,7 +19,6 @@ import (
 
 	. "github.com/onsi/ginkgo/v2/dsl/core"
 	. "github.com/onsi/gomega"
-	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/fieldmaskpb"
 
 	privatev1 "github.com/osac-project/fulfillment-service/internal/api/osac/private/v1"
@@ -178,8 +177,8 @@ var _ = Describe("ComputeInstance with Subnet attachment", func() {
 				Id: computeInstanceId,
 				Spec: publicv1.ComputeInstanceSpec_builder{
 					Template:    computeInstanceTemplateId,
-					Cores:       proto.Int32(2),
-					MemoryGib:   proto.Int32(4),
+					Cores:       new(int32(2)),
+					MemoryGib:   new(int32(4)),
 					RunStrategy: new("Always"),
 					BootDisk: publicv1.ComputeInstanceDisk_builder{
 						SizeGib: 20,
@@ -211,8 +210,8 @@ var _ = Describe("ComputeInstance with Subnet attachment", func() {
 				Id: computeInstanceId,
 				Spec: publicv1.ComputeInstanceSpec_builder{
 					Template:    computeInstanceTemplateId,
-					Cores:       proto.Int32(2),
-					MemoryGib:   proto.Int32(4),
+					Cores:       new(int32(2)),
+					MemoryGib:   new(int32(4)),
 					RunStrategy: new("Always"),
 					BootDisk: publicv1.ComputeInstanceDisk_builder{
 						SizeGib: 20,


### PR DESCRIPTION
## Summary

Continue the modernization started in #610 by replacing the remaining `proto.Int32(value)` calls
with the `new(int32(value))` built-in syntax introduced in Go 1.26. This also removes the
now-unused `"google.golang.org/protobuf/proto"` imports from files where `proto.Int32` was the last
usage of that package.

## Test plan

- [x] Verify that the project compiles successfully.
- [x] Run unit tests with `ginkgo run -r internal`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal code across CLI commands, gRPC servers, and test suites to use native Go pointer allocation for integer fields.
  * Changes apply to pagination parameters (Limit, Offset), compute instance specifications (Cores, MemoryGib), and security rule configurations.
  * End-user functionality and public APIs remain completely unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->