### PR TITLE
OSAC-879: Validate subnet deletion against active compute instances

### DIFF
--- a/internal/database/dao/dao_errors.go
+++ b/internal/database/dao/dao_errors.go
@@ -125,6 +125,20 @@ func (e *ErrReference) Error() string {
 	return e.Reason
 }
 
+// ErrInUse indicates that a deletion was rejected because the object is still referenced by other objects.
+type ErrInUse struct {
+	// Reason is a human-friendly description of what is still using the object.
+	Reason string
+}
+
+// Error returns the error message.
+func (e *ErrInUse) Error() string {
+	if e.Reason == "" {
+		return "object is still in use"
+	}
+	return e.Reason
+}
+
 // Custom PostgreSQL SQLSTATE error codes used by database triggers. These codes use the 'Z' class, which is reserved
 // for user-defined conditions and will not collide with any standard PostgreSQL error code.
 const (
@@ -132,4 +146,12 @@ const (
 	// an update attempts to modify one or more immutable columns. When this error is received the detail field of
 	// the PostgreSQL error contains a JSON array with the names of the columns that the caller tried to modify.
 	errImmutableCode = "Z0001"
+
+	// errReferenceCode is the SQLSTATE error code returned by the 'check_compute_instance_subnet_refs'
+	// trigger when an insert references a resource that does not exist or has been deleted.
+	errReferenceCode = "Z0002"
+
+	// errInUseCode is the SQLSTATE error code returned by the 'check_subnet_not_in_use' trigger when a
+	// soft-delete is rejected because the object is still referenced by other objects.
+	errInUseCode = "Z0003"
 )

--- a/internal/database/dao/generic_dao_create.go
+++ b/internal/database/dao/generic_dao_create.go
@@ -208,6 +208,10 @@ func (r *CreateRequest[O]) translateError(ctx context.Context, id, tenant string
 		return &ErrAlreadyExists{
 			ID: id,
 		}
+	case errReferenceCode:
+		return &ErrReference{
+			Reason: pgErr.Message,
+		}
 	case pgerrcode.ForeignKeyViolation:
 		switch {
 		case strings.HasSuffix(pgErr.ConstraintName, "_tenant_fk"):

--- a/internal/database/dao/generic_dao_delete.go
+++ b/internal/database/dao/generic_dao_delete.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
 
 	"github.com/osac-project/fulfillment-service/internal/database"
 )
@@ -138,6 +139,12 @@ func (r *DeleteRequest[O]) do(ctx context.Context) (response *DeleteResponse, er
 		return
 	}
 	if err != nil {
+		var pgErr *pgconn.PgError
+		if errors.As(err, &pgErr) && pgErr.Code == errInUseCode {
+			err = &ErrInUse{
+				Reason: pgErr.Message,
+			}
+		}
 		return
 	}
 	object := r.newObject()

--- a/internal/database/migrations/52_add_subnet_compute_instance_ref_triggers.up.sql
+++ b/internal/database/migrations/52_add_subnet_compute_instance_ref_triggers.up.sql
@@ -1,0 +1,99 @@
+--
+-- Copyright (c) 2026 Red Hat Inc.
+--
+-- Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+-- the License. You may obtain a copy of the License at
+--
+--   http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+-- an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+-- specific language governing permissions and limitations under the License.
+--
+
+-- This migration adds two triggers that enforce bidirectional referential integrity between subnets and compute
+-- instances:
+--
+-- 1. A BEFORE UPDATE trigger on subnets that prevents soft-deleting a subnet while active compute instances still
+--    reference it.
+--
+-- 2. A BEFORE INSERT trigger on compute_instances that prevents creating a compute instance that references a subnet
+--    that does not exist or has been soft-deleted. This trigger uses FOR SHARE to acquire a shared lock on the subnet
+--    row, which conflicts with the exclusive lock held by a concurrent subnet soft-delete. This bidirectional locking
+--    eliminates the TOCTOU race condition between subnet deletion and compute instance creation. The trigger only
+--    fires on INSERT because subnet references in network_attachments are immutable (enforced by the application).
+
+-- Index to speed up the JSONB containment query used by the trigger:
+create index compute_instances_network_attachments on compute_instances
+  using gin ((data->'spec'->'network_attachments'));
+
+-- Trigger function that checks whether any active compute instance references the subnet being deleted:
+create function check_subnet_not_in_use() returns trigger as $$
+declare
+  ci_id text;
+begin
+  select id into ci_id
+  from compute_instances
+  where deletion_timestamp = 'epoch'
+    and data->'spec'->'network_attachments' @>
+        jsonb_build_array(jsonb_build_object('subnet', old.id))
+  limit 1;
+
+  if ci_id is not null then
+    raise exception using
+      errcode = 'Z0003',
+      message = format(
+        'cannot delete subnet ''%s'': it is in use by at least compute instance ''%s''',
+        old.id, ci_id
+      );
+  end if;
+
+  return new;
+end;
+$$ language plpgsql;
+
+-- Attach the trigger so that it only fires when the row transitions from active to soft-deleted:
+create trigger check_subnet_not_in_use
+  before update on subnets
+  for each row
+  when (old.deletion_timestamp = 'epoch' and new.deletion_timestamp != 'epoch')
+  execute function check_subnet_not_in_use();
+
+-- Trigger function that validates subnet references in a compute instance's network_attachments:
+create function check_compute_instance_subnet_refs() returns trigger as $$
+declare
+  attachment jsonb;
+  subnet_id text;
+  found_id text;
+begin
+  for attachment in select jsonb_array_elements(coalesce(new.data->'spec'->'network_attachments', '[]'::jsonb))
+  loop
+    subnet_id := attachment->>'subnet';
+    if coalesce(subnet_id, '') != '' then
+      select id into found_id
+      from subnets
+      where id = subnet_id
+        and deletion_timestamp = 'epoch'
+      for share;
+
+      if found_id is null then
+        raise exception using
+          errcode = 'Z0002',
+          message = format(
+            'subnet ''%s'' does not exist or has been deleted',
+            subnet_id
+          );
+      end if;
+    end if;
+  end loop;
+
+  return new;
+end;
+$$ language plpgsql;
+
+-- Attach the trigger so that it fires on insert of active compute instances:
+create trigger check_compute_instance_subnet_refs
+  before insert on compute_instances
+  for each row
+  when (new.deletion_timestamp = 'epoch')
+  execute function check_compute_instance_subnet_refs();

--- a/internal/database/migrations/52_add_subnet_compute_instance_ref_triggers_test.go
+++ b/internal/database/migrations/52_add_subnet_compute_instance_ref_triggers_test.go
@@ -1,0 +1,319 @@
+/*
+Copyright (c) 2026 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package migrations
+
+import (
+	"context"
+
+	"github.com/jackc/pgx/v5/pgconn"
+	. "github.com/onsi/ginkgo/v2/dsl/core"
+	. "github.com/onsi/gomega"
+)
+
+var _ = DescribeMigration("Add subnet compute instance ref triggers", func() {
+	It("Creates the 'check_subnet_not_in_use' function", func(ctx context.Context) {
+		err := tool.Migrate(ctx, 52)
+		Expect(err).ToNot(HaveOccurred())
+
+		var count int
+		err = conn.QueryRow(ctx, `
+			select
+				count(*)
+			from
+				information_schema.routines
+			where
+				routine_name = 'check_subnet_not_in_use' and
+				routine_type = 'FUNCTION'
+		`).Scan(&count)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(count).To(Equal(1))
+	})
+
+	It("Adds a trigger to the subnets table", func(ctx context.Context) {
+		err := tool.Migrate(ctx, 52)
+		Expect(err).ToNot(HaveOccurred())
+
+		var count int
+		err = conn.QueryRow(ctx, `
+			select
+				count(*)
+			from
+				information_schema.triggers
+			where
+				trigger_name = 'check_subnet_not_in_use' and
+				event_object_table = 'subnets' and
+				action_timing = 'BEFORE' and
+				event_manipulation = 'UPDATE'
+		`).Scan(&count)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(count).To(Equal(1))
+	})
+
+	It("Creates the GIN index on compute_instances network_attachments", func(ctx context.Context) {
+		err := tool.Migrate(ctx, 52)
+		Expect(err).ToNot(HaveOccurred())
+
+		var count int
+		err = conn.QueryRow(ctx, `
+			select
+				count(*)
+			from
+				pg_indexes
+			where
+				tablename = 'compute_instances' and
+				indexname = 'compute_instances_network_attachments'
+		`).Scan(&count)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(count).To(Equal(1))
+	})
+
+	It("Prevents soft-deleting a subnet that is in use by a compute instance", func(ctx context.Context) {
+		err := tool.Migrate(ctx, 52)
+		Expect(err).ToNot(HaveOccurred())
+
+		// Create a tenant:
+		_, err = conn.Exec(ctx,
+			`insert into organizations (id, name, tenant, creator, data)
+			 values ('test-tenant', 'test-tenant', 'system', 'system', '{}')
+			 on conflict do nothing`)
+		Expect(err).ToNot(HaveOccurred())
+
+		// Create a subnet:
+		_, err = conn.Exec(ctx,
+			`insert into subnets (id, tenant, data)
+			 values ('subnet-1', 'test-tenant', '{}')`)
+		Expect(err).ToNot(HaveOccurred())
+
+		// Create a compute instance referencing that subnet:
+		_, err = conn.Exec(ctx,
+			`insert into compute_instances (id, tenant, data)
+			 values ('ci-1', 'test-tenant', $1::jsonb)`,
+			`{"spec":{"network_attachments":[{"subnet":"subnet-1"}]}}`)
+		Expect(err).ToNot(HaveOccurred())
+
+		// Try to soft-delete the subnet — should fail:
+		_, err = conn.Exec(ctx,
+			`update subnets set deletion_timestamp = now() where id = 'subnet-1'`)
+		Expect(err).To(HaveOccurred())
+		var pgErr *pgconn.PgError
+		Expect(err).To(BeAssignableToTypeOf(&pgconn.PgError{}))
+		pgErr = err.(*pgconn.PgError)
+		Expect(pgErr.Code).To(Equal("Z0003"))
+		Expect(pgErr.Message).To(ContainSubstring("subnet-1"))
+		Expect(pgErr.Message).To(ContainSubstring("ci-1"))
+	})
+
+	It("Allows soft-deleting a subnet that is not in use", func(ctx context.Context) {
+		err := tool.Migrate(ctx, 52)
+		Expect(err).ToNot(HaveOccurred())
+
+		// Create a tenant:
+		_, err = conn.Exec(ctx,
+			`insert into organizations (id, name, tenant, creator, data)
+			 values ('test-tenant', 'test-tenant', 'system', 'system', '{}')
+			 on conflict do nothing`)
+		Expect(err).ToNot(HaveOccurred())
+
+		// Create a subnet with no compute instances:
+		_, err = conn.Exec(ctx,
+			`insert into subnets (id, tenant, data)
+			 values ('subnet-2', 'test-tenant', '{}')`)
+		Expect(err).ToNot(HaveOccurred())
+
+		// Soft-delete should succeed:
+		_, err = conn.Exec(ctx,
+			`update subnets set deletion_timestamp = now() where id = 'subnet-2'`)
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	It("Prevents soft-deleting a subnet when compute instance has additional fields in network attachment", func(ctx context.Context) {
+		err := tool.Migrate(ctx, 52)
+		Expect(err).ToNot(HaveOccurred())
+
+		// Create a tenant:
+		_, err = conn.Exec(ctx,
+			`insert into organizations (id, name, tenant, creator, data)
+			 values ('test-tenant', 'test-tenant', 'system', 'system', '{}')
+			 on conflict do nothing`)
+		Expect(err).ToNot(HaveOccurred())
+
+		// Create a subnet:
+		_, err = conn.Exec(ctx,
+			`insert into subnets (id, tenant, data)
+			 values ('subnet-sg', 'test-tenant', '{}')`)
+		Expect(err).ToNot(HaveOccurred())
+
+		// Create a compute instance with security_groups alongside the subnet:
+		_, err = conn.Exec(ctx,
+			`insert into compute_instances (id, tenant, data)
+			 values ('ci-sg', 'test-tenant', $1::jsonb)`,
+			`{"spec":{"network_attachments":[{"subnet":"subnet-sg","security_groups":["sg-1","sg-2"]}]}}`)
+		Expect(err).ToNot(HaveOccurred())
+
+		// Soft-delete should fail — the JSONB containment operator matches on the subnet
+		// field even when the network attachment object has additional fields:
+		_, err = conn.Exec(ctx,
+			`update subnets set deletion_timestamp = now() where id = 'subnet-sg'`)
+		Expect(err).To(HaveOccurred())
+		var pgErr *pgconn.PgError
+		Expect(err).To(BeAssignableToTypeOf(&pgconn.PgError{}))
+		pgErr = err.(*pgconn.PgError)
+		Expect(pgErr.Code).To(Equal("Z0003"))
+		Expect(pgErr.Message).To(ContainSubstring("subnet-sg"))
+		Expect(pgErr.Message).To(ContainSubstring("ci-sg"))
+	})
+
+	It("Creates the 'check_compute_instance_subnet_refs' function", func(ctx context.Context) {
+		err := tool.Migrate(ctx, 52)
+		Expect(err).ToNot(HaveOccurred())
+
+		var count int
+		err = conn.QueryRow(ctx, `
+			select
+				count(*)
+			from
+				information_schema.routines
+			where
+				routine_name = 'check_compute_instance_subnet_refs' and
+				routine_type = 'FUNCTION'
+		`).Scan(&count)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(count).To(Equal(1))
+	})
+
+	It("Adds a trigger to the compute_instances table", func(ctx context.Context) {
+		err := tool.Migrate(ctx, 52)
+		Expect(err).ToNot(HaveOccurred())
+
+		var count int
+		err = conn.QueryRow(ctx, `
+			select
+				count(*)
+			from
+				information_schema.triggers
+			where
+				trigger_name = 'check_compute_instance_subnet_refs' and
+				event_object_table = 'compute_instances' and
+				action_timing = 'BEFORE' and
+				event_manipulation = 'INSERT'
+		`).Scan(&count)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(count).To(Equal(1))
+	})
+
+	It("Prevents creating a compute instance referencing a non-existent subnet", func(ctx context.Context) {
+		err := tool.Migrate(ctx, 52)
+		Expect(err).ToNot(HaveOccurred())
+
+		// Create a tenant:
+		_, err = conn.Exec(ctx,
+			`insert into organizations (id, name, tenant, creator, data)
+			 values ('test-tenant', 'test-tenant', 'system', 'system', '{}')
+			 on conflict do nothing`)
+		Expect(err).ToNot(HaveOccurred())
+
+		// Try to create a compute instance referencing a subnet that doesn't exist:
+		_, err = conn.Exec(ctx,
+			`insert into compute_instances (id, tenant, data)
+			 values ('ci-ref-1', 'test-tenant', $1::jsonb)`,
+			`{"spec":{"network_attachments":[{"subnet":"no-such-subnet"}]}}`)
+		Expect(err).To(HaveOccurred())
+		var pgErr *pgconn.PgError
+		Expect(err).To(BeAssignableToTypeOf(&pgconn.PgError{}))
+		pgErr = err.(*pgconn.PgError)
+		Expect(pgErr.Code).To(Equal("Z0002"))
+		Expect(pgErr.Message).To(ContainSubstring("no-such-subnet"))
+	})
+
+	It("Prevents creating a compute instance referencing a soft-deleted subnet", func(ctx context.Context) {
+		err := tool.Migrate(ctx, 52)
+		Expect(err).ToNot(HaveOccurred())
+
+		// Create a tenant:
+		_, err = conn.Exec(ctx,
+			`insert into organizations (id, name, tenant, creator, data)
+			 values ('test-tenant', 'test-tenant', 'system', 'system', '{}')
+			 on conflict do nothing`)
+		Expect(err).ToNot(HaveOccurred())
+
+		// Create and soft-delete a subnet:
+		_, err = conn.Exec(ctx,
+			`insert into subnets (id, tenant, data)
+			 values ('subnet-deleted', 'test-tenant', '{}')`)
+		Expect(err).ToNot(HaveOccurred())
+		_, err = conn.Exec(ctx,
+			`update subnets set deletion_timestamp = now() where id = 'subnet-deleted'`)
+		Expect(err).ToNot(HaveOccurred())
+
+		// Try to create a compute instance referencing the deleted subnet:
+		_, err = conn.Exec(ctx,
+			`insert into compute_instances (id, tenant, data)
+			 values ('ci-ref-2', 'test-tenant', $1::jsonb)`,
+			`{"spec":{"network_attachments":[{"subnet":"subnet-deleted"}]}}`)
+		Expect(err).To(HaveOccurred())
+		var pgErr *pgconn.PgError
+		Expect(err).To(BeAssignableToTypeOf(&pgconn.PgError{}))
+		pgErr = err.(*pgconn.PgError)
+		Expect(pgErr.Code).To(Equal("Z0002"))
+		Expect(pgErr.Message).To(ContainSubstring("subnet-deleted"))
+	})
+
+	It("Allows creating a compute instance with no network attachments", func(ctx context.Context) {
+		err := tool.Migrate(ctx, 52)
+		Expect(err).ToNot(HaveOccurred())
+
+		// Create a tenant:
+		_, err = conn.Exec(ctx,
+			`insert into organizations (id, name, tenant, creator, data)
+			 values ('test-tenant', 'test-tenant', 'system', 'system', '{}')
+			 on conflict do nothing`)
+		Expect(err).ToNot(HaveOccurred())
+
+		// Create a compute instance with no network attachments:
+		_, err = conn.Exec(ctx,
+			`insert into compute_instances (id, tenant, data)
+			 values ('ci-ref-3', 'test-tenant', '{"spec":{}}')`)
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	It("Allows soft-deleting a subnet when the compute instance is already deleted", func(ctx context.Context) {
+		err := tool.Migrate(ctx, 52)
+		Expect(err).ToNot(HaveOccurred())
+
+		// Create a tenant:
+		_, err = conn.Exec(ctx,
+			`insert into organizations (id, name, tenant, creator, data)
+			 values ('test-tenant', 'test-tenant', 'system', 'system', '{}')
+			 on conflict do nothing`)
+		Expect(err).ToNot(HaveOccurred())
+
+		// Create a subnet:
+		_, err = conn.Exec(ctx,
+			`insert into subnets (id, tenant, data)
+			 values ('subnet-3', 'test-tenant', '{}')`)
+		Expect(err).ToNot(HaveOccurred())
+
+		// Create a soft-deleted compute instance referencing the subnet:
+		_, err = conn.Exec(ctx,
+			`insert into compute_instances (id, tenant, deletion_timestamp, data)
+			 values ('ci-2', 'test-tenant', now(), $1::jsonb)`,
+			`{"spec":{"network_attachments":[{"subnet":"subnet-3"}]}}`)
+		Expect(err).ToNot(HaveOccurred())
+
+		// Soft-delete should succeed since the compute instance is already deleted:
+		_, err = conn.Exec(ctx,
+			`update subnets set deletion_timestamp = now() where id = 'subnet-3'`)
+		Expect(err).ToNot(HaveOccurred())
+	})
+})

--- a/internal/servers/generic_server.go
+++ b/internal/servers/generic_server.go
@@ -710,6 +710,10 @@ func (s *GenericServer[O]) Delete(ctx context.Context, request any, response any
 		if errors.As(err, &deniedErr) {
 			return grpcstatus.Errorf(grpccodes.PermissionDenied, "%s", deniedErr.Reason)
 		}
+		var inUseErr *dao.ErrInUse
+		if errors.As(err, &inUseErr) {
+			return grpcstatus.Errorf(grpccodes.FailedPrecondition, "%s", inUseErr.Error())
+		}
 		s.logger.ErrorContext(
 			ctx,
 			"Failed to delete object",

--- a/internal/servers/private_subnets_server_test.go
+++ b/internal/servers/private_subnets_server_test.go
@@ -15,6 +15,7 @@ package servers
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -1180,6 +1181,175 @@ var _ = Describe("Private subnets server", func() {
 
 		// SUB-VAL-12, SUB-VAL-13: Tenant isolation for Delete and List operations
 		// are covered by servers_tenancy_test.go, not validation tests
+
+		Context("Deletion validation", func() {
+			var computeInstancesDao *dao.GenericDAO[*privatev1.ComputeInstance]
+
+			BeforeEach(func() {
+				var err error
+				computeInstancesDao, err = dao.NewGenericDAO[*privatev1.ComputeInstance]().
+					SetLogger(logger).
+					SetTenancyLogic(tenancy).
+					Build()
+				Expect(err).ToNot(HaveOccurred())
+			})
+
+			It("rejects deletion when a compute instance uses the subnet", func() {
+				vn := createVirtualNetwork(ctx, "10.0.0.0/16", "")
+
+				createResponse, err := server.Create(ctx, privatev1.SubnetsCreateRequest_builder{
+					Object: privatev1.Subnet_builder{
+						Metadata: privatev1.Metadata_builder{
+							Tenant: auth.SharedTenant,
+						}.Build(),
+						Spec: privatev1.SubnetSpec_builder{
+							Ipv4Cidr:       new("10.0.1.0/24"),
+							VirtualNetwork: vn.GetId(),
+						}.Build(),
+					}.Build(),
+				}.Build())
+				Expect(err).ToNot(HaveOccurred())
+				subnetID := createResponse.GetObject().GetId()
+
+				_, err = computeInstancesDao.Create().
+					SetObject(privatev1.ComputeInstance_builder{
+						Metadata: privatev1.Metadata_builder{
+							Tenant: auth.SharedTenant,
+						}.Build(),
+						Spec: privatev1.ComputeInstanceSpec_builder{
+							NetworkAttachments: []*privatev1.NetworkAttachment{
+								privatev1.NetworkAttachment_builder{
+									Subnet: subnetID,
+								}.Build(),
+							},
+						}.Build(),
+					}.Build()).
+					Do(ctx)
+				Expect(err).ToNot(HaveOccurred())
+
+				_, err = server.Delete(ctx, privatev1.SubnetsDeleteRequest_builder{
+					Id: subnetID,
+				}.Build())
+				Expect(err).To(HaveOccurred())
+				status, ok := grpcstatus.FromError(err)
+				Expect(ok).To(BeTrue())
+				Expect(status.Code()).To(Equal(grpccodes.FailedPrecondition))
+				Expect(status.Message()).To(ContainSubstring("compute instance"))
+			})
+
+			It("allows deletion when no compute instances use the subnet", func() {
+				vn := createVirtualNetwork(ctx, "10.0.0.0/16", "")
+
+				createResponse, err := server.Create(ctx, privatev1.SubnetsCreateRequest_builder{
+					Object: privatev1.Subnet_builder{
+						Metadata: privatev1.Metadata_builder{
+							Tenant: auth.SharedTenant,
+						}.Build(),
+						Spec: privatev1.SubnetSpec_builder{
+							Ipv4Cidr:       new("10.0.1.0/24"),
+							VirtualNetwork: vn.GetId(),
+						}.Build(),
+					}.Build(),
+				}.Build())
+				Expect(err).ToNot(HaveOccurred())
+				subnetID := createResponse.GetObject().GetId()
+
+				_, err = server.Delete(ctx, privatev1.SubnetsDeleteRequest_builder{
+					Id: subnetID,
+				}.Build())
+				Expect(err).ToNot(HaveOccurred())
+			})
+
+			It("rejects creating a compute instance referencing a deleted subnet", func() {
+				vn := createVirtualNetwork(ctx, "10.0.0.0/16", "")
+
+				createResponse, err := server.Create(ctx, privatev1.SubnetsCreateRequest_builder{
+					Object: privatev1.Subnet_builder{
+						Metadata: privatev1.Metadata_builder{
+							Tenant: auth.SharedTenant,
+						}.Build(),
+						Spec: privatev1.SubnetSpec_builder{
+							Ipv4Cidr:       new("10.0.1.0/24"),
+							VirtualNetwork: vn.GetId(),
+						}.Build(),
+					}.Build(),
+				}.Build())
+				Expect(err).ToNot(HaveOccurred())
+				subnetID := createResponse.GetObject().GetId()
+
+				// Soft-delete the subnet:
+				_, err = server.Delete(ctx, privatev1.SubnetsDeleteRequest_builder{
+					Id: subnetID,
+				}.Build())
+				Expect(err).ToNot(HaveOccurred())
+
+				// Try to create a compute instance referencing the deleted subnet:
+				_, err = computeInstancesDao.Create().
+					SetObject(privatev1.ComputeInstance_builder{
+						Metadata: privatev1.Metadata_builder{
+							Tenant: auth.SharedTenant,
+						}.Build(),
+						Spec: privatev1.ComputeInstanceSpec_builder{
+							NetworkAttachments: []*privatev1.NetworkAttachment{
+								privatev1.NetworkAttachment_builder{
+									Subnet: subnetID,
+								}.Build(),
+							},
+						}.Build(),
+					}.Build()).
+					Do(ctx)
+				Expect(err).To(HaveOccurred())
+				var referenceErr *dao.ErrReference
+				Expect(errors.As(err, &referenceErr)).To(BeTrue())
+				Expect(referenceErr.Reason).To(ContainSubstring(subnetID))
+			})
+
+			It("allows deletion when compute instance using it is itself deleted", func() {
+				vn := createVirtualNetwork(ctx, "10.0.0.0/16", "")
+
+				createResponse, err := server.Create(ctx, privatev1.SubnetsCreateRequest_builder{
+					Object: privatev1.Subnet_builder{
+						Metadata: privatev1.Metadata_builder{
+							Tenant: auth.SharedTenant,
+						}.Build(),
+						Spec: privatev1.SubnetSpec_builder{
+							Ipv4Cidr:       new("10.0.1.0/24"),
+							VirtualNetwork: vn.GetId(),
+						}.Build(),
+					}.Build(),
+				}.Build())
+				Expect(err).ToNot(HaveOccurred())
+				subnetID := createResponse.GetObject().GetId()
+
+				ciCreateResponse, err := computeInstancesDao.Create().
+					SetObject(privatev1.ComputeInstance_builder{
+						Metadata: privatev1.Metadata_builder{
+							Tenant: auth.SharedTenant,
+						}.Build(),
+						Spec: privatev1.ComputeInstanceSpec_builder{
+							NetworkAttachments: []*privatev1.NetworkAttachment{
+								privatev1.NetworkAttachment_builder{
+									Subnet: subnetID,
+								}.Build(),
+							},
+						}.Build(),
+					}.Build()).
+					Do(ctx)
+				Expect(err).ToNot(HaveOccurred())
+
+				// Soft-delete the compute instance first:
+				_, err = computeInstancesDao.Delete().
+					SetId(ciCreateResponse.GetObject().GetId()).
+					Do(ctx)
+				Expect(err).ToNot(HaveOccurred())
+
+				// Subnet deletion should now succeed:
+				_, err = server.Delete(ctx, privatev1.SubnetsDeleteRequest_builder{
+					Id: subnetID,
+				}.Build())
+				Expect(err).ToNot(HaveOccurred())
+			})
+		})
 	})
 
 	Describe("GenericDAO Subnet operations", func() {


### PR DESCRIPTION
Reject subnet deletion with FailedPrecondition when any non-deleted compute instance still references it via network_attachments, preventing orphaned compute instances from losing their network configuration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Subnet deletion is blocked if active compute instances reference it; users receive a clear reason why deletion was rejected.
  * Creating a compute instance that references a non-existent or soft-deleted subnet is prevented with explanatory error messages.

* **Tests**
  * Added end-to-end tests covering deletion and creation validations between subnets and compute instances.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->