### PR TITLE
NO-ISSUE: Add `aud` claim to tokens issued by Keycloak

### DIFF
--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -792,6 +792,23 @@ spec:
     organizationsEnabled: true
 
     clientScopes:
+    - name: osac-api
+      description: OSAC API
+      protocol: openid-connect
+      attributes:
+        include.in.token.scope: "false"
+        display.on.consent.screen: "false"
+      protocolMappers:
+      - name: osac-api-aud
+        protocol: openid-connect
+        protocolMapper: oidc-audience-mapper
+        consentRequired: false
+        config:
+          id.token.claim: "false"
+          lightweight.claim: "false"
+          access.token.claim: "true"
+          introspection.token.claim: "true"
+          included.custom.audience: "osac-api"
     - name: username
       description: Username claim
       protocol: openid-connect
@@ -855,6 +872,7 @@ spec:
       - basic
       - username
       - groups
+      - osac-api
       redirectUris:
       - http://localhost
 
@@ -874,6 +892,7 @@ spec:
       - basic
       - username
       - groups
+      - osac-api
 
     - clientId: osac-controller
       name: OSAC controller
@@ -891,6 +910,7 @@ spec:
       - basic
       - username
       - groups
+      - osac-api
 
     users:
     - username: service-account-osac-admin

--- a/it/charts/keycloak/files/realm.json
+++ b/it/charts/keycloak/files/realm.json
@@ -579,7 +579,7 @@
     "authenticationFlowBindingOverrides" : { },
     "fullScopeAllowed" : true,
     "nodeReRegistrationTimeout" : -1,
-    "defaultClientScopes" : [ "groups", "basic", "username", "organization", "roles" ],
+    "defaultClientScopes" : [ "groups", "basic", "username", "organization", "roles", "osac-api" ],
     "optionalClientScopes" : [ ]
   }, {
     "id" : "e37d4620-4ae2-432e-90d8-2b7f6a662f43",
@@ -661,6 +661,32 @@
     "optionalClientScopes" : [ "address", "phone", "organization", "offline_access", "microprofile-jwt" ]
   } ],
   "clientScopes" : [ {
+    "id" : "8899e9f6-9ba9-48c6-8abd-c281dfd067c5",
+    "name" : "osac-api",
+    "description" : "OSAC API",
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "include.in.token.scope" : "false",
+      "display.on.consent.screen" : "false",
+      "gui.order" : "",
+      "consent.screen.text" : "",
+      "include.in.openid.provider.metadata" : "false"
+    },
+    "protocolMappers" : [ {
+      "id" : "9c44741f-8a3a-4468-8911-6b2ea6611b52",
+      "name" : "osac-api-aud",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-audience-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "id.token.claim" : "false",
+        "lightweight.claim" : "false",
+        "access.token.claim" : "true",
+        "introspection.token.claim" : "true",
+        "included.custom.audience" : "osac-api"
+      }
+    } ]
+  }, {
     "id" : "2d4feb76-fd87-46d5-9eca-b7471da62403",
     "name" : "service_account",
     "description" : "Specific scope for a client enabled for service accounts",

--- a/it/it_tool.go
+++ b/it/it_tool.go
@@ -1056,6 +1056,12 @@ func (t *Tool) deployKeycloak(ctx context.Context) error {
 				"directAccessGrantsEnabled": false,
 				"protocol":                  "openid-connect",
 				"fullScopeAllowed":          true,
+				"defaultClientScopes": []string{
+					"basic",
+					"username",
+					"groups",
+					"osac-api",
+				},
 			},
 		)
 		users = append(


### PR DESCRIPTION
## Summary

- Adds an `osac-api` client scope with an audience mapper so that Keycloak includes `osac-api` as the `aud` claim in access tokens.
- Assigns the scope as a default client scope for the `osac-cli`, `osac-admin`, and `osac-controller` clients.
- Updates the integration test realm, the Helm values in `it_tool.go`, and the installation documentation.

This is a preparatory step toward validating the `aud` claim server-side, which will follow in a separate patch. See [RFC 7519 Section 4.1.3](https://datatracker.ietf.org/doc/html/rfc7519#section-4.1.3) and [RFC 8725 Section 3.9](https://datatracker.ietf.org/doc/html/rfc8725#section-3.9) for background on why audience validation is recommended.

## Test plan

- [x] Integration tests pass (120 of 120 specs).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated Keycloak realm configuration so a new `osac-api` client scope is available, including access-token audience mapping and related mapper behavior.
  * Updated default client scopes for service clients to include `osac-api`.

* **Documentation**
  * Revised the Keycloak realm import example in installation docs to include the `osac-api` client scope and audience-mapper configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->