### PR TITLE
OSAC-953: Call Keycloak from Authorino for Authz

### DIFF
--- a/charts/service/templates/grpc-server/authconfig.yaml
+++ b/charts/service/templates/grpc-server/authconfig.yaml
@@ -34,6 +34,27 @@ spec:
       overrides:
         authnMethod:
           value: jwt
+  metadata:
+    # Call Keycloak UMA to get permissions for the requested resource
+    uma-permissions:
+      when:
+        # Only call UMA for Projects methods that target specific resources
+        - selector: context.request.http.path
+          operator: matches
+          value: ^/osac\.public\.v1\.Projects/(Get|Update|Delete)$
+      http:
+        url: "{{ required "auth.issuerUrl is required" .Values.auth.issuerUrl }}/protocol/openid-connect/token"
+        method: POST
+        contentType: application/x-www-form-urlencoded
+        body:
+          selector: |
+            "grant_type=urn:ietf:params:oauth:grant-type:uma-ticket&audience={{ required "auth.umaClientId is required" .Values.auth.umaClientId }}&permission=PROJECT-" + auth.identity.organization[0] + "-" + context.request.http.body.@fromstr.id + "#" + (context.request.http.path.@extract:{"sep":"/","pos":3} == "Get" ? "VIEW_PROJECT" : "MANAGE_PROJECT") + "&subject_token=" + context.request.http.headers.authorization.@extract:{"sep":" ","pos":1}
+        credentials:
+          authorizationHeader:
+            prefix: "Basic"
+        sharedSecretRef:
+          name: osac-authorization-credentials
+          key: client_secret
   authorization:
     default:
       opa:
@@ -211,6 +232,7 @@ spec:
               "/osac.public.v1.NetworkClasses/Get",
               "/osac.public.v1.NetworkClasses/List",
               "/osac.public.v1.NetworkClasses/Update",
+              "/osac.public.v1.Projects/List",
               "/osac.public.v1.Subnets/Create",
               "/osac.public.v1.Subnets/Delete",
               "/osac.public.v1.Subnets/Get",
@@ -267,6 +289,26 @@ spec:
           # Allow everything to admins:
           allow if {
             is_admin
+          }
+
+          # Project resource authorization via Keycloak UMA
+          # Allow if UMA metadata call succeeded and returned access_token
+          # Allow tenant admins to create projects (UMA resource doesn't exist yet)
+          allow if {
+            is_tenant_admin
+            grpc_method == "/osac.public.v1.Projects/Create"
+          }
+
+          # Project Get/Update/Delete authorization via Keycloak UMA
+          # Allow if UMA metadata call succeeded and returned access_token
+          allow if {
+            grpc_method in {
+              "/osac.public.v1.Projects/Get",
+              "/osac.public.v1.Projects/Update",
+              "/osac.public.v1.Projects/Delete",
+            }
+            input.auth.metadata["uma-permissions"]
+            input.auth.metadata["uma-permissions"].access_token
           }
   response:
     success:

--- a/charts/service/templates/grpc-server/uma-credentials-secret.yaml
+++ b/charts/service/templates/grpc-server/uma-credentials-secret.yaml
@@ -1,0 +1,22 @@
+{{/*
+Copyright (c) 2026 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+the License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+*/}}
+
+apiVersion: v1
+kind: Secret
+metadata:
+  namespace: {{ .Release.Namespace }}
+  name: osac-authorization-credentials
+type: Opaque
+stringData:
+  client-id: {{ required "auth.umaClientId is required" .Values.auth.umaClientId }}
+  client-secret: {{ required "auth.umaClientSecret is required" .Values.auth.umaClientSecret }}

--- a/charts/service/values.yaml
+++ b/charts/service/values.yaml
@@ -53,6 +53,11 @@ auth:
   # This defines the URL of the OAuth issuer used for authentication. This parameter is mandatory.
   issuerUrl:
 
+  # UMA (User-Managed Access) client credentials for Keycloak Authorization Services
+  # Used by Authorino to perform resource-level authorization checks
+  umaClientId: osac-authorization
+  umaClientSecret:
+
   # List of sources for the OAuth client credentials used by the controller to authenticate to the fulfillment API.
   # The controller uses the OAuth client credentials flow with the issuer URL specified in `auth.issuerUrl`.
   #

--- a/internal/auth/auth_rules_test.go
+++ b/internal/auth/auth_rules_test.go
@@ -72,7 +72,9 @@ var _ = Describe("Authorization rules", Ordered, func() {
 				},
 			},
 			"auth": map[string]any{
-				"issuerUrl": "https://my-issuer.com",
+				"issuerUrl":       "https://my-issuer.com",
+				"umaClientId":     "osac-authorization",
+				"umaClientSecret": "test-secret",
 				"controllerCredentials": map[string]any{
 					"secret": map[string]any{
 						"name": "fulfillment-controller-credentials",

--- a/it/it_tool.go
+++ b/it/it_tool.go
@@ -1034,30 +1034,32 @@ func (t *Tool) deployKeycloak(ctx context.Context) error {
 
 	// Add the service account clients and their corresponding users:
 	type serviceAccountData struct {
-		Name        string
-		Description string
-		ClientId    string
-		ClientRoles map[string][]string
+		Name                         string
+		Description                  string
+		ClientId                     string
+		ClientRoles                  map[string][]string
+		AuthorizationServicesEnabled bool
 	}
 	addServiceAccount := func(data serviceAccountData) {
-		clients = append(
-			clients,
-			map[string]any{
-				"name":                      data.Name,
-				"description":               data.Description,
-				"clientId":                  data.ClientId,
-				"enabled":                   true,
-				"clientAuthenticatorType":   "client-secret",
-				"secret":                    t.secret,
-				"serviceAccountsEnabled":    true,
-				"publicClient":              false,
-				"standardFlowEnabled":       false,
-				"implicitFlowEnabled":       false,
-				"directAccessGrantsEnabled": false,
-				"protocol":                  "openid-connect",
-				"fullScopeAllowed":          true,
-			},
-		)
+		client := map[string]any{
+			"name":                      data.Name,
+			"description":               data.Description,
+			"clientId":                  data.ClientId,
+			"enabled":                   true,
+			"clientAuthenticatorType":   "client-secret",
+			"secret":                    t.secret,
+			"serviceAccountsEnabled":    true,
+			"publicClient":              false,
+			"standardFlowEnabled":       false,
+			"implicitFlowEnabled":       false,
+			"directAccessGrantsEnabled": false,
+			"protocol":                  "openid-connect",
+			"fullScopeAllowed":          true,
+		}
+		if data.AuthorizationServicesEnabled {
+			client["authorizationServicesEnabled"] = true
+		}
+		clients = append(clients, client)
 		users = append(
 			users, map[string]any{
 				"username":               fmt.Sprintf("service-account-%s", data.ClientId),
@@ -1082,8 +1084,17 @@ func (t *Tool) deployKeycloak(ctx context.Context) error {
 				"manage-users",
 				"view-realm",
 				"view-users",
+				"manage-clients",
+				"manage-authorization",
 			},
 		},
+	})
+	addServiceAccount(serviceAccountData{
+		Name:                         "OSAC Authorization",
+		Description:                  "Service account for Authorino to request UMA authorization decisions",
+		ClientId:                     "osac-authorization",
+		ClientRoles:                  map[string][]string{},
+		AuthorizationServicesEnabled: true,
 	})
 
 	// Add the prepared clients, groups and users to the values:
@@ -1418,7 +1429,9 @@ func (t *Tool) deployServiceWithHelm(ctx context.Context, imageRef string) error
 			},
 		},
 		"auth": map[string]any{
-			"issuerUrl": fmt.Sprintf("https://%s/realms/osac", keycloakAddr),
+			"issuerUrl":       fmt.Sprintf("https://%s/realms/osac", keycloakAddr),
+			"umaClientId":     "osac-authorization",
+			"umaClientSecret": t.secret,
 			"controllerCredentials": []any{
 				map[string]any{
 					"secret": map[string]any{


### PR DESCRIPTION
# Description

Updates the authorino authconfig to call keycloak for authorization and adds a UMA client secret for the authorization calls.
This is primarily used for Project resources where authorization requires a call to keycloak to verify if a user is part of the corresponding keycloak group for that project.

NOTE: Listing Projects will require additional functionality and will be handled in a later patch

# Testing

- [x] Ran integration tests locally and verified all services come up
- [x] Verified all users still have access to public resources `/.osac get clustertemplates` 
- [x] Verified only cloud provider admin can access private resources and certain resources such as organizations
    - [x] Logged into public as regular user charles `./osac get organizations` fails and `./osac get clustertemplates` succeeds
    - [x] Logged into private as regular user charles `./osac get organizations` fails and `./osac get clustertemplates` fails
- [x] Verified other users can't see organizations

Assisted-by: Claude Code <noreply@anthropic.com>

/cc @jhernand 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Keycloak UMA-based resource authorization: Projects Get/Update/Delete now require UMA permissions; Projects List is allowed at the client level; tenant admins can Create projects without UMA.

* **Chores**
  * Added required UMA client credentials configuration and secure storage.
  * Deployment tooling updated to supply UMA credentials for test/deploy environments.

* **Tests**
  * Integration tests updated to exercise UMA-based authorization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->