### PR TITLE
NO-ISSUE: Fix compiler errors in compute instance tests

### DIFF
--- a/internal/servers/compute_instances_server_test.go
+++ b/internal/servers/compute_instances_server_test.go
@@ -18,7 +18,6 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/anypb"
 	"google.golang.org/protobuf/types/known/fieldmaskpb"
 	"google.golang.org/protobuf/types/known/timestamppb"

--- a/internal/servers/private_compute_instances_server_test.go
+++ b/internal/servers/private_compute_instances_server_test.go
@@ -21,7 +21,6 @@ import (
 	. "github.com/onsi/gomega"
 	grpccodes "google.golang.org/grpc/codes"
 	grpcstatus "google.golang.org/grpc/status"
-	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/anypb"
 	"google.golang.org/protobuf/types/known/fieldmaskpb"
 	"google.golang.org/protobuf/types/known/structpb"


### PR DESCRIPTION
## Summary

- Remove unused `google.golang.org/protobuf/proto` import from
  `compute_instances_server_test.go` and
  `private_compute_instances_server_test.go` to fix compiler errors.

## Test plan

- [x] Verify the tests compile: `ginkgo run internal/servers`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed unused import from internal test files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->