### PR TITLE
NO-ISSUE: Clarify credential scope in Keycloak chart README

### DIFF
--- a/it/charts/keycloak/README.md
+++ b/it/charts/keycloak/README.md
@@ -268,9 +268,9 @@ users:
     - view-users
 ```
 
-The `secret` values used here must match the credentials configured in the fulfillment service Helm
-chart (via `auth.controllerCredentials`) or in the Kubernetes secret referenced by the kustomize
-manifests.
+The `secret` for the `osac-controller` client must match the value configured in the fulfillment
+service Helm chart via `auth.controllerCredentials` (or in the Kubernetes secret referenced by the
+kustomize manifests).
 
 ## Exporting the realm
 


### PR DESCRIPTION
## Summary

- Clarified the credential-matching sentence in the Keycloak chart README
  (`it/charts/keycloak/README.md`) so it explicitly states that only the
  `osac-controller` client's `secret` must match the fulfillment service Helm
  chart value `auth.controllerCredentials`, rather than implying all example
  client secrets must match.

## Test plan

- [ ] Read the updated paragraph in `it/charts/keycloak/README.md` and confirm
  the wording is unambiguous.
- [ ] Verify that `auth.controllerCredentials` in `charts/service/values.yaml`
  is indeed specific to the `osac-controller` client.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified Keycloak chart documentation to explicitly specify the relationship between the client secret configuration and corresponding Helm chart values and Kubernetes secret references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->