### PR TITLE
Add UDN-related gRPC methods to AuthConfig

### DIFF
--- a/charts/service/templates/grpc-server/authconfig.yaml
+++ b/charts/service/templates/grpc-server/authconfig.yaml
@@ -194,6 +194,8 @@ spec:
               "/osac.public.v1.Clusters/GetPasswordViaHttp",
               "/osac.public.v1.Clusters/List",
               "/osac.public.v1.Clusters/Update",
+              "/osac.public.v1.ClusterCatalogItems/Get",
+              "/osac.public.v1.ClusterCatalogItems/List",
               "/osac.public.v1.ComputeInstanceTemplates/Get",
               "/osac.public.v1.ComputeInstanceTemplates/List",
               "/osac.public.v1.ComputeInstances/Create",

--- a/manifests/base/grpc-server/authconfig.yaml
+++ b/manifests/base/grpc-server/authconfig.yaml
@@ -193,6 +193,8 @@ spec:
               "/osac.public.v1.Clusters/GetPasswordViaHttp",
               "/osac.public.v1.Clusters/List",
               "/osac.public.v1.Clusters/Update",
+              "/osac.public.v1.ClusterCatalogItems/Get",
+              "/osac.public.v1.ClusterCatalogItems/List",
               "/osac.public.v1.ComputeInstanceTemplates/Get",
               "/osac.public.v1.ComputeInstanceTemplates/List",
               "/osac.public.v1.ComputeInstances/Create",


### PR DESCRIPTION
Added UDN related method to help with CaaS deployment. Cluster creation is now using clustercatalogmethods and we should be able to list,delete,etc them.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Expanded authorization permissions for ClusterCatalogItems operations. Clients, tenant administrators, and identity provider managers are now authorized to create, delete, retrieve, and list catalog items. This authorization update enhances catalog management capabilities, enabling comprehensive workflow support and improved operational flexibility for administrative stakeholders.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->