### PR TITLE
OSAC-953: Update AuthConfig to use organization groups

### DIFF
--- a/internal/auth/grpc_authz_interceptor.go
+++ b/internal/auth/grpc_authz_interceptor.go
@@ -476,8 +476,13 @@ func (i *GrpcAuthzInterceptor) buildInput(ctx context.Context, method string, re
 		if groups := claimAsAnySlice(claims, "groups"); groups != nil {
 			identity["groups"] = groups
 		}
-		if org := claimAsAnySlice(claims, "organization"); org != nil {
-			identity["organization"] = org
+		// Handle organization claim - can be array or object
+		if orgValue := claims["organization"]; orgValue != nil {
+			if orgArray := claimAsAnySlice(claims, "organization"); orgArray != nil {
+				identity["organization"] = orgArray
+			} else if orgObj, ok := orgValue.(map[string]any); ok {
+				identity["organization"] = orgObj
+			}
 		}
 		if orgs := claimAsAnySlice(claims, "organizations"); orgs != nil {
 			identity["organizations"] = orgs

--- a/internal/auth/grpc_authz_interceptor_test.go
+++ b/internal/auth/grpc_authz_interceptor_test.go
@@ -658,61 +658,6 @@ var _ = Describe("Rego authorization interceptor", func() {
 			Expect(handled).To(BeFalse())
 		})
 
-		It("Falls back to groups for tenant when organization and organizations are absent", func(ctx context.Context) {
-			token := createKeycloakUserToken("", "my-user", jwt.MapClaims{
-				"organization": nil,
-				"groups": []any{
-					"my-tenant",
-				},
-			})
-			ctx = ContextWithToken(ctx, token)
-			handled := false
-			_, err := interceptor.UnaryServer(
-				ctx,
-				nil,
-				&grpc.UnaryServerInfo{
-					FullMethod: "/osac.public.v1.Clusters/Create",
-				},
-				func(ctx context.Context, req any) (any, error) {
-					subject := SubjectFromContext(ctx)
-					Expect(subject.User).To(Equal("my-user"))
-					Expect(subject.Tenants.Finite()).To(BeTrue())
-					Expect(subject.Tenants.Inclusions()).To(ConsistOf("my-tenant"))
-					handled = true
-					return nil, nil
-				},
-			)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(handled).To(BeTrue())
-		})
-
-		It("Denies groups-only user without tenant-admin role on user management RPCs", func(ctx context.Context) {
-			token := createKeycloakUserToken("", "my-user", jwt.MapClaims{
-				"organization": nil,
-				"groups": []any{
-					"my-tenant",
-				},
-			})
-			ctx = ContextWithToken(ctx, token)
-			handled := false
-			_, err := interceptor.UnaryServer(
-				ctx,
-				nil,
-				&grpc.UnaryServerInfo{
-					FullMethod: "/osac.public.v1.Users/Create",
-				},
-				func(ctx context.Context, req any) (any, error) {
-					handled = true
-					return nil, nil
-				},
-			)
-			Expect(err).To(HaveOccurred())
-			status, ok := grpcstatus.FromError(err)
-			Expect(ok).To(BeTrue())
-			Expect(status.Code()).To(Equal(grpccodes.PermissionDenied))
-			Expect(handled).To(BeFalse())
-		})
-
 		It("Grants admin privileges when groups include the admins group", func(ctx context.Context) {
 			token := createKeycloakUserToken("", "my-user", jwt.MapClaims{
 				"organization": nil,

--- a/internal/auth/policies/authz.rego
+++ b/internal/auth/policies/authz.rego
@@ -66,24 +66,22 @@ subject_groups = input.auth.identity.groups if {
 
 # Get the subject's tenant(s) from JWT claims or service account namespace
 # For JWT users, this comes from the "organization" scope which is in defaultClientScopes.
-# The organization claim is required for tenant admins and IdP managers.
-# For regular users without organization claim, fall back to groups.
+# JWT users without an organization claim will have an empty tenant list.
+# For service accounts, groups are used as tenants.
 default subject_tenants = []
+
+# Extract tenant names from organization array (simple format: ["org-name"])
 subject_tenants = input.auth.identity.organization if {
   input.auth.identity.authnMethod == "jwt"
-  input.auth.identity.organization
+  is_array(input.auth.identity.organization)
 }
-subject_tenants = input.auth.identity.organizations if {
+
+# Extract tenant names from organization object (Keycloak format: {"org-name": {"groups": [...]}})
+subject_tenants = [org_name | input.auth.identity.organization[org_name]] if {
   input.auth.identity.authnMethod == "jwt"
-  not input.auth.identity.organization
-  input.auth.identity.organizations
+  is_object(input.auth.identity.organization)
 }
-# Fallback to groups for JWT users without organization claim
-subject_tenants = subject_groups if {
-  input.auth.identity.authnMethod == "jwt"
-  not input.auth.identity.organization
-  not input.auth.identity.organizations
-}
+
 # For service accounts, use groups as tenants
 subject_tenants = subject_groups if {
   input.auth.identity.authnMethod == "serviceaccount"
@@ -95,6 +93,25 @@ subject_realm_roles = input.auth.identity.realm_access.roles if {
   input.auth.identity.authnMethod == "jwt"
   input.auth.identity.realm_access
   input.auth.identity.realm_access.roles
+}
+
+# Organization dictionary extraction
+default subject_org_groups = {}
+
+# If organization is an object with groups, use it directly
+subject_org_groups := input.auth.identity.organization if {
+  input.auth.identity.authnMethod == "jwt"
+  is_object(input.auth.identity.organization)
+}
+
+# If organization is an array, build org groups from top-level groups claim
+# This creates a structure: {"org-name": {"groups": ["group1", "group2"]}}
+subject_org_groups := {tenant: {"groups": input.auth.identity.groups} |
+  some tenant in input.auth.identity.organization
+} if {
+  input.auth.identity.authnMethod == "jwt"
+  is_array(input.auth.identity.organization)
+  input.auth.identity.groups
 }
 
 # Check if an account is an admin account:
@@ -287,6 +304,46 @@ allow if {
 # Allow everything to admins:
 allow if {
   is_admin
+}
+
+# Project authorization
+# Tenant admins can create projects
+allow if {
+  is_tenant_admin
+  grpc_method == "/osac.public.v1.Projects/Create"
+}
+
+# All authenticated users with client permissions can list projects
+# (application layer filters results based on actual project memberships)
+allow if {
+  has_client_permissions
+  grpc_method == "/osac.public.v1.Projects/List"
+}
+
+# Project Get authorization - allow viewers or managers
+allow if {
+  grpc_method == "/osac.public.v1.Projects/Get"
+  tenant := input.context.context_extensions.tenant
+  name := input.context.context_extensions.name
+  input.auth.identity.authnMethod == "jwt"
+  some group in subject_org_groups[tenant].groups
+  group in {
+    sprintf("/%s/viewers", [name]),
+    sprintf("/%s/managers", [name]),
+  }
+}
+
+# Project Update/Delete authorization via organization groups
+allow if {
+  grpc_method in {
+    "/osac.public.v1.Projects/Update",
+    "/osac.public.v1.Projects/Delete",
+  }
+  tenant := input.context.context_extensions.tenant
+  name := input.context.context_extensions.name
+  input.auth.identity.authnMethod == "jwt"
+  some group in subject_org_groups[tenant].groups
+  group == sprintf("/%s/managers", [name])
 }
 
 # Subject construction:

--- a/it/charts/keycloak/files/realm.json
+++ b/it/charts/keycloak/files/realm.json
@@ -579,6 +579,7 @@
     "authenticationFlowBindingOverrides" : { },
     "fullScopeAllowed" : true,
     "nodeReRegistrationTimeout" : -1,
+    "protocolMappers" : null,
     "defaultClientScopes" : [ "groups", "basic", "username", "organization", "roles", "osac-api" ],
     "optionalClientScopes" : [ ]
   }, {

--- a/it/it_multitenancy_test.go
+++ b/it/it_multitenancy_test.go
@@ -330,6 +330,8 @@ var _ = Describe("Multitenancy basic tenant isolation", Ordered, Label("multiten
 				}
 				Expect(err).ToNot(HaveOccurred())
 			}
+			// Tenants are already created in tool setup (createTenants),
+			// so we don't need to create them again here.
 		})
 
 		Describe("cluster resources", func() {
@@ -344,6 +346,29 @@ var _ = Describe("Multitenancy basic tenant isolation", Ordered, Label("multiten
 
 				// Create map to track which clusters can be seen by which tenants
 				clusterTenantMapping = make(map[string][]string)
+
+				// Create the tenants used by the tests:
+				tenantsClient := privatev1.NewTenantsClient(tool.InternalView().AdminConn())
+				uniqueTenants := make(map[string]bool)
+				for _, tenants := range OIDCTenants {
+					for _, tenant := range tenants {
+						uniqueTenants[tenant] = true
+					}
+				}
+				for tenant := range uniqueTenants {
+					_, err := tenantsClient.Create(ctx, privatev1.TenantsCreateRequest_builder{
+						Object: privatev1.Tenant_builder{
+							Metadata: privatev1.Metadata_builder{
+								Name: tenant,
+							}.Build(),
+						}.Build(),
+					}.Build())
+					status, ok := grpcstatus.FromError(err)
+					if ok && status.Code() == grpccodes.AlreadyExists {
+						err = nil
+					}
+					Expect(err).ToNot(HaveOccurred())
+				}
 
 				// Create host type for testing
 				hostTypeId := fmt.Sprintf("oidc-isolation-hosttype-%s", uuid.New())

--- a/it/it_tenant_lifecycle_test.go
+++ b/it/it_tenant_lifecycle_test.go
@@ -528,13 +528,9 @@ var _ = Describe("Tenant authorization boundaries", func() {
 		By("Verifying 'organization' claim contains the org name")
 		orgClaim, ok := claims["organization"]
 		Expect(ok).To(BeTrue(), "JWT should contain 'organization' claim")
-		orgList, ok := orgClaim.([]any)
-		Expect(ok).To(BeTrue(), "'organization' claim should be an array")
-		orgStrings := make([]string, len(orgList))
-		for i, o := range orgList {
-			orgStrings[i], _ = o.(string)
-		}
-		Expect(orgStrings).To(ContainElement(name))
+		orgNames, err := ExtractOrganizationNames(orgClaim)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(orgNames).To(ContainElement(name))
 
 		By("Verifying 'tenant-idp-manager' role in realm_access")
 		realmAccess, ok := claims["realm_access"]

--- a/it/it_tool.go
+++ b/it/it_tool.go
@@ -25,6 +25,7 @@ import (
 	"log/slog"
 	"net"
 	"net/http"
+	"net/url"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -74,7 +75,7 @@ var ServiceAccountTenants = map[string]string{
 
 var OIDCTenants = map[string][]string{
 	"adam":    {"engineering"},
-	"ben":     {"engineering", "sales"},
+	"ben":     {"development"},
 	"charles": {"sales"},
 }
 
@@ -426,6 +427,12 @@ func (t *Tool) Setup(ctx context.Context) error {
 
 	// Create the test tenants:
 	err = t.createTenants(ctx)
+	if err != nil {
+		return err
+	}
+
+	// Add users to Keycloak Organizations:
+	err = t.addUsersToKeycloakOrganizations(ctx)
 	if err != nil {
 		return err
 	}
@@ -1775,21 +1782,243 @@ func (t *Tool) createTenants(ctx context.Context) error {
 	// have two tenants, one for regular users and one for system administrators. System administrators belong to
 	// the 'system' tenant, which is built-in and doesn't need to be explicitly created, so we only need to create
 	// the tenant for regular users. Tests may create additional tenants as needed.
-	tenantsClient := privatev1.NewTenantsClient(t.internalView.adminConn)
-	_, err := tenantsClient.Create(ctx, privatev1.TenantsCreateRequest_builder{
-		Object: privatev1.Tenant_builder{
-			Id: usersGroup,
-			Metadata: privatev1.Metadata_builder{
-				Name:   usersGroup,
-				Tenant: usersGroup,
-			}.Build(),
-		}.Build(),
-	}.Build())
-	status, ok := grpcstatus.FromError(err)
-	if ok && status.Code() == grpccodes.AlreadyExists {
-		err = nil
+	uniqueTenants := make(map[string]bool)
+	uniqueTenants[usersGroup] = true
+	for _, tenants := range OIDCTenants {
+		for _, tenant := range tenants {
+			uniqueTenants[tenant] = true
+		}
 	}
-	return err
+	tenantsClient := privatev1.NewTenantsClient(t.internalView.adminConn)
+	for tenant := range uniqueTenants {
+		_, err := tenantsClient.Create(ctx, privatev1.TenantsCreateRequest_builder{
+			Object: privatev1.Tenant_builder{
+				Metadata: privatev1.Metadata_builder{
+					Name:   tenant,
+					Tenant: tenant,
+				}.Build(),
+			}.Build(),
+		}.Build())
+		status, ok := grpcstatus.FromError(err)
+		if ok && status.Code() == grpccodes.AlreadyExists {
+			continue
+		}
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// addUsersToKeycloakOrganizations adds test users to their corresponding tenant (Keycloak organization)
+// so that the organization claim is included in their JWT tokens.
+func (t *Tool) addUsersToKeycloakOrganizations(ctx context.Context) error {
+	// Build a map of tenant name to list of users
+	tenantUsers := make(map[string][]string)
+	tenantUsers[usersGroup] = []string{userUsername}
+	for user, tenants := range OIDCTenants {
+		for _, tenant := range tenants {
+			tenantUsers[tenant] = append(tenantUsers[tenant], user)
+		}
+	}
+
+	// For each tenant, get its Keycloak Organization ID and add all users to it
+	for tenantName, users := range tenantUsers {
+		// Wait for the tenant to be synced to Keycloak by the controller
+		var tenantId string
+		backOff := backoff.NewExponentialBackOff()
+		backOff.InitialInterval = 1 * time.Second
+		backOff.MaxInterval = 10 * time.Second
+		backOff.MaxElapsedTime = 60 * time.Second
+		err := backoff.Retry(func() error {
+			query := url.Values{}
+			query.Set("exact", "true")
+			query.Set("search", tenantName)
+			code, body, err := t.KeycloakAdminRequest(ctx, http.MethodGet,
+				"/organizations?"+query.Encode(), nil)
+			if err != nil {
+				return fmt.Errorf("failed to get tenant '%s': %w", tenantName, err)
+			}
+			if code != http.StatusOK {
+				return fmt.Errorf("failed to get tenant '%s': status=%d body=%s", tenantName, code, string(body))
+			}
+
+			var orgs []map[string]any
+			if err := json.Unmarshal(body, &orgs); err != nil {
+				return fmt.Errorf("failed to parse organizations response: %w", err)
+			}
+			if len(orgs) == 0 {
+				t.logger.DebugContext(
+					ctx,
+					"Tenant not yet synced to Keycloak, will retry",
+					"tenant", tenantName,
+				)
+				return fmt.Errorf("tenant '%s' not found in Keycloak", tenantName)
+			}
+
+			id, ok := orgs[0]["id"].(string)
+			if !ok {
+				return fmt.Errorf("tenant '%s' has no id", tenantName)
+			}
+			tenantId = id
+			return nil
+		}, backoff.WithContext(backOff, ctx))
+		if err != nil {
+			return err
+		}
+
+		// Add each user to this tenant
+		for _, username := range users {
+			// Get user ID by username
+			query := url.Values{}
+			query.Set("username", username)
+			query.Set("exact", "true")
+			code, body, err := t.KeycloakAdminRequest(ctx, http.MethodGet,
+				"/users?"+query.Encode(), nil)
+			if err != nil {
+				return fmt.Errorf("failed to get user '%s': %w", username, err)
+			}
+			if code != http.StatusOK {
+				return fmt.Errorf("failed to get user '%s': status=%d body=%s", username, code, string(body))
+			}
+
+			var usersResult []map[string]any
+			if err := json.Unmarshal(body, &usersResult); err != nil {
+				return fmt.Errorf("failed to parse users response: %w", err)
+			}
+			if len(usersResult) == 0 {
+				return fmt.Errorf("user '%s' not found in Keycloak", username)
+			}
+
+			userId, ok := usersResult[0]["id"].(string)
+			if !ok {
+				return fmt.Errorf("user '%s' has no id", username)
+			}
+
+			// Add user to organization
+			code, body, err = t.KeycloakAdminRequest(ctx, http.MethodPost,
+				fmt.Sprintf("/organizations/%s/members", tenantId), userId)
+			if err != nil {
+				return fmt.Errorf("failed to add user '%s' to tenant '%s': %w", username, tenantName, err)
+			}
+			// 201 Created, 204 No Content, or 409 Conflict (already a member) are all acceptable
+			if code != http.StatusCreated && code != http.StatusNoContent && code != http.StatusConflict {
+				return fmt.Errorf("failed to add user '%s' to organization '%s': status=%d body=%s",
+					username, tenantName, code, string(body))
+			}
+
+			t.logger.InfoContext(ctx, "Added user to Keycloak tenant",
+				"!user", username, "!tenant", tenantName)
+		}
+
+		// Create a default group in the tenant and add all users to it.
+		// This is required for the oidc-tenant-group-membership-mapper to include
+		// the tenant in the JWT token's tenant claim.
+		defaultGroupName := "/members"
+		groupPayload := map[string]any{
+			"name": defaultGroupName,
+		}
+		code, body, err := t.KeycloakAdminRequest(ctx, http.MethodPost,
+			fmt.Sprintf("/organizations/%s/groups", tenantId), groupPayload)
+		if err != nil {
+			return fmt.Errorf("failed to create group '%s' in tenant '%s': %w",
+				defaultGroupName, tenantName, err)
+		}
+		// 201 Created or 409 Conflict (already exists) are acceptable
+		if code != http.StatusCreated && code != http.StatusConflict {
+			return fmt.Errorf("failed to create group '%s' in tenant '%s': status=%d body=%s",
+				defaultGroupName, tenantName, code, string(body))
+		}
+
+		// Get the group ID
+		var groupId string
+		if code == http.StatusCreated {
+			// Parse the created group response to get the ID
+			var groupResp map[string]any
+			if err := json.Unmarshal(body, &groupResp); err != nil {
+				return fmt.Errorf("failed to parse group creation response: %w", err)
+			}
+			groupId, _ = groupResp["id"].(string)
+		}
+
+		if groupId == "" {
+			// Group already existed, need to fetch it
+			code, body, err = t.KeycloakAdminRequest(ctx, http.MethodGet,
+				fmt.Sprintf("/organizations/%s/groups", tenantId), nil)
+			if err != nil {
+				return fmt.Errorf("failed to get groups for tenant '%s': %w", tenantName, err)
+			}
+			if code != http.StatusOK {
+				return fmt.Errorf("failed to get groups for tenant '%s': status=%d body=%s",
+					tenantName, code, string(body))
+			}
+
+			var groups []map[string]any
+			if err := json.Unmarshal(body, &groups); err != nil {
+				return fmt.Errorf("failed to parse groups response: %w", err)
+			}
+
+			for _, g := range groups {
+				if name, ok := g["name"].(string); ok && name == defaultGroupName {
+					groupId, _ = g["id"].(string)
+					break
+				}
+			}
+
+			if groupId == "" {
+				return fmt.Errorf("failed to find group '%s' in tenant '%s'",
+					defaultGroupName, tenantName)
+			}
+		}
+
+		// Add all users in this organization to the default group
+		for _, username := range users {
+			// Get user ID by username
+			query := url.Values{}
+			query.Set("username", username)
+			query.Set("exact", "true")
+			code, body, err = t.KeycloakAdminRequest(ctx, http.MethodGet,
+				"/users?"+query.Encode(), nil)
+			if err != nil {
+				return fmt.Errorf("failed to get user '%s': %w", username, err)
+			}
+			if code != http.StatusOK {
+				return fmt.Errorf("failed to get user '%s': status=%d body=%s",
+					username, code, string(body))
+			}
+
+			var usersResult []map[string]any
+			if err := json.Unmarshal(body, &usersResult); err != nil {
+				return fmt.Errorf("failed to parse users response: %w", err)
+			}
+			if len(usersResult) == 0 {
+				return fmt.Errorf("user '%s' not found in Keycloak", username)
+			}
+
+			userId, ok := usersResult[0]["id"].(string)
+			if !ok {
+				return fmt.Errorf("user '%s' has no id", username)
+			}
+
+			// Add user to the group
+			code, body, err = t.KeycloakAdminRequest(ctx, http.MethodPut,
+				fmt.Sprintf("/organizations/%s/groups/%s/members/%s", tenantId, groupId, userId), nil)
+			if err != nil {
+				return fmt.Errorf("failed to add user '%s' to group '%s' in tenant '%s': %w",
+					username, defaultGroupName, tenantName, err)
+			}
+			// 200 OK, 201 Created, 204 No Content, or 409 Conflict (already a member) are all acceptable
+			if code != http.StatusOK && code != http.StatusCreated && code != http.StatusNoContent && code != http.StatusConflict {
+				return fmt.Errorf("failed to add user '%s' to group '%s' in tenant '%s': status=%d body=%s",
+					username, defaultGroupName, tenantName, code, string(body))
+			}
+
+			t.logger.InfoContext(ctx, "Added user to tenant group",
+				"!user", username, "!tenant", tenantName, "group", defaultGroupName)
+		}
+	}
+
+	return nil
 }
 
 func (t *Tool) createUserServiceAccounts(ctx context.Context) error {
@@ -1862,7 +2091,7 @@ func (t *Tool) makeKeycloakTokenSource(ctx context.Context, username, password s
 		SetClientId("osac-cli").
 		SetUsername(username).
 		SetPassword(password).
-		SetScopes("openid").
+		SetScopes("openid", "organization").
 		Build()
 	return
 }
@@ -2470,3 +2699,30 @@ const (
 	adminClientId      = "osac-admin"
 	controllerClientId = "osac-controller"
 )
+
+// ExtractOrganizationNames extracts organization names from a JWT organization claim.
+// The claim can be in two formats:
+// - Array format: ["org1", "org2"]
+// - Object format with groups: {"org1": {"groups": [...]}, "org2": {"groups": [...]}}
+func ExtractOrganizationNames(orgClaim any) ([]string, error) {
+	switch v := orgClaim.(type) {
+	case []any:
+		// Simple array format: ["org-name"]
+		var orgNames []string
+		for _, o := range v {
+			if s, ok := o.(string); ok {
+				orgNames = append(orgNames, s)
+			}
+		}
+		return orgNames, nil
+	case map[string]any:
+		// Object format with groups: {"org-name": {"groups": [...]}}
+		var orgNames []string
+		for orgName := range v {
+			orgNames = append(orgNames, orgName)
+		}
+		return orgNames, nil
+	default:
+		return nil, fmt.Errorf("organization claim should be an array or object, got %T", orgClaim)
+	}
+}

--- a/manifests/base/grpc-server/authconfig.yaml
+++ b/manifests/base/grpc-server/authconfig.yaml
@@ -90,23 +90,22 @@ spec:
 
           # Get the subject's tenant(s) from JWT claims or service account namespace
           # For JWT users, this comes from the "organization" scope which is in defaultClientScopes.
-          # The organization claim is required for tenant admins and IdP managers.
-          # For regular users without organization claim, fall back to groups.
+          # JWT users without an organization claim will have an empty tenant list.
+          # For service accounts, groups are used as tenants.
           default subject_tenants = []
+
+          # Extract tenant names from organization array (simple format: ["org-name"])
           subject_tenants = input.auth.identity.organization if {
             input.auth.identity.authnMethod == "jwt"
-            input.auth.identity.organization
+            is_array(input.auth.identity.organization)
           }
-          subject_tenants = input.auth.identity.organizations if {
+
+          # Extract tenant names from organization object (Keycloak format: {"org-name": {"groups": [...]}})
+          subject_tenants = [org_name | input.auth.identity.organization[org_name]] if {
             input.auth.identity.authnMethod == "jwt"
-            input.auth.identity.organizations
+            is_object(input.auth.identity.organization)
           }
-          # Fallback to groups for JWT users without organization claim
-          subject_tenants = subject_groups if {
-            input.auth.identity.authnMethod == "jwt"
-            not input.auth.identity.organization
-            not input.auth.identity.organizations
-          }
+
           # For service accounts, use groups as tenants
           subject_tenants = subject_groups if {
             input.auth.identity.authnMethod == "serviceaccount"
@@ -118,6 +117,24 @@ spec:
             input.auth.identity.authnMethod == "jwt"
             input.auth.identity.realm_access
             input.auth.identity.realm_access.roles
+          }
+
+          # Organization dictionary extraction
+          default subject_org_groups = {}
+
+          # If organization is an object with groups, use it directly
+          subject_org_groups := input.auth.identity.organization if {
+            input.auth.identity.authnMethod == "jwt"
+            is_object(input.auth.identity.organization)
+          }
+
+          # If organization is an array, create empty group mappings for each org
+          # Organization groups are only populated by the object-shaped organization claim
+          subject_org_groups := {tenant: {"groups": []} |
+            some tenant in input.auth.identity.organization
+          } if {
+            input.auth.identity.authnMethod == "jwt"
+            is_array(input.auth.identity.organization)
           }
 
           # Check if an account is an admin account:
@@ -271,6 +288,45 @@ spec:
           # Allow everything to admins:
           allow if {
             is_admin
+          }
+          # Project authorization
+          # Tenant admins can create projects
+          allow if {
+            is_tenant_admin
+            grpc_method == "/osac.public.v1.Projects/Create"
+          }
+
+          # All authenticated users with client permissions can list projects
+          # (application layer filters results based on actual project memberships)
+          allow if {
+            has_client_permissions
+            grpc_method == "/osac.public.v1.Projects/List"
+          }
+
+          # Project Get authorization - allow viewers or managers
+          allow if {
+            grpc_method == "/osac.public.v1.Projects/Get"
+            tenant := input.context.context_extensions.tenant
+            name := input.context.context_extensions.name
+            input.auth.identity.authnMethod == "jwt"
+            some group in subject_org_groups[tenant].groups
+            group in {
+              sprintf("/%s/viewers", [name]),
+              sprintf("/%s/managers", [name]),
+            }
+          }
+
+          # Project Update/Delete authorization via organization groups
+          allow if {
+            grpc_method in {
+              "/osac.public.v1.Projects/Update",
+              "/osac.public.v1.Projects/Delete",
+            }
+            tenant := input.context.context_extensions.tenant
+            name := input.context.context_extensions.name
+            input.auth.identity.authnMethod == "jwt"
+            some group in subject_org_groups[tenant].groups
+            group == sprintf("/%s/managers", [name])
           }
   response:
     success:


### PR DESCRIPTION
# Description
Determine if a user can get/update/delete a project based on the organization group they're part of.

# Testing

- [x] Ran integration test
    - Logged in as admin on CLI and created organization test-org, added user ben, assigned ben tenant-admin role
    - Logged in as ben on CLI and created project, verify able to see project
    - Logged in as charles on CLI and verify not able to see project
    - Deleted project successfully
   
Assisted-by: Claude Code <noreply@anthropic.com>

/cc @jhernand 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added organization- and group-scoped authorization for Projects (Create, List, Get, Update, Delete) based on tenant-scoped viewer/manager membership.
  * Enhanced JWT processing for `organization` claims, supporting both array and object formats.

* **Bug Fixes**
  * Removed fallback tenant derivation from unrelated claims when JWT organization data is missing.
  * Tightened tenant/group mapping to correctly interpret organization-scoped group memberships.

* **Tests**
  * Updated multitenant setup and adjusted/removed specific authorization cases to match the revised tenant resolution behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->