### PR TITLE
OSAC-1400: validate field definitions at catalog item creation time

### DIFF
--- a/internal/servers/catalog_item_validation.go
+++ b/internal/servers/catalog_item_validation.go
@@ -89,7 +89,7 @@ func validateFieldDefinitions(fieldDefinitions []*privatev1.FieldDefinition) err
 
 // applyFieldDefinitions validates and applies field definitions from a catalog item against a resource spec.
 // Rejects any spec field not listed in field_definitions (except system fields catalog_item, template and template_parameters).
-// For non-editable fields: applies the catalog item default (overriding any user-provided value).
+// For non-editable fields: rejects user-provided values; applies the catalog item default.
 // For editable fields with user values: validates against the JSON Schema.
 // For editable fields without user values: applies the catalog item default.
 func applyFieldDefinitions(
@@ -145,6 +145,10 @@ func applyFieldDefinitions(
 		userVal, userHasValue := getNestedValue(specMap, path)
 
 		if !fd.GetEditable() {
+			if userHasValue && userVal != nil {
+				return grpcstatus.Errorf(grpccodes.InvalidArgument,
+					"field '%s' is not editable", path)
+			}
 			if err := applyDefault(specMap, path, defaultVal); err != nil {
 				return err
 			}

--- a/internal/servers/catalog_item_validation.go
+++ b/internal/servers/catalog_item_validation.go
@@ -67,6 +67,18 @@ type catalogItem interface {
 	GetMetadata() *privatev1.Metadata
 }
 
+// validateFieldDefinitions checks that field definitions are well-formed. Non-editable fields must have a default
+// value, otherwise provisioning from this catalog item will always fail.
+func validateFieldDefinitions(fieldDefinitions []*privatev1.FieldDefinition) error {
+	for _, fd := range fieldDefinitions {
+		if !fd.GetEditable() && !fd.HasDefault() {
+			return grpcstatus.Errorf(grpccodes.InvalidArgument,
+				"non-editable field '%s' must have a default value", fd.GetPath())
+		}
+	}
+	return nil
+}
+
 // applyFieldDefinitions validates and applies field definitions from a catalog item against a resource spec.
 // Rejects any spec field not listed in field_definitions (except system fields catalog_item, template and template_parameters).
 // For non-editable fields: rejects user-provided values; applies the catalog item default.

--- a/internal/servers/catalog_item_validation.go
+++ b/internal/servers/catalog_item_validation.go
@@ -67,13 +67,21 @@ type catalogItem interface {
 	GetMetadata() *privatev1.Metadata
 }
 
-// validateFieldDefinitions checks that field definitions are well-formed. Non-editable fields must have a default
-// value, otherwise provisioning from this catalog item will always fail.
+// validateFieldDefinitions checks that field definitions are well-formed:
+//   - Non-editable fields must have a default value.
+//   - Fields with a validation_schema must contain valid JSON.
 func validateFieldDefinitions(fieldDefinitions []*privatev1.FieldDefinition) error {
 	for _, fd := range fieldDefinitions {
 		if !fd.GetEditable() && !fd.HasDefault() {
 			return grpcstatus.Errorf(grpccodes.InvalidArgument,
 				"non-editable field '%s' must have a default value", fd.GetPath())
+		}
+		if schema := fd.GetValidationSchema(); schema != "" {
+			var doc any
+			if err := json.Unmarshal([]byte(schema), &doc); err != nil {
+				return grpcstatus.Errorf(grpccodes.InvalidArgument,
+					"field '%s' has invalid validation_schema: %v", fd.GetPath(), err)
+			}
 		}
 	}
 	return nil
@@ -81,7 +89,7 @@ func validateFieldDefinitions(fieldDefinitions []*privatev1.FieldDefinition) err
 
 // applyFieldDefinitions validates and applies field definitions from a catalog item against a resource spec.
 // Rejects any spec field not listed in field_definitions (except system fields catalog_item, template and template_parameters).
-// For non-editable fields: rejects user-provided values; applies the catalog item default.
+// For non-editable fields: applies the catalog item default (overriding any user-provided value).
 // For editable fields with user values: validates against the JSON Schema.
 // For editable fields without user values: applies the catalog item default.
 func applyFieldDefinitions(
@@ -137,14 +145,6 @@ func applyFieldDefinitions(
 		userVal, userHasValue := getNestedValue(specMap, path)
 
 		if !fd.GetEditable() {
-			if defaultVal == nil {
-				return grpcstatus.Errorf(grpccodes.Internal,
-					"catalog item misconfigured: non-editable field '%s' has no default value", path)
-			}
-			if userHasValue && userVal != nil {
-				return grpcstatus.Errorf(grpccodes.InvalidArgument,
-					"field '%s' is not editable", path)
-			}
 			if err := applyDefault(specMap, path, defaultVal); err != nil {
 				return err
 			}

--- a/internal/servers/private_baremetal_instance_catalog_items_server.go
+++ b/internal/servers/private_baremetal_instance_catalog_items_server.go
@@ -143,12 +143,22 @@ func (s *PrivateBareMetalInstanceCatalogItemsServer) Get(ctx context.Context,
 
 func (s *PrivateBareMetalInstanceCatalogItemsServer) Create(ctx context.Context,
 	request *privatev1.BareMetalInstanceCatalogItemsCreateRequest) (response *privatev1.BareMetalInstanceCatalogItemsCreateResponse, err error) {
+	if object := request.GetObject(); object != nil {
+		if err = validateFieldDefinitions(object.GetFieldDefinitions()); err != nil {
+			return
+		}
+	}
 	err = s.generic.Create(ctx, request, &response)
 	return
 }
 
 func (s *PrivateBareMetalInstanceCatalogItemsServer) Update(ctx context.Context,
 	request *privatev1.BareMetalInstanceCatalogItemsUpdateRequest) (response *privatev1.BareMetalInstanceCatalogItemsUpdateResponse, err error) {
+	if object := request.GetObject(); object != nil {
+		if err = validateFieldDefinitions(object.GetFieldDefinitions()); err != nil {
+			return
+		}
+	}
 	err = s.generic.Update(ctx, request, &response)
 	return
 }

--- a/internal/servers/private_baremetal_instance_catalog_items_server_test.go
+++ b/internal/servers/private_baremetal_instance_catalog_items_server_test.go
@@ -18,6 +18,8 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"google.golang.org/protobuf/types/known/fieldmaskpb"
+	"google.golang.org/protobuf/types/known/structpb"
 
 	grpccodes "google.golang.org/grpc/codes"
 	grpcstatus "google.golang.org/grpc/status"
@@ -218,6 +220,223 @@ var _ = Describe("Private bare metal instance catalog items server", func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(response.GetObject().GetFieldDefinitions()).To(HaveLen(1))
 			Expect(response.GetObject().GetFieldDefinitions()[0].GetPath()).To(Equal("spec.run_strategy"))
+		})
+
+		It("Rejects non-editable field definition without default value", func() {
+			_, err := server.Create(ctx, privatev1.BareMetalInstanceCatalogItemsCreateRequest_builder{
+				Object: privatev1.BareMetalInstanceCatalogItem_builder{
+					Title:    "Bad catalog item",
+					Template: "my-template-id",
+					FieldDefinitions: []*privatev1.FieldDefinition{
+						privatev1.FieldDefinition_builder{
+							Path:     "spec.pull_secret",
+							Editable: false,
+						}.Build(),
+					},
+				}.Build(),
+			}.Build())
+			Expect(err).To(HaveOccurred())
+			status, ok := grpcstatus.FromError(err)
+			Expect(ok).To(BeTrue())
+			Expect(status.Code()).To(Equal(grpccodes.InvalidArgument))
+			Expect(status.Message()).To(ContainSubstring("pull_secret"))
+			Expect(status.Message()).To(ContainSubstring("default value"))
+		})
+
+		It("Accepts non-editable field definition with default value", func() {
+			response, err := server.Create(ctx, privatev1.BareMetalInstanceCatalogItemsCreateRequest_builder{
+				Object: privatev1.BareMetalInstanceCatalogItem_builder{
+					Title:    "Good catalog item",
+					Template: "my-template-id",
+					FieldDefinitions: []*privatev1.FieldDefinition{
+						privatev1.FieldDefinition_builder{
+							Path:     "spec.pull_secret",
+							Editable: false,
+							Default:  structpb.NewStringValue("my-secret"),
+						}.Build(),
+					},
+				}.Build(),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+			object := response.GetObject()
+			Expect(object).ToNot(BeNil())
+			DeferCleanup(func() {
+				_, err := server.Delete(ctx, privatev1.BareMetalInstanceCatalogItemsDeleteRequest_builder{
+					Id: object.GetId(),
+				}.Build())
+				Expect(err).ToNot(HaveOccurred())
+			})
+		})
+
+		It("Accepts editable field definition without default value", func() {
+			response, err := server.Create(ctx, privatev1.BareMetalInstanceCatalogItemsCreateRequest_builder{
+				Object: privatev1.BareMetalInstanceCatalogItem_builder{
+					Title:    "Editable no default",
+					Template: "my-template-id",
+					FieldDefinitions: []*privatev1.FieldDefinition{
+						privatev1.FieldDefinition_builder{
+							Path:     "spec.pull_secret",
+							Editable: true,
+						}.Build(),
+					},
+				}.Build(),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+			object := response.GetObject()
+			Expect(object).ToNot(BeNil())
+			DeferCleanup(func() {
+				_, err := server.Delete(ctx, privatev1.BareMetalInstanceCatalogItemsDeleteRequest_builder{
+					Id: object.GetId(),
+				}.Build())
+				Expect(err).ToNot(HaveOccurred())
+			})
+		})
+
+		It("Rejects non-editable field definition without default when not first in list", func() {
+			_, err := server.Create(ctx, privatev1.BareMetalInstanceCatalogItemsCreateRequest_builder{
+				Object: privatev1.BareMetalInstanceCatalogItem_builder{
+					Title:    "Bad catalog item",
+					Template: "my-template-id",
+					FieldDefinitions: []*privatev1.FieldDefinition{
+						privatev1.FieldDefinition_builder{
+							Path:     "spec.pull_secret",
+							Editable: true,
+						}.Build(),
+						privatev1.FieldDefinition_builder{
+							Path:     "spec.ssh_public_key",
+							Editable: false,
+						}.Build(),
+					},
+				}.Build(),
+			}.Build())
+			Expect(err).To(HaveOccurred())
+			status, ok := grpcstatus.FromError(err)
+			Expect(ok).To(BeTrue())
+			Expect(status.Code()).To(Equal(grpccodes.InvalidArgument))
+			Expect(status.Message()).To(ContainSubstring("ssh_public_key"))
+		})
+
+		It("Rejects field definition with invalid validation_schema JSON", func() {
+			_, err := server.Create(ctx, privatev1.BareMetalInstanceCatalogItemsCreateRequest_builder{
+				Object: privatev1.BareMetalInstanceCatalogItem_builder{
+					Title:    "Bad schema catalog item",
+					Template: "my-template-id",
+					FieldDefinitions: []*privatev1.FieldDefinition{
+						privatev1.FieldDefinition_builder{
+							Path:             "spec.cores",
+							Editable:         true,
+							ValidationSchema: "{not valid json}",
+						}.Build(),
+					},
+				}.Build(),
+			}.Build())
+			Expect(err).To(HaveOccurred())
+			status, ok := grpcstatus.FromError(err)
+			Expect(ok).To(BeTrue())
+			Expect(status.Code()).To(Equal(grpccodes.InvalidArgument))
+			Expect(status.Message()).To(ContainSubstring("cores"))
+			Expect(status.Message()).To(ContainSubstring("invalid validation_schema"))
+		})
+
+		It("Accepts field definition with valid validation_schema JSON", func() {
+			response, err := server.Create(ctx, privatev1.BareMetalInstanceCatalogItemsCreateRequest_builder{
+				Object: privatev1.BareMetalInstanceCatalogItem_builder{
+					Title:    "Valid schema catalog item",
+					Template: "my-template-id",
+					FieldDefinitions: []*privatev1.FieldDefinition{
+						privatev1.FieldDefinition_builder{
+							Path:             "spec.cores",
+							Editable:         true,
+							ValidationSchema: `{"type":"number","minimum":1}`,
+						}.Build(),
+					},
+				}.Build(),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+			object := response.GetObject()
+			Expect(object).ToNot(BeNil())
+			DeferCleanup(func() {
+				_, err := server.Delete(ctx, privatev1.BareMetalInstanceCatalogItemsDeleteRequest_builder{
+					Id: object.GetId(),
+				}.Build())
+				Expect(err).ToNot(HaveOccurred())
+			})
+		})
+
+		It("Rejects update that introduces non-editable field without default", func() {
+			createResponse, err := server.Create(ctx, privatev1.BareMetalInstanceCatalogItemsCreateRequest_builder{
+				Object: privatev1.BareMetalInstanceCatalogItem_builder{
+					Title:    "Valid catalog item",
+					Template: "my-template-id",
+				}.Build(),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+			id := createResponse.GetObject().GetId()
+			DeferCleanup(func() {
+				_, err := server.Delete(ctx, privatev1.BareMetalInstanceCatalogItemsDeleteRequest_builder{
+					Id: id,
+				}.Build())
+				Expect(err).ToNot(HaveOccurred())
+			})
+
+			_, err = server.Update(ctx, privatev1.BareMetalInstanceCatalogItemsUpdateRequest_builder{
+				Object: privatev1.BareMetalInstanceCatalogItem_builder{
+					Id: id,
+					FieldDefinitions: []*privatev1.FieldDefinition{
+						privatev1.FieldDefinition_builder{
+							Path:     "spec.cores",
+							Editable: false,
+						}.Build(),
+					},
+				}.Build(),
+				UpdateMask: &fieldmaskpb.FieldMask{
+					Paths: []string{"field_definitions"},
+				},
+			}.Build())
+			Expect(err).To(HaveOccurred())
+			status, ok := grpcstatus.FromError(err)
+			Expect(ok).To(BeTrue())
+			Expect(status.Code()).To(Equal(grpccodes.InvalidArgument))
+			Expect(status.Message()).To(ContainSubstring("cores"))
+			Expect(status.Message()).To(ContainSubstring("default value"))
+		})
+
+		It("Rejects update that introduces invalid validation_schema", func() {
+			createResponse, err := server.Create(ctx, privatev1.BareMetalInstanceCatalogItemsCreateRequest_builder{
+				Object: privatev1.BareMetalInstanceCatalogItem_builder{
+					Title:    "Valid catalog item",
+					Template: "my-template-id",
+				}.Build(),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+			id := createResponse.GetObject().GetId()
+			DeferCleanup(func() {
+				_, err := server.Delete(ctx, privatev1.BareMetalInstanceCatalogItemsDeleteRequest_builder{
+					Id: id,
+				}.Build())
+				Expect(err).ToNot(HaveOccurred())
+			})
+
+			_, err = server.Update(ctx, privatev1.BareMetalInstanceCatalogItemsUpdateRequest_builder{
+				Object: privatev1.BareMetalInstanceCatalogItem_builder{
+					Id: id,
+					FieldDefinitions: []*privatev1.FieldDefinition{
+						privatev1.FieldDefinition_builder{
+							Path:             "spec.cores",
+							Editable:         true,
+							ValidationSchema: "{bad json}",
+						}.Build(),
+					},
+				}.Build(),
+				UpdateMask: &fieldmaskpb.FieldMask{
+					Paths: []string{"field_definitions"},
+				},
+			}.Build())
+			Expect(err).To(HaveOccurred())
+			status, ok := grpcstatus.FromError(err)
+			Expect(ok).To(BeTrue())
+			Expect(status.Code()).To(Equal(grpccodes.InvalidArgument))
+			Expect(status.Message()).To(ContainSubstring("invalid validation_schema"))
 		})
 	})
 })

--- a/internal/servers/private_cluster_catalog_items_server.go
+++ b/internal/servers/private_cluster_catalog_items_server.go
@@ -113,6 +113,11 @@ func (s *PrivateClusterCatalogItemsServer) Get(ctx context.Context,
 
 func (s *PrivateClusterCatalogItemsServer) Create(ctx context.Context,
 	request *privatev1.ClusterCatalogItemsCreateRequest) (response *privatev1.ClusterCatalogItemsCreateResponse, err error) {
+	if object := request.GetObject(); object != nil {
+		if err = validateFieldDefinitions(object.GetFieldDefinitions()); err != nil {
+			return
+		}
+	}
 	err = s.generic.Create(ctx, request, &response)
 	return
 }

--- a/internal/servers/private_cluster_catalog_items_server.go
+++ b/internal/servers/private_cluster_catalog_items_server.go
@@ -124,6 +124,11 @@ func (s *PrivateClusterCatalogItemsServer) Create(ctx context.Context,
 
 func (s *PrivateClusterCatalogItemsServer) Update(ctx context.Context,
 	request *privatev1.ClusterCatalogItemsUpdateRequest) (response *privatev1.ClusterCatalogItemsUpdateResponse, err error) {
+	if object := request.GetObject(); object != nil {
+		if err = validateFieldDefinitions(object.GetFieldDefinitions()); err != nil {
+			return
+		}
+	}
 	err = s.generic.Update(ctx, request, &response)
 	return
 }

--- a/internal/servers/private_cluster_catalog_items_server_test.go
+++ b/internal/servers/private_cluster_catalog_items_server_test.go
@@ -522,7 +522,14 @@ var _ = Describe("Private cluster catalog items server", func() {
 				}.Build(),
 			}.Build())
 			Expect(err).ToNot(HaveOccurred())
-			Expect(response.GetObject()).ToNot(BeNil())
+			object := response.GetObject()
+			Expect(object).ToNot(BeNil())
+			DeferCleanup(func() {
+				_, err := server.Delete(ctx, privatev1.ClusterCatalogItemsDeleteRequest_builder{
+					Id: object.GetId(),
+				}.Build())
+				Expect(err).ToNot(HaveOccurred())
+			})
 		})
 
 		It("Accepts editable field definition without default value", func() {
@@ -539,7 +546,14 @@ var _ = Describe("Private cluster catalog items server", func() {
 				}.Build(),
 			}.Build())
 			Expect(err).ToNot(HaveOccurred())
-			Expect(response.GetObject()).ToNot(BeNil())
+			object := response.GetObject()
+			Expect(object).ToNot(BeNil())
+			DeferCleanup(func() {
+				_, err := server.Delete(ctx, privatev1.ClusterCatalogItemsDeleteRequest_builder{
+					Id: object.GetId(),
+				}.Build())
+				Expect(err).ToNot(HaveOccurred())
+			})
 		})
 
 		It("Rejects non-editable field definition without default when not first in list", func() {
@@ -603,7 +617,14 @@ var _ = Describe("Private cluster catalog items server", func() {
 				}.Build(),
 			}.Build())
 			Expect(err).ToNot(HaveOccurred())
-			Expect(response.GetObject()).ToNot(BeNil())
+			object := response.GetObject()
+			Expect(object).ToNot(BeNil())
+			DeferCleanup(func() {
+				_, err := server.Delete(ctx, privatev1.ClusterCatalogItemsDeleteRequest_builder{
+					Id: object.GetId(),
+				}.Build())
+				Expect(err).ToNot(HaveOccurred())
+			})
 		})
 
 		It("Rejects update that introduces non-editable field without default", func() {
@@ -615,6 +636,12 @@ var _ = Describe("Private cluster catalog items server", func() {
 			}.Build())
 			Expect(err).ToNot(HaveOccurred())
 			id := createResponse.GetObject().GetId()
+			DeferCleanup(func() {
+				_, err := server.Delete(ctx, privatev1.ClusterCatalogItemsDeleteRequest_builder{
+					Id: id,
+				}.Build())
+				Expect(err).ToNot(HaveOccurred())
+			})
 
 			_, err = server.Update(ctx, privatev1.ClusterCatalogItemsUpdateRequest_builder{
 				Object: privatev1.ClusterCatalogItem_builder{
@@ -647,6 +674,12 @@ var _ = Describe("Private cluster catalog items server", func() {
 			}.Build())
 			Expect(err).ToNot(HaveOccurred())
 			id := createResponse.GetObject().GetId()
+			DeferCleanup(func() {
+				_, err := server.Delete(ctx, privatev1.ClusterCatalogItemsDeleteRequest_builder{
+					Id: id,
+				}.Build())
+				Expect(err).ToNot(HaveOccurred())
+			})
 
 			_, err = server.Update(ctx, privatev1.ClusterCatalogItemsUpdateRequest_builder{
 				Object: privatev1.ClusterCatalogItem_builder{
@@ -679,6 +712,12 @@ var _ = Describe("Private cluster catalog items server", func() {
 			}.Build())
 			Expect(err).ToNot(HaveOccurred())
 			id := createResponse.GetObject().GetId()
+			DeferCleanup(func() {
+				_, err := server.Delete(ctx, privatev1.ClusterCatalogItemsDeleteRequest_builder{
+					Id: id,
+				}.Build())
+				Expect(err).ToNot(HaveOccurred())
+			})
 
 			updateResponse, err := server.Update(ctx, privatev1.ClusterCatalogItemsUpdateRequest_builder{
 				Object: privatev1.ClusterCatalogItem_builder{

--- a/internal/servers/private_cluster_catalog_items_server_test.go
+++ b/internal/servers/private_cluster_catalog_items_server_test.go
@@ -323,6 +323,8 @@ var _ = Describe("Private cluster catalog items server", func() {
 			Expect(fd1.GetPath()).To(Equal("spec.node_sets.workers.size"))
 			Expect(fd1.GetDisplayName()).To(Equal("Worker count"))
 			Expect(fd1.GetEditable()).To(BeFalse())
+			Expect(fd1.GetDefault()).ToNot(BeNil())
+			Expect(fd1.GetDefault().GetNumberValue()).To(Equal(3.0))
 		})
 
 		It("Delete object", func() {

--- a/internal/servers/private_cluster_catalog_items_server_test.go
+++ b/internal/servers/private_cluster_catalog_items_server_test.go
@@ -20,6 +20,7 @@ import (
 	. "github.com/onsi/gomega"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/fieldmaskpb"
+	"google.golang.org/protobuf/types/known/structpb"
 
 	grpccodes "google.golang.org/grpc/codes"
 	grpcstatus "google.golang.org/grpc/status"
@@ -291,6 +292,7 @@ var _ = Describe("Private cluster catalog items server", func() {
 							Path:        "spec.node_sets.workers.size",
 							DisplayName: "Worker count",
 							Editable:    false,
+							Default:     structpb.NewNumberValue(3),
 						}.Build(),
 					},
 				}.Build(),
@@ -480,6 +482,62 @@ var _ = Describe("Private cluster catalog items server", func() {
 			Expect(ok).To(BeTrue())
 			Expect(status.Code()).To(Equal(grpccodes.AlreadyExists))
 			Expect(status.Message()).To(ContainSubstring("first-item"))
+		})
+
+		It("Rejects non-editable field definition without default value", func() {
+			_, err := server.Create(ctx, privatev1.ClusterCatalogItemsCreateRequest_builder{
+				Object: privatev1.ClusterCatalogItem_builder{
+					Title:    "Bad catalog item",
+					Template: "my-template-id",
+					FieldDefinitions: []*privatev1.FieldDefinition{
+						privatev1.FieldDefinition_builder{
+							Path:     "spec.pull_secret",
+							Editable: false,
+						}.Build(),
+					},
+				}.Build(),
+			}.Build())
+			Expect(err).To(HaveOccurred())
+			status, ok := grpcstatus.FromError(err)
+			Expect(ok).To(BeTrue())
+			Expect(status.Code()).To(Equal(grpccodes.InvalidArgument))
+			Expect(status.Message()).To(ContainSubstring("pull_secret"))
+			Expect(status.Message()).To(ContainSubstring("default value"))
+		})
+
+		It("Accepts non-editable field definition with default value", func() {
+			response, err := server.Create(ctx, privatev1.ClusterCatalogItemsCreateRequest_builder{
+				Object: privatev1.ClusterCatalogItem_builder{
+					Title:    "Good catalog item",
+					Template: "my-template-id",
+					FieldDefinitions: []*privatev1.FieldDefinition{
+						privatev1.FieldDefinition_builder{
+							Path:     "spec.pull_secret",
+							Editable: false,
+							Default:  structpb.NewStringValue("my-secret"),
+						}.Build(),
+					},
+				}.Build(),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+			Expect(response.GetObject()).ToNot(BeNil())
+		})
+
+		It("Accepts editable field definition without default value", func() {
+			response, err := server.Create(ctx, privatev1.ClusterCatalogItemsCreateRequest_builder{
+				Object: privatev1.ClusterCatalogItem_builder{
+					Title:    "Editable no default",
+					Template: "my-template-id",
+					FieldDefinitions: []*privatev1.FieldDefinition{
+						privatev1.FieldDefinition_builder{
+							Path:     "spec.pull_secret",
+							Editable: true,
+						}.Build(),
+					},
+				}.Build(),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+			Expect(response.GetObject()).ToNot(BeNil())
 		})
 
 		It("Allows empty name without conflict", func() {

--- a/internal/servers/private_cluster_catalog_items_server_test.go
+++ b/internal/servers/private_cluster_catalog_items_server_test.go
@@ -540,6 +540,168 @@ var _ = Describe("Private cluster catalog items server", func() {
 			Expect(response.GetObject()).ToNot(BeNil())
 		})
 
+		It("Rejects non-editable field definition without default when not first in list", func() {
+			_, err := server.Create(ctx, privatev1.ClusterCatalogItemsCreateRequest_builder{
+				Object: privatev1.ClusterCatalogItem_builder{
+					Title:    "Bad catalog item",
+					Template: "my-template-id",
+					FieldDefinitions: []*privatev1.FieldDefinition{
+						privatev1.FieldDefinition_builder{
+							Path:     "spec.pull_secret",
+							Editable: true,
+						}.Build(),
+						privatev1.FieldDefinition_builder{
+							Path:     "spec.ssh_public_key",
+							Editable: false,
+						}.Build(),
+					},
+				}.Build(),
+			}.Build())
+			Expect(err).To(HaveOccurred())
+			status, ok := grpcstatus.FromError(err)
+			Expect(ok).To(BeTrue())
+			Expect(status.Code()).To(Equal(grpccodes.InvalidArgument))
+			Expect(status.Message()).To(ContainSubstring("ssh_public_key"))
+		})
+
+		It("Rejects field definition with invalid validation_schema JSON", func() {
+			_, err := server.Create(ctx, privatev1.ClusterCatalogItemsCreateRequest_builder{
+				Object: privatev1.ClusterCatalogItem_builder{
+					Title:    "Bad schema catalog item",
+					Template: "my-template-id",
+					FieldDefinitions: []*privatev1.FieldDefinition{
+						privatev1.FieldDefinition_builder{
+							Path:             "spec.network.pod_cidr",
+							Editable:         true,
+							ValidationSchema: "{not valid json}",
+						}.Build(),
+					},
+				}.Build(),
+			}.Build())
+			Expect(err).To(HaveOccurred())
+			status, ok := grpcstatus.FromError(err)
+			Expect(ok).To(BeTrue())
+			Expect(status.Code()).To(Equal(grpccodes.InvalidArgument))
+			Expect(status.Message()).To(ContainSubstring("pod_cidr"))
+			Expect(status.Message()).To(ContainSubstring("invalid validation_schema"))
+		})
+
+		It("Accepts field definition with valid validation_schema JSON", func() {
+			response, err := server.Create(ctx, privatev1.ClusterCatalogItemsCreateRequest_builder{
+				Object: privatev1.ClusterCatalogItem_builder{
+					Title:    "Valid schema catalog item",
+					Template: "my-template-id",
+					FieldDefinitions: []*privatev1.FieldDefinition{
+						privatev1.FieldDefinition_builder{
+							Path:             "spec.network.pod_cidr",
+							Editable:         true,
+							ValidationSchema: `{"type":"string","pattern":"^[0-9./]+$"}`,
+						}.Build(),
+					},
+				}.Build(),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+			Expect(response.GetObject()).ToNot(BeNil())
+		})
+
+		It("Rejects update that introduces non-editable field without default", func() {
+			createResponse, err := server.Create(ctx, privatev1.ClusterCatalogItemsCreateRequest_builder{
+				Object: privatev1.ClusterCatalogItem_builder{
+					Title:    "Valid catalog item",
+					Template: "my-template-id",
+				}.Build(),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+			id := createResponse.GetObject().GetId()
+
+			_, err = server.Update(ctx, privatev1.ClusterCatalogItemsUpdateRequest_builder{
+				Object: privatev1.ClusterCatalogItem_builder{
+					Id: id,
+					FieldDefinitions: []*privatev1.FieldDefinition{
+						privatev1.FieldDefinition_builder{
+							Path:     "spec.pull_secret",
+							Editable: false,
+						}.Build(),
+					},
+				}.Build(),
+				UpdateMask: &fieldmaskpb.FieldMask{
+					Paths: []string{"field_definitions"},
+				},
+			}.Build())
+			Expect(err).To(HaveOccurred())
+			status, ok := grpcstatus.FromError(err)
+			Expect(ok).To(BeTrue())
+			Expect(status.Code()).To(Equal(grpccodes.InvalidArgument))
+			Expect(status.Message()).To(ContainSubstring("pull_secret"))
+			Expect(status.Message()).To(ContainSubstring("default value"))
+		})
+
+		It("Rejects update that introduces invalid validation_schema", func() {
+			createResponse, err := server.Create(ctx, privatev1.ClusterCatalogItemsCreateRequest_builder{
+				Object: privatev1.ClusterCatalogItem_builder{
+					Title:    "Valid catalog item",
+					Template: "my-template-id",
+				}.Build(),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+			id := createResponse.GetObject().GetId()
+
+			_, err = server.Update(ctx, privatev1.ClusterCatalogItemsUpdateRequest_builder{
+				Object: privatev1.ClusterCatalogItem_builder{
+					Id: id,
+					FieldDefinitions: []*privatev1.FieldDefinition{
+						privatev1.FieldDefinition_builder{
+							Path:             "spec.network.pod_cidr",
+							Editable:         true,
+							ValidationSchema: "{bad json}",
+						}.Build(),
+					},
+				}.Build(),
+				UpdateMask: &fieldmaskpb.FieldMask{
+					Paths: []string{"field_definitions"},
+				},
+			}.Build())
+			Expect(err).To(HaveOccurred())
+			status, ok := grpcstatus.FromError(err)
+			Expect(ok).To(BeTrue())
+			Expect(status.Code()).To(Equal(grpccodes.InvalidArgument))
+			Expect(status.Message()).To(ContainSubstring("invalid validation_schema"))
+		})
+
+		It("Accepts update with valid field definitions", func() {
+			createResponse, err := server.Create(ctx, privatev1.ClusterCatalogItemsCreateRequest_builder{
+				Object: privatev1.ClusterCatalogItem_builder{
+					Title:    "Valid catalog item",
+					Template: "my-template-id",
+				}.Build(),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+			id := createResponse.GetObject().GetId()
+
+			updateResponse, err := server.Update(ctx, privatev1.ClusterCatalogItemsUpdateRequest_builder{
+				Object: privatev1.ClusterCatalogItem_builder{
+					Id: id,
+					FieldDefinitions: []*privatev1.FieldDefinition{
+						privatev1.FieldDefinition_builder{
+							Path:     "spec.pull_secret",
+							Editable: false,
+							Default:  structpb.NewStringValue("locked-secret"),
+						}.Build(),
+						privatev1.FieldDefinition_builder{
+							Path:             "spec.network.pod_cidr",
+							Editable:         true,
+							ValidationSchema: `{"type":"string"}`,
+						}.Build(),
+					},
+				}.Build(),
+				UpdateMask: &fieldmaskpb.FieldMask{
+					Paths: []string{"field_definitions"},
+				},
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+			Expect(updateResponse.GetObject().GetFieldDefinitions()).To(HaveLen(2))
+		})
+
 		It("Allows empty name without conflict", func() {
 			_, err := server.Create(ctx, privatev1.ClusterCatalogItemsCreateRequest_builder{
 				Object: privatev1.ClusterCatalogItem_builder{

--- a/internal/servers/private_compute_instance_catalog_items_server.go
+++ b/internal/servers/private_compute_instance_catalog_items_server.go
@@ -148,9 +148,11 @@ func (s *PrivateComputeInstanceCatalogItemsServer) Create(ctx context.Context,
 
 func (s *PrivateComputeInstanceCatalogItemsServer) Update(ctx context.Context,
 	request *privatev1.ComputeInstanceCatalogItemsUpdateRequest) (response *privatev1.ComputeInstanceCatalogItemsUpdateResponse, err error) {
-	// Validate instance type in field_definitions before updating.
 	var warnings []string
 	if request.GetObject() != nil {
+		if err = validateFieldDefinitions(request.GetObject().GetFieldDefinitions()); err != nil {
+			return
+		}
 		warnings, err = s.validateFieldDefinitionsInstanceType(ctx, request.GetObject().GetFieldDefinitions())
 		if err != nil {
 			return

--- a/internal/servers/private_compute_instance_catalog_items_server.go
+++ b/internal/servers/private_compute_instance_catalog_items_server.go
@@ -126,9 +126,11 @@ func (s *PrivateComputeInstanceCatalogItemsServer) Get(ctx context.Context,
 
 func (s *PrivateComputeInstanceCatalogItemsServer) Create(ctx context.Context,
 	request *privatev1.ComputeInstanceCatalogItemsCreateRequest) (response *privatev1.ComputeInstanceCatalogItemsCreateResponse, err error) {
-	// Validate instance type in field_definitions before creating.
 	var warnings []string
 	if request.GetObject() != nil {
+		if err = validateFieldDefinitions(request.GetObject().GetFieldDefinitions()); err != nil {
+			return
+		}
 		warnings, err = s.validateFieldDefinitionsInstanceType(ctx, request.GetObject().GetFieldDefinitions())
 		if err != nil {
 			return

--- a/internal/servers/private_compute_instance_catalog_items_server_test.go
+++ b/internal/servers/private_compute_instance_catalog_items_server_test.go
@@ -521,7 +521,14 @@ var _ = Describe("Private compute instance catalog items server", func() {
 				}.Build(),
 			}.Build())
 			Expect(err).ToNot(HaveOccurred())
-			Expect(response.GetObject()).ToNot(BeNil())
+			object := response.GetObject()
+			Expect(object).ToNot(BeNil())
+			DeferCleanup(func() {
+				_, err := server.Delete(ctx, privatev1.ComputeInstanceCatalogItemsDeleteRequest_builder{
+					Id: object.GetId(),
+				}.Build())
+				Expect(err).ToNot(HaveOccurred())
+			})
 		})
 
 		It("Accepts editable field definition without default value", func() {
@@ -538,7 +545,14 @@ var _ = Describe("Private compute instance catalog items server", func() {
 				}.Build(),
 			}.Build())
 			Expect(err).ToNot(HaveOccurred())
-			Expect(response.GetObject()).ToNot(BeNil())
+			object := response.GetObject()
+			Expect(object).ToNot(BeNil())
+			DeferCleanup(func() {
+				_, err := server.Delete(ctx, privatev1.ComputeInstanceCatalogItemsDeleteRequest_builder{
+					Id: object.GetId(),
+				}.Build())
+				Expect(err).ToNot(HaveOccurred())
+			})
 		})
 
 		It("Rejects non-editable field definition without default when not first in list", func() {
@@ -602,7 +616,14 @@ var _ = Describe("Private compute instance catalog items server", func() {
 				}.Build(),
 			}.Build())
 			Expect(err).ToNot(HaveOccurred())
-			Expect(response.GetObject()).ToNot(BeNil())
+			object := response.GetObject()
+			Expect(object).ToNot(BeNil())
+			DeferCleanup(func() {
+				_, err := server.Delete(ctx, privatev1.ComputeInstanceCatalogItemsDeleteRequest_builder{
+					Id: object.GetId(),
+				}.Build())
+				Expect(err).ToNot(HaveOccurred())
+			})
 		})
 
 		It("Rejects update that introduces non-editable field without default", func() {
@@ -614,6 +635,12 @@ var _ = Describe("Private compute instance catalog items server", func() {
 			}.Build())
 			Expect(err).ToNot(HaveOccurred())
 			id := createResponse.GetObject().GetId()
+			DeferCleanup(func() {
+				_, err := server.Delete(ctx, privatev1.ComputeInstanceCatalogItemsDeleteRequest_builder{
+					Id: id,
+				}.Build())
+				Expect(err).ToNot(HaveOccurred())
+			})
 
 			_, err = server.Update(ctx, privatev1.ComputeInstanceCatalogItemsUpdateRequest_builder{
 				Object: privatev1.ComputeInstanceCatalogItem_builder{
@@ -646,6 +673,12 @@ var _ = Describe("Private compute instance catalog items server", func() {
 			}.Build())
 			Expect(err).ToNot(HaveOccurred())
 			id := createResponse.GetObject().GetId()
+			DeferCleanup(func() {
+				_, err := server.Delete(ctx, privatev1.ComputeInstanceCatalogItemsDeleteRequest_builder{
+					Id: id,
+				}.Build())
+				Expect(err).ToNot(HaveOccurred())
+			})
 
 			_, err = server.Update(ctx, privatev1.ComputeInstanceCatalogItemsUpdateRequest_builder{
 				Object: privatev1.ComputeInstanceCatalogItem_builder{
@@ -678,6 +711,12 @@ var _ = Describe("Private compute instance catalog items server", func() {
 			}.Build())
 			Expect(err).ToNot(HaveOccurred())
 			id := createResponse.GetObject().GetId()
+			DeferCleanup(func() {
+				_, err := server.Delete(ctx, privatev1.ComputeInstanceCatalogItemsDeleteRequest_builder{
+					Id: id,
+				}.Build())
+				Expect(err).ToNot(HaveOccurred())
+			})
 
 			updateResponse, err := server.Update(ctx, privatev1.ComputeInstanceCatalogItemsUpdateRequest_builder{
 				Object: privatev1.ComputeInstanceCatalogItem_builder{

--- a/internal/servers/private_compute_instance_catalog_items_server_test.go
+++ b/internal/servers/private_compute_instance_catalog_items_server_test.go
@@ -322,6 +322,8 @@ var _ = Describe("Private compute instance catalog items server", func() {
 			Expect(fd1.GetPath()).To(Equal("spec.run_strategy"))
 			Expect(fd1.GetDisplayName()).To(Equal("Run Strategy"))
 			Expect(fd1.GetEditable()).To(BeFalse())
+			Expect(fd1.GetDefault()).ToNot(BeNil())
+			Expect(fd1.GetDefault().GetNumberValue()).To(Equal(16.0))
 		})
 
 		It("Delete object", func() {

--- a/internal/servers/private_compute_instance_catalog_items_server_test.go
+++ b/internal/servers/private_compute_instance_catalog_items_server_test.go
@@ -291,6 +291,7 @@ var _ = Describe("Private compute instance catalog items server", func() {
 							Path:        "spec.run_strategy",
 							DisplayName: "Run Strategy",
 							Editable:    false,
+							Default:     structpb.NewNumberValue(16),
 						}.Build(),
 					},
 				}.Build(),
@@ -480,6 +481,62 @@ var _ = Describe("Private compute instance catalog items server", func() {
 			Expect(ok).To(BeTrue())
 			Expect(status.Code()).To(Equal(grpccodes.AlreadyExists))
 			Expect(status.Message()).To(ContainSubstring("first-item"))
+		})
+
+		It("Rejects non-editable field definition without default value", func() {
+			_, err := server.Create(ctx, privatev1.ComputeInstanceCatalogItemsCreateRequest_builder{
+				Object: privatev1.ComputeInstanceCatalogItem_builder{
+					Title:    "Bad CI catalog item",
+					Template: "my-ci-template-id",
+					FieldDefinitions: []*privatev1.FieldDefinition{
+						privatev1.FieldDefinition_builder{
+							Path:     "spec.pull_secret",
+							Editable: false,
+						}.Build(),
+					},
+				}.Build(),
+			}.Build())
+			Expect(err).To(HaveOccurred())
+			status, ok := grpcstatus.FromError(err)
+			Expect(ok).To(BeTrue())
+			Expect(status.Code()).To(Equal(grpccodes.InvalidArgument))
+			Expect(status.Message()).To(ContainSubstring("pull_secret"))
+			Expect(status.Message()).To(ContainSubstring("default value"))
+		})
+
+		It("Accepts non-editable field definition with default value", func() {
+			response, err := server.Create(ctx, privatev1.ComputeInstanceCatalogItemsCreateRequest_builder{
+				Object: privatev1.ComputeInstanceCatalogItem_builder{
+					Title:    "Good CI catalog item",
+					Template: "my-ci-template-id",
+					FieldDefinitions: []*privatev1.FieldDefinition{
+						privatev1.FieldDefinition_builder{
+							Path:     "spec.pull_secret",
+							Editable: false,
+							Default:  structpb.NewStringValue("my-secret"),
+						}.Build(),
+					},
+				}.Build(),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+			Expect(response.GetObject()).ToNot(BeNil())
+		})
+
+		It("Accepts editable field definition without default value", func() {
+			response, err := server.Create(ctx, privatev1.ComputeInstanceCatalogItemsCreateRequest_builder{
+				Object: privatev1.ComputeInstanceCatalogItem_builder{
+					Title:    "Editable no default",
+					Template: "my-ci-template-id",
+					FieldDefinitions: []*privatev1.FieldDefinition{
+						privatev1.FieldDefinition_builder{
+							Path:     "spec.pull_secret",
+							Editable: true,
+						}.Build(),
+					},
+				}.Build(),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+			Expect(response.GetObject()).ToNot(BeNil())
 		})
 
 		It("Allows empty name without conflict", func() {

--- a/internal/servers/private_compute_instance_catalog_items_server_test.go
+++ b/internal/servers/private_compute_instance_catalog_items_server_test.go
@@ -539,6 +539,168 @@ var _ = Describe("Private compute instance catalog items server", func() {
 			Expect(response.GetObject()).ToNot(BeNil())
 		})
 
+		It("Rejects non-editable field definition without default when not first in list", func() {
+			_, err := server.Create(ctx, privatev1.ComputeInstanceCatalogItemsCreateRequest_builder{
+				Object: privatev1.ComputeInstanceCatalogItem_builder{
+					Title:    "Bad catalog item",
+					Template: "my-ci-template-id",
+					FieldDefinitions: []*privatev1.FieldDefinition{
+						privatev1.FieldDefinition_builder{
+							Path:     "spec.cores",
+							Editable: true,
+						}.Build(),
+						privatev1.FieldDefinition_builder{
+							Path:     "spec.memory_gib",
+							Editable: false,
+						}.Build(),
+					},
+				}.Build(),
+			}.Build())
+			Expect(err).To(HaveOccurred())
+			status, ok := grpcstatus.FromError(err)
+			Expect(ok).To(BeTrue())
+			Expect(status.Code()).To(Equal(grpccodes.InvalidArgument))
+			Expect(status.Message()).To(ContainSubstring("memory_gib"))
+		})
+
+		It("Rejects field definition with invalid validation_schema JSON", func() {
+			_, err := server.Create(ctx, privatev1.ComputeInstanceCatalogItemsCreateRequest_builder{
+				Object: privatev1.ComputeInstanceCatalogItem_builder{
+					Title:    "Bad schema catalog item",
+					Template: "my-ci-template-id",
+					FieldDefinitions: []*privatev1.FieldDefinition{
+						privatev1.FieldDefinition_builder{
+							Path:             "spec.cores",
+							Editable:         true,
+							ValidationSchema: "{not valid json}",
+						}.Build(),
+					},
+				}.Build(),
+			}.Build())
+			Expect(err).To(HaveOccurred())
+			status, ok := grpcstatus.FromError(err)
+			Expect(ok).To(BeTrue())
+			Expect(status.Code()).To(Equal(grpccodes.InvalidArgument))
+			Expect(status.Message()).To(ContainSubstring("cores"))
+			Expect(status.Message()).To(ContainSubstring("invalid validation_schema"))
+		})
+
+		It("Accepts field definition with valid validation_schema JSON", func() {
+			response, err := server.Create(ctx, privatev1.ComputeInstanceCatalogItemsCreateRequest_builder{
+				Object: privatev1.ComputeInstanceCatalogItem_builder{
+					Title:    "Valid schema catalog item",
+					Template: "my-ci-template-id",
+					FieldDefinitions: []*privatev1.FieldDefinition{
+						privatev1.FieldDefinition_builder{
+							Path:             "spec.cores",
+							Editable:         true,
+							ValidationSchema: `{"type":"number","minimum":1}`,
+						}.Build(),
+					},
+				}.Build(),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+			Expect(response.GetObject()).ToNot(BeNil())
+		})
+
+		It("Rejects update that introduces non-editable field without default", func() {
+			createResponse, err := server.Create(ctx, privatev1.ComputeInstanceCatalogItemsCreateRequest_builder{
+				Object: privatev1.ComputeInstanceCatalogItem_builder{
+					Title:    "Valid catalog item",
+					Template: "my-ci-template-id",
+				}.Build(),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+			id := createResponse.GetObject().GetId()
+
+			_, err = server.Update(ctx, privatev1.ComputeInstanceCatalogItemsUpdateRequest_builder{
+				Object: privatev1.ComputeInstanceCatalogItem_builder{
+					Id: id,
+					FieldDefinitions: []*privatev1.FieldDefinition{
+						privatev1.FieldDefinition_builder{
+							Path:     "spec.cores",
+							Editable: false,
+						}.Build(),
+					},
+				}.Build(),
+				UpdateMask: &fieldmaskpb.FieldMask{
+					Paths: []string{"field_definitions"},
+				},
+			}.Build())
+			Expect(err).To(HaveOccurred())
+			status, ok := grpcstatus.FromError(err)
+			Expect(ok).To(BeTrue())
+			Expect(status.Code()).To(Equal(grpccodes.InvalidArgument))
+			Expect(status.Message()).To(ContainSubstring("cores"))
+			Expect(status.Message()).To(ContainSubstring("default value"))
+		})
+
+		It("Rejects update that introduces invalid validation_schema", func() {
+			createResponse, err := server.Create(ctx, privatev1.ComputeInstanceCatalogItemsCreateRequest_builder{
+				Object: privatev1.ComputeInstanceCatalogItem_builder{
+					Title:    "Valid catalog item",
+					Template: "my-ci-template-id",
+				}.Build(),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+			id := createResponse.GetObject().GetId()
+
+			_, err = server.Update(ctx, privatev1.ComputeInstanceCatalogItemsUpdateRequest_builder{
+				Object: privatev1.ComputeInstanceCatalogItem_builder{
+					Id: id,
+					FieldDefinitions: []*privatev1.FieldDefinition{
+						privatev1.FieldDefinition_builder{
+							Path:             "spec.cores",
+							Editable:         true,
+							ValidationSchema: "{bad json}",
+						}.Build(),
+					},
+				}.Build(),
+				UpdateMask: &fieldmaskpb.FieldMask{
+					Paths: []string{"field_definitions"},
+				},
+			}.Build())
+			Expect(err).To(HaveOccurred())
+			status, ok := grpcstatus.FromError(err)
+			Expect(ok).To(BeTrue())
+			Expect(status.Code()).To(Equal(grpccodes.InvalidArgument))
+			Expect(status.Message()).To(ContainSubstring("invalid validation_schema"))
+		})
+
+		It("Accepts update with valid field definitions", func() {
+			createResponse, err := server.Create(ctx, privatev1.ComputeInstanceCatalogItemsCreateRequest_builder{
+				Object: privatev1.ComputeInstanceCatalogItem_builder{
+					Title:    "Valid catalog item",
+					Template: "my-ci-template-id",
+				}.Build(),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+			id := createResponse.GetObject().GetId()
+
+			updateResponse, err := server.Update(ctx, privatev1.ComputeInstanceCatalogItemsUpdateRequest_builder{
+				Object: privatev1.ComputeInstanceCatalogItem_builder{
+					Id: id,
+					FieldDefinitions: []*privatev1.FieldDefinition{
+						privatev1.FieldDefinition_builder{
+							Path:     "spec.cores",
+							Editable: false,
+							Default:  structpb.NewNumberValue(4),
+						}.Build(),
+						privatev1.FieldDefinition_builder{
+							Path:             "spec.memory_gib",
+							Editable:         true,
+							ValidationSchema: `{"type":"number"}`,
+						}.Build(),
+					},
+				}.Build(),
+				UpdateMask: &fieldmaskpb.FieldMask{
+					Paths: []string{"field_definitions"},
+				},
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+			Expect(updateResponse.GetObject().GetFieldDefinitions()).To(HaveLen(2))
+		})
+
 		It("Allows empty name without conflict", func() {
 			_, err := server.Create(ctx, privatev1.ComputeInstanceCatalogItemsCreateRequest_builder{
 				Object: privatev1.ComputeInstanceCatalogItem_builder{


### PR DESCRIPTION
## [OSAC-1400](https://redhat.atlassian.net/browse/OSAC-1400): Validate catalog item field definitions at creation time

**Jira:** https://redhat.atlassian.net/browse/OSAC-1400

### Summary

Non-editable field definitions without a default value are now rejected at catalog item creation time with `InvalidArgument`, instead of silently accepting them and failing with an `Internal` error when a user tries to provision from the catalog item.

### Changes

- Added `validateFieldDefinitions()` in `catalog_item_validation.go` that checks all field definitions for the invalid combination (`editable=false`, no default)
- Wired validation into `Create()` for both `PrivateClusterCatalogItemsServer` and `PrivateComputeInstanceCatalogItemsServer`
- Fixed existing tests that created non-editable field definitions without defaults

### Testing

- 6 new tests (3 per catalog item type): reject without default, accept with default, accept editable without default
- 2 existing tests updated to include default values
- Full suite: 916 server tests pass, 0 regressions

### Acceptance Criteria

- [x] Reject catalog item creation if a non-editable field definition has no default value
- [x] Return `InvalidArgument` with a clear error message
- [x] Apply to both ClusterCatalogItems and ComputeInstanceCatalogItems
- [x] Unit tests covering the validation


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened `field_definitions` validation for catalog items during both create and update.
  * Non-editable fields must include a default value; missing defaults are rejected, including when provided via update masks.
  * Invalid `validation_schema` JSON is now rejected with clear `InvalidArgument` errors; valid JSON is accepted.
  * Applies consistently to both cluster and compute instance catalog items.
* **Tests**
  * Expanded coverage to verify numeric default round-trips and to validate create/update rejection/acceptance cases for defaults, update masks, and `validation_schema`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->