### PR TITLE
NO-ISSUE: Add Helm build artifacts to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,7 @@
 /osac-dev
 __debug_bin*
 __pycache__
+
+# Helm dependency build artifacts
+charts/*/charts/
+charts/*/Chart.lock


### PR DESCRIPTION
## Summary
- Add `charts/*/charts/` and `charts/*/Chart.lock` to `.gitignore`
- These are generated by `helm dependency build` and should not be tracked

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build configuration to ignore Helm dependency artifacts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->