### PR TITLE
NO-ISSUE: Fix miscellaneous issues in `dev.py` tooling

### DIFF
--- a/dev/README.md
+++ b/dev/README.md
@@ -18,6 +18,15 @@ The `dev/` package is organized as follows:
   GitHub release pages.
 - `dev/lint.py` - The `lint` command.
 
+The `setup` command downloads tool binaries from GitHub and verifies their integrity using SHA-256
+checksums stored in `dev/tools.py`. The verification is a two-stage process: first the checksums
+manifest published alongside the release is checked against the hash committed in `dev/tools.py`,
+then the downloaded artifact is checked against the hash extracted from that manifest. If either
+check fails the command raises an exception (non-zero exit) and logs the expected vs. actual
+checksums so developers can investigate. This detects tampering or corruption in transit, but
+ultimately relies on trusting the upstream release that published the manifest. When updating a tool
+version, replace the corresponding entry in `dev/tools.py` with the new checksums.
+
 To add a new command, create a new module in `dev/` (e.g. `dev/build.py`), define a Click command
 in it, register it in `dev/__init__.py`, and add it to the CLI group in `dev.py`. Follow the
 existing modules as examples.

--- a/dev/setup.py
+++ b/dev/setup.py
@@ -74,8 +74,9 @@ def install_golangci_lint() -> None:
 
     # Extract the checksum of the artifact from the downloaded checksums:
     artifact_name = f"golangci-lint-{tool.version}-{os_name}-{arch_name}.tar.gz"
+    artifact_pattern = re.escape(artifact_name)
     artifact_match = re.search(
-        pattern=fr'^(?P<checksum>[0-9a-fA-F]+)\s+{artifact_name}$',
+        pattern=fr'^(?P<checksum>[0-9a-fA-F]+)\s+{artifact_pattern}$',
         string=checksums_content.decode("utf-8"),
         flags=re.MULTILINE,
     )


### PR DESCRIPTION
These are issues that were reported by the AI code review tool but were not addressed before merging the commit that added `dev.py`. The changes are:

In `dev/setup.py`, use `re.escape()` on the artifact name before interpolating it into the regex pattern that searches the checksums file. Without this, dots in filenames like `golangci-lint-2.12.2-linux-amd64.tar.gz` act as regex wildcards and could match unintended lines.

In `AGENTS.md`, document the security posture of the binary download verification performed by the `setup` command, including the two-stage SHA-256 check, the failure behaviour, and the trust boundary.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tool installation verification to more reliably detect checksum mismatches and version mismatches.
  * Installation now clearly fails when the expected tool version is not present.

* **Documentation**
  * Added more detail about how setup validates downloaded tool binaries and what happens when verification fails.
  * Clarified how to update tool checksums when upgrading versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->