### PR TITLE
NO-ISSUE: Fix exit.Error type assertion in cmd/osac

### DIFF
--- a/cmd/osac/main.go
+++ b/cmd/osac/main.go
@@ -24,7 +24,7 @@ import (
 
 func main() {
 	err := run()
-	exitErr, ok := errors.AsType[*exit.Error](err)
+	exitErr, ok := errors.AsType[exit.Error](err)
 	if ok {
 		os.Exit(exitErr.Code())
 	}


### PR DESCRIPTION
## Summary

- Fix `errors.AsType[*exit.Error]` to `errors.AsType[exit.Error]` in `cmd/osac/main.go`.
  `exit.Error` is a named `int` type and all callers return it as a value, not a pointer. The
  pointer form caused the assertion to silently fail, making the program fall through to the
  generic error handler and print a confusing `Error: 1` message even though the command had
  already rendered its own error output.

## Test plan

- [x] Manual: run `osac login --client-secret=s --user=u https://...` and verify the output ends
  after the command's own error message without an extra `Error: 1` line.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved error handling mechanism for enhanced code maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->