### PR TITLE
OSAC-833: sync PublicIPAttachments to Kubernetes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@
 /osac
 /osac-dev
 __debug_bin*
+.artifacts

--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/mattn/go-isatty v0.0.22
 	github.com/neilotoole/jsoncolor v0.9.1
 	github.com/open-policy-agent/opa v1.16.2
-	github.com/osac-project/osac-operator/api v0.0.2
+	github.com/osac-project/osac-operator/api v0.0.3
 	github.com/prometheus/client_golang v1.23.2
 	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2
 	github.com/skratchdot/open-golang v0.0.0-20200116055534-eef842397966
@@ -41,7 +41,6 @@ require (
 	k8s.io/apimachinery v0.36.1
 	k8s.io/client-go v0.36.1
 	k8s.io/klog/v2 v2.140.0
-	k8s.io/utils v0.0.0-20260210185600-b8788abfbbc2
 	sigs.k8s.io/controller-runtime v0.24.1
 )
 
@@ -131,6 +130,7 @@ require (
 	gopkg.in/evanphx/json-patch.v4 v4.13.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20260317180543-43fb72c5454a // indirect
+	k8s.io/utils v0.0.0-20260210185600-b8788abfbbc2 // indirect
 	sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 // indirect
 	sigs.k8s.io/randfill v1.0.0 // indirect
 	sigs.k8s.io/structured-merge-diff/v6 v6.3.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -279,8 +279,8 @@ github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/opencontainers/image-spec v1.1.1 h1:y0fUlFfIZhPF1W537XOLg0/fcx6zcHCJwooC2xJA040=
 github.com/opencontainers/image-spec v1.1.1/go.mod h1:qpqAh3Dmcf36wStyyWU+kCeDgrGnAve2nCC8+7h8Q0M=
-github.com/osac-project/osac-operator/api v0.0.2 h1:FXVA4nCog/xF6nxCxZ2IZECSt2GCM/col41pBdiaGI0=
-github.com/osac-project/osac-operator/api v0.0.2/go.mod h1:JBz/wSWPT4NhksjXZs2QUjulga+KTUdW5UJX0kB22aA=
+github.com/osac-project/osac-operator/api v0.0.3 h1:6zBZDwGpc3pgZoA4Fd/gt6w02wNHp4xk1pJb6VgIEwQ=
+github.com/osac-project/osac-operator/api v0.0.3/go.mod h1:JBz/wSWPT4NhksjXZs2QUjulga+KTUdW5UJX0kB22aA=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10 h1:GFCKgmp0tecUJ0sJuv4pzYCqS9+RGSn52M3FUwPs+uo=

--- a/internal/cmd/service/start/controller/start_controller_cmd.go
+++ b/internal/cmd/service/start/controller/start_controller_cmd.go
@@ -45,6 +45,7 @@ import (
 	"github.com/osac-project/fulfillment-service/internal/controllers/organization"
 	"github.com/osac-project/fulfillment-service/internal/controllers/project"
 	"github.com/osac-project/fulfillment-service/internal/controllers/publicip"
+	"github.com/osac-project/fulfillment-service/internal/controllers/publicipattachment"
 	"github.com/osac-project/fulfillment-service/internal/controllers/publicippool"
 	"github.com/osac-project/fulfillment-service/internal/controllers/role"
 	"github.com/osac-project/fulfillment-service/internal/controllers/rolebinding"
@@ -627,6 +628,43 @@ func (r *runnerContext) run(cmd *cobra.Command, argv []string) error {
 			r.logger.InfoContext(
 				ctx,
 				"Public IP reconciler failed",
+				slog.Any("error", err),
+			)
+		}
+	}()
+
+	// Create the public IP attachment reconciler:
+	r.logger.InfoContext(ctx, "Creating public IP attachment reconciler")
+	publicIPAttachmentReconcilerFunction, err := publicipattachment.NewFunction().
+		SetLogger(r.logger).
+		SetConnection(r.client).
+		SetHubCache(hubCache).
+		Build()
+	if err != nil {
+		return fmt.Errorf("failed to create public IP attachment reconciler function: %w", err)
+	}
+	publicIPAttachmentReconciler, err := controllers.NewReconciler[*privatev1.PublicIPAttachment]().
+		SetLogger(r.logger).
+		SetName("public_ip_attachment").
+		SetClient(r.client).
+		SetFunction(publicIPAttachmentReconcilerFunction).
+		SetEventFilter("has(event.public_ip_attachment) || (has(event.hub) && event.type == EVENT_TYPE_OBJECT_CREATED)").
+		SetHealthReporter(healthAggregator).
+		Build()
+	if err != nil {
+		return fmt.Errorf("failed to create public IP attachment reconciler: %w", err)
+	}
+
+	// Start the public IP attachment reconciler:
+	r.logger.InfoContext(ctx, "Starting public IP attachment reconciler")
+	go func() {
+		err := publicIPAttachmentReconciler.Start(ctx)
+		if err == nil || errors.Is(err, context.Canceled) {
+			r.logger.InfoContext(ctx, "Public IP attachment reconciler finished")
+		} else {
+			r.logger.InfoContext(
+				ctx,
+				"Public IP attachment reconciler failed",
 				slog.Any("error", err),
 			)
 		}

--- a/internal/controllers/publicipattachment/public_ip_attachment_reconciler_function.go
+++ b/internal/controllers/publicipattachment/public_ip_attachment_reconciler_function.go
@@ -1,0 +1,379 @@
+/*
+Copyright (c) 2025 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package publicipattachment
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"slices"
+
+	"google.golang.org/grpc"
+	"google.golang.org/protobuf/proto"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clnt "sigs.k8s.io/controller-runtime/pkg/client"
+
+	osacv1alpha1 "github.com/osac-project/osac-operator/api/v1alpha1"
+
+	privatev1 "github.com/osac-project/fulfillment-service/internal/api/osac/private/v1"
+	"github.com/osac-project/fulfillment-service/internal/controllers"
+	"github.com/osac-project/fulfillment-service/internal/controllers/finalizers"
+	"github.com/osac-project/fulfillment-service/internal/kubernetes/annotations"
+	"github.com/osac-project/fulfillment-service/internal/kubernetes/labels"
+	"github.com/osac-project/fulfillment-service/internal/masks"
+)
+
+const objectPrefix = "publicipattachment-"
+
+// FunctionBuilder contains the data and logic needed to build a function that reconciles public IP attachments.
+type FunctionBuilder struct {
+	logger     *slog.Logger
+	connection *grpc.ClientConn
+	hubCache   controllers.HubCache
+}
+
+type function struct {
+	logger                    *slog.Logger
+	hubCache                  controllers.HubCache
+	publicIPAttachmentsClient privatev1.PublicIPAttachmentsClient
+	publicIPsClient           privatev1.PublicIPsClient
+	maskCalculator            *masks.Calculator
+}
+
+type task struct {
+	r                  *function
+	publicIPAttachment *privatev1.PublicIPAttachment
+	hubId              string
+	hubNamespace       string
+	hubClient          clnt.Client
+}
+
+// NewFunction creates a new builder that can then be used to create a new public IP attachment reconciler function.
+func NewFunction() *FunctionBuilder {
+	return &FunctionBuilder{}
+}
+
+// SetLogger sets the logger. This is mandatory.
+func (b *FunctionBuilder) SetLogger(value *slog.Logger) *FunctionBuilder {
+	b.logger = value
+	return b
+}
+
+// SetConnection sets the gRPC client connection. This is mandatory.
+func (b *FunctionBuilder) SetConnection(value *grpc.ClientConn) *FunctionBuilder {
+	b.connection = value
+	return b
+}
+
+// SetHubCache sets the cache of hubs. This is mandatory.
+func (b *FunctionBuilder) SetHubCache(value controllers.HubCache) *FunctionBuilder {
+	b.hubCache = value
+	return b
+}
+
+// Build uses the information stored in the builder to create a new public IP attachment reconciler.
+func (b *FunctionBuilder) Build() (result controllers.ReconcilerFunction[*privatev1.PublicIPAttachment], err error) {
+	if b.logger == nil {
+		err = errors.New("logger is mandatory")
+		return
+	}
+	if b.connection == nil {
+		err = errors.New("client is mandatory")
+		return
+	}
+	if b.hubCache == nil {
+		err = errors.New("hub cache is mandatory")
+		return
+	}
+
+	object := &function{
+		logger:                    b.logger,
+		publicIPAttachmentsClient: privatev1.NewPublicIPAttachmentsClient(b.connection),
+		publicIPsClient:           privatev1.NewPublicIPsClient(b.connection),
+		hubCache:                  b.hubCache,
+		maskCalculator:            masks.NewCalculator().Build(),
+	}
+	result = object.run
+	return
+}
+
+func (r *function) run(ctx context.Context, publicIPAttachment *privatev1.PublicIPAttachment) error {
+	oldAttachment := proto.Clone(publicIPAttachment).(*privatev1.PublicIPAttachment)
+	t := task{
+		r:                  r,
+		publicIPAttachment: publicIPAttachment,
+	}
+	var err error
+	if publicIPAttachment.HasMetadata() && publicIPAttachment.GetMetadata().HasDeletionTimestamp() {
+		err = t.delete(ctx)
+	} else {
+		err = t.update(ctx)
+	}
+	if err != nil {
+		return err
+	}
+	updateMask := r.maskCalculator.Calculate(oldAttachment, publicIPAttachment)
+	if len(updateMask.GetPaths()) == 0 {
+		return nil
+	}
+
+	_, err = r.publicIPAttachmentsClient.Update(ctx, privatev1.PublicIPAttachmentsUpdateRequest_builder{
+		Object:     publicIPAttachment,
+		UpdateMask: updateMask,
+	}.Build())
+
+	return err
+}
+
+func (t *task) update(ctx context.Context) error {
+	if t.addFinalizer() {
+		return nil
+	}
+
+	t.setDefaults()
+
+	if err := t.validateTenant(); err != nil {
+		return err
+	}
+
+	if err := t.selectHub(ctx); err != nil {
+		return err
+	}
+
+	t.publicIPAttachment.GetStatus().SetHub(t.hubId)
+
+	object, err := t.getKubeObject(ctx)
+	if err != nil {
+		return err
+	}
+
+	spec := t.buildSpec()
+
+	if object == nil {
+		newObject := &osacv1alpha1.PublicIPAttachment{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace:    t.hubNamespace,
+				GenerateName: objectPrefix,
+				Labels: map[string]string{
+					labels.PublicIPAttachmentUuid: t.publicIPAttachment.GetId(),
+				},
+				Annotations: map[string]string{
+					annotations.Tenant: t.publicIPAttachment.GetMetadata().GetTenant(),
+				},
+			},
+			Spec: spec,
+		}
+		err = t.hubClient.Create(ctx, newObject)
+		if err != nil {
+			return err
+		}
+		t.r.logger.DebugContext(
+			ctx,
+			"Created public IP attachment",
+			slog.String("namespace", newObject.GetNamespace()),
+			slog.String("name", newObject.GetName()),
+		)
+	} else {
+		update := object.DeepCopy()
+		update.Spec = spec
+		err = t.hubClient.Patch(ctx, update, clnt.MergeFrom(object))
+		if err != nil {
+			return err
+		}
+		t.r.logger.DebugContext(
+			ctx,
+			"Updated public IP attachment",
+			slog.String("namespace", object.GetNamespace()),
+			slog.String("name", object.GetName()),
+		)
+	}
+
+	return err
+}
+
+func (t *task) setDefaults() {
+	if !t.publicIPAttachment.HasStatus() {
+		t.publicIPAttachment.SetStatus(&privatev1.PublicIPAttachmentStatus{})
+	}
+	if t.publicIPAttachment.GetStatus().GetState() == privatev1.PublicIPAttachmentState_PUBLIC_IP_ATTACHMENT_STATE_UNSPECIFIED {
+		t.publicIPAttachment.GetStatus().SetState(privatev1.PublicIPAttachmentState_PUBLIC_IP_ATTACHMENT_STATE_PENDING)
+	}
+}
+
+func (t *task) validateTenant() error {
+	if !t.publicIPAttachment.HasMetadata() || t.publicIPAttachment.GetMetadata().GetTenant() == "" {
+		return errors.New("public IP attachment must have a tenant assigned")
+	}
+	return nil
+}
+
+func (t *task) delete(ctx context.Context) (err error) {
+	t.hubId = t.publicIPAttachment.GetStatus().GetHub()
+	if t.hubId == "" {
+		t.removeFinalizer()
+		return nil
+	}
+	err = t.getHub(ctx)
+	if err != nil {
+		if errors.Is(err, controllers.ErrHubNotFound) {
+			controllers.RemoveFinalizerOnDecommissionedHub(ctx, t.r.logger, t.hubId, "public_ip_attachment_id", t.publicIPAttachment.GetId(), t.removeFinalizer)
+			return nil
+		}
+		return
+	}
+
+	object, err := t.getKubeObject(ctx)
+	if err != nil {
+		return
+	}
+	if object == nil {
+		t.r.logger.DebugContext(
+			ctx,
+			"Public IP attachment doesn't exist",
+			slog.String("id", t.publicIPAttachment.GetId()),
+		)
+		t.removeFinalizer()
+		return
+	}
+
+	if object.GetDeletionTimestamp() == nil {
+		err = t.hubClient.Delete(ctx, object)
+		if err != nil {
+			return
+		}
+		t.r.logger.DebugContext(
+			ctx,
+			"Deleted public IP attachment",
+			slog.String("namespace", object.GetNamespace()),
+			slog.String("name", object.GetName()),
+		)
+	} else {
+		t.r.logger.DebugContext(
+			ctx,
+			"Public IP attachment is still being deleted, waiting for K8s finalizers",
+			slog.String("namespace", object.GetNamespace()),
+			slog.String("name", object.GetName()),
+		)
+	}
+
+	return
+}
+
+func (t *task) selectHub(ctx context.Context) error {
+	t.hubId = t.publicIPAttachment.GetStatus().GetHub()
+	if t.hubId == "" {
+		pipResponse, err := t.r.publicIPsClient.Get(ctx, privatev1.PublicIPsGetRequest_builder{
+			Id: t.publicIPAttachment.GetSpec().GetPublicIp(),
+		}.Build())
+		if err != nil {
+			return err
+		}
+		pipHub := pipResponse.GetObject().GetStatus().GetHub()
+		if pipHub == "" {
+			return fmt.Errorf(
+				"public IP %s has no hub assigned yet, skipping",
+				t.publicIPAttachment.GetSpec().GetPublicIp(),
+			)
+		}
+		t.hubId = pipHub
+	}
+	t.r.logger.DebugContext(
+		ctx,
+		"Selected hub",
+		slog.String("id", t.hubId),
+	)
+	hubEntry, err := t.r.hubCache.Get(ctx, t.hubId)
+	if err != nil {
+		return err
+	}
+	t.hubNamespace = hubEntry.Namespace
+	t.hubClient = hubEntry.Client
+	return nil
+}
+
+func (t *task) getHub(ctx context.Context) error {
+	t.hubId = t.publicIPAttachment.GetStatus().GetHub()
+	hubEntry, err := t.r.hubCache.Get(ctx, t.hubId)
+	if err != nil {
+		return err
+	}
+	t.hubNamespace = hubEntry.Namespace
+	t.hubClient = hubEntry.Client
+	return nil
+}
+
+func (t *task) getKubeObject(ctx context.Context) (result *osacv1alpha1.PublicIPAttachment, err error) {
+	list := &osacv1alpha1.PublicIPAttachmentList{}
+	err = t.hubClient.List(
+		ctx, list,
+		clnt.InNamespace(t.hubNamespace),
+		clnt.MatchingLabels{
+			labels.PublicIPAttachmentUuid: t.publicIPAttachment.GetId(),
+		},
+	)
+	if err != nil {
+		return
+	}
+	items := list.Items
+	count := len(items)
+	if count > 1 {
+		err = fmt.Errorf(
+			"expected at most one public IP attachment with identifier '%s' but found %d",
+			t.publicIPAttachment.GetId(), count,
+		)
+		return
+	}
+	if count > 0 {
+		result = &items[0]
+	}
+	return
+}
+
+func (t *task) addFinalizer() bool {
+	if !t.publicIPAttachment.HasMetadata() {
+		t.publicIPAttachment.SetMetadata(&privatev1.Metadata{})
+	}
+	list := t.publicIPAttachment.GetMetadata().GetFinalizers()
+	if !slices.Contains(list, finalizers.Controller) {
+		list = append(list, finalizers.Controller)
+		t.publicIPAttachment.GetMetadata().SetFinalizers(list)
+		return true
+	}
+	return false
+}
+
+func (t *task) removeFinalizer() {
+	if !t.publicIPAttachment.HasMetadata() {
+		return
+	}
+	list := t.publicIPAttachment.GetMetadata().GetFinalizers()
+	if slices.Contains(list, finalizers.Controller) {
+		list = slices.DeleteFunc(list, func(item string) bool {
+			return item == finalizers.Controller
+		})
+		t.publicIPAttachment.GetMetadata().SetFinalizers(list)
+	}
+}
+
+func (t *task) buildSpec() osacv1alpha1.PublicIPAttachmentSpec {
+	spec := osacv1alpha1.PublicIPAttachmentSpec{
+		PublicIP: t.publicIPAttachment.GetSpec().GetPublicIp(),
+	}
+	if t.publicIPAttachment.GetSpec().HasComputeInstance() {
+		ci := t.publicIPAttachment.GetSpec().GetComputeInstance()
+		spec.ComputeInstance = &ci
+	}
+	return spec
+}

--- a/internal/controllers/publicipattachment/public_ip_attachment_reconciler_function_test.go
+++ b/internal/controllers/publicipattachment/public_ip_attachment_reconciler_function_test.go
@@ -98,12 +98,12 @@ func newTaskForDelete(attachmentID, hubID string, hubCache controllers.HubCache)
 
 var _ = Describe("buildSpec", func() {
 	It("Includes publicIP and computeInstance in spec", func() {
-		ci := "ci-abc123"
+		ci := "ci-uuid-abc123"
 		t := &task{
 			publicIPAttachment: privatev1.PublicIPAttachment_builder{
-				Id: "pia-test-1",
+				Id: "pia-uuid-test-1",
 				Spec: privatev1.PublicIPAttachmentSpec_builder{
-					PublicIp:        "pip-abc123",
+					PublicIp:        "pip-uuid-abc123",
 					ComputeInstance: &ci,
 				}.Build(),
 			}.Build(),
@@ -111,34 +111,34 @@ var _ = Describe("buildSpec", func() {
 
 		spec := t.buildSpec()
 
-		Expect(spec.PublicIP).To(Equal("pip-abc123"))
+		Expect(spec.PublicIP).To(Equal("pip-uuid-abc123"))
 		Expect(spec.ComputeInstance).ToNot(BeNil())
-		Expect(*spec.ComputeInstance).To(Equal("ci-abc123"))
+		Expect(*spec.ComputeInstance).To(Equal("ci-uuid-abc123"))
 	})
 
 	It("Handles nil computeInstance", func() {
 		t := &task{
 			publicIPAttachment: privatev1.PublicIPAttachment_builder{
-				Id: "pia-test-2",
+				Id: "pia-uuid-test-2",
 				Spec: privatev1.PublicIPAttachmentSpec_builder{
-					PublicIp: "pip-abc456",
+					PublicIp: "pip-uuid-abc456",
 				}.Build(),
 			}.Build(),
 		}
 
 		spec := t.buildSpec()
 
-		Expect(spec.PublicIP).To(Equal("pip-abc456"))
+		Expect(spec.PublicIP).To(Equal("pip-uuid-abc456"))
 		Expect(spec.ComputeInstance).To(BeNil())
 	})
 
 	It("Does not include status fields", func() {
-		ci := "ci-xyz"
+		ci := "ci-uuid-xyz"
 		t := &task{
 			publicIPAttachment: privatev1.PublicIPAttachment_builder{
-				Id: "pia-test-3",
+				Id: "pia-uuid-test-3",
 				Spec: privatev1.PublicIPAttachmentSpec_builder{
-					PublicIp:        "pip-abc789",
+					PublicIp:        "pip-uuid-abc789",
 					ComputeInstance: &ci,
 				}.Build(),
 				Status: privatev1.PublicIPAttachmentStatus_builder{
@@ -151,13 +151,13 @@ var _ = Describe("buildSpec", func() {
 
 		spec := t.buildSpec()
 
-		Expect(spec.PublicIP).To(Equal("pip-abc789"))
+		Expect(spec.PublicIP).To(Equal("pip-uuid-abc789"))
 	})
 })
 
 var _ = Describe("delete", func() {
 	const (
-		attachmentID = "pia-delete-id"
+		attachmentID = "pia-uuid-delete-id"
 		hubID        = "test-hub"
 		hubNamespace = "test-ns"
 		crName       = "publicipattachment-test"
@@ -368,7 +368,7 @@ var _ = Describe("validateTenant", func() {
 var _ = Describe("setDefaults", func() {
 	It("should set PENDING state when status is unspecified", func() {
 		attachment := privatev1.PublicIPAttachment_builder{
-			Id: "pia-defaults",
+			Id: "pia-uuid-defaults",
 		}.Build()
 
 		t := &task{
@@ -384,7 +384,7 @@ var _ = Describe("setDefaults", func() {
 
 	It("should not overwrite existing state", func() {
 		attachment := privatev1.PublicIPAttachment_builder{
-			Id: "pia-existing-state",
+			Id: "pia-uuid-existing-state",
 			Status: privatev1.PublicIPAttachmentStatus_builder{
 				State: privatev1.PublicIPAttachmentState_PUBLIC_IP_ATTACHMENT_STATE_READY,
 			}.Build(),
@@ -403,7 +403,7 @@ var _ = Describe("setDefaults", func() {
 
 	It("should create status if it doesn't exist", func() {
 		attachment := privatev1.PublicIPAttachment_builder{
-			Id: "pia-no-status",
+			Id: "pia-uuid-no-status",
 		}.Build()
 
 		t := &task{
@@ -424,7 +424,7 @@ var _ = Describe("setDefaults", func() {
 var _ = Describe("addFinalizer", func() {
 	It("should add finalizer when not present", func() {
 		attachment := privatev1.PublicIPAttachment_builder{
-			Id: "pia-no-finalizer",
+			Id: "pia-uuid-no-finalizer",
 			Metadata: privatev1.Metadata_builder{
 				Finalizers: []string{},
 			}.Build(),
@@ -442,7 +442,7 @@ var _ = Describe("addFinalizer", func() {
 
 	It("should not add finalizer when already present", func() {
 		attachment := privatev1.PublicIPAttachment_builder{
-			Id: "pia-has-finalizer",
+			Id: "pia-uuid-has-finalizer",
 			Metadata: privatev1.Metadata_builder{
 				Finalizers: []string{finalizers.Controller},
 			}.Build(),
@@ -461,7 +461,7 @@ var _ = Describe("addFinalizer", func() {
 
 	It("should create metadata if it doesn't exist", func() {
 		attachment := privatev1.PublicIPAttachment_builder{
-			Id: "pia-no-metadata",
+			Id: "pia-uuid-no-metadata",
 		}.Build()
 
 		t := &task{
@@ -481,7 +481,7 @@ var _ = Describe("addFinalizer", func() {
 var _ = Describe("removeFinalizer", func() {
 	It("should remove finalizer when present", func() {
 		attachment := privatev1.PublicIPAttachment_builder{
-			Id: "pia-has-finalizer",
+			Id: "pia-uuid-has-finalizer",
 			Metadata: privatev1.Metadata_builder{
 				Finalizers: []string{finalizers.Controller, "other-finalizer"},
 			}.Build(),
@@ -501,7 +501,7 @@ var _ = Describe("removeFinalizer", func() {
 
 	It("should do nothing when finalizer not present", func() {
 		attachment := privatev1.PublicIPAttachment_builder{
-			Id: "pia-no-finalizer",
+			Id: "pia-uuid-no-finalizer",
 			Metadata: privatev1.Metadata_builder{
 				Finalizers: []string{"other-finalizer"},
 			}.Build(),
@@ -521,7 +521,7 @@ var _ = Describe("removeFinalizer", func() {
 
 	It("should do nothing when metadata doesn't exist", func() {
 		attachment := privatev1.PublicIPAttachment_builder{
-			Id: "pia-no-metadata",
+			Id: "pia-uuid-no-metadata",
 		}.Build()
 
 		t := &task{
@@ -556,9 +556,9 @@ var _ = Describe("selectHub", func() {
 			}, nil)
 
 		attachment := privatev1.PublicIPAttachment_builder{
-			Id: "pia-existing-hub",
+			Id: "pia-uuid-existing-hub",
 			Spec: privatev1.PublicIPAttachmentSpec_builder{
-				PublicIp: "pip-1",
+				PublicIp: "pip-uuid-1",
 			}.Build(),
 			Status: privatev1.PublicIPAttachmentStatus_builder{
 				Hub: "hub-1",
@@ -585,7 +585,7 @@ var _ = Describe("selectHub", func() {
 		publicIPsClient := &fakePublicIPsClient{
 			getResponse: privatev1.PublicIPsGetResponse_builder{
 				Object: privatev1.PublicIP_builder{
-					Id: "pip-1",
+					Id: "pip-uuid-1",
 					Status: privatev1.PublicIPStatus_builder{
 						Hub: "pip-hub-1",
 					}.Build(),
@@ -602,9 +602,9 @@ var _ = Describe("selectHub", func() {
 			}, nil)
 
 		attachment := privatev1.PublicIPAttachment_builder{
-			Id: "pia-derive-hub",
+			Id: "pia-uuid-derive-hub",
 			Spec: privatev1.PublicIPAttachmentSpec_builder{
-				PublicIp: "pip-1",
+				PublicIp: "pip-uuid-1",
 			}.Build(),
 		}.Build()
 
@@ -629,16 +629,16 @@ var _ = Describe("selectHub", func() {
 		publicIPsClient := &fakePublicIPsClient{
 			getResponse: privatev1.PublicIPsGetResponse_builder{
 				Object: privatev1.PublicIP_builder{
-					Id:     "pip-no-hub",
+					Id:     "pip-uuid-no-hub",
 					Status: privatev1.PublicIPStatus_builder{}.Build(),
 				}.Build(),
 			}.Build(),
 		}
 
 		attachment := privatev1.PublicIPAttachment_builder{
-			Id: "pia-pip-no-hub",
+			Id: "pia-uuid-pip-no-hub",
 			Spec: privatev1.PublicIPAttachmentSpec_builder{
-				PublicIp: "pip-no-hub",
+				PublicIp: "pip-uuid-no-hub",
 			}.Build(),
 		}.Build()
 
@@ -663,9 +663,9 @@ var _ = Describe("selectHub", func() {
 		}
 
 		attachment := privatev1.PublicIPAttachment_builder{
-			Id: "pia-pip-error",
+			Id: "pia-uuid-pip-error",
 			Spec: privatev1.PublicIPAttachmentSpec_builder{
-				PublicIp: "pip-missing",
+				PublicIp: "pip-uuid-missing",
 			}.Build(),
 		}.Build()
 

--- a/internal/controllers/publicipattachment/public_ip_attachment_reconciler_function_test.go
+++ b/internal/controllers/publicipattachment/public_ip_attachment_reconciler_function_test.go
@@ -1,0 +1,686 @@
+/*
+Copyright (c) 2025 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package publicipattachment
+
+import (
+	"context"
+	"errors"
+	"slices"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	osacv1alpha1 "github.com/osac-project/osac-operator/api/v1alpha1"
+	"go.uber.org/mock/gomock"
+	"google.golang.org/grpc"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	clnt "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+
+	privatev1 "github.com/osac-project/fulfillment-service/internal/api/osac/private/v1"
+	"github.com/osac-project/fulfillment-service/internal/controllers"
+	"github.com/osac-project/fulfillment-service/internal/controllers/finalizers"
+	"github.com/osac-project/fulfillment-service/internal/kubernetes/labels"
+)
+
+// fakePublicIPsClient implements the PublicIPsClient interface for testing selectHub.
+type fakePublicIPsClient struct {
+	privatev1.PublicIPsClient
+	getResponse *privatev1.PublicIPsGetResponse
+	getErr      error
+}
+
+func (f *fakePublicIPsClient) Get(
+	_ context.Context,
+	_ *privatev1.PublicIPsGetRequest,
+	_ ...grpc.CallOption,
+) (*privatev1.PublicIPsGetResponse, error) {
+	return f.getResponse, f.getErr
+}
+
+// newAttachmentCR creates a typed PublicIPAttachment CR for use with the fake client.
+func newAttachmentCR(id, namespace, name string, deletionTimestamp *metav1.Time) *osacv1alpha1.PublicIPAttachment {
+	obj := &osacv1alpha1.PublicIPAttachment{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      name,
+			Labels: map[string]string{
+				labels.PublicIPAttachmentUuid: id,
+			},
+		},
+	}
+	if deletionTimestamp != nil {
+		obj.SetDeletionTimestamp(deletionTimestamp)
+		obj.SetFinalizers([]string{"osac.openshift.io/publicipattachment"})
+	}
+	return obj
+}
+
+// hasFinalizer checks if the fulfillment-controller finalizer is present on the attachment.
+func hasFinalizer(attachment *privatev1.PublicIPAttachment) bool {
+	return slices.Contains(attachment.GetMetadata().GetFinalizers(), finalizers.Controller)
+}
+
+// newTaskForDelete creates a task configured for testing delete() with hub-dependent paths.
+func newTaskForDelete(attachmentID, hubID string, hubCache controllers.HubCache) *task {
+	attachment := privatev1.PublicIPAttachment_builder{
+		Id: attachmentID,
+		Metadata: privatev1.Metadata_builder{
+			Finalizers: []string{finalizers.Controller},
+		}.Build(),
+		Status: privatev1.PublicIPAttachmentStatus_builder{
+			Hub: hubID,
+		}.Build(),
+	}.Build()
+
+	f := &function{
+		logger:   logger,
+		hubCache: hubCache,
+	}
+
+	return &task{
+		r:                  f,
+		publicIPAttachment: attachment,
+	}
+}
+
+var _ = Describe("buildSpec", func() {
+	It("Includes publicIP and computeInstance in spec", func() {
+		ci := "ci-abc123"
+		t := &task{
+			publicIPAttachment: privatev1.PublicIPAttachment_builder{
+				Id: "pia-test-1",
+				Spec: privatev1.PublicIPAttachmentSpec_builder{
+					PublicIp:        "pip-abc123",
+					ComputeInstance: &ci,
+				}.Build(),
+			}.Build(),
+		}
+
+		spec := t.buildSpec()
+
+		Expect(spec.PublicIP).To(Equal("pip-abc123"))
+		Expect(spec.ComputeInstance).ToNot(BeNil())
+		Expect(*spec.ComputeInstance).To(Equal("ci-abc123"))
+	})
+
+	It("Handles nil computeInstance", func() {
+		t := &task{
+			publicIPAttachment: privatev1.PublicIPAttachment_builder{
+				Id: "pia-test-2",
+				Spec: privatev1.PublicIPAttachmentSpec_builder{
+					PublicIp: "pip-abc456",
+				}.Build(),
+			}.Build(),
+		}
+
+		spec := t.buildSpec()
+
+		Expect(spec.PublicIP).To(Equal("pip-abc456"))
+		Expect(spec.ComputeInstance).To(BeNil())
+	})
+
+	It("Does not include status fields", func() {
+		ci := "ci-xyz"
+		t := &task{
+			publicIPAttachment: privatev1.PublicIPAttachment_builder{
+				Id: "pia-test-3",
+				Spec: privatev1.PublicIPAttachmentSpec_builder{
+					PublicIp:        "pip-abc789",
+					ComputeInstance: &ci,
+				}.Build(),
+				Status: privatev1.PublicIPAttachmentStatus_builder{
+					State:           privatev1.PublicIPAttachmentState_PUBLIC_IP_ATTACHMENT_STATE_READY,
+					Hub:             "hub-1",
+					PublicIpAddress: "10.0.0.5",
+				}.Build(),
+			}.Build(),
+		}
+
+		spec := t.buildSpec()
+
+		Expect(spec.PublicIP).To(Equal("pip-abc789"))
+	})
+})
+
+var _ = Describe("delete", func() {
+	const (
+		attachmentID = "pia-delete-id"
+		hubID        = "test-hub"
+		hubNamespace = "test-ns"
+		crName       = "publicipattachment-test"
+	)
+
+	var (
+		ctx  context.Context
+		ctrl *gomock.Controller
+	)
+
+	BeforeEach(func() {
+		ctx = context.Background()
+		ctrl = gomock.NewController(GinkgoT())
+		DeferCleanup(ctrl.Finish)
+	})
+
+	It("should remove finalizer when K8s object doesn't exist", func() {
+		scheme := runtime.NewScheme()
+		Expect(osacv1alpha1.AddToScheme(scheme)).To(Succeed())
+		fakeClient := fake.NewClientBuilder().
+			WithScheme(scheme).
+			Build()
+
+		hubCache := controllers.NewMockHubCache(ctrl)
+		hubCache.EXPECT().
+			Get(gomock.Any(), hubID).
+			Return(&controllers.HubEntry{
+				Namespace: hubNamespace,
+				Client:    fakeClient,
+			}, nil)
+
+		t := newTaskForDelete(attachmentID, hubID, hubCache)
+		Expect(hasFinalizer(t.publicIPAttachment)).To(BeTrue())
+
+		err := t.delete(ctx)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(hasFinalizer(t.publicIPAttachment)).To(BeFalse())
+	})
+
+	It("should call hubClient.Delete when K8s object exists without DeletionTimestamp", func() {
+		cr := newAttachmentCR(attachmentID, hubNamespace, crName, nil)
+
+		scheme := runtime.NewScheme()
+		Expect(osacv1alpha1.AddToScheme(scheme)).To(Succeed())
+
+		deleteCalled := false
+		fakeClient := fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithObjects(cr).
+			WithInterceptorFuncs(interceptor.Funcs{
+				Delete: func(ctx context.Context, client clnt.WithWatch, obj clnt.Object, opts ...clnt.DeleteOption) error {
+					deleteCalled = true
+					return nil
+				},
+			}).
+			Build()
+
+		hubCache := controllers.NewMockHubCache(ctrl)
+		hubCache.EXPECT().
+			Get(gomock.Any(), hubID).
+			Return(&controllers.HubEntry{
+				Namespace: hubNamespace,
+				Client:    fakeClient,
+			}, nil)
+
+		t := newTaskForDelete(attachmentID, hubID, hubCache)
+
+		err := t.delete(ctx)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(deleteCalled).To(BeTrue())
+		Expect(hasFinalizer(t.publicIPAttachment)).To(BeTrue())
+	})
+
+	It("should not call hubClient.Delete when K8s object has DeletionTimestamp", func() {
+		now := metav1.Now()
+		cr := newAttachmentCR(attachmentID, hubNamespace, crName, &now)
+
+		scheme := runtime.NewScheme()
+		Expect(osacv1alpha1.AddToScheme(scheme)).To(Succeed())
+
+		deleteCalled := false
+		fakeClient := fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithObjects(cr).
+			WithInterceptorFuncs(interceptor.Funcs{
+				Delete: func(ctx context.Context, client clnt.WithWatch, obj clnt.Object, opts ...clnt.DeleteOption) error {
+					deleteCalled = true
+					return nil
+				},
+			}).
+			Build()
+
+		hubCache := controllers.NewMockHubCache(ctrl)
+		hubCache.EXPECT().
+			Get(gomock.Any(), hubID).
+			Return(&controllers.HubEntry{
+				Namespace: hubNamespace,
+				Client:    fakeClient,
+			}, nil)
+
+		t := newTaskForDelete(attachmentID, hubID, hubCache)
+
+		err := t.delete(ctx)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(deleteCalled).To(BeFalse())
+		Expect(hasFinalizer(t.publicIPAttachment)).To(BeTrue())
+	})
+
+	It("should propagate error when hub cache returns error", func() {
+		hubCache := controllers.NewMockHubCache(ctrl)
+		hubCache.EXPECT().
+			Get(gomock.Any(), hubID).
+			Return(nil, errors.New("hub not found"))
+
+		t := newTaskForDelete(attachmentID, hubID, hubCache)
+
+		err := t.delete(ctx)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("hub not found"))
+		Expect(hasFinalizer(t.publicIPAttachment)).To(BeTrue())
+	})
+
+	It("should remove finalizer when hub cache returns ErrHubNotFound", func() {
+		hubCache := controllers.NewMockHubCache(ctrl)
+		hubCache.EXPECT().
+			Get(gomock.Any(), hubID).
+			Return(nil, controllers.ErrHubNotFound)
+
+		t := newTaskForDelete(attachmentID, hubID, hubCache)
+		Expect(hasFinalizer(t.publicIPAttachment)).To(BeTrue())
+
+		err := t.delete(ctx)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(hasFinalizer(t.publicIPAttachment)).To(BeFalse())
+	})
+
+	It("should remove finalizer when no hub is assigned", func() {
+		attachment := privatev1.PublicIPAttachment_builder{
+			Id: attachmentID,
+			Metadata: privatev1.Metadata_builder{
+				Finalizers: []string{finalizers.Controller},
+			}.Build(),
+			Status: privatev1.PublicIPAttachmentStatus_builder{}.Build(),
+		}.Build()
+
+		f := &function{
+			logger: logger,
+		}
+
+		t := &task{
+			r:                  f,
+			publicIPAttachment: attachment,
+		}
+
+		Expect(hasFinalizer(t.publicIPAttachment)).To(BeTrue())
+
+		err := t.delete(ctx)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(hasFinalizer(t.publicIPAttachment)).To(BeFalse())
+	})
+})
+
+var _ = Describe("validateTenant", func() {
+	It("should succeed when a tenant is assigned", func() {
+		attachment := privatev1.PublicIPAttachment_builder{
+			Metadata: privatev1.Metadata_builder{
+				Tenant: "tenant-1",
+			}.Build(),
+		}.Build()
+
+		t := &task{
+			publicIPAttachment: attachment,
+		}
+
+		err := t.validateTenant()
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	It("should fail when tenant is empty", func() {
+		attachment := privatev1.PublicIPAttachment_builder{
+			Metadata: privatev1.Metadata_builder{
+				Tenant: "",
+			}.Build(),
+		}.Build()
+
+		t := &task{
+			publicIPAttachment: attachment,
+		}
+
+		err := t.validateTenant()
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("tenant"))
+	})
+
+	It("should fail when metadata is missing", func() {
+		attachment := privatev1.PublicIPAttachment_builder{}.Build()
+
+		t := &task{
+			publicIPAttachment: attachment,
+		}
+
+		err := t.validateTenant()
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("tenant"))
+	})
+})
+
+var _ = Describe("setDefaults", func() {
+	It("should set PENDING state when status is unspecified", func() {
+		attachment := privatev1.PublicIPAttachment_builder{
+			Id: "pia-defaults",
+		}.Build()
+
+		t := &task{
+			publicIPAttachment: attachment,
+		}
+
+		t.setDefaults()
+
+		Expect(t.publicIPAttachment.GetStatus().GetState()).To(
+			Equal(privatev1.PublicIPAttachmentState_PUBLIC_IP_ATTACHMENT_STATE_PENDING),
+		)
+	})
+
+	It("should not overwrite existing state", func() {
+		attachment := privatev1.PublicIPAttachment_builder{
+			Id: "pia-existing-state",
+			Status: privatev1.PublicIPAttachmentStatus_builder{
+				State: privatev1.PublicIPAttachmentState_PUBLIC_IP_ATTACHMENT_STATE_READY,
+			}.Build(),
+		}.Build()
+
+		t := &task{
+			publicIPAttachment: attachment,
+		}
+
+		t.setDefaults()
+
+		Expect(t.publicIPAttachment.GetStatus().GetState()).To(
+			Equal(privatev1.PublicIPAttachmentState_PUBLIC_IP_ATTACHMENT_STATE_READY),
+		)
+	})
+
+	It("should create status if it doesn't exist", func() {
+		attachment := privatev1.PublicIPAttachment_builder{
+			Id: "pia-no-status",
+		}.Build()
+
+		t := &task{
+			publicIPAttachment: attachment,
+		}
+
+		Expect(t.publicIPAttachment.HasStatus()).To(BeFalse())
+
+		t.setDefaults()
+
+		Expect(t.publicIPAttachment.HasStatus()).To(BeTrue())
+		Expect(t.publicIPAttachment.GetStatus().GetState()).To(
+			Equal(privatev1.PublicIPAttachmentState_PUBLIC_IP_ATTACHMENT_STATE_PENDING),
+		)
+	})
+})
+
+var _ = Describe("addFinalizer", func() {
+	It("should add finalizer when not present", func() {
+		attachment := privatev1.PublicIPAttachment_builder{
+			Id: "pia-no-finalizer",
+			Metadata: privatev1.Metadata_builder{
+				Finalizers: []string{},
+			}.Build(),
+		}.Build()
+
+		t := &task{
+			publicIPAttachment: attachment,
+		}
+
+		added := t.addFinalizer()
+
+		Expect(added).To(BeTrue())
+		Expect(hasFinalizer(t.publicIPAttachment)).To(BeTrue())
+	})
+
+	It("should not add finalizer when already present", func() {
+		attachment := privatev1.PublicIPAttachment_builder{
+			Id: "pia-has-finalizer",
+			Metadata: privatev1.Metadata_builder{
+				Finalizers: []string{finalizers.Controller},
+			}.Build(),
+		}.Build()
+
+		t := &task{
+			publicIPAttachment: attachment,
+		}
+
+		added := t.addFinalizer()
+
+		Expect(added).To(BeFalse())
+		Expect(hasFinalizer(t.publicIPAttachment)).To(BeTrue())
+		Expect(len(t.publicIPAttachment.GetMetadata().GetFinalizers())).To(Equal(1))
+	})
+
+	It("should create metadata if it doesn't exist", func() {
+		attachment := privatev1.PublicIPAttachment_builder{
+			Id: "pia-no-metadata",
+		}.Build()
+
+		t := &task{
+			publicIPAttachment: attachment,
+		}
+
+		Expect(t.publicIPAttachment.HasMetadata()).To(BeFalse())
+
+		added := t.addFinalizer()
+
+		Expect(added).To(BeTrue())
+		Expect(t.publicIPAttachment.HasMetadata()).To(BeTrue())
+		Expect(hasFinalizer(t.publicIPAttachment)).To(BeTrue())
+	})
+})
+
+var _ = Describe("removeFinalizer", func() {
+	It("should remove finalizer when present", func() {
+		attachment := privatev1.PublicIPAttachment_builder{
+			Id: "pia-has-finalizer",
+			Metadata: privatev1.Metadata_builder{
+				Finalizers: []string{finalizers.Controller, "other-finalizer"},
+			}.Build(),
+		}.Build()
+
+		t := &task{
+			publicIPAttachment: attachment,
+		}
+
+		Expect(hasFinalizer(t.publicIPAttachment)).To(BeTrue())
+
+		t.removeFinalizer()
+
+		Expect(hasFinalizer(t.publicIPAttachment)).To(BeFalse())
+		Expect(t.publicIPAttachment.GetMetadata().GetFinalizers()).To(ContainElement("other-finalizer"))
+	})
+
+	It("should do nothing when finalizer not present", func() {
+		attachment := privatev1.PublicIPAttachment_builder{
+			Id: "pia-no-finalizer",
+			Metadata: privatev1.Metadata_builder{
+				Finalizers: []string{"other-finalizer"},
+			}.Build(),
+		}.Build()
+
+		t := &task{
+			publicIPAttachment: attachment,
+		}
+
+		Expect(hasFinalizer(t.publicIPAttachment)).To(BeFalse())
+
+		t.removeFinalizer()
+
+		Expect(hasFinalizer(t.publicIPAttachment)).To(BeFalse())
+		Expect(t.publicIPAttachment.GetMetadata().GetFinalizers()).To(ContainElement("other-finalizer"))
+	})
+
+	It("should do nothing when metadata doesn't exist", func() {
+		attachment := privatev1.PublicIPAttachment_builder{
+			Id: "pia-no-metadata",
+		}.Build()
+
+		t := &task{
+			publicIPAttachment: attachment,
+		}
+
+		t.removeFinalizer()
+
+		Expect(t.publicIPAttachment.HasMetadata()).To(BeFalse())
+	})
+})
+
+var _ = Describe("selectHub", func() {
+	var (
+		ctx  context.Context
+		ctrl *gomock.Controller
+	)
+
+	BeforeEach(func() {
+		ctx = context.Background()
+		ctrl = gomock.NewController(GinkgoT())
+		DeferCleanup(ctrl.Finish)
+	})
+
+	It("should use existing hub from status", func() {
+		hubCache := controllers.NewMockHubCache(ctrl)
+		hubCache.EXPECT().
+			Get(gomock.Any(), "hub-1").
+			Return(&controllers.HubEntry{
+				Namespace: "hub-ns",
+				Client:    fake.NewClientBuilder().Build(),
+			}, nil)
+
+		attachment := privatev1.PublicIPAttachment_builder{
+			Id: "pia-existing-hub",
+			Spec: privatev1.PublicIPAttachmentSpec_builder{
+				PublicIp: "pip-1",
+			}.Build(),
+			Status: privatev1.PublicIPAttachmentStatus_builder{
+				Hub: "hub-1",
+			}.Build(),
+		}.Build()
+
+		f := &function{
+			logger:   logger,
+			hubCache: hubCache,
+		}
+
+		t := &task{
+			r:                  f,
+			publicIPAttachment: attachment,
+		}
+
+		err := t.selectHub(ctx)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(t.hubId).To(Equal("hub-1"))
+		Expect(t.hubNamespace).To(Equal("hub-ns"))
+	})
+
+	It("should derive hub from parent PublicIP when status hub is empty", func() {
+		publicIPsClient := &fakePublicIPsClient{
+			getResponse: privatev1.PublicIPsGetResponse_builder{
+				Object: privatev1.PublicIP_builder{
+					Id: "pip-1",
+					Status: privatev1.PublicIPStatus_builder{
+						Hub: "pip-hub-1",
+					}.Build(),
+				}.Build(),
+			}.Build(),
+		}
+
+		hubCache := controllers.NewMockHubCache(ctrl)
+		hubCache.EXPECT().
+			Get(gomock.Any(), "pip-hub-1").
+			Return(&controllers.HubEntry{
+				Namespace: "pip-hub-ns",
+				Client:    fake.NewClientBuilder().Build(),
+			}, nil)
+
+		attachment := privatev1.PublicIPAttachment_builder{
+			Id: "pia-derive-hub",
+			Spec: privatev1.PublicIPAttachmentSpec_builder{
+				PublicIp: "pip-1",
+			}.Build(),
+		}.Build()
+
+		f := &function{
+			logger:          logger,
+			hubCache:        hubCache,
+			publicIPsClient: publicIPsClient,
+		}
+
+		t := &task{
+			r:                  f,
+			publicIPAttachment: attachment,
+		}
+
+		err := t.selectHub(ctx)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(t.hubId).To(Equal("pip-hub-1"))
+		Expect(t.hubNamespace).To(Equal("pip-hub-ns"))
+	})
+
+	It("should return error when parent PublicIP has no hub", func() {
+		publicIPsClient := &fakePublicIPsClient{
+			getResponse: privatev1.PublicIPsGetResponse_builder{
+				Object: privatev1.PublicIP_builder{
+					Id: "pip-no-hub",
+					Status: privatev1.PublicIPStatus_builder{}.Build(),
+				}.Build(),
+			}.Build(),
+		}
+
+		attachment := privatev1.PublicIPAttachment_builder{
+			Id: "pia-pip-no-hub",
+			Spec: privatev1.PublicIPAttachmentSpec_builder{
+				PublicIp: "pip-no-hub",
+			}.Build(),
+		}.Build()
+
+		f := &function{
+			logger:          logger,
+			publicIPsClient: publicIPsClient,
+		}
+
+		t := &task{
+			r:                  f,
+			publicIPAttachment: attachment,
+		}
+
+		err := t.selectHub(ctx)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("no hub assigned yet"))
+	})
+
+	It("should return error when PublicIP lookup fails", func() {
+		publicIPsClient := &fakePublicIPsClient{
+			getErr: errors.New("public IP not found"),
+		}
+
+		attachment := privatev1.PublicIPAttachment_builder{
+			Id: "pia-pip-error",
+			Spec: privatev1.PublicIPAttachmentSpec_builder{
+				PublicIp: "pip-missing",
+			}.Build(),
+		}.Build()
+
+		f := &function{
+			logger:          logger,
+			publicIPsClient: publicIPsClient,
+		}
+
+		t := &task{
+			r:                  f,
+			publicIPAttachment: attachment,
+		}
+
+		err := t.selectHub(ctx)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("public IP not found"))
+	})
+})

--- a/internal/controllers/publicipattachment/public_ip_attachment_reconciler_function_test.go
+++ b/internal/controllers/publicipattachment/public_ip_attachment_reconciler_function_test.go
@@ -629,7 +629,7 @@ var _ = Describe("selectHub", func() {
 		publicIPsClient := &fakePublicIPsClient{
 			getResponse: privatev1.PublicIPsGetResponse_builder{
 				Object: privatev1.PublicIP_builder{
-					Id: "pip-no-hub",
+					Id:     "pip-no-hub",
 					Status: privatev1.PublicIPStatus_builder{}.Build(),
 				}.Build(),
 			}.Build(),

--- a/internal/controllers/publicipattachment/publicipattachment_suite_test.go
+++ b/internal/controllers/publicipattachment/publicipattachment_suite_test.go
@@ -1,0 +1,43 @@
+/*
+Copyright (c) 2025 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package publicipattachment
+
+import (
+	"log/slog"
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2/dsl/core"
+	. "github.com/onsi/gomega"
+	"github.com/osac-project/fulfillment-service/internal/logging"
+)
+
+func TestPublicIPAttachment(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Public IP attachment controller")
+}
+
+// Logger used for tests:
+var logger *slog.Logger
+
+var _ = BeforeSuite(func() {
+	var err error
+
+	// Create a logger that writes to the Ginkgo writer, so that the log messages will be attached to the output of
+	// the right test:
+	logger, err = logging.NewLogger().
+		SetLevel(slog.LevelDebug.String()).
+		SetWriter(GinkgoWriter).
+		Build()
+	Expect(err).ToNot(HaveOccurred())
+})

--- a/internal/kubernetes/gvks/kubernetes_gkvs.go
+++ b/internal/kubernetes/gvks/kubernetes_gkvs.go
@@ -13,7 +13,19 @@ language governing permissions and limitations under the License.
 
 package gvks
 
-import "k8s.io/apimachinery/pkg/runtime/schema"
+import (
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	osacv1alpha1 "github.com/osac-project/osac-operator/api/v1alpha1"
+)
+
+var PublicIPAttachment = schema.GroupVersionKind{
+	Group:   osacv1alpha1.GroupVersion.Group,
+	Version: osacv1alpha1.GroupVersion.Version,
+	Kind:    "PublicIPAttachment",
+}
+
+var PublicIPAttachmentList = listGVK(PublicIPAttachment)
 
 var HostedCluster = schema.GroupVersionKind{
 	Group:   "hypershift.openshift.io",

--- a/internal/kubernetes/labels/kubernetes_labels.go
+++ b/internal/kubernetes/labels/kubernetes_labels.go
@@ -44,3 +44,6 @@ var SecurityGroupUuid = fmt.Sprintf("%s/%s", group, "securitygroup-uuid")
 
 // PublicIPUuid is the label where the fulfillment API will write the identifier of the public IP.
 var PublicIPUuid = fmt.Sprintf("%s/%s", group, "publicip-uuid")
+
+// PublicIPAttachmentUuid is the label where the fulfillment API will write the identifier of the public IP attachment.
+var PublicIPAttachmentUuid = fmt.Sprintf("%s/%s", group, "publicipattachment-uuid")

--- a/internal/rendering/tables/osac.private.v1.PublicIP.yaml
+++ b/internal/rendering/tables/osac.private.v1.PublicIP.yaml
@@ -34,5 +34,5 @@ columns:
   type: osac.private.v1.Hub
   lookup: true
 
-- header: COMPUTE-INSTANCE
-  value: "has(this.spec.compute_instance)? this.spec.compute_instance: '-'"
+- header: ATTACHED
+  value: this.status.attached

--- a/internal/rendering/tables/osac.public.v1.PublicIP.yaml
+++ b/internal/rendering/tables/osac.public.v1.PublicIP.yaml
@@ -29,5 +29,5 @@ columns:
 - header: ADDRESS
   value: "this.status.address != ''? this.status.address: '-'"
 
-- header: COMPUTE-INSTANCE
-  value: "has(this.spec.compute_instance)? this.spec.compute_instance: '-'"
+- header: ATTACHED
+  value: this.status.attached


### PR DESCRIPTION
## Summary

Implement the fulfillment-service reconciler that syncs PublicIPAttachment
records from PostgreSQL to Kubernetes CRDs on hub clusters. This enables the
osac-operator to process attach/detach operations and report status back
through the feedback loop.

- Bump osac-operator API to v0.0.3 (includes PublicIPAttachment CRD types)
- Add GVK constants (`PublicIPAttachment`, `PublicIPAttachmentList`) and
  label constant (`PublicIPAttachmentUuid`)
- Implement reconciler function following the PublicIP reconciler pattern:
  builder construction, finalizer management, create/update/delete lifecycle,
  hub derivation from parent PublicIP
- Register reconciler in controller startup with event filter for
  `public_ip_attachment` events and hub creation events

## Why

The PublicIPAttachment resource manages the attach/detach lifecycle of public
IPs to compute instances. The fulfillment-service needs a reconciler to push
these records to hub clusters so the osac-operator can provision the actual
network bindings via AAP. Without this reconciler, PublicIPAttachment records
created through the API have no effect on the infrastructure.

## Testing

```bash
# Package tests (25 specs)
go run github.com/onsi/ginkgo/v2/ginkgo run -r internal/controllers/publicipattachment
# 25/25 PASS

# Full controller suite (no regressions)
go run github.com/onsi/ginkgo/v2/ginkgo run -r internal/controllers/
# 11 suites, 249 specs, all PASS

# Full test suite
go run github.com/onsi/ginkgo/v2/ginkgo run --timeout 1h -r internal
# 61 suites, all PASS
```

Unit tests cover: `buildSpec`, `delete` (6 scenarios), `validateTenant`,
`setDefaults`, `addFinalizer`, `removeFinalizer`, `selectHub` (4 scenarios).
Coverage profile (55.9%) matches the pattern reconciler (publicip: 55.0%);
untested code is builder wiring and orchestration covered by integration tests.

## Ticket

[OSAC-833](https://redhat.atlassian.net/browse/OSAC-833)

<br>

<small>Signed-off-by: akshaynadkarni <25892229+akshaynadkarni@users.noreply.github.com></small>
<small>Assisted-by: Cursor/Claude</small>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added PublicIPAttachment resource management with full reconciliation (create/update/delete).

* **UI / Rendering**
  * PublicIP tables now show an "ATTACHED" column (reflecting attachment status) instead of the compute-instance column.

* **Tests**
  * Added comprehensive unit and integration tests covering PublicIPAttachment behavior and validation.

* **Chores**
  * Updated module dependencies and repository ignore rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->