### PR TITLE
NO-ISSUE: Move `End` method from `TxManager` to `Tx` interface

### DIFF
--- a/internal/cmd/service/start/grpcserver/start_grpc_server_cmd.go
+++ b/internal/cmd/service/start/grpcserver/start_grpc_server_cmd.go
@@ -970,7 +970,7 @@ func (c *runnerContext) run(cmd *cobra.Command, argv []string) error {
 			if err != nil {
 				return nil, err
 			}
-			defer txManager.End(ctx, tx)
+			defer tx.End(ctx)
 			txCtx := database.TxIntoContext(ctx, tx)
 			resp, err := privateHubsServer.Get(txCtx, privatev1.HubsGetRequest_builder{
 				Id: id,

--- a/internal/database/dao/generic_dao_events_test.go
+++ b/internal/database/dao/generic_dao_events_test.go
@@ -42,7 +42,7 @@ var _ = Describe("Generic DAO events", func() {
 		tx, err := tm.Begin(ctx)
 		Expect(err).ToNot(HaveOccurred())
 		defer func() {
-			err := tm.End(ctx, tx)
+			err := tx.End(ctx)
 			Expect(err).ToNot(HaveOccurred())
 		}()
 		taskCtx := database.TxIntoContext(ctx, tx)

--- a/internal/database/dao/generic_dao_immutability_test.go
+++ b/internal/database/dao/generic_dao_immutability_test.go
@@ -63,7 +63,7 @@ var _ = Describe("Immutable fields", func() {
 		tx, err = tm.Begin(ctx)
 		Expect(err).ToNot(HaveOccurred())
 		DeferCleanup(func() {
-			err := tm.End(ctx, tx)
+			err := tx.End(ctx)
 			Expect(err).ToNot(HaveOccurred())
 		})
 		ctx = database.TxIntoContext(ctx, tx)

--- a/internal/database/dao/generic_dao_integrity_test.go
+++ b/internal/database/dao/generic_dao_integrity_test.go
@@ -64,7 +64,7 @@ var _ = Describe("Referential integrity", func() {
 		tx, err := tm.Begin(ctx)
 		Expect(err).ToNot(HaveOccurred())
 		DeferCleanup(func() {
-			err := tm.End(ctx, tx)
+			err := tx.End(ctx)
 			Expect(err).ToNot(HaveOccurred())
 		})
 		ctx = database.TxIntoContext(ctx, tx)

--- a/internal/database/dao/generic_dao_lock_test.go
+++ b/internal/database/dao/generic_dao_lock_test.go
@@ -143,7 +143,7 @@ var _ = Describe("Lock", func() {
 		tx, err := tm.Begin(ctx)
 		Expect(err).ToNot(HaveOccurred())
 		DeferCleanup(func() {
-			err := tm.End(ctx, tx)
+			err := tx.End(ctx)
 			Expect(err).ToNot(HaveOccurred())
 		})
 		ctx = database.TxIntoContext(ctx, tx)
@@ -164,7 +164,7 @@ var _ = Describe("Lock", func() {
 		tx, err := tm.Begin(ctx)
 		Expect(err).ToNot(HaveOccurred())
 		DeferCleanup(func() {
-			err := tm.End(ctx, tx)
+			err := tx.End(ctx)
 			Expect(err).ToNot(HaveOccurred())
 		})
 		ctx = database.TxIntoContext(ctx, tx)
@@ -181,7 +181,7 @@ var _ = Describe("Lock", func() {
 		tx, err := tm.Begin(ctx)
 		Expect(err).ToNot(HaveOccurred())
 		DeferCleanup(func() {
-			err := tm.End(ctx, tx)
+			err := tx.End(ctx)
 			Expect(err).ToNot(HaveOccurred())
 		})
 		ctx = database.TxIntoContext(ctx, tx)
@@ -201,7 +201,7 @@ var _ = Describe("Lock", func() {
 		tx, err := tm.Begin(ctx)
 		Expect(err).ToNot(HaveOccurred())
 		DeferCleanup(func() {
-			err := tm.End(ctx, tx)
+			err := tx.End(ctx)
 			Expect(err).ToNot(HaveOccurred())
 		})
 		ctx = database.TxIntoContext(ctx, tx)
@@ -227,7 +227,7 @@ var _ = Describe("Lock", func() {
 			Do(ctx)
 		Expect(err).ToNot(HaveOccurred())
 
-		err = tm.End(ctx, tx)
+		err = tx.End(ctx)
 		Expect(err).ToNot(HaveOccurred())
 		checkNotLocked("obj1")
 	})
@@ -245,7 +245,7 @@ var _ = Describe("Lock", func() {
 
 		rollbackErr := errors.New("force rollback")
 		tx.ReportError(&rollbackErr)
-		err = tm.End(ctx, tx)
+		err = tx.End(ctx)
 		Expect(err).ToNot(HaveOccurred())
 		checkNotLocked("obj1")
 	})
@@ -276,7 +276,7 @@ var _ = Describe("Lock", func() {
 			_, lockErr := generic.Lock().
 				AddIds("b", "a").
 				Do(ctx)
-			err = tm.End(ctx, tx2)
+			err = tx2.End(ctx)
 			done <- errors.Join(lockErr, err)
 		}()
 

--- a/internal/database/dao/generic_dao_metrics_test.go
+++ b/internal/database/dao/generic_dao_metrics_test.go
@@ -67,7 +67,7 @@ var _ = Describe("Metrics", func() {
 		tx, err := tm.Begin(ctx)
 		Expect(err).ToNot(HaveOccurred())
 		DeferCleanup(func() {
-			err := tm.End(ctx, tx)
+			err := tx.End(ctx)
 			Expect(err).ToNot(HaveOccurred())
 		})
 		ctx = database.TxIntoContext(ctx, tx)

--- a/internal/database/dao/generic_dao_tenancy_test.go
+++ b/internal/database/dao/generic_dao_tenancy_test.go
@@ -61,7 +61,7 @@ var _ = Describe("Tenancy logic", func() {
 		tx, err = tm.Begin(ctx)
 		Expect(err).ToNot(HaveOccurred())
 		DeferCleanup(func() {
-			err := tm.End(ctx, tx)
+			err := tx.End(ctx)
 			Expect(err).ToNot(HaveOccurred())
 		})
 		ctx = database.TxIntoContext(ctx, tx)

--- a/internal/database/dao/generic_dao_test.go
+++ b/internal/database/dao/generic_dao_test.go
@@ -85,7 +85,7 @@ var _ = Describe("Generic DAO", func() {
 		tx, err = tm.Begin(ctx)
 		Expect(err).ToNot(HaveOccurred())
 		DeferCleanup(func() {
-			err := tm.End(ctx, tx)
+			err := tx.End(ctx)
 			Expect(err).ToNot(HaveOccurred())
 		})
 		ctx = database.TxIntoContext(ctx, tx)

--- a/internal/database/dao/generic_dao_version_test.go
+++ b/internal/database/dao/generic_dao_version_test.go
@@ -67,7 +67,7 @@ var _ = Describe("Version", func() {
 		tx, err = tm.Begin(ctx)
 		Expect(err).ToNot(HaveOccurred())
 		DeferCleanup(func() {
-			err := tm.End(ctx, tx)
+			err := tx.End(ctx)
 			Expect(err).ToNot(HaveOccurred())
 		})
 		ctx = database.TxIntoContext(ctx, tx)

--- a/internal/database/database_listener_test.go
+++ b/internal/database/database_listener_test.go
@@ -162,7 +162,7 @@ var _ = Describe("Listener", func() {
 		notify := func(payload proto.Message) {
 			tx, err := tm.Begin(ctx)
 			defer func() {
-				err := tm.End(ctx, tx)
+				err := tx.End(ctx)
 				Expect(err).ToNot(HaveOccurred())
 			}()
 			ctx = TxIntoContext(ctx, tx)

--- a/internal/database/database_notifier_test.go
+++ b/internal/database/database_notifier_test.go
@@ -60,7 +60,7 @@ var _ = Describe("Notifier", func() {
 		Expect(err).ToNot(HaveOccurred())
 		taskCtx := TxIntoContext(ctx, tx)
 		task(taskCtx)
-		err = tm.End(ctx, tx)
+		err = tx.End(ctx)
 		Expect(err).ToNot(HaveOccurred())
 	}
 

--- a/internal/database/database_tx.go
+++ b/internal/database/database_tx.go
@@ -62,4 +62,8 @@ type Tx interface {
 	//
 	// It this method is called multiple times for the same transaction the reported errors will be accumulated.
 	ReportError(err *error)
+
+	// End finishes a transaction. It will be committed if no errors have been reported, or rolled back otherwise.
+	// See the ReportError method for details on how errors are tracked.
+	End(ctx context.Context) error
 }

--- a/internal/database/database_tx_interceptor.go
+++ b/internal/database/database_tx_interceptor.go
@@ -94,7 +94,7 @@ func (i *TxInterceptor) UnaryServer(ctx context.Context, request any, info *grpc
 	// transaction fails, then we will return an internal error.
 	defer func() {
 		// Try to end the transaction:
-		txErr := i.manager.End(ctx, tx)
+		txErr := tx.End(ctx)
 
 		// Write to the log both errors, the one returned by the method and the one resulting from trying to
 		// end the transaction.

--- a/internal/database/database_tx_interceptor_test.go
+++ b/internal/database/database_tx_interceptor_test.go
@@ -71,7 +71,7 @@ var _ = Describe("Transactions interceptor", func() {
 			// Prepare the manager mock:
 			tx := NewMockTx(ctrl)
 			manager.EXPECT().Begin(ctx).Return(tx, nil).Times(1)
-			manager.EXPECT().End(ctx, tx).Return(nil).Times(1)
+			tx.EXPECT().End(ctx).Return(nil).Times(1)
 
 			// Call the interceptor:
 			var request any
@@ -87,7 +87,7 @@ var _ = Describe("Transactions interceptor", func() {
 			// Prepare the manager mock:
 			tx := NewMockTx(ctrl)
 			manager.EXPECT().Begin(ctx).Return(tx, nil).Times(1)
-			manager.EXPECT().End(ctx, tx).Return(nil).Times(1)
+			tx.EXPECT().End(ctx).Return(nil).Times(1)
 
 			// Call the interceptor:
 			var request any
@@ -106,7 +106,7 @@ var _ = Describe("Transactions interceptor", func() {
 			// Prepare the manager mock:
 			tx := NewMockTx(ctrl)
 			manager.EXPECT().Begin(ctx).Return(tx, nil).Times(1)
-			manager.EXPECT().End(ctx, tx).Return(nil).Times(1)
+			tx.EXPECT().End(ctx).Return(nil).Times(1)
 
 			// Call the interceptor:
 			var request any
@@ -160,7 +160,7 @@ var _ = Describe("Transactions interceptor", func() {
 			// Prepare the manager mock:
 			tx := NewMockTx(ctrl)
 			manager.EXPECT().Begin(ctx).Return(tx, nil).Times(1)
-			manager.EXPECT().End(ctx, tx).Return(nil).Times(1)
+			tx.EXPECT().End(ctx).Return(nil).Times(1)
 
 			// Call the interceptor:
 			var request any
@@ -182,7 +182,7 @@ var _ = Describe("Transactions interceptor", func() {
 			tx := NewMockTx(ctrl)
 			err := errors.New("tx error")
 			manager.EXPECT().Begin(ctx).Return(tx, nil).Times(1)
-			manager.EXPECT().End(ctx, tx).Return(err).Times(1)
+			tx.EXPECT().End(ctx).Return(err).Times(1)
 
 			// Call the interceptor:
 			var request any

--- a/internal/database/database_tx_manager.go
+++ b/internal/database/database_tx_manager.go
@@ -16,7 +16,6 @@ package database
 import (
 	"context"
 	"errors"
-	"fmt"
 	"log/slog"
 
 	"github.com/jackc/pgx/v5"
@@ -24,17 +23,12 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 )
 
-// TxManager is a database transaction manager. It knows how to start, commit and rollback transactions.
+// TxManager is a database transaction manager. It knows how to start transactions.
 //
 //go:generate mockgen -destination=database_tx_manager_mock.go -package=database . TxManager
 type TxManager interface {
 	// Begin starts a new transaction.
 	Begin(ctx context.Context) (Tx, error)
-
-	// End finishes a transaction. It will be commited or rolled back according to the errors that have been
-	// reported during its execution. See the ReportError of the Tx interface for details. Note that this only
-	// supports transactions created with the Begin method of the same transaction manager.
-	End(ctx context.Context, tx Tx) error
 }
 
 // TxManagerBuilder is a builder responsible for constructing database transaction managers. Don't create instances of
@@ -98,42 +92,20 @@ func (m *txManager) Begin(ctx context.Context) (tx Tx, err error) {
 	return
 }
 
-// End ends the given transaction, commiting it if no errors have been reported, or rolling it back otherwise. Note that
-// this only supports transactions returned by the Begin method of the same transaction manager.
-func (m *txManager) End(ctx context.Context, tx Tx) error {
-	if tx == nil {
+func (t *managedTx) End(ctx context.Context) error {
+	if t.real == nil {
 		return nil
 	}
-	switch tx := tx.(type) {
-	case *managedTx:
-		return m.end(ctx, tx)
-	default:
-		return fmt.Errorf("unsupported transaction type %T", tx)
+	if len(t.errs) == 0 {
+		t.manager.logger.DebugContext(ctx, "Committing transaction")
+		return t.real.Commit(ctx)
 	}
-}
-
-func (m *txManager) end(ctx context.Context, tx *managedTx) error {
-	// Reject the transaction if it hasn't been created by this transaction manager:
-	if tx.manager != m {
-		return errors.New("transaction belongs to another transaction manager")
-	}
-
-	// Nothing to do if no real transaction was started:
-	if tx.real == nil {
-		return nil
-	}
-
-	// Commit the transaction if there are no errors, otherwise roll it back:
-	if len(tx.errs) == 0 {
-		m.logger.DebugContext(ctx, "Committing transaction")
-		return tx.real.Commit(ctx)
-	}
-	m.logger.DebugContext(
+	t.manager.logger.DebugContext(
 		ctx,
 		"Rolling back transaction",
-		slog.Any("errors", tx.errs),
+		slog.Any("errors", t.errs),
 	)
-	return tx.real.Rollback(ctx)
+	return t.real.Rollback(ctx)
 }
 
 // managedTx is an implementation of the transaction interface that will start a real transaction only when one of the

--- a/internal/database/database_tx_manager_mock.go
+++ b/internal/database/database_tx_manager_mock.go
@@ -54,17 +54,3 @@ func (mr *MockTxManagerMockRecorder) Begin(ctx any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Begin", reflect.TypeOf((*MockTxManager)(nil).Begin), ctx)
 }
-
-// End mocks base method.
-func (m *MockTxManager) End(ctx context.Context, tx Tx) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "End", ctx, tx)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// End indicates an expected call of End.
-func (mr *MockTxManagerMockRecorder) End(ctx, tx any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "End", reflect.TypeOf((*MockTxManager)(nil).End), ctx, tx)
-}

--- a/internal/database/database_tx_manager_test.go
+++ b/internal/database/database_tx_manager_test.go
@@ -7,13 +7,11 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"go.uber.org/mock/gomock"
 )
 
 var _ = Describe("Transaction manager", func() {
 	var (
 		ctx  context.Context
-		ctrl *gomock.Controller
 		pool *pgxpool.Pool
 	)
 
@@ -21,9 +19,6 @@ var _ = Describe("Transaction manager", func() {
 		var err error
 
 		ctx = context.Background()
-
-		ctrl = gomock.NewController(GinkgoT())
-		DeferCleanup(ctrl.Finish)
 
 		db, err := server.NewInstance().Build()
 		Expect(err).ToNot(HaveOccurred())
@@ -89,31 +84,6 @@ var _ = Describe("Transaction manager", func() {
 			Expect(err).ToNot(HaveOccurred())
 		})
 
-		It("Should return an error for unsupported transaction types", func() {
-			tx := NewMockTx(ctrl)
-			err := manager.End(ctx, tx)
-			Expect(err).To(MatchError("unsupported transaction type *database.MockTx"))
-		})
-
-		It("Should reject transactions created by another manager", func() {
-			// Create a transaction with another manager:
-			another, err := NewTxManager().
-				SetLogger(logger).
-				SetPool(pool).
-				Build()
-			Expect(err).ToNot(HaveOccurred())
-			tx, err := another.Begin(ctx)
-			Expect(err).ToNot(HaveOccurred())
-			defer func() {
-				err := another.End(ctx, tx)
-				Expect(err).ToNot(HaveOccurred())
-			}()
-
-			// Verify that it is rejected:
-			err = manager.End(ctx, tx)
-			Expect(err).To(MatchError("transaction belongs to another transaction manager"))
-		})
-
 		It("Should commit the transaction if no errors are reported", func() {
 			// Create a table:
 			_, err := pool.Exec(ctx, "create table my_table (my_column text)")
@@ -124,7 +94,7 @@ var _ = Describe("Transaction manager", func() {
 				tx, err := manager.Begin(ctx)
 				Expect(err).ToNot(HaveOccurred())
 				defer func() {
-					err := manager.End(ctx, tx)
+					err := tx.End(ctx)
 					Expect(err).ToNot(HaveOccurred())
 				}()
 				_, err = tx.Exec(ctx, "insert into my_table (my_column) values ($1)", "my_value")
@@ -149,7 +119,7 @@ var _ = Describe("Transaction manager", func() {
 				tx, err := manager.Begin(ctx)
 				Expect(err).ToNot(HaveOccurred())
 				defer func() {
-					err := manager.End(ctx, tx)
+					err := tx.End(ctx)
 					Expect(err).ToNot(HaveOccurred())
 				}()
 				_, err = tx.Exec(ctx, "insert into my_table (my_column) values ($1)", "my_value")

--- a/internal/database/database_tx_mock.go
+++ b/internal/database/database_tx_mock.go
@@ -42,6 +42,20 @@ func (m *MockTx) EXPECT() *MockTxMockRecorder {
 	return m.recorder
 }
 
+// End mocks base method.
+func (m *MockTx) End(ctx context.Context) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "End", ctx)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// End indicates an expected call of End.
+func (mr *MockTxMockRecorder) End(ctx any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "End", reflect.TypeOf((*MockTx)(nil).End), ctx)
+}
+
 // Exec mocks base method.
 func (m *MockTx) Exec(ctx context.Context, query string, args ...any) (pgconn.CommandTag, error) {
 	m.ctrl.T.Helper()

--- a/internal/servers/cluster_templates_server_test.go
+++ b/internal/servers/cluster_templates_server_test.go
@@ -56,7 +56,7 @@ var _ = Describe("Cluster templates server", func() {
 		tx, err = tm.Begin(ctx)
 		Expect(err).ToNot(HaveOccurred())
 		DeferCleanup(func() {
-			err := tm.End(ctx, tx)
+			err := tx.End(ctx)
 			Expect(err).ToNot(HaveOccurred())
 		})
 		ctx = database.TxIntoContext(ctx, tx)

--- a/internal/servers/clusters_server_test.go
+++ b/internal/servers/clusters_server_test.go
@@ -72,7 +72,7 @@ var _ = Describe("Clusters server", func() {
 		tx, err = tm.Begin(ctx)
 		Expect(err).ToNot(HaveOccurred())
 		DeferCleanup(func() {
-			err := tm.End(ctx, tx)
+			err := tx.End(ctx)
 			Expect(err).ToNot(HaveOccurred())
 		})
 		ctx = database.TxIntoContext(ctx, tx)

--- a/internal/servers/compute_instance_catalog_items_server_test.go
+++ b/internal/servers/compute_instance_catalog_items_server_test.go
@@ -55,7 +55,7 @@ var _ = Describe("Compute instance catalog items server", func() {
 		tx, err = tm.Begin(ctx)
 		Expect(err).ToNot(HaveOccurred())
 		DeferCleanup(func() {
-			err := tm.End(ctx, tx)
+			err := tx.End(ctx)
 			Expect(err).ToNot(HaveOccurred())
 		})
 		ctx = database.TxIntoContext(ctx, tx)

--- a/internal/servers/compute_instance_templates_server_test.go
+++ b/internal/servers/compute_instance_templates_server_test.go
@@ -56,7 +56,7 @@ var _ = Describe("Compute instance templates server", func() {
 		tx, err = tm.Begin(ctx)
 		Expect(err).ToNot(HaveOccurred())
 		DeferCleanup(func() {
-			err := tm.End(ctx, tx)
+			err := tx.End(ctx)
 			Expect(err).ToNot(HaveOccurred())
 		})
 		ctx = database.TxIntoContext(ctx, tx)

--- a/internal/servers/console_server.go
+++ b/internal/servers/console_server.go
@@ -363,7 +363,7 @@ func (s *consoleServer) resolveComputeInstance(ctx context.Context, id string) (
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "failed to begin transaction: %v", err)
 	}
-	defer s.txManager.End(ctx, tx)
+	defer tx.End(ctx)
 
 	txCtx := database.TxIntoContext(ctx, tx)
 	resp, err := s.ciServer.Get(txCtx, privatev1.ComputeInstancesGetRequest_builder{

--- a/internal/servers/console_server_test.go
+++ b/internal/servers/console_server_test.go
@@ -156,6 +156,8 @@ func (m *mockTx) Exec(ctx context.Context, query string, args ...any) (pgconn.Co
 
 func (m *mockTx) ReportError(err *error) {}
 
+func (m *mockTx) End(ctx context.Context) error { return nil }
+
 // newFakeHubClientFactory returns a HubClientFactory that ignores the kubeconfig
 // and always returns the provided fake client.
 func newFakeHubClientFactory(client clnt.Client) HubClientFactory {

--- a/internal/servers/public_ip_pools_server_test.go
+++ b/internal/servers/public_ip_pools_server_test.go
@@ -59,7 +59,7 @@ var _ = Describe("Public IP pools server", func() {
 		tx, err = tm.Begin(ctx)
 		Expect(err).ToNot(HaveOccurred())
 		DeferCleanup(func() {
-			err := tm.End(ctx, tx)
+			err := tx.End(ctx)
 			Expect(err).ToNot(HaveOccurred())
 		})
 		ctx = database.TxIntoContext(ctx, tx)

--- a/internal/servers/servers_suite_test.go
+++ b/internal/servers/servers_suite_test.go
@@ -116,7 +116,7 @@ var _ = BeforeEach(func() {
 	tx, err := tm.Begin(ctx)
 	Expect(err).ToNot(HaveOccurred())
 	DeferCleanup(func() {
-		err := tm.End(ctx, tx)
+		err := tx.End(ctx)
 		Expect(err).ToNot(HaveOccurred())
 	})
 	ctx = database.TxIntoContext(ctx, tx)


### PR DESCRIPTION
## Summary

- Moves the `End` method from the `TxManager` interface to the `Tx` interface so that
  callers can simply call `tx.End(ctx)` instead of `manager.End(ctx, tx)`. The
  `managedTx` implementation already holds a back-reference to its manager, so there
  is no need for the transaction manager to mediate the commit/rollback decision.
- Consolidates the commit/rollback logic that was previously split across
  `txManager.End` and `txManager.end` into a single `managedTx.End` method, removing
  the type-switch dispatch and the cross-manager ownership check.
- Updates all production callers, test callers, interceptor mock expectations, and
  regenerated mocks across 26 files.

## Test plan

- [x] `go build ./...` compiles successfully
- [x] `ginkgo run -r internal` passes all 62 test suites

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal transaction management refactoring: transaction completion is now handled directly on transaction objects rather than through a separate transaction manager interface. This change affects how transactions are finalized internally with no impact to end-user functionality or features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->