### PR TITLE
NO-ISSUE: Add `persist-credentials: false` to checkout steps

### DIFF
--- a/.github/workflows/check-pull-request.yaml
+++ b/.github/workflows/check-pull-request.yaml
@@ -29,6 +29,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
+      with:
+        persist-credentials: false
     - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6
     - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd  # v3.0.1
 
@@ -37,6 +39,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
+      with:
+        persist-credentials: false
     - uses: ./.github/actions/setup-go
     - run: |
         gofmt -s -l -w .
@@ -47,6 +51,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
+      with:
+        persist-credentials: false
     - uses: bufbuild/buf-action@91da6f6a1a2c877c182debad24ca0a8a9d848be7  # v1
       with:
         version: '1.50.0'
@@ -60,6 +66,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
+      with:
+        persist-credentials: false
     - uses: ./.github/actions/setup-go
     - run: |
         ginkgo run --timeout 1h -r internal
@@ -69,6 +77,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
+      with:
+        persist-credentials: false
     - uses: ./.github/actions/setup-go
     - uses: goreleaser/goreleaser-action@5daf1e915a5f0af01ddbcd89a43b8061ff4f1a89  # v7
       with:
@@ -79,6 +89,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
+      with:
+        persist-credentials: false
     - uses: ./.github/actions/setup-go
     - run: |
         echo '127.0.0.1 fulfillment-api.osac.svc.cluster.local' | sudo tee -a /etc/hosts
@@ -97,6 +109,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
+      with:
+        persist-credentials: false
     - uses: ./.github/actions/setup-go
     - run: |
         echo '127.0.0.1 fulfillment-api.osac.svc.cluster.local' | sudo tee -a /etc/hosts

--- a/.github/workflows/publish-binaries.yaml
+++ b/.github/workflows/publish-binaries.yaml
@@ -30,6 +30,7 @@ jobs:
     - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
       with:
         fetch-depth: 0
+        persist-credentials: false
     - uses: ./.github/actions/setup-go
     - uses: goreleaser/goreleaser-action@5daf1e915a5f0af01ddbcd89a43b8061ff4f1a89  # v7
       with:

--- a/.github/workflows/publish-charts.yaml
+++ b/.github/workflows/publish-charts.yaml
@@ -31,6 +31,7 @@ jobs:
     - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
       with:
         fetch-depth: 0
+        persist-credentials: false
     - id: run
       run: |
         # Login to the registry:

--- a/.github/workflows/publish-image.yaml
+++ b/.github/workflows/publish-image.yaml
@@ -28,6 +28,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
+        with:
+          persist-credentials: false
 
       # Login against a Docker registry except on PR
       # https://github.com/docker/login-action

--- a/.github/workflows/publish-proto.yaml
+++ b/.github/workflows/publish-proto.yaml
@@ -28,6 +28,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
+      with:
+        persist-credentials: false
     - uses: bufbuild/buf-action@91da6f6a1a2c877c182debad24ca0a8a9d848be7  # v1
       with:
         setup_only: true


### PR DESCRIPTION
## Summary

- Adds `persist-credentials: false` to every `actions/checkout` step across all GitHub Actions
  workflows (`check-pull-request`, `publish-binaries`, `publish-charts`, `publish-image`, and
  `publish-proto`). The `publish-openapi` workflow already had this setting and was left unchanged.
- This prevents the checkout action from persisting git credentials into the workspace, where
  they could be picked up by subsequent steps. This is a hardening measure that CodeRabbit
  frequently flags as a potential security risk during pull request reviews.

## Test plan

- Verify that all CI jobs pass with the new setting (no workflow relies on persisted credentials
  for git operations in later steps).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow configurations to disable persisting credentials after repository checkout.
  * Applied across workflows handling code checks, tests, builds, and publishing (binaries, images, charts, and proto artifacts).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->