### PR TITLE
NO-ISSUE: Fix wrong condition when logging config file removal error

### DIFF
--- a/internal/database/database_container.go
+++ b/internal/database/database_container.go
@@ -369,7 +369,7 @@ func (s *Container) Stop(ctx context.Context) error {
 			return
 		}
 		removeErr := os.Remove(s.configFile)
-		if removeErr == nil {
+		if removeErr != nil {
 			s.logger.ErrorContext(
 				ctx,
 				"Failed to remove configuration file",


### PR DESCRIPTION
## Summary

- Fix an inverted condition in the `Stop` method of the database `Container`: the code checked
  `removeErr == nil` before logging the error from `os.Remove`, which meant the error was logged
  when the removal succeeded and silently swallowed when it failed. The fix flips the condition to
  `removeErr != nil`.
- The practical impact is minimal because `os.Remove` on a small temporary file is very unlikely to
  fail; the only consequence was a missing log line in that unlikely situation.
- The bug was introduced in pull request #629.

## Test plan

- [x] Verified that the change is a single-character fix (`==` to `!=`)
- [x] Existing unit tests pass (`ginkgo run -r internal`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed incorrect error reporting during database container shutdown. Error logs are now properly generated only when cleanup operations fail.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->