### PR TITLE
NO-ISSUE: Move dev.py documentation into dev/README.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,26 +70,8 @@ See [README.md](README.md) for instructions on running the service locally, incl
 ## Development Tooling
 
 Development and build tasks are automated through the `dev.py` script, which is run with `uv run
-dev.py <command>`. When a new task needs to be automated (for example building, formatting,
-generating code, running tests with specific options, or installing a tool), it should be added as a
-new command or sub-command in the `dev/` Python package rather than as a standalone shell script or
-a Makefile target.
-
-The `dev/` package is organized as follows:
-
-- `dev.py` - Entry point that registers all commands via Click.
-- `dev/commands.py` - Helpers for running external commands, with automatic resolution of binaries
-  installed in the project's `bin/` directory.
-- `dev/dirs.py` - Functions that return well-known project directories (`project()`, `bin()`).
-- `dev/tools.py` - Definitions of external tools (name, version, checksums) used by the `setup`
-  command.
-- `dev/setup.py` - The `setup` command, which downloads and verifies tool binaries from their
-  GitHub release pages.
-- `dev/lint.py` - The `lint` command.
-
-To add a new command, create a new module in `dev/` (e.g. `dev/build.py`), define a Click command
-in it, register it in `dev/__init__.py`, and add it to the CLI group in `dev.py`. Follow the
-existing modules as examples.
+dev.py`. When a new task needs to be automated (for example building, formatting, generating code,
+running tests with specific options, or installing a tool), refer to [dev/README.md](dev/README.md).
 
 ## Architecture
 

--- a/dev/README.md
+++ b/dev/README.md
@@ -1,4 +1,23 @@
 # Development tools
 
-This directory contains the code for the `dev.py` development tool used for building, generating
-code, etc.
+Development and build tasks are automated through the `dev.py` script, which is run with `uv run
+dev.py <command>`. When a new task needs to be automated (for example building, formatting,
+generating code, running tests with specific options, or installing a tool), it should be added as a
+new command or sub-command in the `dev/` Python package rather than as a standalone shell script or
+a Makefile target.
+
+The `dev/` package is organized as follows:
+
+- `dev.py` - Entry point that registers all commands via Click.
+- `dev/commands.py` - Helpers for running external commands, with automatic resolution of binaries
+  installed in the project's `bin/` directory.
+- `dev/dirs.py` - Functions that return well-known project directories (`project()`, `bin()`).
+- `dev/tools.py` - Definitions of external tools (name, version, checksums) used by the `setup`
+  command.
+- `dev/setup.py` - The `setup` command, which downloads and verifies tool binaries from their
+  GitHub release pages.
+- `dev/lint.py` - The `lint` command.
+
+To add a new command, create a new module in `dev/` (e.g. `dev/build.py`), define a Click command
+in it, register it in `dev/__init__.py`, and add it to the CLI group in `dev.py`. Follow the
+existing modules as examples.


### PR DESCRIPTION
## Summary

- Moves the detailed `dev/` package documentation (directory layout, how to add new commands) from
  `AGENTS.md` into `dev/README.md`, where it is more discoverable for developers working in that
  directory.
- Replaces the removed section in `AGENTS.md` with a short pointer to `dev/README.md`.

## Test plan

- [ ] Verify `dev/README.md` renders correctly on GitHub.
- [ ] Verify the `AGENTS.md` link to `dev/README.md` resolves properly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Pointed project guidance to a single, centralized development automation guide.
  * Expanded that guide into a contributor-focused reference: how to run development automation, create and register new CLI-based automation tasks, and follow the recommended layout for adding tooling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->