### PR TITLE
NO-ISSUE: Upgrade PostgreSQL from 15 to 18

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ To quickly run a local postgresql database in a container, run the following com
 ```
 podman run -d --name postgresql_database \
   -e POSTGRESQL_USER=user -e POSTGRESQL_PASSWORD=pass -e POSTGRESQL_DATABASE=db \
-  -p 127.0.0.1:5432:5432 quay.io/sclorg/postgresql-15-c9s:latest
+  -p 127.0.0.1:5432:5432 quay.io/sclorg/postgresql-18-c10s:latest
 ```
 
 Done!

--- a/docs/AUTH.md
+++ b/docs/AUTH.md
@@ -124,7 +124,7 @@ helm install keycloak oci://ghcr.io/osac/charts/keycloak \
 | `certs.issuerRef.kind` | The kind of cert-manager issuer (`ClusterIssuer` or `Issuer`) | No | `ClusterIssuer` |
 | `certs.issuerRef.name` | The name of the cert-manager issuer for TLS certificates | **Yes** | None |
 | `images.keycloak` | The Keycloak container image | No | `quay.io/keycloak/keycloak:26.3` |
-| `images.postgres` | The PostgreSQL container image | No | `quay.io/sclorg/postgresql-15-c9s:latest` |
+| `images.postgres` | The PostgreSQL container image | No | `quay.io/sclorg/postgresql-18-c10s:latest` |
 
 ### Important Notes
 

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -3,7 +3,7 @@
 This document describes how to install the service on OpenShift. It uses the Keycloak operator for
 identity management and presents three options for the PostgreSQL database: CloudNativePG (CNPG),
 the Crunchy PostgreSQL operator (PGO), and the Zalando PostgreSQL operator. These are just
-suggestions. The service will work with any PostgreSQL 15+ database as long as the connection
+suggestions. The service will work with any PostgreSQL 18+ database as long as the connection
 details are provided correctly. Similarly, the service requires Keycloak specifically, but it will
 work with any Keycloak installation regardless of how it was deployed - whether via the operator,
 manually, or by other means - as long as it is correctly configured with the required realm,
@@ -192,7 +192,7 @@ on OpenShift.
 
 ## Install the PostgreSQL operator
 
-The service requires a PostgreSQL 15+ database. This guide presents three options for deploying
+The service requires a PostgreSQL 18+ database. This guide presents three options for deploying
 PostgreSQL on Kubernetes: CloudNativePG (CNPG), the Crunchy PostgreSQL operator (PGO), and the
 Zalando PostgreSQL operator. Choose one of the options below and follow the corresponding
 instructions. The rest of this guide will note where commands differ depending on which operator
@@ -343,10 +343,10 @@ helm upgrade pgo oci://registry.developers.crunchydata.com/crunchydata/pgo \
 --wait
 ```
 
-PGO creates databases owned by the `postgres` superuser. In PostgreSQL 15 the default privileges on
-the `public` schema were tightened, so application users cannot create tables unless they own the
-schema. To fix this, create a ConfigMap with initialization SQL that transfers schema ownership to
-each application user. PGO will run this SQL automatically as part of cluster creation:
+PGO creates databases owned by the `postgres` superuser. Beginning with PostgreSQL 15, the default
+privileges on the `public` schema were tightened, so application users cannot create tables unless
+they own the schema. To fix this, create a ConfigMap with initialization SQL that transfers schema
+ownership to each application user. PGO will run this SQL automatically as part of cluster creation:
 
 ```shell
 oc create configmap -n postgres osac-init-sql --from-literal=init.sql='
@@ -414,7 +414,7 @@ metadata:
   namespace: postgres
   name: osac
 spec:
-  postgresVersion: 15
+  postgresVersion: 18
   customTLSSecret:
     name: osac-server-tls
   customReplicationTLSSecret:
@@ -549,7 +549,7 @@ spec:
   volume:
     size: 10Gi
   postgresql:
-    version: "15"
+    version: "18"
   users:
     keycloak: []
     service: []

--- a/internal/database/database_container.go
+++ b/internal/database/database_container.go
@@ -675,8 +675,8 @@ var containerTools = []string{
 
 // containerImage is the PostgreSQL container image. This is the same sclorg image used by the integration test Helm
 // chart.
-const containerImage = "quay.io/sclorg/postgresql-15-c9s" +
-	"@sha256:c51a29654b63e2683f83efde5c751833fc79d360918c30269801608dff3c533a"
+const containerImage = "quay.io/sclorg/postgresql-18-c10s" +
+	"@sha256:6be2c9d855f06fb665257a6b0911676a38d740be7022cc61acee1c99a832b1b2"
 
 // containerConfigPath is the path inside the container where the custom configuration file is mounted. The sclorg image
 // includes all *.conf files from this directory at the end of the generated postgresql.conf.

--- a/it/charts/postgres/README.md
+++ b/it/charts/postgres/README.md
@@ -20,7 +20,7 @@ The following table lists the configurable parameters of the PostgreSQL chart:
 | `certs.issuerRef.kind`     | The kind of cert-manager issuer (`ClusterIssuer` or `Issuer`) | No       | `ClusterIssuer`                              |
 | `certs.issuerRef.name`     | The name of the cert-manager issuer for TLS certificates      | **Yes**  | None                                         |
 | `certs.caBundle.configMap` | ConfigMap with trusted CA certificates for client auth        | No       | Uses the server certificate CA               |
-| `images.postgres`          | The PostgreSQL container image                                | No       | `quay.io/sclorg/postgresql-15-c9s:latest`    |
+| `images.postgres`          | The PostgreSQL container image                                | No       | `quay.io/sclorg/postgresql-18-c10s:latest`    |
 | `databases`                | List of databases and users to create (see below)             | No       | `[]`                                         |
 
 Note that the `certs.issuerRef.name` parameter is required. For example, to install the chart in a

--- a/it/charts/postgres/values.yaml
+++ b/it/charts/postgres/values.yaml
@@ -28,7 +28,7 @@ certs:
 
 # Image configuration:
 images:
-  postgres: quay.io/sclorg/postgresql-15-c9s:latest
+  postgres: quay.io/sclorg/postgresql-18-c10s@sha256:6be2c9d855f06fb665257a6b0911676a38d740be7022cc61acee1c99a832b1b2
 
 # List of databases and users to create. The default is an empty list, which means only the PostgreSQL server itself
 # is deployed without any application databases.

--- a/manifests/base/kustomization.yaml
+++ b/manifests/base/kustomization.yaml
@@ -36,5 +36,5 @@ images:
   newName: ghcr.io/osac-project/fulfillment-service
   newTag: main
 - name: postgres
-  newName: quay.io/sclorg/postgresql-15-c9s
-  newTag: latest
+  newName: quay.io/sclorg/postgresql-18-c10s
+  digest: sha256:6be2c9d855f06fb665257a6b0911676a38d740be7022cc61acee1c99a832b1b2


### PR DESCRIPTION
## Summary

Upgrade all PostgreSQL container image references and version pins from 15 to 18. The unit test
container uses `docker.io/postgres:18`, while the integration test chart and kustomize manifests
now use `quay.io/sclorg/postgresql-18-c10s:latest`.

## Motivation

PostgreSQL 18 introduces two features that we plan to adopt:

- The built-in `uuidv7()` function for generating unique identifiers directly in the database,
  removing the need to generate them in application code.
- Support for dashes in `ltree` column values, which will enable hierarchical project names that
  contain the `-` character.

## Compatibility

This change does not yet make use of any PostgreSQL 18 features, so existing installations running
PostgreSQL 15 will continue to work without modification. However, future patches will begin relying
on 18-only functionality, at which point PostgreSQL 15 will no longer be supported.

## Upgrade path

Because the project has not yet cut a release, we are free to bump the minimum required version
without providing an automated migration path. The PostgreSQL Helm chart included in this repository
is used exclusively for integration tests and does not manage production data. Users who maintain a
PostgreSQL 15 database and wish to preserve its data should follow the upstream upgrade
documentation:

https://www.postgresql.org/docs/18/upgrading.html

## Test plan

- [x] Unit tests pass (`ginkgo run -r internal`)
- [x] Integration tests pass with the new container images

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated PostgreSQL image/reference from v15 to v18 across manifests, local container startup, Helm chart defaults, and deployment overrides.
* **Documentation**
  * Revised installation, auth, and chart docs and examples to require PostgreSQL 18+ and updated related configuration snippets and run instructions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->