### PR TITLE
OSAC-1079: Bump chart versions from 0.0.0 to 0.1.0

### DIFF
--- a/charts/service/Chart.yaml
+++ b/charts/service/Chart.yaml
@@ -15,5 +15,5 @@ apiVersion: v2
 name: fulfillment-service
 description: Fulfillment service
 type: application
-version: 0.0.0
-appVersion: 0.0.0
+version: 0.1.0
+appVersion: 0.1.0

--- a/it/charts/keycloak/Chart.yaml
+++ b/it/charts/keycloak/Chart.yaml
@@ -15,5 +15,5 @@ apiVersion: v2
 name: keycloak
 description: A Helm chart for Keycloak for use in OSAC development and testing environments (not for production)
 type: application
-version: 0.0.0
+version: 0.1.0
 appVersion: "26.5.6"

--- a/it/charts/postgres/Chart.yaml
+++ b/it/charts/postgres/Chart.yaml
@@ -15,5 +15,5 @@ apiVersion: v2
 name: postgres
 description: A Helm chart for PostgreSQL for use in OSAC development and testing environments (not for production)
 type: application
-version: 0.0.0
+version: 0.1.0
 appVersion: "15"

--- a/it/charts/prometheus/Chart.yaml
+++ b/it/charts/prometheus/Chart.yaml
@@ -15,5 +15,5 @@ apiVersion: v2
 name: prometheus
 description: A Helm chart for Prometheus for use in the OSAC project
 type: application
-version: 0.0.0
+version: 0.1.0
 appVersion: "3.10.0"


### PR DESCRIPTION
## Summary
- Bump all chart versions from `0.0.0` to `0.1.0`: service, ca, keycloak, postgres, prometheus
- Also bumps `appVersion` in `charts/service/Chart.yaml` from `0.0.0` to `0.1.0`

Part of Helm chart production readiness ([OSAC-1072](https://redhat.atlassian.net/browse/OSAC-1072)). Replaces placeholder versions with real semver as the first step toward OCI publication.

## Test plan
- [ ] `helm lint charts/service`
- [ ] `helm lint charts/ca`
- [ ] `helm lint charts/keycloak`
- [ ] `helm lint charts/postgres`
- [ ] `helm lint charts/prometheus`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated deployment configuration chart versions to 0.1.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->