### PR TITLE
fix: use osac.openshift.io for all annotations

### DIFF
--- a/internal/api/osac/private/v1/security_group_type.pb.go
+++ b/internal/api/osac/private/v1/security_group_type.pb.go
@@ -216,7 +216,7 @@ func (x SecurityGroupState) Number() protoreflect.EnumNumber {
 // SecurityGroups are scoped to a VirtualNetwork and can be attached to multiple compute instances within that
 // network. They cannot be used across different VirtualNetworks.
 //
-// The parent VirtualNetwork relationship is established via metadata.annotations using the 'osac.io/owner-reference'
+// The parent VirtualNetwork relationship is established via metadata.annotations using the 'osac.openshift.io/owner-reference'
 // key with the VirtualNetwork ID as the value. This enables proper resource hierarchy for garbage collection - when
 // a VirtualNetwork is deleted, all associated SecurityGroups are automatically cleaned up.
 //
@@ -229,7 +229,7 @@ type SecurityGroup struct {
 	// Metadata of the security group, including name, labels, tenant, and timestamps.
 	//
 	// The parent VirtualNetwork relationship should be specified via metadata.annotations using the
-	// 'osac.io/owner-reference' key with the VirtualNetwork ID as the value. This establishes resource
+	// 'osac.openshift.io/owner-reference' key with the VirtualNetwork ID as the value. This establishes resource
 	// hierarchy for garbage collection.
 	Metadata *Metadata `protobuf:"bytes,2,opt,name=metadata,proto3" json:"metadata,omitempty"`
 	// Desired configuration of the security group (user-modifiable).
@@ -350,7 +350,7 @@ type SecurityGroup_builder struct {
 	// Metadata of the security group, including name, labels, tenant, and timestamps.
 	//
 	// The parent VirtualNetwork relationship should be specified via metadata.annotations using the
-	// 'osac.io/owner-reference' key with the VirtualNetwork ID as the value. This establishes resource
+	// 'osac.openshift.io/owner-reference' key with the VirtualNetwork ID as the value. This establishes resource
 	// hierarchy for garbage collection.
 	Metadata *Metadata
 	// Desired configuration of the security group (user-modifiable).

--- a/internal/api/osac/private/v1/security_group_type_protoopaque.pb.go
+++ b/internal/api/osac/private/v1/security_group_type_protoopaque.pb.go
@@ -216,7 +216,7 @@ func (x SecurityGroupState) Number() protoreflect.EnumNumber {
 // SecurityGroups are scoped to a VirtualNetwork and can be attached to multiple compute instances within that
 // network. They cannot be used across different VirtualNetworks.
 //
-// The parent VirtualNetwork relationship is established via metadata.annotations using the 'osac.io/owner-reference'
+// The parent VirtualNetwork relationship is established via metadata.annotations using the 'osac.openshift.io/owner-reference'
 // key with the VirtualNetwork ID as the value. This enables proper resource hierarchy for garbage collection - when
 // a VirtualNetwork is deleted, all associated SecurityGroups are automatically cleaned up.
 //
@@ -342,7 +342,7 @@ type SecurityGroup_builder struct {
 	// Metadata of the security group, including name, labels, tenant, and timestamps.
 	//
 	// The parent VirtualNetwork relationship should be specified via metadata.annotations using the
-	// 'osac.io/owner-reference' key with the VirtualNetwork ID as the value. This establishes resource
+	// 'osac.openshift.io/owner-reference' key with the VirtualNetwork ID as the value. This establishes resource
 	// hierarchy for garbage collection.
 	Metadata *Metadata
 	// Desired configuration of the security group (user-modifiable).

--- a/internal/api/osac/private/v1/subnet_type.pb.go
+++ b/internal/api/osac/private/v1/subnet_type.pb.go
@@ -149,7 +149,7 @@ func (x SubnetState) Number() protoreflect.EnumNumber {
 // - IPv6-only: Set ipv6_cidr, leave ipv4_cidr empty
 // - Dual-stack: Set both ipv4_cidr and ipv6_cidr
 //
-// The parent VirtualNetwork relationship should be specified via metadata.annotations using the 'osac.io/owner-reference'
+// The parent VirtualNetwork relationship should be specified via metadata.annotations using the 'osac.openshift.io/owner-reference'
 // key with the VirtualNetwork ID as the value. This establishes resource hierarchy for garbage collection, ensuring
 // that Subnets are automatically cleaned up when their parent VirtualNetwork is deleted.
 //
@@ -162,7 +162,7 @@ type Subnet struct {
 	// Metadata of the subnet, including name, labels, tenant, and timestamps.
 	//
 	// The parent VirtualNetwork relationship should be specified via metadata.annotations using the
-	// 'osac.io/owner-reference' key with the VirtualNetwork ID as the value. This establishes resource
+	// 'osac.openshift.io/owner-reference' key with the VirtualNetwork ID as the value. This establishes resource
 	// hierarchy for garbage collection.
 	Metadata *Metadata `protobuf:"bytes,2,opt,name=metadata,proto3" json:"metadata,omitempty"`
 	// Desired configuration of the subnet (user-modifiable).
@@ -283,7 +283,7 @@ type Subnet_builder struct {
 	// Metadata of the subnet, including name, labels, tenant, and timestamps.
 	//
 	// The parent VirtualNetwork relationship should be specified via metadata.annotations using the
-	// 'osac.io/owner-reference' key with the VirtualNetwork ID as the value. This establishes resource
+	// 'osac.openshift.io/owner-reference' key with the VirtualNetwork ID as the value. This establishes resource
 	// hierarchy for garbage collection.
 	Metadata *Metadata
 	// Desired configuration of the subnet (user-modifiable).

--- a/internal/api/osac/private/v1/subnet_type_protoopaque.pb.go
+++ b/internal/api/osac/private/v1/subnet_type_protoopaque.pb.go
@@ -149,7 +149,7 @@ func (x SubnetState) Number() protoreflect.EnumNumber {
 // - IPv6-only: Set ipv6_cidr, leave ipv4_cidr empty
 // - Dual-stack: Set both ipv4_cidr and ipv6_cidr
 //
-// The parent VirtualNetwork relationship should be specified via metadata.annotations using the 'osac.io/owner-reference'
+// The parent VirtualNetwork relationship should be specified via metadata.annotations using the 'osac.openshift.io/owner-reference'
 // key with the VirtualNetwork ID as the value. This establishes resource hierarchy for garbage collection, ensuring
 // that Subnets are automatically cleaned up when their parent VirtualNetwork is deleted.
 //
@@ -275,7 +275,7 @@ type Subnet_builder struct {
 	// Metadata of the subnet, including name, labels, tenant, and timestamps.
 	//
 	// The parent VirtualNetwork relationship should be specified via metadata.annotations using the
-	// 'osac.io/owner-reference' key with the VirtualNetwork ID as the value. This establishes resource
+	// 'osac.openshift.io/owner-reference' key with the VirtualNetwork ID as the value. This establishes resource
 	// hierarchy for garbage collection.
 	Metadata *Metadata
 	// Desired configuration of the subnet (user-modifiable).

--- a/internal/api/osac/public/v1/security_group_type.pb.go
+++ b/internal/api/osac/public/v1/security_group_type.pb.go
@@ -216,7 +216,7 @@ func (x SecurityGroupState) Number() protoreflect.EnumNumber {
 // SecurityGroups are scoped to a VirtualNetwork and can be attached to multiple compute instances within that
 // network. They cannot be used across different VirtualNetworks.
 //
-// The parent VirtualNetwork relationship is established via metadata.annotations using the 'osac.io/owner-reference'
+// The parent VirtualNetwork relationship is established via metadata.annotations using the 'osac.openshift.io/owner-reference'
 // key with the VirtualNetwork ID as the value. This enables proper resource hierarchy for garbage collection - when
 // a VirtualNetwork is deleted, all associated SecurityGroups are automatically cleaned up.
 type SecurityGroup struct {
@@ -226,7 +226,7 @@ type SecurityGroup struct {
 	// Metadata of the security group, including name, labels, tenant, and timestamps.
 	//
 	// The parent VirtualNetwork relationship should be specified via metadata.annotations using the
-	// 'osac.io/owner-reference' key with the VirtualNetwork ID as the value. This establishes resource
+	// 'osac.openshift.io/owner-reference' key with the VirtualNetwork ID as the value. This establishes resource
 	// hierarchy for garbage collection.
 	Metadata *Metadata `protobuf:"bytes,2,opt,name=metadata,proto3" json:"metadata,omitempty"`
 	// Desired configuration of the security group (user-modifiable).
@@ -347,7 +347,7 @@ type SecurityGroup_builder struct {
 	// Metadata of the security group, including name, labels, tenant, and timestamps.
 	//
 	// The parent VirtualNetwork relationship should be specified via metadata.annotations using the
-	// 'osac.io/owner-reference' key with the VirtualNetwork ID as the value. This establishes resource
+	// 'osac.openshift.io/owner-reference' key with the VirtualNetwork ID as the value. This establishes resource
 	// hierarchy for garbage collection.
 	Metadata *Metadata
 	// Desired configuration of the security group (user-modifiable).

--- a/internal/api/osac/public/v1/security_group_type_protoopaque.pb.go
+++ b/internal/api/osac/public/v1/security_group_type_protoopaque.pb.go
@@ -216,7 +216,7 @@ func (x SecurityGroupState) Number() protoreflect.EnumNumber {
 // SecurityGroups are scoped to a VirtualNetwork and can be attached to multiple compute instances within that
 // network. They cannot be used across different VirtualNetworks.
 //
-// The parent VirtualNetwork relationship is established via metadata.annotations using the 'osac.io/owner-reference'
+// The parent VirtualNetwork relationship is established via metadata.annotations using the 'osac.openshift.io/owner-reference'
 // key with the VirtualNetwork ID as the value. This enables proper resource hierarchy for garbage collection - when
 // a VirtualNetwork is deleted, all associated SecurityGroups are automatically cleaned up.
 type SecurityGroup struct {
@@ -339,7 +339,7 @@ type SecurityGroup_builder struct {
 	// Metadata of the security group, including name, labels, tenant, and timestamps.
 	//
 	// The parent VirtualNetwork relationship should be specified via metadata.annotations using the
-	// 'osac.io/owner-reference' key with the VirtualNetwork ID as the value. This establishes resource
+	// 'osac.openshift.io/owner-reference' key with the VirtualNetwork ID as the value. This establishes resource
 	// hierarchy for garbage collection.
 	Metadata *Metadata
 	// Desired configuration of the security group (user-modifiable).

--- a/internal/api/osac/public/v1/subnet_type.pb.go
+++ b/internal/api/osac/public/v1/subnet_type.pb.go
@@ -149,7 +149,7 @@ func (x SubnetState) Number() protoreflect.EnumNumber {
 // - IPv6-only: Set ipv6_cidr, leave ipv4_cidr empty
 // - Dual-stack: Set both ipv4_cidr and ipv6_cidr
 //
-// The parent VirtualNetwork relationship should be specified via metadata.annotations using the 'osac.io/owner-reference'
+// The parent VirtualNetwork relationship should be specified via metadata.annotations using the 'osac.openshift.io/owner-reference'
 // key with the VirtualNetwork ID as the value. This establishes resource hierarchy for garbage collection, ensuring
 // that Subnets are automatically cleaned up when their parent VirtualNetwork is deleted.
 //
@@ -162,7 +162,7 @@ type Subnet struct {
 	// Metadata of the subnet, including name, labels, tenant, and timestamps.
 	//
 	// The parent VirtualNetwork relationship should be specified via metadata.annotations using the
-	// 'osac.io/owner-reference' key with the VirtualNetwork ID as the value. This establishes resource
+	// 'osac.openshift.io/owner-reference' key with the VirtualNetwork ID as the value. This establishes resource
 	// hierarchy for garbage collection.
 	Metadata *Metadata `protobuf:"bytes,2,opt,name=metadata,proto3" json:"metadata,omitempty"`
 	// Desired configuration of the subnet (user-modifiable).
@@ -283,7 +283,7 @@ type Subnet_builder struct {
 	// Metadata of the subnet, including name, labels, tenant, and timestamps.
 	//
 	// The parent VirtualNetwork relationship should be specified via metadata.annotations using the
-	// 'osac.io/owner-reference' key with the VirtualNetwork ID as the value. This establishes resource
+	// 'osac.openshift.io/owner-reference' key with the VirtualNetwork ID as the value. This establishes resource
 	// hierarchy for garbage collection.
 	Metadata *Metadata
 	// Desired configuration of the subnet (user-modifiable).

--- a/internal/api/osac/public/v1/subnet_type_protoopaque.pb.go
+++ b/internal/api/osac/public/v1/subnet_type_protoopaque.pb.go
@@ -149,7 +149,7 @@ func (x SubnetState) Number() protoreflect.EnumNumber {
 // - IPv6-only: Set ipv6_cidr, leave ipv4_cidr empty
 // - Dual-stack: Set both ipv4_cidr and ipv6_cidr
 //
-// The parent VirtualNetwork relationship should be specified via metadata.annotations using the 'osac.io/owner-reference'
+// The parent VirtualNetwork relationship should be specified via metadata.annotations using the 'osac.openshift.io/owner-reference'
 // key with the VirtualNetwork ID as the value. This establishes resource hierarchy for garbage collection, ensuring
 // that Subnets are automatically cleaned up when their parent VirtualNetwork is deleted.
 //
@@ -275,7 +275,7 @@ type Subnet_builder struct {
 	// Metadata of the subnet, including name, labels, tenant, and timestamps.
 	//
 	// The parent VirtualNetwork relationship should be specified via metadata.annotations using the
-	// 'osac.io/owner-reference' key with the VirtualNetwork ID as the value. This establishes resource
+	// 'osac.openshift.io/owner-reference' key with the VirtualNetwork ID as the value. This establishes resource
 	// hierarchy for garbage collection.
 	Metadata *Metadata
 	// Desired configuration of the subnet (user-modifiable).

--- a/internal/database/migrations/22_create_security_groups_tables.up.sql
+++ b/internal/database/migrations/22_create_security_groups_tables.up.sql
@@ -32,7 +32,7 @@
 -- - ipv6_cidr: IPv6 source/destination CIDR (optional for IPv4-only rules)
 --
 -- Parent-child relationship with VirtualNetwork is established via metadata.annotations using the
--- 'osac.io/owner-reference' key. This enables proper resource hierarchy for garbage collection.
+-- 'osac.openshift.io/owner-reference' key. This enables proper resource hierarchy for garbage collection.
 --
 create table security_groups (
   id text not null primary key,

--- a/internal/servers/private_security_groups_server.go
+++ b/internal/servers/private_security_groups_server.go
@@ -153,7 +153,7 @@ func (s *PrivateSecurityGroupsServer) Create(ctx context.Context,
 	if securityGroup.GetMetadata().GetAnnotations() == nil {
 		securityGroup.Metadata.Annotations = make(map[string]string)
 	}
-	securityGroup.Metadata.Annotations["osac.io/owner-reference"] = securityGroup.GetSpec().GetVirtualNetwork()
+	securityGroup.Metadata.Annotations["osac.openshift.io/owner-reference"] = securityGroup.GetSpec().GetVirtualNetwork()
 
 	err = s.generic.Create(ctx, request, &response)
 	return

--- a/internal/servers/private_subnets_server.go
+++ b/internal/servers/private_subnets_server.go
@@ -152,7 +152,7 @@ func (s *PrivateSubnetsServer) Create(ctx context.Context,
 	if subnet.GetMetadata().GetAnnotations() == nil {
 		subnet.Metadata.Annotations = make(map[string]string)
 	}
-	subnet.Metadata.Annotations["osac.io/owner-reference"] = subnet.GetSpec().GetVirtualNetwork()
+	subnet.Metadata.Annotations["osac.openshift.io/owner-reference"] = subnet.GetSpec().GetVirtualNetwork()
 
 	err = s.generic.Create(ctx, request, &response)
 	return

--- a/internal/servers/private_subnets_server_test.go
+++ b/internal/servers/private_subnets_server_test.go
@@ -712,7 +712,7 @@ var _ = Describe("Private subnets server", func() {
 				if subnet.GetMetadata().GetAnnotations() == nil {
 					subnet.Metadata.Annotations = make(map[string]string)
 				}
-				subnet.Metadata.Annotations["osac.io/owner-reference"] = subnet.GetSpec().GetVirtualNetwork()
+				subnet.Metadata.Annotations["osac.openshift.io/owner-reference"] = subnet.GetSpec().GetVirtualNetwork()
 
 				// Create the subnet
 				createResponse, err := subnetDao.Create().
@@ -722,8 +722,8 @@ var _ = Describe("Private subnets server", func() {
 				created := createResponse.GetObject()
 
 				// Verify annotation is set
-				Expect(created.GetMetadata().GetAnnotations()).To(HaveKey("osac.io/owner-reference"))
-				Expect(created.GetMetadata().GetAnnotations()["osac.io/owner-reference"]).To(Equal(vn.GetId()))
+				Expect(created.GetMetadata().GetAnnotations()).To(HaveKey("osac.openshift.io/owner-reference"))
+				Expect(created.GetMetadata().GetAnnotations()["osac.openshift.io/owner-reference"]).To(Equal(vn.GetId()))
 			})
 		})
 

--- a/proto/private/osac/private/v1/security_group_type.proto
+++ b/proto/private/osac/private/v1/security_group_type.proto
@@ -30,7 +30,7 @@ import "osac/private/v1/metadata_type.proto";
 // SecurityGroups are scoped to a VirtualNetwork and can be attached to multiple compute instances within that
 // network. They cannot be used across different VirtualNetworks.
 //
-// The parent VirtualNetwork relationship is established via metadata.annotations using the 'osac.io/owner-reference'
+// The parent VirtualNetwork relationship is established via metadata.annotations using the 'osac.openshift.io/owner-reference'
 // key with the VirtualNetwork ID as the value. This enables proper resource hierarchy for garbage collection - when
 // a VirtualNetwork is deleted, all associated SecurityGroups are automatically cleaned up.
 //
@@ -43,7 +43,7 @@ message SecurityGroup {
   // Metadata of the security group, including name, labels, tenant, and timestamps.
   //
   // The parent VirtualNetwork relationship should be specified via metadata.annotations using the
-  // 'osac.io/owner-reference' key with the VirtualNetwork ID as the value. This establishes resource
+  // 'osac.openshift.io/owner-reference' key with the VirtualNetwork ID as the value. This establishes resource
   // hierarchy for garbage collection.
   Metadata metadata = 2;
 

--- a/proto/private/osac/private/v1/subnet_type.proto
+++ b/proto/private/osac/private/v1/subnet_type.proto
@@ -30,7 +30,7 @@ import "osac/private/v1/metadata_type.proto";
 // - IPv6-only: Set ipv6_cidr, leave ipv4_cidr empty
 // - Dual-stack: Set both ipv4_cidr and ipv6_cidr
 //
-// The parent VirtualNetwork relationship should be specified via metadata.annotations using the 'osac.io/owner-reference'
+// The parent VirtualNetwork relationship should be specified via metadata.annotations using the 'osac.openshift.io/owner-reference'
 // key with the VirtualNetwork ID as the value. This establishes resource hierarchy for garbage collection, ensuring
 // that Subnets are automatically cleaned up when their parent VirtualNetwork is deleted.
 //
@@ -43,7 +43,7 @@ message Subnet {
   // Metadata of the subnet, including name, labels, tenant, and timestamps.
   //
   // The parent VirtualNetwork relationship should be specified via metadata.annotations using the
-  // 'osac.io/owner-reference' key with the VirtualNetwork ID as the value. This establishes resource
+  // 'osac.openshift.io/owner-reference' key with the VirtualNetwork ID as the value. This establishes resource
   // hierarchy for garbage collection.
   Metadata metadata = 2;
 

--- a/proto/public/osac/public/v1/security_group_type.proto
+++ b/proto/public/osac/public/v1/security_group_type.proto
@@ -30,7 +30,7 @@ import "osac/public/v1/metadata_type.proto";
 // SecurityGroups are scoped to a VirtualNetwork and can be attached to multiple compute instances within that
 // network. They cannot be used across different VirtualNetworks.
 //
-// The parent VirtualNetwork relationship is established via metadata.annotations using the 'osac.io/owner-reference'
+// The parent VirtualNetwork relationship is established via metadata.annotations using the 'osac.openshift.io/owner-reference'
 // key with the VirtualNetwork ID as the value. This enables proper resource hierarchy for garbage collection - when
 // a VirtualNetwork is deleted, all associated SecurityGroups are automatically cleaned up.
 message SecurityGroup {
@@ -40,7 +40,7 @@ message SecurityGroup {
   // Metadata of the security group, including name, labels, tenant, and timestamps.
   //
   // The parent VirtualNetwork relationship should be specified via metadata.annotations using the
-  // 'osac.io/owner-reference' key with the VirtualNetwork ID as the value. This establishes resource
+  // 'osac.openshift.io/owner-reference' key with the VirtualNetwork ID as the value. This establishes resource
   // hierarchy for garbage collection.
   Metadata metadata = 2;
 

--- a/proto/public/osac/public/v1/subnet_type.proto
+++ b/proto/public/osac/public/v1/subnet_type.proto
@@ -30,7 +30,7 @@ import "osac/public/v1/metadata_type.proto";
 // - IPv6-only: Set ipv6_cidr, leave ipv4_cidr empty
 // - Dual-stack: Set both ipv4_cidr and ipv6_cidr
 //
-// The parent VirtualNetwork relationship should be specified via metadata.annotations using the 'osac.io/owner-reference'
+// The parent VirtualNetwork relationship should be specified via metadata.annotations using the 'osac.openshift.io/owner-reference'
 // key with the VirtualNetwork ID as the value. This establishes resource hierarchy for garbage collection, ensuring
 // that Subnets are automatically cleaned up when their parent VirtualNetwork is deleted.
 //
@@ -43,7 +43,7 @@ message Subnet {
   // Metadata of the subnet, including name, labels, tenant, and timestamps.
   //
   // The parent VirtualNetwork relationship should be specified via metadata.annotations using the
-  // 'osac.io/owner-reference' key with the VirtualNetwork ID as the value. This establishes resource
+  // 'osac.openshift.io/owner-reference' key with the VirtualNetwork ID as the value. This establishes resource
   // hierarchy for garbage collection.
   Metadata metadata = 2;
 


### PR DESCRIPTION
## Summary

Standardizes all OSAC annotations to use the `osac.openshift.io` domain prefix to align with:
- CRD API group: `osac.openshift.io`
- Existing tenant annotation: `osac.openshift.io/tenant`

## Changes

- Updated proto definitions (public and private API) for Subnet and SecurityGroup
- Changed `osac.io/owner-reference` → `osac.openshift.io/owner-reference` in:
  - Proto documentation comments
  - Server code that sets the annotation
  - Test assertions
- Regenerated all proto Go files with `buf generate`

## Impact

- Proto API documentation now consistent
- Server code correctly sets `osac.openshift.io/owner-reference`
- Tests verify the correct annotation key

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated metadata annotation keys used for establishing parent-child resource relationships to align with OpenShift-standard naming conventions

* **Documentation**
  * Updated related documentation across resource specifications to reflect the new annotation key format

* **Tests**
  * Updated test validations and assertions to verify correct use of the updated annotation keys

<!-- end of auto-generated comment: release notes by coderabbit.ai -->