### PR TITLE
OSAC-1124: Fix Keycloak Group creation per Project

### DIFF
--- a/internal/controllers/project/project_reconciler_function_test.go
+++ b/internal/controllers/project/project_reconciler_function_test.go
@@ -214,12 +214,12 @@ var _ = Describe("Validation and Activation", func() {
 
 			// Expect viewers group creation (new organization groups API)
 			mockIdpClient.EXPECT().
-				CreateAuthorizationGroup(gomock.Any(), "acme", "viewers", "/projects/test-project/viewers").
+				CreateAuthorizationGroup(gomock.Any(), "acme", "viewers", "/test-project/viewers").
 				Return(nil)
 
 			// Expect managers group creation (new organization groups API)
 			mockIdpClient.EXPECT().
-				CreateAuthorizationGroup(gomock.Any(), "acme", "managers", "/projects/test-project/managers").
+				CreateAuthorizationGroup(gomock.Any(), "acme", "managers", "/test-project/managers").
 				Return(nil)
 
 			task := &task{
@@ -258,12 +258,12 @@ var _ = Describe("Validation and Activation", func() {
 
 			// Expect viewers group creation (new organization groups API)
 			mockIdpClient.EXPECT().
-				CreateAuthorizationGroup(gomock.Any(), "acme", "viewers", "/projects/test-project/viewers").
+				CreateAuthorizationGroup(gomock.Any(), "acme", "viewers", "/test-project/viewers").
 				Return(nil)
 
 			// Expect managers group creation (new organization groups API)
 			mockIdpClient.EXPECT().
-				CreateAuthorizationGroup(gomock.Any(), "acme", "managers", "/projects/test-project/managers").
+				CreateAuthorizationGroup(gomock.Any(), "acme", "managers", "/test-project/managers").
 				Return(nil)
 
 			task := &task{
@@ -321,12 +321,12 @@ var _ = Describe("Validation and Activation", func() {
 
 			// Expect viewers group creation (new organization groups API)
 			mockIdpClient.EXPECT().
-				CreateAuthorizationGroup(gomock.Any(), "acme", "viewers", "/projects/child-project/viewers").
+				CreateAuthorizationGroup(gomock.Any(), "acme", "viewers", "/child-project/viewers").
 				Return(nil)
 
 			// Expect managers group creation (new organization groups API)
 			mockIdpClient.EXPECT().
-				CreateAuthorizationGroup(gomock.Any(), "acme", "managers", "/projects/child-project/managers").
+				CreateAuthorizationGroup(gomock.Any(), "acme", "managers", "/child-project/managers").
 				Return(nil)
 
 			task := &task{
@@ -396,12 +396,12 @@ var _ = Describe("Validation and Activation", func() {
 
 			// Expect viewers group creation (new organization groups API)
 			mockIdpClient.EXPECT().
-				CreateAuthorizationGroup(gomock.Any(), "acme", "viewers", "/projects/child-project/viewers").
+				CreateAuthorizationGroup(gomock.Any(), "acme", "viewers", "/child-project/viewers").
 				Return(nil)
 
 			// Expect managers group creation (new organization groups API)
 			mockIdpClient.EXPECT().
-				CreateAuthorizationGroup(gomock.Any(), "acme", "managers", "/projects/child-project/managers").
+				CreateAuthorizationGroup(gomock.Any(), "acme", "managers", "/child-project/managers").
 				Return(nil)
 
 			task := &task{
@@ -787,7 +787,7 @@ var _ = Describe("Deletion Cleanup", func() {
 
 		// Expect viewers group ID lookup (new organization groups API with new paths)
 		mockIdpClient.EXPECT().
-			GetGroupIDByPath(gomock.Any(), "acme", "/projects/test-project/viewers").
+			GetGroupIDByPath(gomock.Any(), "acme", "/test-project/viewers").
 			Return("viewers-group-id", nil)
 
 		// Expect viewers group deletion (new organization groups API)
@@ -797,7 +797,7 @@ var _ = Describe("Deletion Cleanup", func() {
 
 		// Expect managers group ID lookup (new organization groups API with new paths)
 		mockIdpClient.EXPECT().
-			GetGroupIDByPath(gomock.Any(), "acme", "/projects/test-project/managers").
+			GetGroupIDByPath(gomock.Any(), "acme", "/test-project/managers").
 			Return("managers-group-id", nil)
 
 		// Expect managers group deletion (new organization groups API)

--- a/internal/idp/authz_constants.go
+++ b/internal/idp/authz_constants.go
@@ -14,14 +14,11 @@ language governing permissions and limitations under the License.
 package idp
 
 // Authorization group constants for hierarchical project access control.
-// These define the group names and path segments used in Keycloak organization groups.
+// These define the group names used in Keycloak organization groups.
 const (
 	// GroupNameViewers is the name for viewer access groups
 	GroupNameViewers = "viewers"
 
 	// GroupNameManagers is the name for manager access groups
 	GroupNameManagers = "managers"
-
-	// GroupPathProjects is the root path segment for project groups
-	GroupPathProjects = "projects"
 )

--- a/internal/idp/keycloak/authz_groups.go
+++ b/internal/idp/keycloak/authz_groups.go
@@ -20,16 +20,22 @@ import (
 	"log/slog"
 	"net/http"
 	"net/url"
+	"strings"
 )
 
 // CreateAuthorizationGroup creates a Keycloak organization group for authorization purposes.
 // Organization groups are scoped to the organization and support hierarchical paths.
 //
-// Group path format:
-//   - Top-level project: "/Projects/{project-name}/{Viewers|Managers}"
-//   - Nested project: "/Projects/{parent-name}/{project-name}/{Viewers|Managers}"
+// Group path format examples:
+//   - Top-level project: "/{project-name}/{viewers|managers}"
+//     Example: "/web-app/viewers"
+//   - Nested project: "/{parent-project}/{sub-project}/{viewers|managers}"
+//     Example: "/web-app/api/viewers"
+//   - Deeper nesting: "/{project}/{sub-project}/{component}/{viewers|managers}"
+//     Example: "/platform/web-app/api/viewers"
 //
 // Organization groups are scoped per organization, so paths can be simple and readable.
+// This method creates the full hierarchy if parent groups don't exist.
 // See https://www.keycloak.org/2026/04/org-groups for details.
 func (c *Client) CreateAuthorizationGroup(ctx context.Context, organizationName, groupName, groupPath string) error {
 	c.logger.DebugContext(ctx, "Creating organization authorization group",
@@ -44,26 +50,20 @@ func (c *Client) CreateAuthorizationGroup(ctx context.Context, organizationName,
 		return fmt.Errorf("failed to get organization: %w", err)
 	}
 
-	// Use organization groups API instead of realm groups
-	path := fmt.Sprintf("/admin/realms/%s/organizations/%s/groups",
-		url.PathEscape(c.realmName),
-		url.PathEscape(org.ID),
-	)
-
-	groupPayload := map[string]interface{}{
-		"name": groupName,
-		"path": groupPath,
-	}
-
-	response, err := c.httpClient.DoRequest(ctx, http.MethodPost, path, groupPayload)
+	// Parse the path to create parent groups if needed
+	// Path format: /web-app/viewers
+	// We need to ensure /web-app exists, then create viewers under it
+	// Use a cache to avoid redundant API calls within the same operation
+	cache := make(map[string]string) // path -> groupID
+	err = c.ensureGroupHierarchyWithCache(ctx, org.ID, groupPath, cache)
 	if err != nil {
-		return fmt.Errorf("failed to create organization group: %w", err)
+		return fmt.Errorf("failed to ensure group hierarchy: %w", err)
 	}
-	defer response.Body.Close()
 
 	c.logger.DebugContext(ctx, "Created organization authorization group",
 		slog.String("organizationName", organizationName),
 		slog.String("groupName", groupName),
+		slog.String("groupPath", groupPath),
 	)
 
 	return nil
@@ -104,6 +104,181 @@ func (c *Client) DeleteAuthorizationGroup(ctx context.Context, organizationName,
 }
 
 // Helper methods
+
+// ensureGroupHierarchy creates all groups in the path hierarchy if they don't exist.
+//
+// Examples:
+//
+//   - For path "/web-app/viewers":
+//     1. /web-app exists (create if missing)
+//     2. /web-app/viewers exists (create under /web-app if missing)
+//
+//   - For path "/web-app/api/viewers":
+//     1. /web-app exists (create if missing)
+//     2. /web-app/api exists (create under /web-app if missing)
+//     3. /web-app/api/viewers exists (create under /web-app/api if missing)
+func (c *Client) ensureGroupHierarchy(ctx context.Context, orgID, groupPath string) error {
+	cache := make(map[string]string)
+	return c.ensureGroupHierarchyWithCache(ctx, orgID, groupPath, cache)
+}
+
+func (c *Client) ensureGroupHierarchyWithCache(ctx context.Context, orgID, groupPath string, cache map[string]string) error {
+	// Split path into segments (removing leading slash)
+	// "/web-app/viewers" -> ["web-app", "viewers"]
+	segments := strings.Split(strings.Trim(groupPath, "/"), "/")
+	if len(segments) == 0 {
+		return fmt.Errorf("invalid group path: %s", groupPath)
+	}
+
+	var currentPath string
+	var parentID string
+
+	for _, segment := range segments {
+		// Build the current path
+		currentPath = currentPath + "/" + segment
+
+		// Check cache first
+		if cachedID, exists := cache[currentPath]; exists {
+			parentID = cachedID
+			continue
+		}
+
+		// Try to create the group - if it already exists (409), just look it up
+		groupID, err := c.createOrganizationGroupWithParent(ctx, orgID, segment, parentID)
+		if err != nil {
+			// Check if it's a "already exists" error (409 conflict)
+			if strings.Contains(err.Error(), "already exists") || strings.Contains(err.Error(), "status=409") {
+				// Group already exists, look up its ID using orgID directly
+				groupID, lookupErr := c.getGroupIDByPathWithOrgID(ctx, orgID, currentPath)
+				if lookupErr != nil {
+					return fmt.Errorf("group %s already exists but failed to look up ID: %w", currentPath, lookupErr)
+				}
+				// Cache it for subsequent use
+				cache[currentPath] = groupID
+				parentID = groupID
+				continue
+			}
+			return fmt.Errorf("failed to create group %s: %w", currentPath, err)
+		}
+
+		// Cache the created group
+		cache[currentPath] = groupID
+		// Use this group as parent for next iteration
+		parentID = groupID
+	}
+
+	return nil
+}
+
+// createOrganizationGroupWithParent creates a group under a specific parent.
+// If parentID is empty, creates a top-level group.
+func (c *Client) createOrganizationGroupWithParent(ctx context.Context, orgID, name, parentID string) (string, error) {
+	var path string
+	if parentID == "" {
+		// Create top-level group
+		path = fmt.Sprintf("/admin/realms/%s/organizations/%s/groups",
+			url.PathEscape(c.realmName),
+			url.PathEscape(orgID),
+		)
+	} else {
+		// Create child group under parent
+		path = fmt.Sprintf("/admin/realms/%s/organizations/%s/groups/%s/children",
+			url.PathEscape(c.realmName),
+			url.PathEscape(orgID),
+			url.PathEscape(parentID),
+		)
+	}
+
+	groupPayload := map[string]interface{}{
+		"name": name,
+	}
+
+	response, err := c.httpClient.DoRequest(ctx, http.MethodPost, path, groupPayload)
+	if err != nil {
+		return "", fmt.Errorf("failed to create organization group: %w", err)
+	}
+	defer response.Body.Close()
+
+	// Extract the created group ID from the Location header
+	location := response.Header.Get("Location")
+	if location == "" {
+		return "", fmt.Errorf("no Location header in create group response")
+	}
+
+	// Location format: .../groups/{group-id}
+	parts := strings.Split(location, "/")
+	if len(parts) == 0 {
+		return "", fmt.Errorf("invalid Location header: %s", location)
+	}
+	groupID := parts[len(parts)-1]
+
+	return groupID, nil
+}
+
+// groupNode represents a group in the hierarchy for recursive traversal
+type groupNode struct {
+	ID        string      `json:"id"`
+	Name      string      `json:"name"`
+	Path      string      `json:"path"`
+	SubGroups []groupNode `json:"subGroups"`
+}
+
+// getGroupIDByPathWithOrgID returns the group ID for a path using orgID directly (not organization name).
+// This is used internally when we already have the orgID to avoid an extra lookup.
+// Lists all groups and recursively searches the hierarchy since the search parameter is unreliable
+// for recently-created groups.
+func (c *Client) getGroupIDByPathWithOrgID(ctx context.Context, orgID, groupPath string) (string, error) {
+	// List ALL organization groups (without search parameter)
+	// The search parameter is unreliable for recently-created groups
+	path := fmt.Sprintf("/admin/realms/%s/organizations/%s/groups",
+		url.PathEscape(c.realmName),
+		url.PathEscape(orgID),
+	)
+
+	response, err := c.httpClient.DoRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return "", fmt.Errorf("failed to list organization groups: %w", err)
+	}
+	defer response.Body.Close()
+
+	var groups []groupNode
+	if err := json.NewDecoder(response.Body).Decode(&groups); err != nil {
+		return "", fmt.Errorf("failed to decode organization groups: %w", err)
+	}
+
+	// Recursively search through the hierarchy
+	var findGroupByPath func([]groupNode, string) string
+	findGroupByPath = func(groupList []groupNode, targetPath string) string {
+		for _, group := range groupList {
+			if group.Path == targetPath {
+				return group.ID
+			}
+			// Search in subgroups recursively
+			if id := findGroupByPath(group.SubGroups, targetPath); id != "" {
+				return id
+			}
+		}
+		return ""
+	}
+
+	groupID := findGroupByPath(groups, groupPath)
+	if groupID == "" {
+		return "", fmt.Errorf("organization group not found: %s", groupPath)
+	}
+
+	return groupID, nil
+}
+
+// getGroupIDByPathNoError returns the group ID for a path, or empty string if not found (no error).
+// This is only used as a fallback when handling 409 conflicts.
+func (c *Client) getGroupIDByPathNoError(ctx context.Context, orgID, groupPath string) (string, error) {
+	groupID, err := c.getGroupIDByPath(ctx, orgID, groupPath)
+	if err != nil {
+		// If not found, return empty string instead of error
+		return "", nil
+	}
+	return groupID, nil
+}
 
 // GetGroupIDByPath gets a Keycloak organization group ID by its path.
 // This is exposed for use by the ResourceManager.

--- a/internal/idp/keycloak/client_test.go
+++ b/internal/idp/keycloak/client_test.go
@@ -1758,8 +1758,8 @@ var _ = Describe("Keycloak Client", func() {
 
 	Describe("Authorization Groups", func() {
 		Describe("CreateAuthorizationGroup", func() {
-			It("should create an organization group with name and path", func() {
-				var receivedPayload map[string]interface{}
+			It("should create hierarchical organization groups", func() {
+				createdGroups := make(map[string]string) // name -> id
 				server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 					// First request: get organization by name
 					if r.Method == http.MethodGet && r.URL.Path == "/admin/realms/osac/organizations" && r.URL.RawQuery == "exact=true&search=acme-corp" {
@@ -1774,12 +1774,31 @@ var _ = Describe("Keycloak Client", func() {
 						}
 						return
 					}
-					// Second request: create organization group
+					// Create parent group: /web-app
 					if r.Method == http.MethodPost && r.URL.Path == "/admin/realms/osac/organizations/org-123/groups" {
-						if err := json.NewDecoder(r.Body).Decode(&receivedPayload); err != nil {
+						var payload map[string]interface{}
+						if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
 							http.Error(w, err.Error(), http.StatusBadRequest)
 							return
 						}
+						groupName := payload["name"].(string)
+						groupID := "group-" + groupName
+						createdGroups[groupName] = groupID
+						w.Header().Set("Location", "/admin/realms/osac/organizations/org-123/groups/"+groupID)
+						w.WriteHeader(http.StatusCreated)
+						return
+					}
+					// Create child group: viewers under /web-app
+					if r.Method == http.MethodPost && strings.Contains(r.URL.Path, "/children") {
+						var payload map[string]interface{}
+						if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+							http.Error(w, err.Error(), http.StatusBadRequest)
+							return
+						}
+						groupName := payload["name"].(string)
+						groupID := "group-" + groupName
+						createdGroups[groupName] = groupID
+						w.Header().Set("Location", "/admin/realms/osac/organizations/org-123/groups/"+groupID)
 						w.WriteHeader(http.StatusCreated)
 						return
 					}
@@ -1788,10 +1807,10 @@ var _ = Describe("Keycloak Client", func() {
 
 				client = createTestClient(server.URL)
 
-				err := client.CreateAuthorizationGroup(ctx, "acme-corp", "viewers", "/projects/web-app/viewers")
+				err := client.CreateAuthorizationGroup(ctx, "acme-corp", "viewers", "/web-app/viewers")
 				Expect(err).ToNot(HaveOccurred())
-				Expect(receivedPayload["name"]).To(Equal("viewers"))
-				Expect(receivedPayload["path"]).To(Equal("/projects/web-app/viewers"))
+				Expect(createdGroups).To(HaveKey("web-app"))
+				Expect(createdGroups).To(HaveKey("viewers"))
 			})
 
 			It("should return error when organization is not found", func() {
@@ -1810,15 +1829,16 @@ var _ = Describe("Keycloak Client", func() {
 
 				client = createTestClient(server.URL)
 
-				err := client.CreateAuthorizationGroup(ctx, "nonexistent-org", "viewers", "/projects/web-app/viewers")
+				err := client.CreateAuthorizationGroup(ctx, "nonexistent-org", "viewers", "/web-app/viewers")
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("failed to get organization"))
 			})
 
-			It("should return error when group creation fails", func() {
+			It("should handle 409 conflict by looking up existing group", func() {
+				createdGroups := make(map[string]string)
 				server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-					// First request: get organization
-					if r.Method == http.MethodGet && r.URL.Path == "/admin/realms/osac/organizations" {
+					// Get organization
+					if r.Method == http.MethodGet && r.URL.Path == "/admin/realms/osac/organizations" && strings.Contains(r.URL.RawQuery, "search=acme-corp") {
 						orgs := []keycloakOrganization{
 							{ID: "org-123", Name: "acme-corp"},
 						}
@@ -1830,9 +1850,42 @@ var _ = Describe("Keycloak Client", func() {
 						}
 						return
 					}
-					// Second request: create group fails
+					// List or search for existing group
+					if r.Method == http.MethodGet && r.URL.Path == "/admin/realms/osac/organizations/org-123/groups" {
+						// Return the existing group for both search and list operations
+						groups := []struct {
+							ID   string `json:"id"`
+							Path string `json:"path"`
+						}{
+							{ID: "existing-group-id", Path: "/web-app"},
+						}
+						w.Header().Set("Content-Type", "application/json")
+						w.WriteHeader(http.StatusOK)
+						if err := json.NewEncoder(w).Encode(groups); err != nil {
+							http.Error(w, err.Error(), http.StatusInternalServerError)
+							return
+						}
+						return
+					}
+					// Create parent group fails with 409
 					if r.Method == http.MethodPost && r.URL.Path == "/admin/realms/osac/organizations/org-123/groups" {
+						w.Header().Set("Content-Type", "application/json")
 						w.WriteHeader(http.StatusConflict)
+						json.NewEncoder(w).Encode(map[string]string{"errorMessage": "Group with the given name already exists."})
+						return
+					}
+					// Create child group under existing parent
+					if r.Method == http.MethodPost && strings.Contains(r.URL.Path, "/children") {
+						var payload map[string]interface{}
+						if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+							http.Error(w, err.Error(), http.StatusBadRequest)
+							return
+						}
+						groupName := payload["name"].(string)
+						groupID := "group-" + groupName
+						createdGroups[groupName] = groupID
+						w.Header().Set("Location", "/admin/realms/osac/organizations/org-123/groups/"+groupID)
+						w.WriteHeader(http.StatusCreated)
 						return
 					}
 					w.WriteHeader(http.StatusNotFound)
@@ -1840,9 +1893,9 @@ var _ = Describe("Keycloak Client", func() {
 
 				client = createTestClient(server.URL)
 
-				err := client.CreateAuthorizationGroup(ctx, "acme-corp", "viewers", "/projects/web-app/viewers")
-				Expect(err).To(HaveOccurred())
-				Expect(err.Error()).To(ContainSubstring("failed to create organization group"))
+				err := client.CreateAuthorizationGroup(ctx, "acme-corp", "viewers", "/web-app/viewers")
+				Expect(err).ToNot(HaveOccurred())
+				Expect(createdGroups).To(HaveKey("viewers"))
 			})
 		})
 
@@ -1950,7 +2003,7 @@ var _ = Describe("Keycloak Client", func() {
 					// Second request: search organization groups
 					if r.Method == http.MethodGet && r.URL.Path == "/admin/realms/osac/organizations/org-123/groups" {
 						// Verify search query is present with the expected path
-						expectedSearch := "search=%2Fprojects%2Fweb-app%2Fviewers" // URL-encoded "/projects/web-app/viewers"
+						expectedSearch := "search=%2Fweb-app%2Fviewers" // URL-encoded "/web-app/viewers"
 						if !strings.Contains(r.URL.RawQuery, expectedSearch) {
 							w.WriteHeader(http.StatusBadRequest)
 							return
@@ -1959,8 +2012,8 @@ var _ = Describe("Keycloak Client", func() {
 							ID   string `json:"id"`
 							Path string `json:"path"`
 						}{
-							{ID: "group-123", Path: "/projects/web-app/viewers"},
-							{ID: "group-456", Path: "/projects/web-app/managers"},
+							{ID: "group-123", Path: "/web-app/viewers"},
+							{ID: "group-456", Path: "/web-app/managers"},
 						}
 						w.Header().Set("Content-Type", "application/json")
 						w.WriteHeader(http.StatusOK)
@@ -1975,7 +2028,7 @@ var _ = Describe("Keycloak Client", func() {
 
 				client = createTestClient(server.URL)
 
-				groupID, err := client.GetGroupIDByPath(ctx, "acme-corp", "/projects/web-app/viewers")
+				groupID, err := client.GetGroupIDByPath(ctx, "acme-corp", "/web-app/viewers")
 				Expect(err).ToNot(HaveOccurred())
 				Expect(groupID).To(Equal("group-123"))
 			})
@@ -1996,7 +2049,7 @@ var _ = Describe("Keycloak Client", func() {
 
 				client = createTestClient(server.URL)
 
-				_, err := client.GetGroupIDByPath(ctx, "nonexistent-org", "/projects/web-app/viewers")
+				_, err := client.GetGroupIDByPath(ctx, "nonexistent-org", "/web-app/viewers")
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("failed to get organization"))
 			})
@@ -2065,7 +2118,7 @@ var _ = Describe("Keycloak Client", func() {
 
 				client = createTestClient(server.URL)
 
-				_, err := client.GetGroupIDByPath(ctx, "acme-corp", "/projects/web-app/viewers")
+				_, err := client.GetGroupIDByPath(ctx, "acme-corp", "/web-app/viewers")
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("failed to search organization groups"))
 			})

--- a/internal/idp/resource_manager.go
+++ b/internal/idp/resource_manager.go
@@ -129,13 +129,20 @@ func (m *ResourceManager) CreateProjectAuthorizationResource(ctx context.Context
 
 // createProjectAuthorizationGroups creates Keycloak organization groups
 // for viewer and manager access to a project.
-// Uses the hierarchical naming convention: /{projects}/{project-name}/{viewers|managers}
+//
+// Uses the hierarchical naming convention:
+//   - Top-level: /{project-name}/{viewers|managers}
+//   - Nested: /{parent-project}/{sub-project}/{viewers|managers}
+//
+// The projectName parameter should contain the full project path (e.g., "web-app" or "web-app/api").
 func (m *ResourceManager) createProjectAuthorizationGroups(ctx context.Context, resourceID, organizationName, projectName string) error {
 	resourceName := fmt.Sprintf("PROJECT-%s-%s", organizationName, projectName)
 
-	// Create viewers group using new naming convention
-	// Group path: /{projects}/{project-name}/{viewers}
-	viewersGroupPath := fmt.Sprintf("/%s/%s/%s", GroupPathProjects, projectName, GroupNameViewers)
+	// Create viewers group using hierarchical path
+	// Group path: /{project-name}/{viewers}
+	// The CreateAuthorizationGroup method will create parent group (/{project-name})
+	// if it doesn't exist, then create the viewers group under it
+	viewersGroupPath := fmt.Sprintf("/%s/%s", projectName, GroupNameViewers)
 	err := m.client.CreateAuthorizationGroup(ctx, organizationName, GroupNameViewers, viewersGroupPath)
 	if err != nil {
 		return fmt.Errorf("failed to create viewers group: %w", err)
@@ -147,11 +154,9 @@ func (m *ResourceManager) createProjectAuthorizationGroups(ctx context.Context, 
 		slog.String("organization", organizationName),
 	)
 
-	// Create managers group using new naming convention
-	// Group path: /{projects}/{project-name}/{managers}
-	managersGroupName := GroupNameManagers
-	managersGroupPath := fmt.Sprintf("/%s/%s/%s", GroupPathProjects, projectName, GroupNameManagers)
-	err = m.client.CreateAuthorizationGroup(ctx, organizationName, managersGroupName, managersGroupPath)
+	// Create managers group using hierarchical path
+	managersGroupPath := fmt.Sprintf("/%s/%s", projectName, GroupNameManagers)
+	err = m.client.CreateAuthorizationGroup(ctx, organizationName, GroupNameManagers, managersGroupPath)
 	if err != nil {
 		// Clean up viewers group on failure
 		viewersGroupID, getErr := m.getGroupIDByPath(ctx, organizationName, viewersGroupPath)
@@ -258,9 +263,9 @@ func (m *ResourceManager) deleteProjectAuthorizationGroups(ctx context.Context, 
 	if len(parts) > firstDash+1 {
 		projectName := parts[firstDash+1:] // Skip tenant and dash
 
-		// Use new hierarchical paths: /{projects}/{project-name}/{viewers|managers}
-		viewersGroupPath := fmt.Sprintf("/%s/%s/%s", GroupPathProjects, projectName, GroupNameViewers)
-		managersGroupPath := fmt.Sprintf("/%s/%s/%s", GroupPathProjects, projectName, GroupNameManagers)
+		// Use new hierarchical paths: /{project-name}/{viewers|managers}
+		viewersGroupPath := fmt.Sprintf("/%s/%s", projectName, GroupNameViewers)
+		managersGroupPath := fmt.Sprintf("/%s/%s", projectName, GroupNameManagers)
 
 		// TODO: Delete policies first (they reference the groups)
 

--- a/internal/idp/resource_manager_test.go
+++ b/internal/idp/resource_manager_test.go
@@ -98,12 +98,12 @@ var _ = Describe("ResourceManager", func() {
 
 			// Expect viewers group creation (new organization groups API)
 			mockClient.EXPECT().
-				CreateAuthorizationGroup(ctx, "acme", "viewers", "/projects/web-app/viewers").
+				CreateAuthorizationGroup(ctx, "acme", "viewers", "/web-app/viewers").
 				Return(nil)
 
 			// Expect managers group creation (new organization groups API)
 			mockClient.EXPECT().
-				CreateAuthorizationGroup(ctx, "acme", "managers", "/projects/web-app/managers").
+				CreateAuthorizationGroup(ctx, "acme", "managers", "/web-app/managers").
 				Return(nil)
 
 			resourceID, err := manager.CreateProjectAuthorizationResource(ctx, testProjectID, testTenant, testProject, testScopes)
@@ -139,7 +139,7 @@ var _ = Describe("ResourceManager", func() {
 
 			// Viewers group creation fails
 			mockClient.EXPECT().
-				CreateAuthorizationGroup(ctx, "acme", "viewers", "/projects/web-app/viewers").
+				CreateAuthorizationGroup(ctx, "acme", "viewers", "/web-app/viewers").
 				Return(context.DeadlineExceeded)
 
 			// Expect cleanup: delete the resource
@@ -167,17 +167,17 @@ var _ = Describe("ResourceManager", func() {
 
 			// Viewers group creation succeeds
 			mockClient.EXPECT().
-				CreateAuthorizationGroup(ctx, "acme", "viewers", "/projects/web-app/viewers").
+				CreateAuthorizationGroup(ctx, "acme", "viewers", "/web-app/viewers").
 				Return(nil)
 
 			// Managers group creation fails
 			mockClient.EXPECT().
-				CreateAuthorizationGroup(ctx, "acme", "managers", "/projects/web-app/managers").
+				CreateAuthorizationGroup(ctx, "acme", "managers", "/web-app/managers").
 				Return(context.DeadlineExceeded)
 
 			// Expect cleanup: get viewers group ID, then delete it
 			mockClient.EXPECT().
-				GetGroupIDByPath(ctx, "acme", "/projects/web-app/viewers").
+				GetGroupIDByPath(ctx, "acme", "/web-app/viewers").
 				Return("viewers-group-id", nil)
 			mockClient.EXPECT().
 				DeleteAuthorizationGroup(ctx, "acme", "viewers-group-id").
@@ -213,7 +213,7 @@ var _ = Describe("ResourceManager", func() {
 
 			// Get viewers group ID (new organization groups API)
 			mockClient.EXPECT().
-				GetGroupIDByPath(ctx, "acme", "/projects/web-app/viewers").
+				GetGroupIDByPath(ctx, "acme", "/web-app/viewers").
 				Return("viewers-group-id", nil)
 
 			// Delete viewers group (new organization groups API)
@@ -223,7 +223,7 @@ var _ = Describe("ResourceManager", func() {
 
 			// Get managers group ID (new organization groups API)
 			mockClient.EXPECT().
-				GetGroupIDByPath(ctx, "acme", "/projects/web-app/managers").
+				GetGroupIDByPath(ctx, "acme", "/web-app/managers").
 				Return("managers-group-id", nil)
 
 			// Delete managers group (new organization groups API)
@@ -276,12 +276,12 @@ var _ = Describe("ResourceManager", func() {
 
 			// Viewers group lookup fails
 			mockClient.EXPECT().
-				GetGroupIDByPath(ctx, "acme", "/projects/web-app/viewers").
+				GetGroupIDByPath(ctx, "acme", "/web-app/viewers").
 				Return("", context.DeadlineExceeded)
 
 			// Managers group lookup succeeds
 			mockClient.EXPECT().
-				GetGroupIDByPath(ctx, "acme", "/projects/web-app/managers").
+				GetGroupIDByPath(ctx, "acme", "/web-app/managers").
 				Return("managers-group-id", nil)
 
 			// Managers group deletion fails


### PR DESCRIPTION
# Description
This creates the group hierarchy correctly.

Previously, the group was a flat structure of viewers and managers, and did not have the project hierarchy. If more than one project/group was created in the same organization, this would fail with the group already existing because we only had the "viewers" and "managers" groups.

This creates an actual group per project, which creates viewers and managers groups within that project.

# Testing

- [x] Build passes `go build ./...`
- [x] All unit tests successfully passed 
- [x] Created integration test environment and created projects in the same organization successfully

<img width="1245" height="624" alt="Screenshot 2026-06-05 at 3 03 50 PM" src="https://github.com/user-attachments/assets/057f99a2-a429-4d93-ab63-901abf394c8d" />


Assisted-by: Claude Code <noreply@anthropic.com>

/cc @jhernand 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified authorization group path structure by removing the `/projects/` prefix segment; groups now use a flatter hierarchy (e.g., `/<project-name>/viewers` instead of `/projects/<project-name>/viewers`).
  * Enhanced hierarchical group creation to automatically establish parent-child relationships and gracefully handle existing groups during creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->