### PR TITLE
NO-ISSUE: Fix compiler errors in tests

### DIFF
--- a/internal/controllers/computeinstance/computeinstance_reconciler_function_test.go
+++ b/internal/controllers/computeinstance/computeinstance_reconciler_function_test.go
@@ -24,7 +24,6 @@ import (
 	. "github.com/onsi/gomega"
 	osacv1alpha1 "github.com/osac-project/osac-operator/api/v1alpha1"
 	"go.uber.org/mock/gomock"
-	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/anypb"
 	"google.golang.org/protobuf/types/known/timestamppb"
 	"google.golang.org/protobuf/types/known/wrapperspb"

--- a/internal/servers/cluster_catalog_items_server_test.go
+++ b/internal/servers/cluster_catalog_items_server_test.go
@@ -243,9 +243,8 @@ var _ = Describe("Cluster catalog items server", func() {
 
 			targetID := publishedResponse.GetObject().GetId()
 			unpublishedID := unpublishedResponse.GetObject().GetId()
-			filter := fmt.Sprintf("this.id == '%s' || this.id == '%s'", targetID, unpublishedID)
 			response, err := server.List(ctx, publicv1.ClusterCatalogItemsListRequest_builder{
-				Filter: proto.String(filter),
+				Filter: new(fmt.Sprintf("this.id == %q || this.id == %q", targetID, unpublishedID)),
 			}.Build())
 			Expect(err).ToNot(HaveOccurred())
 			Expect(response.GetItems()).To(HaveLen(1))

--- a/internal/servers/compute_instance_catalog_items_server_test.go
+++ b/internal/servers/compute_instance_catalog_items_server_test.go
@@ -243,9 +243,8 @@ var _ = Describe("Compute instance catalog items server", func() {
 
 			targetID := publishedResponse.GetObject().GetId()
 			unpublishedID := unpublishedResponse.GetObject().GetId()
-			filter := fmt.Sprintf("this.id == '%s' || this.id == '%s'", targetID, unpublishedID)
 			response, err := server.List(ctx, publicv1.ComputeInstanceCatalogItemsListRequest_builder{
-				Filter: proto.String(filter),
+				Filter: new(fmt.Sprintf("this.id == %q || this.id == %q", targetID, unpublishedID)),
 			}.Build())
 			Expect(err).ToNot(HaveOccurred())
 			Expect(response.GetItems()).To(HaveLen(1))

--- a/internal/servers/compute_instances_server_test.go
+++ b/internal/servers/compute_instances_server_test.go
@@ -139,7 +139,7 @@ var _ = Describe("Compute instances server", func() {
 				}.Build(),
 				Spec: privatev1.SubnetSpec_builder{
 					VirtualNetwork: "test-vnet",
-					Ipv4Cidr:       proto.String("10.0.0.0/24"),
+					Ipv4Cidr:       new("10.0.0.0/24"),
 				}.Build(),
 				Status: privatev1.SubnetStatus_builder{
 					State: privatev1.SubnetState_SUBNET_STATE_READY,

--- a/internal/servers/private_compute_instances_server_test.go
+++ b/internal/servers/private_compute_instances_server_test.go
@@ -83,7 +83,7 @@ var _ = Describe("Private compute instances server", func() {
 			}.Build(),
 			Spec: privatev1.SubnetSpec_builder{
 				VirtualNetwork: "test-vnet",
-				Ipv4Cidr:       proto.String("10.0.0.0/24"),
+				Ipv4Cidr:       new("10.0.0.0/24"),
 			}.Build(),
 			Status: privatev1.SubnetStatus_builder{
 				State: privatev1.SubnetState_SUBNET_STATE_READY,
@@ -1435,7 +1435,7 @@ var _ = Describe("Private compute instances server", func() {
 						Id: "pod-network-vm",
 						Spec: privatev1.ComputeInstanceSpec_builder{
 							Template:    template.GetId(),
-							RunStrategy: proto.String("Always"),
+							RunStrategy: new("Always"),
 						}.Build(),
 					}.Build(),
 					UpdateMask: &fieldmaskpb.FieldMask{


### PR DESCRIPTION
## Summary

- Replace calls to `proto.String` with Go's built-in `new` function in five test files where the
  former is no longer available.
- Remove the unused `proto` import left behind in the compute instance reconciler function test.

## Test plan

- [x] Verify the affected test files compile without errors.
- [x] Run `ginkgo run -r internal` to confirm all unit tests pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated internal test infrastructure and fixtures across multiple test suites.

**Note:** These are internal testing improvements with no impact on user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->