### PR TITLE
NO-ISSUE: Pin GitHub Actions to specific commit SHAs

### DIFF
--- a/.github/actions/setup-go/action.yaml
+++ b/.github/actions/setup-go/action.yaml
@@ -17,14 +17,14 @@ description: Install and Go and Ginkgo
 runs:
   using: composite
   steps:
-  - uses: actions/setup-go@v6
+  - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6
     with:
       go-version: '1.26.2'
   - shell: bash
     run: |
       go mod download
   - id: ginkgo-cache
-    uses: actions/cache@v5
+    uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5
     with:
       key: ginkgo
       path: ~/go/bin/ginkgo

--- a/.github/workflows/check-pull-request.yaml
+++ b/.github/workflows/check-pull-request.yaml
@@ -28,15 +28,15 @@ jobs:
     name: Check pre-commit
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v6
-    - uses: actions/setup-python@v6
-    - uses: pre-commit/action@v3.0.1
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
+    - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6
+    - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd  # v3.0.1
 
   check-code-format:
     name: Check code format
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
     - uses: ./.github/actions/setup-go
     - run: |
         gofmt -s -l -w .
@@ -46,8 +46,8 @@ jobs:
     name: Check generated code
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v6
-    - uses: bufbuild/buf-action@v1
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
+    - uses: bufbuild/buf-action@91da6f6a1a2c877c182debad24ca0a8a9d848be7  # v1
       with:
         version: '1.50.0'
         setup_only: true
@@ -59,7 +59,7 @@ jobs:
     name: Run unit tests
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
     - uses: ./.github/actions/setup-go
     - run: |
         ginkgo run --timeout 1h -r internal
@@ -68,9 +68,9 @@ jobs:
     name: Build binaries
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
     - uses: ./.github/actions/setup-go
-    - uses: goreleaser/goreleaser-action@v7
+    - uses: goreleaser/goreleaser-action@5daf1e915a5f0af01ddbcd89a43b8061ff4f1a89  # v7
       with:
         args: build --snapshot --clean
 
@@ -78,7 +78,7 @@ jobs:
     name: Run integration tests - Helm
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
     - uses: ./.github/actions/setup-go
     - run: |
         echo '127.0.0.1 fulfillment-api.osac.svc.cluster.local' | sudo tee -a /etc/hosts
@@ -86,7 +86,7 @@ jobs:
         echo '127.0.0.1 keycloak.keycloak.svc.cluster.local' | sudo tee -a /etc/hosts
         IT_DEPLOY_MODE=helm ginkgo run --timeout 1h -v it
     - if: always()
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
       with:
         name: logs-helm
         path: logs
@@ -96,7 +96,7 @@ jobs:
     name: Run integration tests - Kustomize
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
     - uses: ./.github/actions/setup-go
     - run: |
         echo '127.0.0.1 fulfillment-api.osac.svc.cluster.local' | sudo tee -a /etc/hosts
@@ -104,7 +104,7 @@ jobs:
         echo '127.0.0.1 keycloak.keycloak.svc.cluster.local' | sudo tee -a /etc/hosts
         IT_DEPLOY_MODE=kustomize ginkgo run --timeout 1h -v it
     - if: always()
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
       with:
         name: logs-kustomize
         path: logs

--- a/.github/workflows/publish-binaries.yaml
+++ b/.github/workflows/publish-binaries.yaml
@@ -27,11 +27,11 @@ jobs:
     permissions:
       contents: write
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
       with:
         fetch-depth: 0
     - uses: ./.github/actions/setup-go
-    - uses: goreleaser/goreleaser-action@v7
+    - uses: goreleaser/goreleaser-action@5daf1e915a5f0af01ddbcd89a43b8061ff4f1a89  # v7
       with:
         args: release --clean
       env:

--- a/.github/workflows/publish-charts.yaml
+++ b/.github/workflows/publish-charts.yaml
@@ -28,7 +28,7 @@ jobs:
       contents: read
       packages: write
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
       with:
         fetch-depth: 0
     - id: run

--- a/.github/workflows/publish-image.yaml
+++ b/.github/workflows/publish-image.yaml
@@ -27,13 +27,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
 
       # Login against a Docker registry except on PR
       # https://github.com/docker/login-action
       - name: Log into registry ${{ env.REGISTRY }}
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@v4
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee  # v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -43,7 +43,7 @@ jobs:
       # https://github.com/docker/metadata-action
       - name: Extract Docker metadata
         id: meta
-        uses: docker/metadata-action@v6
+        uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9  # v6
         with:
           context: git
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
@@ -60,7 +60,7 @@ jobs:
       # Build and push Docker image with Buildx (don't push on PR)
       # https://github.com/docker/build-push-action
       - name: Build and push Docker image
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf  # v7
         with:
           context: .
           file: Containerfile

--- a/.github/workflows/publish-openapi.yaml
+++ b/.github/workflows/publish-openapi.yaml
@@ -38,21 +38,21 @@ jobs:
     environment:
       name: github-pages
     steps:
-    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       with:
         persist-credentials: false
     - uses: ./.github/actions/setup-go
-    - uses: bufbuild/buf-action@91da6f6a1a2c877c182debad24ca0a8a9d848be7
+    - uses: bufbuild/buf-action@91da6f6a1a2c877c182debad24ca0a8a9d848be7  # v1
       with:
         setup_only: true
-    - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654
+    - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654  # v5
       with:
         distribution: 'temurin'
         java-version: '21'
     - run: |
         go build ./cmd/osac-dev
         ./osac-dev generate openapi --project-dir . --output-dir pages/openapi
-    - uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b
+    - uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b  # v4
       with:
         path: pages
-    - uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e
+    - uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e  # v4

--- a/.github/workflows/publish-proto.yaml
+++ b/.github/workflows/publish-proto.yaml
@@ -27,8 +27,8 @@ jobs:
     name: Publish proto
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v6
-    - uses: bufbuild/buf-action@v1
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
+    - uses: bufbuild/buf-action@91da6f6a1a2c877c182debad24ca0a8a9d848be7  # v1
       with:
         setup_only: true
         token: ${{ secrets.BUF_TOKEN }}


### PR DESCRIPTION
## Summary

- Pin all GitHub Actions references from mutable version tags to immutable commit SHAs
  across all workflow files and the composite `setup-go` action, hardening the CI/CD
  pipeline against supply-chain attacks.
- Preserve the original version tag in a trailing `# vX` comment for readability and
  to ensure Dependabot continues proposing updates in the same SHA-pinned format.
- This eliminates a recurring CodeRabbit finding that adds noise to pull request reviews.

## Test plan

- Verify that all workflow files parse correctly (yamllint passes via pre-commit hook).
- Confirm that CI jobs run successfully with the SHA-pinned action references.
- Confirm that Dependabot continues to detect and propose updates for SHA-pinned actions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflows to pin third‑party actions to exact revisions across build, test, and release pipelines while preserving existing job logic and steps—improves reproducibility and stability of automated builds and deployments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->