### PR TITLE
OSAC-366: migrate net.ParseCIDR to netip.ParsePrefix in server code

### DIFF
--- a/internal/servers/private_clusters_server.go
+++ b/internal/servers/private_clusters_server.go
@@ -18,7 +18,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
-	"net"
+	"net/netip"
 	"sort"
 	"strconv"
 	"strings"
@@ -752,13 +752,13 @@ func validateNetworkCIDRs(spec *privatev1.ClusterSpec) error {
 	}
 	network := spec.GetNetwork()
 	if network.HasPodCidr() {
-		if _, _, err := net.ParseCIDR(network.GetPodCidr()); err != nil {
+		if _, err := netip.ParsePrefix(network.GetPodCidr()); err != nil {
 			return grpcstatus.Errorf(grpccodes.InvalidArgument,
 				"invalid pod_cidr format '%s': %v", network.GetPodCidr(), err)
 		}
 	}
 	if network.HasServiceCidr() {
-		if _, _, err := net.ParseCIDR(network.GetServiceCidr()); err != nil {
+		if _, err := netip.ParsePrefix(network.GetServiceCidr()); err != nil {
 			return grpcstatus.Errorf(grpccodes.InvalidArgument,
 				"invalid service_cidr format '%s': %v", network.GetServiceCidr(), err)
 		}

--- a/internal/servers/private_public_ip_pools_server.go
+++ b/internal/servers/private_public_ip_pools_server.go
@@ -18,7 +18,7 @@ import (
 	"errors"
 	"log/slog"
 	"math"
-	"net"
+	"net/netip"
 	"sort"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -236,13 +236,13 @@ func validateUpdate(newPool *privatev1.PublicIPPool, existing *privatev1.PublicI
 
 // validatePoolCIDRFormat validates CIDR string is parseable and belongs to the specified IP family
 func validatePoolCIDRFormat(cidrStr string, ipFamily privatev1.IPFamily, idx int) error {
-	_, network, err := net.ParseCIDR(cidrStr)
+	prefix, err := netip.ParsePrefix(cidrStr)
 	if err != nil {
 		return grpcstatus.Errorf(grpccodes.InvalidArgument,
 			"invalid CIDR format in field 'spec.cidrs[%d]': '%s': %v", idx, cidrStr, err)
 	}
 
-	isIPv4 := network.IP.To4() != nil
+	isIPv4 := prefix.Addr().Is4()
 	switch ipFamily {
 	case privatev1.IPFamily_IP_FAMILY_IPV4:
 		if !isIPv4 {
@@ -335,12 +335,13 @@ func calculatePoolCapacity(cidrs []string, ipFamily privatev1.IPFamily) int64 {
 
 // calculateCIDRCapacity returns the number of usable IP addresses for a single CIDR
 func calculateCIDRCapacity(cidrStr string, ipFamily privatev1.IPFamily) int64 {
-	_, network, err := net.ParseCIDR(cidrStr)
+	prefix, err := netip.ParsePrefix(cidrStr)
 	if err != nil {
 		return 0
 	}
-	ones, bits := network.Mask.Size()
-	if ones == 0 && bits == 0 {
+	bits := prefix.Addr().BitLen()
+	ones := prefix.Bits()
+	if ones < 0 {
 		return 0
 	}
 	hostBits := bits - ones

--- a/internal/servers/private_subnets_server.go
+++ b/internal/servers/private_subnets_server.go
@@ -18,7 +18,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
-	"net"
+	"net/netip"
 
 	"github.com/prometheus/client_golang/prometheus"
 	grpccodes "google.golang.org/grpc/codes"
@@ -255,29 +255,29 @@ func (s *PrivateSubnetsServer) validateSubnet(ctx context.Context,
 // validateCIDRSubset validates that subnetCIDR is a proper subset of parentCIDR.
 func validateCIDRSubset(subnetCIDR string, parentCIDR string, ipVersion string) error {
 	// Parse subnet CIDR
-	_, subnetNetwork, err := net.ParseCIDR(subnetCIDR)
+	subnetPrefix, err := netip.ParsePrefix(subnetCIDR)
 	if err != nil {
 		return grpcstatus.Errorf(grpccodes.InvalidArgument,
 			"invalid subnet %s CIDR format '%s': %v", ipVersion, subnetCIDR, err)
 	}
 
 	// Parse parent CIDR
-	_, parentNetwork, err := net.ParseCIDR(parentCIDR)
+	parentPrefix, err := netip.ParsePrefix(parentCIDR)
 	if err != nil {
 		return grpcstatus.Errorf(grpccodes.Internal,
 			"invalid parent %s CIDR format '%s': %v", ipVersion, parentCIDR, err)
 	}
 
 	// Check parent contains subnet network address
-	if !parentNetwork.Contains(subnetNetwork.IP) {
+	if !parentPrefix.Contains(subnetPrefix.Addr()) {
 		return grpcstatus.Errorf(grpccodes.InvalidArgument,
 			"subnet %s CIDR '%s' is not within parent VirtualNetwork CIDR '%s'",
 			ipVersion, subnetCIDR, parentCIDR)
 	}
 
 	// Check subnet mask is more specific than parent mask (prevents subnet larger than parent)
-	subnetMaskSize, _ := subnetNetwork.Mask.Size()
-	parentMaskSize, _ := parentNetwork.Mask.Size()
+	subnetMaskSize := subnetPrefix.Bits()
+	parentMaskSize := parentPrefix.Bits()
 	if subnetMaskSize < parentMaskSize {
 		return grpcstatus.Errorf(grpccodes.InvalidArgument,
 			"subnet %s CIDR '%s' (/%d) is less specific than parent CIDR '%s' (/%d)",
@@ -429,15 +429,15 @@ func (s *PrivateSubnetsServer) validateNoCIDROverlap(ctx context.Context,
 
 // cidrsOverlap returns true if two CIDRs overlap (one contains any part of the other).
 func cidrsOverlap(cidrA, cidrB string) (bool, error) {
-	_, netA, errA := net.ParseCIDR(cidrA)
-	_, netB, errB := net.ParseCIDR(cidrB)
+	prefixA, errA := netip.ParsePrefix(cidrA)
+	prefixB, errB := netip.ParsePrefix(cidrB)
 	if errA != nil || errB != nil {
 		return false, fmt.Errorf(
 			"failed to parse CIDRs: %q: %w, %q: %w",
 			cidrA, errA, cidrB, errB,
 		)
 	}
-	return netA.Contains(netB.IP) || netB.Contains(netA.IP), nil
+	return prefixA.Contains(prefixB.Addr()) || prefixB.Contains(prefixA.Addr()), nil
 }
 
 // validateImmutableFieldsSubnet validates that immutable fields have not been changed.

--- a/internal/servers/private_virtual_networks_server.go
+++ b/internal/servers/private_virtual_networks_server.go
@@ -18,7 +18,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
-	"net"
+	"net/netip"
 
 	"github.com/prometheus/client_golang/prometheus"
 	grpccodes "google.golang.org/grpc/codes"
@@ -263,14 +263,14 @@ func (s *PrivateVirtualNetworksServer) validateVirtualNetwork(ctx context.Contex
 
 // validateCIDR validates a CIDR string and checks if it matches the expected IP version.
 func validateCIDR(cidrStr string, ipVersion string) error {
-	_, network, err := net.ParseCIDR(cidrStr)
+	prefix, err := netip.ParsePrefix(cidrStr)
 	if err != nil {
 		return grpcstatus.Errorf(grpccodes.InvalidArgument,
 			"invalid %s CIDR format '%s': %v", ipVersion, cidrStr, err)
 	}
 
 	// Validate IP version matches field name
-	isIPv4 := network.IP.To4() != nil
+	isIPv4 := prefix.Addr().Is4()
 	if ipVersion == "IPv4" && !isIPv4 {
 		return grpcstatus.Errorf(grpccodes.InvalidArgument,
 			"field 'ipv4_cidr' contains IPv6 address: %s", cidrStr)

--- a/internal/utils/cluster_spec_defaults.go
+++ b/internal/utils/cluster_spec_defaults.go
@@ -14,7 +14,7 @@ language governing permissions and limitations under the License.
 package utils
 
 import (
-	"net"
+	"net/netip"
 
 	grpccodes "google.golang.org/grpc/codes"
 	grpcstatus "google.golang.org/grpc/status"
@@ -83,7 +83,7 @@ func validateClusterNetwork(network *privatev1.ClusterNetwork) error {
 		return nil
 	}
 	if network.HasPodCidr() {
-		if _, _, err := net.ParseCIDR(network.GetPodCidr()); err != nil {
+		if _, err := netip.ParsePrefix(network.GetPodCidr()); err != nil {
 			return grpcstatus.Errorf(
 				grpccodes.InvalidArgument,
 				"invalid pod_cidr %q: %v",
@@ -92,7 +92,7 @@ func validateClusterNetwork(network *privatev1.ClusterNetwork) error {
 		}
 	}
 	if network.HasServiceCidr() {
-		if _, _, err := net.ParseCIDR(network.GetServiceCidr()); err != nil {
+		if _, err := netip.ParsePrefix(network.GetServiceCidr()); err != nil {
 			return grpcstatus.Errorf(
 				grpccodes.InvalidArgument,
 				"invalid service_cidr %q: %v",


### PR DESCRIPTION
## Summary
- Replaces all 11 `net.ParseCIDR` call sites in server code with `netip.ParsePrefix`
- Switches `"net"` import to `"net/netip"` in all 5 affected files
- No behavioral change — pure refactor to the modern, allocation-free `netip` API

## Files changed
- `internal/servers/private_virtual_networks_server.go` — CIDR validation with IP version check
- `internal/servers/private_subnets_server.go` — CIDR subset validation and overlap detection
- `internal/servers/private_public_ip_pools_server.go` — CIDR format validation and capacity calculation
- `internal/servers/private_clusters_server.go` — pod/service CIDR validation
- `internal/utils/cluster_spec_defaults.go` — cluster network CIDR validation

## Test plan
- [x] `go build ./...` — clean compilation
- [x] `go test ./internal/servers/... ./internal/utils/...` — all tests pass
- [x] Verified zero `net.ParseCIDR` calls remain in server code

Resolves: https://redhat.atlassian.net/browse/OSAC-366

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved CIDR validation and parsing mechanisms across multiple network configuration services—including cluster provisioning, subnet management, virtual network configuration, and IP pool operations. Updated implementation uses modern Go networking utilities to significantly enhance internal code quality, consistency, and maintainability without affecting any user-facing features or overall system operational behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->