### PR TITLE
OSAC-953: Pass tenant and project name to get/delete requests

### DIFF
--- a/internal/auth/grpc_external_auth_interceptor.go
+++ b/internal/auth/grpc_external_auth_interceptor.go
@@ -32,15 +32,20 @@ import (
 	"google.golang.org/protobuf/proto"
 )
 
+// MetadataFetcher fetches object metadata (tenant and project name) for authorization.
+// Returns empty strings if object not found or on error.
+type MetadataFetcher func(ctx context.Context, id string) (tenant, project string)
+
 // GrpcExternalAuthType is the name of the external authentication type.
 const GrpcExternalAuthType = "external"
 
 // GrpcExternalAuthInterceptorBuilder contains the data and logic needed to build an interceptor that performs
 // authentication and authorization by calling an external service using the Envoy ext_authz gRPC protocol.
 type GrpcExternalAuthInterceptorBuilder struct {
-	logger        *slog.Logger
-	grpcClient    *grpc.ClientConn
-	publicMethods []string
+	logger          *slog.Logger
+	grpcClient      *grpc.ClientConn
+	publicMethods   []string
+	metadataFetcher MetadataFetcher
 }
 
 // GrpcExternalAuthInterceptor is an interceptor that performs authentication and authorization by calling an external
@@ -50,9 +55,10 @@ type GrpcExternalAuthInterceptorBuilder struct {
 // downstream handlers. The interceptor also has access to the request message, allowing it to include object-specific
 // details (like identifiers and tenants) in the authorization request.
 type GrpcExternalAuthInterceptor struct {
-	logger        *slog.Logger
-	authClient    envoyauthv3.AuthorizationClient
-	publicMethods []*regexp.Regexp
+	logger          *slog.Logger
+	authClient      envoyauthv3.AuthorizationClient
+	publicMethods   []*regexp.Regexp
+	metadataFetcher MetadataFetcher
 }
 
 // NewGrpcExternalAuthInterceptor creates a builder that can then be used to configure and create an authentication
@@ -86,6 +92,13 @@ func (b *GrpcExternalAuthInterceptorBuilder) AddPublicMethodRegex(value string) 
 	return b
 }
 
+// SetMetadataFetcher sets the function used to retrieve object metadata (tenant and project name) for authorization.
+// This is optional - if not set, metadata will not be fetched for authorization.
+func (b *GrpcExternalAuthInterceptorBuilder) SetMetadataFetcher(value MetadataFetcher) *GrpcExternalAuthInterceptorBuilder {
+	b.metadataFetcher = value
+	return b
+}
+
 // Build uses the data stored in the builder to create and configure a new interceptor.
 func (b *GrpcExternalAuthInterceptorBuilder) Build() (result *GrpcExternalAuthInterceptor, err error) {
 	// Check parameters:
@@ -112,9 +125,10 @@ func (b *GrpcExternalAuthInterceptorBuilder) Build() (result *GrpcExternalAuthIn
 
 	// Create and populate the object:
 	result = &GrpcExternalAuthInterceptor{
-		logger:        b.logger,
-		authClient:    authClient,
-		publicMethods: publicMethods,
+		logger:          b.logger,
+		authClient:      authClient,
+		publicMethods:   publicMethods,
+		metadataFetcher: b.metadataFetcher,
 	}
 	return
 }
@@ -269,6 +283,18 @@ func (i *GrpcExternalAuthInterceptor) buildCheckRequest(ctx context.Context, met
 		id := i.extractId(ctx, request)
 		if id != "" {
 			extensions["id"] = id
+		}
+
+		// For project Get/Delete/Update operations, fetch the authoritative tenant and name from the database
+		// to prevent clients from spoofing these values for authorization bypass.
+		if i.shouldFetchProjectMetadata(method, id) && i.metadataFetcher != nil {
+			tenant, name := i.metadataFetcher(ctx, id)
+			if tenant != "" {
+				extensions["tenant"] = tenant
+			}
+			if name != "" {
+				extensions["name"] = name
+			}
 		}
 	}
 
@@ -436,6 +462,19 @@ func (i *GrpcExternalAuthInterceptor) isPublicMethod(method string) bool {
 		}
 	}
 	return false
+}
+
+// shouldFetchProjectMetadata determines if we should fetch project metadata from the database for authorization.
+// This is needed for Get/Delete/Update operations to prevent clients from spoofing tenant/name values for
+// authorization bypass.
+func (i *GrpcExternalAuthInterceptor) shouldFetchProjectMetadata(method string, id string) bool {
+	if id == "" {
+		return false
+	}
+	// Fetch metadata for Projects Get, Delete, and Update operations
+	return method == "/osac.public.v1.Projects/Get" ||
+		method == "/osac.public.v1.Projects/Delete" ||
+		method == "/osac.public.v1.Projects/Update"
 }
 
 // grpcExternalAuthInternalError is the error returned an internal error is detected that pevents completing the

--- a/internal/auth/grpc_external_auth_interceptor_metadata_test.go
+++ b/internal/auth/grpc_external_auth_interceptor_metadata_test.go
@@ -1,0 +1,349 @@
+/*
+Copyright (c) 2025 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package auth
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/json"
+	"fmt"
+	"net"
+	"os"
+
+	envoycorev3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+	envoyauthv3 "github.com/envoyproxy/go-control-plane/envoy/service/auth/v3"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"google.golang.org/genproto/googleapis/rpc/status"
+	"google.golang.org/grpc"
+	grpccodes "google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials"
+	"google.golang.org/protobuf/types/known/fieldmaskpb"
+
+	publicv1 "github.com/osac-project/fulfillment-service/internal/api/osac/public/v1"
+	"github.com/osac-project/fulfillment-service/internal/collections"
+	. "github.com/osac-project/fulfillment-service/internal/testing"
+)
+
+var _ = Describe("GrpcExternalAuthInterceptor project metadata authorization", func() {
+	var (
+		ctx                   context.Context
+		client                *grpc.ClientConn
+		mock                  *GrpcExternalAuthMock
+		interceptor           *GrpcExternalAuthInterceptor
+		metadataFetcherCalled bool
+		metadataFetcherID     string
+	)
+
+	BeforeEach(func() {
+		var err error
+
+		ctx = context.Background()
+		mock = &GrpcExternalAuthMock{}
+
+		crtFile, keyFile, caFile := LocalhostCertificateFiles()
+		DeferCleanup(func() {
+			_ = os.Remove(crtFile)
+			_ = os.Remove(keyFile)
+			_ = os.Remove(caFile)
+		})
+		caData, err := os.ReadFile(caFile)
+		Expect(err).ToNot(HaveOccurred())
+
+		caPool, err := x509.SystemCertPool()
+		Expect(err).ToNot(HaveOccurred())
+		ok := caPool.AppendCertsFromPEM(caData)
+		Expect(ok).To(BeTrue())
+
+		crt, err := tls.LoadX509KeyPair(crtFile, keyFile)
+		Expect(err).ToNot(HaveOccurred())
+		listener, err := net.Listen("tcp", "127.0.0.1:0")
+		Expect(err).ToNot(HaveOccurred())
+		listener = tls.NewListener(listener, &tls.Config{
+			RootCAs: caPool,
+			Certificates: []tls.Certificate{
+				crt,
+			},
+			NextProtos: []string{"h2"},
+		})
+		address := listener.Addr().String()
+
+		endpoint := fmt.Sprintf("dns:///%s", address)
+		creds := credentials.NewTLS(&tls.Config{
+			RootCAs: caPool,
+		})
+		options := []grpc.DialOption{
+			grpc.WithTransportCredentials(creds),
+		}
+		client, err = grpc.NewClient(endpoint, options...)
+		Expect(err).ToNot(HaveOccurred())
+		DeferCleanup(client.Close)
+
+		server := grpc.NewServer()
+		DeferCleanup(server.Stop)
+		envoyauthv3.RegisterAuthorizationServer(server, mock)
+		go server.Serve(listener)
+
+		metadataFetcherCalled = false
+		metadataFetcherID = ""
+
+		mockMetadataFetcher := func(ctx context.Context, id string) (string, string) {
+			metadataFetcherCalled = true
+			metadataFetcherID = id
+			return "authoritative-tenant", "authoritative-project"
+		}
+
+		interceptor, err = NewGrpcExternalAuthInterceptor().
+			SetLogger(logger).
+			SetGrpcClient(client).
+			SetMetadataFetcher(mockMetadataFetcher).
+			Build()
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	makeOkResponse := func(subject *Subject) *envoyauthv3.CheckResponse {
+		header := ""
+		if subject != nil {
+			data, err := json.Marshal(subject)
+			Expect(err).ToNot(HaveOccurred())
+			header = string(data)
+		}
+		return &envoyauthv3.CheckResponse{
+			Status: &status.Status{
+				Code: int32(grpccodes.OK),
+			},
+			HttpResponse: &envoyauthv3.CheckResponse_OkResponse{
+				OkResponse: &envoyauthv3.OkHttpResponse{
+					Headers: []*envoycorev3.HeaderValueOption{{
+						Header: &envoycorev3.HeaderValue{
+							Key:   SubjectHeader,
+							Value: header,
+						},
+					}},
+				},
+			},
+		}
+	}
+
+	Describe("Projects Get operation", func() {
+		It("Should fetch metadata from database and include in context extensions", func() {
+			mock.Func = func(ctx context.Context,
+				request *envoyauthv3.CheckRequest) (response *envoyauthv3.CheckResponse, err error) {
+				Expect(request).ToNot(BeNil())
+				extensions := request.GetAttributes().GetContextExtensions()
+				Expect(extensions).To(HaveKeyWithValue("id", "project-123"))
+				Expect(extensions).To(HaveKeyWithValue("tenant", "authoritative-tenant"))
+				Expect(extensions).To(HaveKeyWithValue("name", "authoritative-project"))
+				response = makeOkResponse(&Subject{
+					User:    "my-user",
+					Tenants: collections.NewSet("my-group"),
+				})
+				return
+			}
+
+			handler := func(context.Context, any) (any, error) {
+				return nil, nil
+			}
+			info := &grpc.UnaryServerInfo{
+				FullMethod: "/osac.public.v1.Projects/Get",
+			}
+			request := &publicv1.ProjectsGetRequest{
+				Id: "project-123",
+			}
+
+			_, err := interceptor.UnaryServer(ctx, request, info, handler)
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(metadataFetcherCalled).To(BeTrue())
+			Expect(metadataFetcherID).To(Equal("project-123"))
+		})
+	})
+
+	Describe("Projects Delete operation", func() {
+		It("Should fetch metadata from database and include in context extensions", func() {
+			mock.Func = func(ctx context.Context,
+				request *envoyauthv3.CheckRequest) (response *envoyauthv3.CheckResponse, err error) {
+				Expect(request).ToNot(BeNil())
+				extensions := request.GetAttributes().GetContextExtensions()
+				Expect(extensions).To(HaveKeyWithValue("id", "project-456"))
+				Expect(extensions).To(HaveKeyWithValue("tenant", "authoritative-tenant"))
+				Expect(extensions).To(HaveKeyWithValue("name", "authoritative-project"))
+				response = makeOkResponse(&Subject{
+					User:    "my-user",
+					Tenants: collections.NewSet("my-group"),
+				})
+				return
+			}
+
+			handler := func(context.Context, any) (any, error) {
+				return nil, nil
+			}
+			info := &grpc.UnaryServerInfo{
+				FullMethod: "/osac.public.v1.Projects/Delete",
+			}
+			request := &publicv1.ProjectsDeleteRequest{
+				Id: "project-456",
+			}
+
+			_, err := interceptor.UnaryServer(ctx, request, info, handler)
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(metadataFetcherCalled).To(BeTrue())
+			Expect(metadataFetcherID).To(Equal("project-456"))
+		})
+	})
+
+	Describe("Projects Update operation", func() {
+		It("Should fetch metadata from database and include in context extensions", func() {
+			mock.Func = func(ctx context.Context,
+				request *envoyauthv3.CheckRequest) (response *envoyauthv3.CheckResponse, err error) {
+				Expect(request).ToNot(BeNil())
+				extensions := request.GetAttributes().GetContextExtensions()
+				Expect(extensions).To(HaveKeyWithValue("id", "project-789"))
+				Expect(extensions).To(HaveKeyWithValue("tenant", "authoritative-tenant"))
+				Expect(extensions).To(HaveKeyWithValue("name", "authoritative-project"))
+				response = makeOkResponse(&Subject{
+					User:    "my-user",
+					Tenants: collections.NewSet("my-group"),
+				})
+				return
+			}
+
+			handler := func(context.Context, any) (any, error) {
+				return nil, nil
+			}
+			info := &grpc.UnaryServerInfo{
+				FullMethod: "/osac.public.v1.Projects/Update",
+			}
+			request := &publicv1.ProjectsUpdateRequest{
+				Object: &publicv1.Project{
+					Id: "project-789",
+					Metadata: &publicv1.Metadata{
+						Tenant: "client-spoofed-tenant",
+						Name:   "client-spoofed-name",
+					},
+				},
+				UpdateMask: &fieldmaskpb.FieldMask{},
+			}
+
+			_, err := interceptor.UnaryServer(ctx, request, info, handler)
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(metadataFetcherCalled).To(BeTrue())
+			Expect(metadataFetcherID).To(Equal("project-789"))
+		})
+
+		It("Should ignore client-provided metadata values and use authoritative database values", func() {
+			var capturedExtensions map[string]string
+
+			mock.Func = func(ctx context.Context,
+				request *envoyauthv3.CheckRequest) (response *envoyauthv3.CheckResponse, err error) {
+				capturedExtensions = request.GetAttributes().GetContextExtensions()
+				response = makeOkResponse(&Subject{
+					User:    "my-user",
+					Tenants: collections.NewSet("my-group"),
+				})
+				return
+			}
+
+			handler := func(context.Context, any) (any, error) {
+				return nil, nil
+			}
+			info := &grpc.UnaryServerInfo{
+				FullMethod: "/osac.public.v1.Projects/Update",
+			}
+			request := &publicv1.ProjectsUpdateRequest{
+				Object: &publicv1.Project{
+					Id: "project-999",
+					Metadata: &publicv1.Metadata{
+						Tenant: "malicious-tenant",
+						Name:   "malicious-project",
+					},
+				},
+				UpdateMask: &fieldmaskpb.FieldMask{},
+			}
+
+			_, err := interceptor.UnaryServer(ctx, request, info, handler)
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(capturedExtensions["tenant"]).To(Equal("authoritative-tenant"))
+			Expect(capturedExtensions["name"]).To(Equal("authoritative-project"))
+			Expect(capturedExtensions["tenant"]).ToNot(Equal("malicious-tenant"))
+			Expect(capturedExtensions["name"]).ToNot(Equal("malicious-project"))
+		})
+	})
+
+	Describe("Projects List operation", func() {
+		It("Should not fetch metadata for list operations", func() {
+			mock.Func = func(ctx context.Context,
+				request *envoyauthv3.CheckRequest) (response *envoyauthv3.CheckResponse, err error) {
+				Expect(request).ToNot(BeNil())
+				extensions := request.GetAttributes().GetContextExtensions()
+				Expect(extensions).ToNot(HaveKey("tenant"))
+				Expect(extensions).ToNot(HaveKey("name"))
+				response = makeOkResponse(&Subject{
+					User:    "my-user",
+					Tenants: collections.NewSet("my-group"),
+				})
+				return
+			}
+
+			handler := func(context.Context, any) (any, error) {
+				return nil, nil
+			}
+			info := &grpc.UnaryServerInfo{
+				FullMethod: "/osac.public.v1.Projects/List",
+			}
+			request := &publicv1.ProjectsListRequest{}
+
+			_, err := interceptor.UnaryServer(ctx, request, info, handler)
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(metadataFetcherCalled).To(BeFalse())
+		})
+	})
+
+	Describe("Other resource operations", func() {
+		It("Should not fetch project metadata for Clusters operations", func() {
+			mock.Func = func(ctx context.Context,
+				request *envoyauthv3.CheckRequest) (response *envoyauthv3.CheckResponse, err error) {
+				Expect(request).ToNot(BeNil())
+				extensions := request.GetAttributes().GetContextExtensions()
+				Expect(extensions).To(HaveKeyWithValue("id", "cluster-123"))
+				Expect(extensions).ToNot(HaveKey("tenant"))
+				Expect(extensions).ToNot(HaveKey("name"))
+				response = makeOkResponse(&Subject{
+					User: "my-user",
+				})
+				return
+			}
+
+			handler := func(context.Context, any) (any, error) {
+				return nil, nil
+			}
+			info := &grpc.UnaryServerInfo{
+				FullMethod: "/osac.public.v1.Clusters/Get",
+			}
+			request := &publicv1.ClustersGetRequest{
+				Id: "cluster-123",
+			}
+
+			_, err := interceptor.UnaryServer(ctx, request, info, handler)
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(metadataFetcherCalled).To(BeFalse())
+		})
+	})
+})

--- a/internal/cmd/service/start/grpcserver/start_grpc_server_cmd.go
+++ b/internal/cmd/service/start/grpcserver/start_grpc_server_cmd.go
@@ -43,6 +43,7 @@ import (
 	"github.com/osac-project/fulfillment-service/internal/auth/jwe"
 	"github.com/osac-project/fulfillment-service/internal/console"
 	"github.com/osac-project/fulfillment-service/internal/database"
+	"github.com/osac-project/fulfillment-service/internal/database/dao"
 	hubscheme "github.com/osac-project/fulfillment-service/internal/kubernetes/scheme"
 	"github.com/osac-project/fulfillment-service/internal/logging"
 	"github.com/osac-project/fulfillment-service/internal/metrics"
@@ -232,6 +233,45 @@ func (c *runnerContext) run(cmd *cobra.Command, argv []string) error { //nolint:
 	// Calculate the user agent:
 	userAgent := fmt.Sprintf("%s/%s", grpcServerUserAgent, version.Get())
 
+	// Create the tenancy logic:
+	c.logger.InfoContext(
+		ctx,
+		"Creating tenancy logic",
+		slog.String("type", c.args.tenancyLogic),
+	)
+	var tenancyLogic auth.TenancyLogic
+	switch strings.ToLower(c.args.tenancyLogic) {
+	case "default":
+		tenancyLogic, err = auth.NewDefaultTenancyLogic().
+			SetLogger(c.logger).
+			Build()
+		if err != nil {
+			return fmt.Errorf("failed to create default tenancy logic: %w", err)
+		}
+	case "guest":
+		tenancyLogic, err = auth.NewGuestTenancyLogic().
+			SetLogger(c.logger).
+			Build()
+		if err != nil {
+			return fmt.Errorf("failed to create guest tenancy logic: %w", err)
+		}
+	default:
+		return fmt.Errorf(
+			"unknown tenancy logic '%s', valid values are 'default' and 'guest'",
+			c.args.tenancyLogic,
+		)
+	}
+
+	// Prepare the transactions manager:
+	c.logger.InfoContext(ctx, "Creating transactions manager")
+	txManager, err := database.NewTxManager().
+		SetLogger(c.logger).
+		SetPool(dbPool).
+		Build()
+	if err != nil {
+		return fmt.Errorf("failed to create transactions manager: %w", err)
+	}
+
 	// Prepare the auth interceptor:
 	c.logger.InfoContext(
 		ctx,
@@ -268,10 +308,20 @@ func (c *runnerContext) run(cmd *cobra.Command, argv []string) error { //nolint:
 		if err != nil {
 			return fmt.Errorf("failed to create external auth client: %w", err)
 		}
+		// Create metadata fetcher for project authorization
+		metadataFetcher, err := dao.NewMetadataFetcher().
+			SetLogger(c.logger).
+			SetTable("projects").
+			Build()
+		if err != nil {
+			return fmt.Errorf("failed to create metadata fetcher: %w", err)
+		}
+
 		externalAuthInterceptor, err := auth.NewGrpcExternalAuthInterceptor().
 			SetLogger(c.logger).
 			SetGrpcClient(externalAuthClient).
 			AddPublicMethodRegex(publicMethodRegex).
+			SetMetadataFetcher(metadataFetcher).
 			Build()
 		if err != nil {
 			return fmt.Errorf("failed to create external auth interceptor: %w", err)
@@ -306,13 +356,6 @@ func (c *runnerContext) run(cmd *cobra.Command, argv []string) error { //nolint:
 
 	// Prepare the transactions interceptor:
 	c.logger.InfoContext(ctx, "Creating transactions interceptor")
-	txManager, err := database.NewTxManager().
-		SetLogger(c.logger).
-		SetPool(dbPool).
-		Build()
-	if err != nil {
-		return fmt.Errorf("failed to create transactions manager: %w", err)
-	}
 	txInterceptor, err := database.NewTxInterceptor().
 		SetLogger(c.logger).
 		SetManager(txManager).
@@ -379,35 +422,6 @@ func (c *runnerContext) run(cmd *cobra.Command, argv []string) error { //nolint:
 		Build()
 	if err != nil {
 		return fmt.Errorf("failed to create public attribution logic: %w", err)
-	}
-
-	// Create the tenancy logic:
-	c.logger.InfoContext(
-		ctx,
-		"Creating tenancy logic",
-		slog.String("type", c.args.tenancyLogic),
-	)
-	var tenancyLogic auth.TenancyLogic
-	switch strings.ToLower(c.args.tenancyLogic) {
-	case "default":
-		tenancyLogic, err = auth.NewDefaultTenancyLogic().
-			SetLogger(c.logger).
-			Build()
-		if err != nil {
-			return fmt.Errorf("failed to create default tenancy logic: %w", err)
-		}
-	case "guest":
-		tenancyLogic, err = auth.NewGuestTenancyLogic().
-			SetLogger(c.logger).
-			Build()
-		if err != nil {
-			return fmt.Errorf("failed to create guest tenancy logic: %w", err)
-		}
-	default:
-		return fmt.Errorf(
-			"unknown tenancy logic '%s', valid values are 'default' and 'guest'",
-			c.args.tenancyLogic,
-		)
 	}
 
 	// Create the private attribution logic:

--- a/internal/database/dao/metadata_fetcher.go
+++ b/internal/database/dao/metadata_fetcher.go
@@ -1,0 +1,89 @@
+/*
+Copyright (c) 2026 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package dao
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+
+	"github.com/osac-project/fulfillment-service/internal/auth"
+	"github.com/osac-project/fulfillment-service/internal/database"
+)
+
+// MetadataFetcherBuilder builds a metadata fetcher that queries object metadata for authorization.
+type MetadataFetcherBuilder struct {
+	logger *slog.Logger
+	table  string
+}
+
+// NewMetadataFetcher creates a new metadata fetcher builder.
+func NewMetadataFetcher() *MetadataFetcherBuilder {
+	return &MetadataFetcherBuilder{}
+}
+
+// SetLogger sets the logger.
+func (b *MetadataFetcherBuilder) SetLogger(value *slog.Logger) *MetadataFetcherBuilder {
+	b.logger = value
+	return b
+}
+
+// SetTable sets the database table name to query.
+func (b *MetadataFetcherBuilder) SetTable(value string) *MetadataFetcherBuilder {
+	b.table = value
+	return b
+}
+
+// Build creates the metadata fetcher function.
+// This bypasses authorization checks since it's used FOR authorization.
+func (b *MetadataFetcherBuilder) Build() (auth.MetadataFetcher, error) {
+	// Check required parameters:
+	if b.logger == nil {
+		return nil, errors.New("logger is mandatory")
+	}
+	if b.table == "" {
+		return nil, errors.New("table is mandatory")
+	}
+
+	// Capture builder values in closure:
+	logger := b.logger
+	query := fmt.Sprintf("select tenant, name from %s where id = $1", b.table)
+
+	return func(ctx context.Context, id string) (tenant, project string) {
+		var objectTenant, objectName string
+
+		// Get transaction from context
+		tx, err := database.TxFromContext(ctx)
+		if err != nil {
+			logger.WarnContext(ctx, "Failed to get transaction from context for metadata fetch",
+				slog.String("id", id),
+				slog.Any("error", err),
+			)
+			return "", ""
+		}
+
+		row := tx.QueryRow(ctx, query, id)
+		err = row.Scan(&objectTenant, &objectName)
+		if err != nil {
+			logger.WarnContext(ctx, "Failed to fetch object metadata for authorization",
+				slog.String("id", id),
+				slog.Any("error", err),
+			)
+			return "", ""
+		}
+
+		return objectTenant, objectName
+	}, nil
+}


### PR DESCRIPTION
# Description

The tenant and project name are used to determine authorization.

# Testing

- [x] Ran integration test
    - Logged in as admin on CLI and created organization test-org, added user ben, assigned ben tenant-admin role
    - Logged in as ben on CLI and created project, verify able to see project
    - Logged in as charles on CLI and verify not able to see project
    - Deleted project successfully
   
Assisted-by: Claude Code <noreply@anthropic.com>

/cc @jhernand 