### PR TITLE
NO-ISSUE: Use `uv run dev.py lint` from the pre-commit hook

### DIFF
--- a/.github/workflows/check-pull-request.yaml
+++ b/.github/workflows/check-pull-request.yaml
@@ -56,7 +56,6 @@ jobs:
     - uses: ./.github/actions/setup-go
     - uses: ./.github/actions/setup-python
     - run: |
-        uv run dev.py setup
         uv run dev.py lint
 
   check-generated-code:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,4 +27,4 @@ repos:
     name: golangci-lint
     language: system
     files: \.go$
-    entry: bin/golangci-lint run --fix
+    entry: uv run dev.py lint

--- a/dev/lint.py
+++ b/dev/lint.py
@@ -18,7 +18,7 @@ import logging
 import click
 
 from . import commands
-from . import tools
+from . import setup
 
 
 @click.command()
@@ -27,7 +27,8 @@ def lint() -> None:
     Runs the linter.
     """
     logging.info("Running linter")
+    setup.install_golangci_lint()
     commands.run(
-        args=[tools.GOLANGCI_LINT.name, "run"],
+        args=["golangci-lint", "run"],
         check=True,
     )

--- a/dev/setup.py
+++ b/dev/setup.py
@@ -140,28 +140,38 @@ def install_golangci_lint() -> None:
 
 def is_installed(tool: tools.Tool) -> bool:
     """
-    Checks if the given tool is already installed.
+    Checks if the given tool is already installed. It first looks in the project's bin directory,
+    then falls back to the system PATH.
     """
-    installed_path = shutil.which(tool.name)
-    if installed_path is not None:
-        tool_code, tool_out = commands.eval(args=tool.version_command)
-        if tool_code != 0:
-            raise Exception(f"Failed to find version of installed '{tool.name}'")
-        version_match = re.search(
-            pattern=tool.version_pattern,
-            string=tool_out,
-            flags=re.MULTILINE,
-        )
-        if version_match is None:
-            raise Exception(f"Failed to find version of installed '{tool.name}'")
-        installed_version = version_match.group("version")
-        if installed_version == tool.version:
-            logging.info(
-                f"Version {tool.version} of '{tool.name}' is already installed at '{installed_path}'"
-            )
-            return True
-        logging.info(
-            f"Found '{tool.name}' already installed at '{installed_path}', but version is '{installed_version}' "
-            f"instead of '{tool.version}'"
-        )
+    # Check the project bin directory first, then the system path:
+    bin_path = dirs.bin() / tool.name
+    if bin_path.exists():
+        installed_path = str(bin_path)
+    else:
+        installed_path = shutil.which(tool.name)
+    if installed_path is None:
         return False
+
+    # Build the version command using the resolved path so we check the right binary:
+    version_command = [installed_path] + tool.version_command[1:]
+    tool_code, tool_out = commands.eval(args=version_command)
+    if tool_code != 0:
+        raise Exception(f"Failed to find version of installed '{tool.name}'")
+    version_match = re.search(
+        pattern=tool.version_pattern,
+        string=tool_out,
+        flags=re.MULTILINE,
+    )
+    if version_match is None:
+        raise Exception(f"Failed to find version of installed '{tool.name}'")
+    installed_version = version_match.group("version")
+    if installed_version == tool.version:
+        logging.info(
+            f"Version {tool.version} of '{tool.name}' is already installed at '{installed_path}'"
+        )
+        return True
+    logging.info(
+        f"Found '{tool.name}' already installed at '{installed_path}', but version is '{installed_version}' "
+        f"instead of '{tool.version}'"
+    )
+    return False


### PR DESCRIPTION
## Summary

The pre-commit hook was calling `bin/golangci-lint` directly, which required the tool to be
installed separately before linting could work. This changes the hook to call `uv run dev.py lint`
instead, so that the project's development tooling manages the linter lifecycle end to end.

- The `lint` command now calls `setup.install_golangci_lint` before running, making it
  self-contained.
- The `is_installed` helper in `setup.py` is updated to check the project's `bin/` directory first
  and to use the resolved path when verifying the installed version.
- The separate `uv run dev.py setup` step in the CI workflow is removed since `lint` now handles
  its own setup.

## Test plan

- [x] Run `uv run dev.py lint` locally without `golangci-lint` pre-installed and verify it installs
  the tool and runs the linter successfully.
- [x] Run `uv run dev.py lint` locally with `golangci-lint` already in `bin/` and verify it skips
  installation and runs the linter.
- [x] Trigger the pre-commit hook by committing a `.go` file and verify it invokes
  `uv run dev.py lint`.
- [x] Verify CI passes without the `uv run dev.py setup` step.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Streamlined CI/CD workflow by consolidating tool setup with linting operations.
  * Updated pre-commit hook configuration to use unified linting command.
  * Improved tool installation detection to prioritize project-level binaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->