### PR TITLE
OSAC-1273: acquire row lock in updatePoolCapacity to prevent counter drift

### DIFF
--- a/internal/servers/private_public_ips_server.go
+++ b/internal/servers/private_public_ips_server.go
@@ -357,6 +357,7 @@ func (s *PrivatePublicIPsServer) validatePoolReference(ctx context.Context, pool
 func (s *PrivatePublicIPsServer) updatePoolCapacity(ctx context.Context, poolID string, delta int64) error {
 	poolResponse, err := s.publicIPPoolDao.Get().
 		SetId(poolID).
+		SetLock(true).
 		Do(ctx)
 	if err != nil {
 		s.logger.ErrorContext(ctx, "Failed to get pool for capacity update",


### PR DESCRIPTION
## Summary

[OSAC-1273](https://redhat.atlassian.net/browse/OSAC-1273): Fix a race condition where the `PublicIPPool.status.allocated` counter becomes stale after deleting a PublicIP, making the pool undeletable.

## Why

`updatePoolCapacity()` reads the pool record without a row lock, then writes the entire proto back with updated counters. A concurrent pool reconciler update can interleave and overwrite the counter change, leaving the pool with a stale `allocated` count. The pool delete precondition then fails with "N public IP(s) are still allocated" even when no IPs exist.

## Testing

Deployed to edge22 and verified the full lifecycle:

```
# Create pool
grpcurl ... osac.private.v1.PublicIPPools/Create -> allocated: 0, available: 6

# Create IP
osac create publicip --name test-fix-ip --pool test-fix-pool -> ALLOCATED

# Pool shows allocated: 1, available: 5

# Delete IP
osac delete publicip test-fix-ip -> Deleted

# Pool now shows allocated: 0, available: 6 (FIXED, previously stayed at 1)

# Delete pool succeeds (previously failed with stale counter)
grpcurl ... osac.private.v1.PublicIPPools/Delete -> {}
```

Unit tests: 853/853 pass (`ginkgo run ./internal/servers/`).

## Ticket

[OSAC-1273](https://redhat.atlassian.net/browse/OSAC-1273)

<br>

<small>Signed-off-by: akshaynadkarni <25892229+akshaynadkarni@users.noreply.github.com></small>
<small>Assisted-by: Cursor/Claude</small>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced pool capacity update mechanism to improve data consistency during concurrent operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->