### PR TITLE
OSAC-953: Fix transaction for getting tenant and project name

### DIFF
--- a/internal/cmd/service/start/grpcserver/start_grpc_server_cmd.go
+++ b/internal/cmd/service/start/grpcserver/start_grpc_server_cmd.go
@@ -379,8 +379,8 @@ func (c *runnerContext) run(cmd *cobra.Command, argv []string) error { //nolint:
 			panicInterceptor.UnaryServer,
 			metricsInterceptor.UnaryServer,
 			loggingInterceptor.UnaryServer,
-			authUnaryInterceptor,
 			txInterceptor.UnaryServer,
+			authUnaryInterceptor,
 		),
 		grpc.ChainStreamInterceptor(
 			panicInterceptor.StreamServer,


### PR DESCRIPTION
# Description
The changes added in https://github.com/osac-project/fulfillment-service/pull/667 didn't get the tenant and project name correctly. This is because of the ordering. The auth interceptor ran before the tx interceptor.

This reorders it so that way the metadata fetcher would use the same transaction.

# Testing
- [x] Ran integration tests and verified project deletion was allowed by a user in the managers group

Assisted-by: Claude Code <noreply@anthropic.com>