### PR TITLE
OSAC-58: block deletion of catalog items referenced by resources

### DIFF
--- a/internal/servers/cluster_catalog_items_server.go
+++ b/internal/servers/cluster_catalog_items_server.go
@@ -119,6 +119,7 @@ func (b *ClusterCatalogItemsServerBuilder) Build() (result *ClusterCatalogItemsS
 		SetAttributionLogic(b.attributionLogic).
 		SetTenancyLogic(b.tenancyLogic).
 		SetMetricsRegisterer(b.metricsRegisterer).
+		SetReferenceChecker(referenceChecker).
 		Build()
 	if err != nil {
 		return

--- a/internal/servers/compute_instance_catalog_items_server.go
+++ b/internal/servers/compute_instance_catalog_items_server.go
@@ -119,6 +119,7 @@ func (b *ComputeInstanceCatalogItemsServerBuilder) Build() (result *ComputeInsta
 		SetAttributionLogic(b.attributionLogic).
 		SetTenancyLogic(b.tenancyLogic).
 		SetMetricsRegisterer(b.metricsRegisterer).
+		SetReferenceChecker(referenceChecker).
 		Build()
 	if err != nil {
 		return

--- a/internal/servers/private_cluster_catalog_items_server.go
+++ b/internal/servers/private_cluster_catalog_items_server.go
@@ -20,8 +20,12 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 
+	grpccodes "google.golang.org/grpc/codes"
+	grpcstatus "google.golang.org/grpc/status"
+
 	privatev1 "github.com/osac-project/fulfillment-service/internal/api/osac/private/v1"
 	"github.com/osac-project/fulfillment-service/internal/auth"
+	"github.com/osac-project/fulfillment-service/internal/database/dao"
 	"github.com/osac-project/fulfillment-service/internal/events"
 )
 
@@ -31,14 +35,16 @@ type PrivateClusterCatalogItemsServerBuilder struct {
 	attributionLogic  auth.AttributionLogic
 	tenancyLogic      auth.TenancyLogic
 	metricsRegisterer prometheus.Registerer
+	referenceChecker  catalogItemReferenceChecker
 }
 
 var _ privatev1.ClusterCatalogItemsServer = (*PrivateClusterCatalogItemsServer)(nil)
 
 type PrivateClusterCatalogItemsServer struct {
 	privatev1.UnimplementedClusterCatalogItemsServer
-	logger  *slog.Logger
-	generic *GenericServer[*privatev1.ClusterCatalogItem]
+	logger           *slog.Logger
+	generic          *GenericServer[*privatev1.ClusterCatalogItem]
+	referenceChecker catalogItemReferenceChecker
 }
 
 func NewPrivateClusterCatalogItemsServer() *PrivateClusterCatalogItemsServerBuilder {
@@ -71,6 +77,11 @@ func (b *PrivateClusterCatalogItemsServerBuilder) SetMetricsRegisterer(value pro
 	return b
 }
 
+func (b *PrivateClusterCatalogItemsServerBuilder) SetReferenceChecker(value catalogItemReferenceChecker) *PrivateClusterCatalogItemsServerBuilder {
+	b.referenceChecker = value
+	return b
+}
+
 func (b *PrivateClusterCatalogItemsServerBuilder) Build() (result *PrivateClusterCatalogItemsServer, err error) {
 	if b.logger == nil {
 		err = errors.New("logger is mandatory")
@@ -80,7 +91,6 @@ func (b *PrivateClusterCatalogItemsServerBuilder) Build() (result *PrivateCluste
 		err = errors.New("tenancy logic is mandatory")
 		return
 	}
-
 	generic, err := NewGenericServer[*privatev1.ClusterCatalogItem]().
 		SetLogger(b.logger).
 		SetService(privatev1.ClusterCatalogItems_ServiceDesc.ServiceName).
@@ -93,9 +103,24 @@ func (b *PrivateClusterCatalogItemsServerBuilder) Build() (result *PrivateCluste
 		return
 	}
 
+	refChecker := b.referenceChecker
+	if refChecker == nil {
+		clustersDao, daoErr := dao.NewGenericDAO[*privatev1.Cluster]().
+			SetLogger(b.logger).
+			SetTenancyLogic(b.tenancyLogic).
+			SetMetricsRegisterer(b.metricsRegisterer).
+			Build()
+		if daoErr != nil {
+			err = daoErr
+			return
+		}
+		refChecker = &daoReferenceChecker[*privatev1.Cluster]{resourceDao: clustersDao}
+	}
+
 	result = &PrivateClusterCatalogItemsServer{
-		logger:  b.logger,
-		generic: generic,
+		logger:           b.logger,
+		generic:          generic,
+		referenceChecker: refChecker,
 	}
 	return
 }
@@ -126,6 +151,18 @@ func (s *PrivateClusterCatalogItemsServer) Update(ctx context.Context,
 
 func (s *PrivateClusterCatalogItemsServer) Delete(ctx context.Context,
 	request *privatev1.ClusterCatalogItemsDeleteRequest) (response *privatev1.ClusterCatalogItemsDeleteResponse, err error) {
+	hasRef, err := s.referenceChecker.hasReference(ctx, request.GetId())
+	if err != nil {
+		return
+	}
+	if hasRef {
+		err = grpcstatus.Errorf(
+			grpccodes.FailedPrecondition,
+			"cannot delete catalog item '%s': it is still referenced by one or more clusters",
+			request.GetId(),
+		)
+		return
+	}
 	err = s.generic.Delete(ctx, request, &response)
 	return
 }

--- a/internal/servers/private_cluster_catalog_items_server_test.go
+++ b/internal/servers/private_cluster_catalog_items_server_test.go
@@ -21,7 +21,12 @@ import (
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/fieldmaskpb"
 
+	"go.uber.org/mock/gomock"
+	grpccodes "google.golang.org/grpc/codes"
+	grpcstatus "google.golang.org/grpc/status"
+
 	privatev1 "github.com/osac-project/fulfillment-service/internal/api/osac/private/v1"
+	"github.com/osac-project/fulfillment-service/internal/database/dao"
 )
 
 var _ = Describe("Private cluster catalog items server", func() {
@@ -62,6 +67,16 @@ var _ = Describe("Private cluster catalog items server", func() {
 				Build()
 			Expect(err).To(MatchError("tenancy logic is mandatory"))
 			Expect(server).To(BeNil())
+		})
+
+		It("Can be built without explicit reference checker", func() {
+			server, err := NewPrivateClusterCatalogItemsServer().
+				SetLogger(logger).
+				SetAttributionLogic(attribution).
+				SetTenancyLogic(tenancy).
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(server).ToNot(BeNil())
 		})
 	})
 
@@ -341,6 +356,76 @@ var _ = Describe("Private cluster catalog items server", func() {
 			}.Build())
 			Expect(err).ToNot(HaveOccurred())
 			Expect(getResponse.GetObject().GetMetadata().GetDeletionTimestamp()).ToNot(BeNil())
+		})
+
+		It("Blocks delete when referenced by a cluster", func() {
+			createResponse, err := server.Create(ctx, privatev1.ClusterCatalogItemsCreateRequest_builder{
+				Object: privatev1.ClusterCatalogItem_builder{
+					Title:     "Referenced catalog item",
+					Template:  "my-template-id",
+					Published: true,
+				}.Build(),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+			catalogItem := createResponse.GetObject()
+
+			clustersDao, err := dao.NewGenericDAO[*privatev1.Cluster]().
+				SetLogger(logger).
+				SetTenancyLogic(tenancy).
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+			_, err = clustersDao.Create().SetObject(
+				privatev1.Cluster_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name:   "ref-cluster",
+						Tenant: "system",
+					}.Build(),
+					Spec: privatev1.ClusterSpec_builder{
+						CatalogItem: catalogItem.GetId(),
+						Template:    "my-template-id",
+					}.Build(),
+				}.Build(),
+			).Do(ctx)
+			Expect(err).ToNot(HaveOccurred())
+
+			_, err = server.Delete(ctx, privatev1.ClusterCatalogItemsDeleteRequest_builder{
+				Id: catalogItem.GetId(),
+			}.Build())
+			Expect(err).To(HaveOccurred())
+			status, ok := grpcstatus.FromError(err)
+			Expect(ok).To(BeTrue())
+			Expect(status.Code()).To(Equal(grpccodes.FailedPrecondition))
+			Expect(status.Message()).To(ContainSubstring("still referenced"))
+
+			getResponse, err := server.Get(ctx, privatev1.ClusterCatalogItemsGetRequest_builder{
+				Id: catalogItem.GetId(),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+			Expect(getResponse.GetObject()).ToNot(BeNil())
+			Expect(getResponse.GetObject().GetMetadata().GetDeletionTimestamp()).To(BeNil())
+		})
+
+		It("Returns error when reference check fails during delete", func() {
+			createResponse, err := server.Create(ctx, privatev1.ClusterCatalogItemsCreateRequest_builder{
+				Object: privatev1.ClusterCatalogItem_builder{
+					Title:    "Catalog item with failing check",
+					Template: "my-template-id",
+				}.Build(),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+			catalogItem := createResponse.GetObject()
+
+			mockCtrl := gomock.NewController(GinkgoT())
+			mockChecker := NewMockCatalogItemReferenceChecker(mockCtrl)
+			mockChecker.EXPECT().hasReference(gomock.Any(), catalogItem.GetId()).
+				Return(false, fmt.Errorf("database connection lost"))
+			server.referenceChecker = mockChecker
+
+			_, err = server.Delete(ctx, privatev1.ClusterCatalogItemsDeleteRequest_builder{
+				Id: catalogItem.GetId(),
+			}.Build())
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("database connection lost"))
 		})
 	})
 })

--- a/internal/servers/private_compute_instance_catalog_items_server.go
+++ b/internal/servers/private_compute_instance_catalog_items_server.go
@@ -20,8 +20,12 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 
+	grpccodes "google.golang.org/grpc/codes"
+	grpcstatus "google.golang.org/grpc/status"
+
 	privatev1 "github.com/osac-project/fulfillment-service/internal/api/osac/private/v1"
 	"github.com/osac-project/fulfillment-service/internal/auth"
+	"github.com/osac-project/fulfillment-service/internal/database/dao"
 	"github.com/osac-project/fulfillment-service/internal/events"
 )
 
@@ -31,14 +35,16 @@ type PrivateComputeInstanceCatalogItemsServerBuilder struct {
 	attributionLogic  auth.AttributionLogic
 	tenancyLogic      auth.TenancyLogic
 	metricsRegisterer prometheus.Registerer
+	referenceChecker  catalogItemReferenceChecker
 }
 
 var _ privatev1.ComputeInstanceCatalogItemsServer = (*PrivateComputeInstanceCatalogItemsServer)(nil)
 
 type PrivateComputeInstanceCatalogItemsServer struct {
 	privatev1.UnimplementedComputeInstanceCatalogItemsServer
-	logger  *slog.Logger
-	generic *GenericServer[*privatev1.ComputeInstanceCatalogItem]
+	logger           *slog.Logger
+	generic          *GenericServer[*privatev1.ComputeInstanceCatalogItem]
+	referenceChecker catalogItemReferenceChecker
 }
 
 func NewPrivateComputeInstanceCatalogItemsServer() *PrivateComputeInstanceCatalogItemsServerBuilder {
@@ -71,6 +77,11 @@ func (b *PrivateComputeInstanceCatalogItemsServerBuilder) SetMetricsRegisterer(v
 	return b
 }
 
+func (b *PrivateComputeInstanceCatalogItemsServerBuilder) SetReferenceChecker(value catalogItemReferenceChecker) *PrivateComputeInstanceCatalogItemsServerBuilder {
+	b.referenceChecker = value
+	return b
+}
+
 func (b *PrivateComputeInstanceCatalogItemsServerBuilder) Build() (result *PrivateComputeInstanceCatalogItemsServer, err error) {
 	if b.logger == nil {
 		err = errors.New("logger is mandatory")
@@ -80,7 +91,6 @@ func (b *PrivateComputeInstanceCatalogItemsServerBuilder) Build() (result *Priva
 		err = errors.New("tenancy logic is mandatory")
 		return
 	}
-
 	generic, err := NewGenericServer[*privatev1.ComputeInstanceCatalogItem]().
 		SetLogger(b.logger).
 		SetService(privatev1.ComputeInstanceCatalogItems_ServiceDesc.ServiceName).
@@ -93,9 +103,24 @@ func (b *PrivateComputeInstanceCatalogItemsServerBuilder) Build() (result *Priva
 		return
 	}
 
+	refChecker := b.referenceChecker
+	if refChecker == nil {
+		ciDao, daoErr := dao.NewGenericDAO[*privatev1.ComputeInstance]().
+			SetLogger(b.logger).
+			SetTenancyLogic(b.tenancyLogic).
+			SetMetricsRegisterer(b.metricsRegisterer).
+			Build()
+		if daoErr != nil {
+			err = daoErr
+			return
+		}
+		refChecker = &daoReferenceChecker[*privatev1.ComputeInstance]{resourceDao: ciDao}
+	}
+
 	result = &PrivateComputeInstanceCatalogItemsServer{
-		logger:  b.logger,
-		generic: generic,
+		logger:           b.logger,
+		generic:          generic,
+		referenceChecker: refChecker,
 	}
 	return
 }
@@ -126,6 +151,18 @@ func (s *PrivateComputeInstanceCatalogItemsServer) Update(ctx context.Context,
 
 func (s *PrivateComputeInstanceCatalogItemsServer) Delete(ctx context.Context,
 	request *privatev1.ComputeInstanceCatalogItemsDeleteRequest) (response *privatev1.ComputeInstanceCatalogItemsDeleteResponse, err error) {
+	hasRef, err := s.referenceChecker.hasReference(ctx, request.GetId())
+	if err != nil {
+		return
+	}
+	if hasRef {
+		err = grpcstatus.Errorf(
+			grpccodes.FailedPrecondition,
+			"cannot delete catalog item '%s': it is still referenced by one or more compute instances",
+			request.GetId(),
+		)
+		return
+	}
 	err = s.generic.Delete(ctx, request, &response)
 	return
 }

--- a/internal/servers/private_compute_instance_catalog_items_server_test.go
+++ b/internal/servers/private_compute_instance_catalog_items_server_test.go
@@ -21,7 +21,12 @@ import (
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/fieldmaskpb"
 
+	"go.uber.org/mock/gomock"
+	grpccodes "google.golang.org/grpc/codes"
+	grpcstatus "google.golang.org/grpc/status"
+
 	privatev1 "github.com/osac-project/fulfillment-service/internal/api/osac/private/v1"
+	"github.com/osac-project/fulfillment-service/internal/database/dao"
 )
 
 var _ = Describe("Private compute instance catalog items server", func() {
@@ -62,6 +67,16 @@ var _ = Describe("Private compute instance catalog items server", func() {
 				Build()
 			Expect(err).To(MatchError("tenancy logic is mandatory"))
 			Expect(server).To(BeNil())
+		})
+
+		It("Can be built without explicit reference checker", func() {
+			server, err := NewPrivateComputeInstanceCatalogItemsServer().
+				SetLogger(logger).
+				SetAttributionLogic(attribution).
+				SetTenancyLogic(tenancy).
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(server).ToNot(BeNil())
 		})
 	})
 
@@ -340,6 +355,76 @@ var _ = Describe("Private compute instance catalog items server", func() {
 			}.Build())
 			Expect(err).ToNot(HaveOccurred())
 			Expect(getResponse.GetObject().GetMetadata().GetDeletionTimestamp()).ToNot(BeNil())
+		})
+
+		It("Blocks delete when referenced by a compute instance", func() {
+			createResponse, err := server.Create(ctx, privatev1.ComputeInstanceCatalogItemsCreateRequest_builder{
+				Object: privatev1.ComputeInstanceCatalogItem_builder{
+					Title:     "Referenced CI catalog item",
+					Template:  "my-ci-template-id",
+					Published: true,
+				}.Build(),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+			catalogItem := createResponse.GetObject()
+
+			ciDao, err := dao.NewGenericDAO[*privatev1.ComputeInstance]().
+				SetLogger(logger).
+				SetTenancyLogic(tenancy).
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+			_, err = ciDao.Create().SetObject(
+				privatev1.ComputeInstance_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name:   "ref-ci",
+						Tenant: "system",
+					}.Build(),
+					Spec: privatev1.ComputeInstanceSpec_builder{
+						CatalogItem: catalogItem.GetId(),
+						Template:    "my-ci-template-id",
+					}.Build(),
+				}.Build(),
+			).Do(ctx)
+			Expect(err).ToNot(HaveOccurred())
+
+			_, err = server.Delete(ctx, privatev1.ComputeInstanceCatalogItemsDeleteRequest_builder{
+				Id: catalogItem.GetId(),
+			}.Build())
+			Expect(err).To(HaveOccurred())
+			status, ok := grpcstatus.FromError(err)
+			Expect(ok).To(BeTrue())
+			Expect(status.Code()).To(Equal(grpccodes.FailedPrecondition))
+			Expect(status.Message()).To(ContainSubstring("still referenced"))
+
+			getResponse, err := server.Get(ctx, privatev1.ComputeInstanceCatalogItemsGetRequest_builder{
+				Id: catalogItem.GetId(),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+			Expect(getResponse.GetObject()).ToNot(BeNil())
+			Expect(getResponse.GetObject().GetMetadata().GetDeletionTimestamp()).To(BeNil())
+		})
+
+		It("Returns error when reference check fails during delete", func() {
+			createResponse, err := server.Create(ctx, privatev1.ComputeInstanceCatalogItemsCreateRequest_builder{
+				Object: privatev1.ComputeInstanceCatalogItem_builder{
+					Title:    "CI catalog item with failing check",
+					Template: "my-ci-template-id",
+				}.Build(),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+			catalogItem := createResponse.GetObject()
+
+			mockCtrl := gomock.NewController(GinkgoT())
+			mockChecker := NewMockCatalogItemReferenceChecker(mockCtrl)
+			mockChecker.EXPECT().hasReference(gomock.Any(), catalogItem.GetId()).
+				Return(false, fmt.Errorf("database connection lost"))
+			server.referenceChecker = mockChecker
+
+			_, err = server.Delete(ctx, privatev1.ComputeInstanceCatalogItemsDeleteRequest_builder{
+				Id: catalogItem.GetId(),
+			}.Build())
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("database connection lost"))
 		})
 	})
 })


### PR DESCRIPTION
## Summary
- Add referential integrity checks to the private Delete handlers for both ClusterCatalogItems and ComputeInstanceCatalogItems
- Before deleting, the server queries whether any cluster or compute instance references the catalog item via `spec.catalog_item`
- If a reference exists, returns `FailedPrecondition` instead of allowing the delete, preventing dangling references
- The reference checker infrastructure already existed but was only used in the public Get handler for unpublished item visibility

## Test plan
- [x] Unit test: `Blocks delete when referenced by a cluster` - verifies FailedPrecondition is returned
- [x] Unit test: `Blocks delete when referenced by a compute instance` - verifies FailedPrecondition is returned
- [x] All 68 existing catalog-related tests continue to pass
- [ ] E2E: `test_delete_catalog_item_blocked_when_referenced` in osac-test-infra (currently xfail, will pass once this merges)

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevent deletion of catalog items that are still referenced by clusters or compute instances; attempts now return a clear "still referenced" error and do not remove the item.
  * GET behavior for unpublished or missing catalog items now considers existing references, improving consistency.
  * Delete errors now propagate underlying failure details when reference checks fail, aiding troubleshooting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->