### PR TITLE
OSAC-1380: Fix deleting groups when deleting projects

### DIFF
--- a/internal/controllers/project/project_reconciler_function_test.go
+++ b/internal/controllers/project/project_reconciler_function_test.go
@@ -750,24 +750,14 @@ var _ = Describe("Deletion Cleanup", func() {
 				Size: 0,
 			}, nil)
 
-		// Expect viewers group ID lookup
+		// Expect parent project group ID lookup
 		mockIdpClient.EXPECT().
-			GetGroupIDByPath(gomock.Any(), "acme", "/test-project/viewers").
-			Return("viewers-group-id", nil)
+			GetGroupIDByPath(gomock.Any(), "acme", "/test-project").
+			Return("project-group-id", nil)
 
-		// Expect viewers group deletion
+		// Expect parent project group deletion (cascades to delete viewers and managers subgroups)
 		mockIdpClient.EXPECT().
-			DeleteAuthorizationGroup(gomock.Any(), "acme", "viewers-group-id").
-			Return(nil)
-
-		// Expect managers group ID lookup
-		mockIdpClient.EXPECT().
-			GetGroupIDByPath(gomock.Any(), "acme", "/test-project/managers").
-			Return("managers-group-id", nil)
-
-		// Expect managers group deletion
-		mockIdpClient.EXPECT().
-			DeleteAuthorizationGroup(gomock.Any(), "acme", "managers-group-id").
+			DeleteAuthorizationGroup(gomock.Any(), "acme", "project-group-id").
 			Return(nil)
 
 		task := &task{
@@ -797,14 +787,9 @@ var _ = Describe("Deletion Cleanup", func() {
 				Size: 0,
 			}, nil)
 
-		// Expect viewers group ID lookup to fail
+		// Expect parent project group ID lookup to fail
 		mockIdpClient.EXPECT().
-			GetGroupIDByPath(gomock.Any(), "acme", "/test-project/viewers").
-			Return("", status.Error(codes.NotFound, "group not found"))
-
-		// Expect managers group ID lookup to fail
-		mockIdpClient.EXPECT().
-			GetGroupIDByPath(gomock.Any(), "acme", "/test-project/managers").
+			GetGroupIDByPath(gomock.Any(), "acme", "/test-project").
 			Return("", status.Error(codes.NotFound, "group not found"))
 
 		task := &task{

--- a/internal/idp/keycloak/authz_groups.go
+++ b/internal/idp/keycloak/authz_groups.go
@@ -208,11 +208,7 @@ type groupNode struct {
 
 // getGroupIDByPathWithOrgID returns the group ID for a path using orgID directly (not organization name).
 // This is used internally when we already have the orgID to avoid an extra lookup.
-// Lists all groups and recursively searches the hierarchy since the search parameter is unreliable
-// for recently-created groups.
 func (c *Client) getGroupIDByPathWithOrgID(ctx context.Context, orgID, groupPath string) (string, error) {
-	// List ALL organization groups (without search parameter)
-	// The search parameter is unreliable for recently-created groups
 	path := fmt.Sprintf("/admin/realms/%s/organizations/%s/groups",
 		url.PathEscape(c.realmName),
 		url.PathEscape(orgID),
@@ -229,27 +225,31 @@ func (c *Client) getGroupIDByPathWithOrgID(ctx context.Context, orgID, groupPath
 		return "", fmt.Errorf("failed to decode organization groups: %w", err)
 	}
 
-	// Recursively search through the hierarchy
-	var findGroupByPath func([]groupNode, string) string
-	findGroupByPath = func(groupList []groupNode, targetPath string) string {
-		for _, group := range groupList {
-			if group.Path == targetPath {
-				return group.ID
-			}
-			// Search in subgroups recursively
-			if id := findGroupByPath(group.SubGroups, targetPath); id != "" {
-				return id
-			}
+	// Search recursively through the group hierarchy
+	for _, group := range groups {
+		if id := searchGroupRecursively(group, groupPath); id != "" {
+			return id, nil
 		}
-		return ""
 	}
 
-	groupID := findGroupByPath(groups, groupPath)
-	if groupID == "" {
-		return "", fmt.Errorf("organization group not found: %s", groupPath)
-	}
+	c.logger.WarnContext(ctx, "Group not found in listed groups",
+		slog.String("target_path", groupPath),
+		slog.Int("total_groups", len(groups)),
+	)
+	return "", fmt.Errorf("organization group not found: %s", groupPath)
+}
 
-	return groupID, nil
+// searchGroupRecursively searches for a group by path in the group hierarchy.
+func searchGroupRecursively(group groupNode, targetPath string) string {
+	if group.Path == targetPath {
+		return group.ID
+	}
+	for _, subGroup := range group.SubGroups {
+		if id := searchGroupRecursively(subGroup, targetPath); id != "" {
+			return id
+		}
+	}
+	return ""
 }
 
 // GetGroupIDByPath gets a Keycloak organization group ID by its path.
@@ -265,34 +265,7 @@ func (c *Client) getGroupIDByPath(ctx context.Context, organizationName, groupPa
 		return "", fmt.Errorf("failed to get organization: %w", err)
 	}
 
-	// Search for organization group by path
-	// Note: Keycloak doesn't have a direct "get by path" API, so we search by name
-	// and verify the path matches
-	path := fmt.Sprintf("/admin/realms/%s/organizations/%s/groups?search=%s",
-		url.PathEscape(c.realmName),
-		url.PathEscape(org.ID),
-		url.QueryEscape(groupPath),
-	)
-
-	response, err := c.httpClient.DoRequest(ctx, http.MethodGet, path, nil)
-	if err != nil {
-		return "", fmt.Errorf("failed to search organization groups: %w", err)
-	}
-	defer response.Body.Close()
-
-	var groups []struct {
-		ID   string `json:"id"`
-		Path string `json:"path"`
-	}
-	if err := json.NewDecoder(response.Body).Decode(&groups); err != nil {
-		return "", fmt.Errorf("failed to decode organization groups: %w", err)
-	}
-
-	for _, group := range groups {
-		if group.Path == groupPath {
-			return group.ID, nil
-		}
-	}
-
-	return "", fmt.Errorf("organization group not found: %s", groupPath)
+	// Use getGroupIDByPathWithOrgID which lists all groups instead of using the search parameter.
+	// The search parameter is unreliable for recently-created groups.
+	return c.getGroupIDByPathWithOrgID(ctx, org.ID, groupPath)
 }

--- a/internal/idp/keycloak/authz_groups_test.go
+++ b/internal/idp/keycloak/authz_groups_test.go
@@ -1,0 +1,132 @@
+/*
+Copyright (c) 2026 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package keycloak
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("searchGroupRecursively", func() {
+	It("should find a top-level group", func() {
+		group := groupNode{
+			ID:   "group-123",
+			Name: "web-app",
+			Path: "/web-app",
+		}
+
+		id := searchGroupRecursively(group, "/web-app")
+		Expect(id).To(Equal("group-123"))
+	})
+
+	It("should find a nested group one level deep", func() {
+		group := groupNode{
+			ID:   "group-123",
+			Name: "web-app",
+			Path: "/web-app",
+			SubGroups: []groupNode{
+				{ID: "group-456", Name: "viewers", Path: "/web-app/viewers"},
+				{ID: "group-789", Name: "managers", Path: "/web-app/managers"},
+			},
+		}
+
+		id := searchGroupRecursively(group, "/web-app/viewers")
+		Expect(id).To(Equal("group-456"))
+	})
+
+	It("should find a deeply nested group three levels deep", func() {
+		group := groupNode{
+			ID:   "group-parent",
+			Name: "parent-project",
+			Path: "/parent-project",
+			SubGroups: []groupNode{
+				{
+					ID:   "group-child",
+					Name: "child-project",
+					Path: "/parent-project/child-project",
+					SubGroups: []groupNode{
+						{ID: "group-viewers", Name: "viewers", Path: "/parent-project/child-project/viewers"},
+						{ID: "group-managers", Name: "managers", Path: "/parent-project/child-project/managers"},
+					},
+				},
+			},
+		}
+
+		id := searchGroupRecursively(group, "/parent-project/child-project/viewers")
+		Expect(id).To(Equal("group-viewers"))
+	})
+
+	It("should return empty string when group is not found", func() {
+		group := groupNode{
+			ID:   "group-123",
+			Name: "web-app",
+			Path: "/web-app",
+			SubGroups: []groupNode{
+				{ID: "group-456", Name: "viewers", Path: "/web-app/viewers"},
+			},
+		}
+
+		id := searchGroupRecursively(group, "/nonexistent")
+		Expect(id).To(Equal(""))
+	})
+
+	It("should search across multiple branches", func() {
+		group := groupNode{
+			ID:   "group-root",
+			Name: "root",
+			Path: "/root",
+			SubGroups: []groupNode{
+				{
+					ID:   "group-branch1",
+					Name: "branch1",
+					Path: "/root/branch1",
+					SubGroups: []groupNode{
+						{ID: "group-leaf1", Name: "leaf1", Path: "/root/branch1/leaf1"},
+					},
+				},
+				{
+					ID:   "group-branch2",
+					Name: "branch2",
+					Path: "/root/branch2",
+					SubGroups: []groupNode{
+						{ID: "group-leaf2", Name: "leaf2", Path: "/root/branch2/leaf2"},
+					},
+				},
+			},
+		}
+
+		// Should find in first branch
+		id := searchGroupRecursively(group, "/root/branch1/leaf1")
+		Expect(id).To(Equal("group-leaf1"))
+
+		// Should find in second branch
+		id = searchGroupRecursively(group, "/root/branch2/leaf2")
+		Expect(id).To(Equal("group-leaf2"))
+	})
+
+	It("should handle empty subgroups", func() {
+		group := groupNode{
+			ID:        "group-123",
+			Name:      "web-app",
+			Path:      "/web-app",
+			SubGroups: []groupNode{},
+		}
+
+		id := searchGroupRecursively(group, "/web-app")
+		Expect(id).To(Equal("group-123"))
+
+		id = searchGroupRecursively(group, "/web-app/viewers")
+		Expect(id).To(Equal(""))
+	})
+})

--- a/internal/idp/keycloak/client_test.go
+++ b/internal/idp/keycloak/client_test.go
@@ -2000,14 +2000,9 @@ var _ = Describe("Keycloak Client", func() {
 						}
 						return
 					}
-					// Second request: search organization groups
+					// Second request: list organization groups (no search parameter - returns all groups)
 					if r.Method == http.MethodGet && r.URL.Path == "/admin/realms/osac/organizations/org-123/groups" {
-						// Verify search query is present with the expected path
-						expectedSearch := "search=%2Fweb-app%2Fviewers" // URL-encoded "/web-app/viewers"
-						if !strings.Contains(r.URL.RawQuery, expectedSearch) {
-							w.WriteHeader(http.StatusBadRequest)
-							return
-						}
+						// Return all groups - implementation searches recursively through the list
 						groups := []struct {
 							ID   string `json:"id"`
 							Path string `json:"path"`
@@ -2093,7 +2088,7 @@ var _ = Describe("Keycloak Client", func() {
 				Expect(err.Error()).To(ContainSubstring("organization group not found"))
 			})
 
-			It("should return error when search fails", func() {
+			It("should return error when list fails", func() {
 				server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 					// First request: get organization
 					if r.Method == http.MethodGet && r.URL.Path == "/admin/realms/osac/organizations" {
@@ -2108,7 +2103,7 @@ var _ = Describe("Keycloak Client", func() {
 						}
 						return
 					}
-					// Second request: search fails
+					// Second request: list fails
 					if r.Method == http.MethodGet && r.URL.Path == "/admin/realms/osac/organizations/org-123/groups" {
 						w.WriteHeader(http.StatusInternalServerError)
 						return
@@ -2120,7 +2115,7 @@ var _ = Describe("Keycloak Client", func() {
 
 				_, err := client.GetGroupIDByPath(ctx, "acme-corp", "/web-app/viewers")
 				Expect(err).To(HaveOccurred())
-				Expect(err.Error()).To(ContainSubstring("failed to search organization groups"))
+				Expect(err.Error()).To(ContainSubstring("failed to list organization groups"))
 			})
 		})
 	})

--- a/internal/idp/resource_manager.go
+++ b/internal/idp/resource_manager.go
@@ -18,6 +18,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"strings"
 )
 
 // ResourceManager handles Keycloak group operations for authorization.
@@ -77,43 +78,41 @@ func (m *ResourceManager) DeleteProjectGroups(ctx context.Context, tenant, proje
 		return fmt.Errorf("project name is required")
 	}
 
-	m.logger.DebugContext(ctx, "Deleting project groups",
-		slog.String("tenant", tenant),
+	// Delete the parent project group, which will cascade delete the viewers and managers subgroups
+	projectGroupPath := fmt.Sprintf("/%s", projectName)
+
+	projectGroupID, err := m.getGroupIDByPath(ctx, tenant, projectGroupPath)
+	if err != nil {
+		// Only swallow "not found" errors - propagate other errors (network, auth, etc.) for retry
+		if strings.Contains(err.Error(), "organization group not found") {
+			m.logger.WarnContext(ctx, "Project group not found, skipping deletion",
+				slog.String("group_path", projectGroupPath),
+				slog.String("tenant", tenant),
+			)
+			return nil
+		}
+		m.logger.ErrorContext(ctx, "Failed to get project group ID",
+			slog.String("group_path", projectGroupPath),
+			slog.String("tenant", tenant),
+			slog.Any("error", err),
+		)
+		return fmt.Errorf("failed to get project group ID: %w", err)
+	}
+
+	if err = m.client.DeleteAuthorizationGroup(ctx, tenant, projectGroupID); err != nil {
+		m.logger.ErrorContext(ctx, "Failed to delete project group",
+			slog.String("group_id", projectGroupID),
+			slog.String("group_path", projectGroupPath),
+			slog.Any("error", err),
+		)
+		return fmt.Errorf("failed to delete project group %s: %w", projectGroupPath, err)
+	}
+
+	m.logger.InfoContext(ctx, "Deleted project group and subgroups",
+		slog.String("group_path", projectGroupPath),
 		slog.String("project_name", projectName),
+		slog.String("tenant", tenant),
 	)
-
-	viewersGroupPath := fmt.Sprintf("/%s/%s", projectName, GroupNameViewers)
-	managersGroupPath := fmt.Sprintf("/%s/%s", projectName, GroupNameManagers)
-
-	viewersGroupID, err := m.getGroupIDByPath(ctx, tenant, viewersGroupPath)
-	if err != nil {
-		m.logger.WarnContext(ctx, "Failed to get viewers group ID",
-			slog.String("group_path", viewersGroupPath),
-			slog.Any("error", err),
-		)
-	} else if viewersGroupID != "" {
-		if err = m.client.DeleteAuthorizationGroup(ctx, tenant, viewersGroupID); err != nil {
-			m.logger.WarnContext(ctx, "Failed to delete viewers group",
-				slog.String("group_id", viewersGroupID),
-				slog.Any("error", err),
-			)
-		}
-	}
-
-	managersGroupID, err := m.getGroupIDByPath(ctx, tenant, managersGroupPath)
-	if err != nil {
-		m.logger.WarnContext(ctx, "Failed to get managers group ID",
-			slog.String("group_path", managersGroupPath),
-			slog.Any("error", err),
-		)
-	} else if managersGroupID != "" {
-		if err = m.client.DeleteAuthorizationGroup(ctx, tenant, managersGroupID); err != nil {
-			m.logger.WarnContext(ctx, "Failed to delete managers group",
-				slog.String("group_id", managersGroupID),
-				slog.Any("error", err),
-			)
-		}
-	}
 
 	return nil
 }

--- a/internal/idp/resource_manager_test.go
+++ b/internal/idp/resource_manager_test.go
@@ -14,6 +14,9 @@ language governing permissions and limitations under the License.
 package idp
 
 import (
+	"context"
+	"errors"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"go.uber.org/mock/gomock"
@@ -23,6 +26,7 @@ var _ = Describe("ResourceManager", func() {
 	var (
 		ctrl       *gomock.Controller
 		mockClient *MockClient
+		ctx        = context.Background()
 	)
 
 	BeforeEach(func() {
@@ -49,6 +53,136 @@ var _ = Describe("ResourceManager", func() {
 				Build()
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("IdP client is mandatory"))
+		})
+	})
+
+	Describe("DeleteProjectGroups", func() {
+		var manager *ResourceManager
+
+		BeforeEach(func() {
+			var err error
+			manager, err = NewResourceManager().
+				SetLogger(logger).
+				SetClient(mockClient).
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("should delete parent project group only (cascade delete)", func() {
+			mockClient.EXPECT().
+				GetGroupIDByPath(gomock.Any(), "test-org", "/test-project").
+				Return("group-id-123", nil)
+
+			mockClient.EXPECT().
+				DeleteAuthorizationGroup(gomock.Any(), "test-org", "group-id-123").
+				Return(nil)
+
+			err := manager.DeleteProjectGroups(ctx, "test-org", "test-project")
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("should return nil when parent group is not found", func() {
+			mockClient.EXPECT().
+				GetGroupIDByPath(gomock.Any(), "test-org", "/test-project").
+				Return("", errors.New("organization group not found: /test-project"))
+
+			err := manager.DeleteProjectGroups(ctx, "test-org", "test-project")
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("should propagate non-not-found errors from GetGroupIDByPath", func() {
+			mockClient.EXPECT().
+				GetGroupIDByPath(gomock.Any(), "test-org", "/test-project").
+				Return("", errors.New("network error: connection timeout"))
+
+			err := manager.DeleteProjectGroups(ctx, "test-org", "test-project")
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("failed to get project group ID"))
+			Expect(err.Error()).To(ContainSubstring("network error"))
+		})
+
+		It("should return error when deletion fails", func() {
+			mockClient.EXPECT().
+				GetGroupIDByPath(gomock.Any(), "test-org", "/test-project").
+				Return("group-id-123", nil)
+
+			mockClient.EXPECT().
+				DeleteAuthorizationGroup(gomock.Any(), "test-org", "group-id-123").
+				Return(errors.New("keycloak error"))
+
+			err := manager.DeleteProjectGroups(ctx, "test-org", "test-project")
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("failed to delete project group"))
+		})
+
+		It("should return error when tenant is empty", func() {
+			err := manager.DeleteProjectGroups(ctx, "", "test-project")
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("tenant is required"))
+		})
+
+		It("should return error when project name is empty", func() {
+			err := manager.DeleteProjectGroups(ctx, "test-org", "")
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("project name is required"))
+		})
+	})
+
+	Describe("CreateProjectGroups", func() {
+		var manager *ResourceManager
+
+		BeforeEach(func() {
+			var err error
+			manager, err = NewResourceManager().
+				SetLogger(logger).
+				SetClient(mockClient).
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("should create hierarchical viewers and managers groups", func() {
+			mockClient.EXPECT().
+				CreateAuthorizationGroup(gomock.Any(), "test-org", GroupNameViewers, "/test-project/viewers").
+				Return(nil)
+
+			mockClient.EXPECT().
+				CreateAuthorizationGroup(gomock.Any(), "test-org", GroupNameManagers, "/test-project/managers").
+				Return(nil)
+
+			err := manager.CreateProjectGroups(ctx, "test-org", "test-project")
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("should rollback viewers group when managers group creation fails", func() {
+			mockClient.EXPECT().
+				CreateAuthorizationGroup(gomock.Any(), "test-org", GroupNameViewers, "/test-project/viewers").
+				Return(nil)
+
+			mockClient.EXPECT().
+				CreateAuthorizationGroup(gomock.Any(), "test-org", GroupNameManagers, "/test-project/managers").
+				Return(errors.New("keycloak error"))
+
+			mockClient.EXPECT().
+				GetGroupIDByPath(gomock.Any(), "test-org", "/test-project/viewers").
+				Return("viewers-group-id", nil)
+
+			mockClient.EXPECT().
+				DeleteAuthorizationGroup(gomock.Any(), "test-org", "viewers-group-id").
+				Return(nil)
+
+			err := manager.CreateProjectGroups(ctx, "test-org", "test-project")
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("failed to create managers group"))
+		})
+
+		It("should return error when viewers group creation fails", func() {
+			mockClient.EXPECT().
+				CreateAuthorizationGroup(gomock.Any(), "test-org", GroupNameViewers, "/test-project/viewers").
+				Return(errors.New("keycloak error"))
+
+			err := manager.CreateProjectGroups(ctx, "test-org", "test-project")
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("failed to create viewers group"))
 		})
 	})
 })


### PR DESCRIPTION
# Description 
The groups weren't fully removed from Keycloak when a project was deleted before.
Includes minor refactoring for finding groups.

# Testing

- [x] Ran integration test, created org and project, deleted project and verified the groups were removed from keycloak

Assisted-by: Claude Code <noreply@anthropic.com>

/cc @jhernand 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Simplified project group deletion by cascading deletion from the parent group rather than deleting individual subgroups separately
  * Enhanced error handling for group deletion: missing parent groups are now handled gracefully without causing operation failures
  * Improved logging and diagnostics for group management operations

* **Tests**
  * Expanded test coverage for group creation and deletion workflows, including error scenarios and rollback behavior verification

<!-- end of auto-generated comment: release notes by coderabbit.ai -->