### PR TITLE
NO-ISSUE: Infer OAuth flow from other login flags

### DIFF
--- a/internal/cmd/cli/login/login_cmd.go
+++ b/internal/cmd/cli/login/login_cmd.go
@@ -257,6 +257,12 @@ func (c *runnerContext) run(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to load templates: %w", err)
 	}
 
+	// Infer the OAuth flow from other flags when it hasn't been explicitly set:
+	err = c.inferFlow(ctx)
+	if err != nil {
+		return err
+	}
+
 	// The address used to be specified with a command line flag, but now we also take it from the arguments:
 	c.address = c.args.address
 	if c.address == "" {
@@ -539,6 +545,29 @@ func (c *runnerContext) createTokenSource(ctx context.Context, tokenIssuer strin
 	return
 }
 
+// inferFlow infers the OAuth flow from other command line flags when the user hasn't explicitly set the '--flow' flag.
+// If '--client-secret' is provided, the flow is inferred to be 'credentials'. If '--user' or '--password' is provided,
+// the flow is inferred to be 'password'. If both sets of flags are present without an explicit '--flow', an error is
+// returned asking the user to disambiguate.
+func (c *runnerContext) inferFlow(ctx context.Context) error {
+	if c.flags.Changed("flow") || c.flags.Changed("oauth-flow") {
+		return nil
+	}
+	credentialsHint := c.flags.Changed("client-secret") || c.flags.Changed("oauth-client-secret")
+	passwordHint := c.flags.Changed("user") || c.flags.Changed("oauth-user") || c.flags.Changed("password") ||
+		c.flags.Changed("oauth-password")
+	if credentialsHint && passwordHint {
+		c.console.Render(ctx, "ambiguous_flow.txt", nil)
+		return exit.Error(1)
+	}
+	if credentialsHint {
+		c.args.flow = string(oauth.CredentialsFlow)
+	} else if passwordHint {
+		c.args.flow = string(oauth.PasswordFlow)
+	}
+	return nil
+}
+
 type oauthFlowListener struct {
 	runner *runnerContext
 }
@@ -676,6 +705,11 @@ _URL_ - OAuth issuer URL. This is optional; by default, the issuer advertised by
 const flowFlagHelp = `
 _FLOW_ - OAuth flow to use. Must be one of {{ bt }}code{{ bt }}, {{ bt }}device{{ bt }}, {{ bt }}credentials{{ bt }} or
 {{ bt }}password{{ bt }}.
+
+When this flag is omitted, the flow is inferred from other flags. If {{ bt }}--client-secret{{ bt }} is provided, the
+flow is set to {{ bt }}credentials{{ bt }}. If {{ bt }}--user{{ bt }} or {{ bt }}--password{{ bt }} is provided, the
+flow is set to {{ bt }}password{{ bt }}. If both {{ bt }}--client-secret{{ bt }} and {{ bt }}--user{{ bt }} or {{ bt
+}}--password{{ bt }} are provided, the flow cannot be inferred and this flag must be set explicitly.
 `
 
 const clientIdFlagHelp = `

--- a/internal/cmd/cli/login/templates/ambiguous_flow.txt
+++ b/internal/cmd/cli/login/templates/ambiguous_flow.txt
@@ -1,0 +1,2 @@
+Cannot infer the OAuth flow because both client credentials and user/password flags have been
+provided. Use the '--flow' flag to specify the flow explicitly.


### PR DESCRIPTION
## Summary

- When the `--flow` flag is not explicitly provided, the login command now infers the OAuth flow
  from other flags: `credentials` when `--client-secret` is present, and `password` when `--user`
  or `--password` is present. If both sets are given without an explicit `--flow`, the command
  renders an error asking the user to disambiguate.
- The `--flow` flag help text has been updated to describe the inference rules and the default
  fallback to `device`.

## Test plan

- [x] Unit tests pass (`ginkgo run internal/cmd/cli/login` -- 12 specs)
- [x] Manual: `osac login --client-id=my-sa --client-secret=s https://...` uses `credentials` flow
- [x] Manual: `osac login --user=admin --password=p https://...` uses `password` flow
- [x] Manual: `osac login --client-secret=s --user=u https://...` prints error and exits
- [x] Manual: `osac login --flow=code --client-secret=s https://...` honours explicit `--flow`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * OAuth flow is now automatically inferred from provided credential or password flags during login.
  * Clear error message displayed when OAuth flow is ambiguous due to conflicting flags; users are directed to explicitly specify the flow flag.

* **Documentation**
  * Updated help text for the flow flag to document the new inference behavior and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->