### PR TITLE
Add helm as a requirement development tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ To work with this project you will need the following tools:
 - [curl](https://curl.se) - Used to test the REST API from the CLI.
 - [jq](https://jqlang.org) - Used by some of the commands in this document.
 - [kind](https://kind.sigs.k8s.io) - Used to create Kubernetes clusters for integration tests.
-- [helm](https://helm.sh/) - Used when running integration tests.
+- [helm](https://helm.sh/) - Used by default to deploy the service during integration tests.
 
 ## Building the binaries
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ To work with this project you will need the following tools:
 - [curl](https://curl.se) - Used to test the REST API from the CLI.
 - [jq](https://jqlang.org) - Used by some of the commands in this document.
 - [kind](https://kind.sigs.k8s.io) - Used to create Kubernetes clusters for integration tests.
+- [helm](https://helm.sh/) - Used when running integration tests.
 
 ## Building the binaries
 


### PR DESCRIPTION
I added helm as a requirement to the project in the README since it's needed when running the integration tests, it fails without it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the project's README to include Helm in the list of required development tools, ensuring contributors are aware of this additional local tool requirement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->