### PR TITLE
OSAC-1284: Automatically add the project creator to the Manager's group

### DIFF
--- a/internal/controllers/project/project_reconciler_function.go
+++ b/internal/controllers/project/project_reconciler_function.go
@@ -205,9 +205,11 @@ func (t *task) validateAndActivate(ctx context.Context) error {
 	}
 
 	// Create Keycloak groups for project authorization
-	if err := t.r.resourceManager.CreateProjectGroups(ctx,
+	// Returns the managers group ID to avoid timing issues with group lookup
+	managersGroupID, err := t.r.resourceManager.CreateProjectGroups(ctx,
 		t.project.GetMetadata().GetTenant(),
-		t.project.GetMetadata().GetName()); err != nil {
+		t.project.GetMetadata().GetName())
+	if err != nil {
 		t.updateCondition(
 			privatev1.ProjectConditionType_PROJECT_CONDITION_TYPE_KEYCLOAK_SYNC,
 			privatev1.ConditionStatus_CONDITION_STATUS_FALSE,
@@ -229,6 +231,31 @@ func (t *task) validateAndActivate(ctx context.Context) error {
 			}
 		}
 		return fmt.Errorf("failed to create Keycloak groups: %w", err)
+	}
+
+	// Add the project creator to the managers group using the ID from creation
+	// This avoids timing issues where the group isn't immediately visible in searches
+	creator := t.project.GetMetadata().GetCreator()
+	if creator != "" {
+		if err := t.r.resourceManager.AddUserToGroupByID(ctx,
+			t.project.GetMetadata().GetTenant(),
+			creator,
+			managersGroupID); err != nil {
+			t.r.logger.WarnContext(ctx, "Failed to add creator to managers group",
+				slog.String("project", t.project.GetMetadata().GetName()),
+				slog.String("!creator", creator),
+				slog.String("managers_group_id", managersGroupID),
+				slog.Any("error", err),
+			)
+			// Don't fail the reconciliation if this fails - the groups are still created
+			// The user can be added manually later
+		} else {
+			t.r.logger.InfoContext(ctx, "Added creator to project managers group",
+				slog.String("project", t.project.GetMetadata().GetName()),
+				slog.String("!creator", creator),
+				slog.String("managers_group_id", managersGroupID),
+			)
+		}
 	}
 
 	// Update condition with success

--- a/internal/controllers/project/project_reconciler_function_test.go
+++ b/internal/controllers/project/project_reconciler_function_test.go
@@ -207,12 +207,12 @@ var _ = Describe("Validation and Activation", func() {
 			// Expect viewers group creation
 			mockIdpClient.EXPECT().
 				CreateAuthorizationGroup(gomock.Any(), "acme", "viewers", "/test-project/viewers").
-				Return(nil)
+				Return("viewers-id", nil)
 
 			// Expect managers group creation
 			mockIdpClient.EXPECT().
 				CreateAuthorizationGroup(gomock.Any(), "acme", "managers", "/test-project/managers").
-				Return(nil)
+				Return("managers-id", nil)
 
 			task := &task{
 				r:       functionObj,
@@ -243,12 +243,12 @@ var _ = Describe("Validation and Activation", func() {
 			// Expect viewers group creation
 			mockIdpClient.EXPECT().
 				CreateAuthorizationGroup(gomock.Any(), "acme", "viewers", "/test-project/viewers").
-				Return(nil)
+				Return("viewers-id", nil)
 
 			// Expect managers group creation
 			mockIdpClient.EXPECT().
 				CreateAuthorizationGroup(gomock.Any(), "acme", "managers", "/test-project/managers").
-				Return(nil)
+				Return("managers-id", nil)
 
 			task := &task{
 				r:       functionObj,
@@ -307,12 +307,12 @@ var _ = Describe("Validation and Activation", func() {
 			// Expect viewers group creation
 			mockIdpClient.EXPECT().
 				CreateAuthorizationGroup(gomock.Any(), "acme", "viewers", "/child-project/viewers").
-				Return(nil)
+				Return("viewers-id", nil)
 
 			// Expect managers group creation
 			mockIdpClient.EXPECT().
 				CreateAuthorizationGroup(gomock.Any(), "acme", "managers", "/child-project/managers").
-				Return(nil)
+				Return("managers-id", nil)
 
 			task := &task{
 				r:       functionObj,
@@ -374,12 +374,12 @@ var _ = Describe("Validation and Activation", func() {
 			// Expect viewers group creation
 			mockIdpClient.EXPECT().
 				CreateAuthorizationGroup(gomock.Any(), "acme", "viewers", "/child-project/viewers").
-				Return(nil)
+				Return("viewers-id", nil)
 
 			// Expect managers group creation (new organization groups API)
 			mockIdpClient.EXPECT().
 				CreateAuthorizationGroup(gomock.Any(), "acme", "managers", "/child-project/managers").
-				Return(nil)
+				Return("managers-id", nil)
 
 			task := &task{
 				r:       functionObj,
@@ -787,7 +787,7 @@ var _ = Describe("Deletion Cleanup", func() {
 				Size: 0,
 			}, nil)
 
-		// Expect parent project group ID lookup to fail
+		// Expect parent project group ID lookup to fail (groups already deleted or never existed)
 		mockIdpClient.EXPECT().
 			GetGroupIDByPath(gomock.Any(), "acme", "/test-project").
 			Return("", status.Error(codes.NotFound, "group not found"))

--- a/internal/database/dao/generic_dao_update.go
+++ b/internal/database/dao/generic_dao_update.go
@@ -281,6 +281,8 @@ func (r *UpdateRequest[O]) translateError(ctx context.Context, id, name, tenant 
 				fields = append(fields, "metadata.name")
 			case "tenant":
 				fields = append(fields, "metadata.tenant")
+			case "creator":
+				fields = append(fields, "metadata.creator")
 			default:
 				r.dao.logger.WarnContext(
 					ctx,

--- a/internal/database/migrations/60_add_projects_immutable_trigger.up.sql
+++ b/internal/database/migrations/60_add_projects_immutable_trigger.up.sql
@@ -1,0 +1,20 @@
+--
+-- Copyright (c) 2026 Red Hat Inc.
+--
+-- Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+-- the License. You may obtain a copy of the License at
+--
+--   http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+-- an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+-- specific language governing permissions and limitations under the License.
+--
+
+-- Attach the immutable column trigger to the projects table to prevent mutation of server-assigned fields.
+-- The creator field is server-assigned at creation time and used by the project reconciler to grant
+-- managers-group membership. Allowing clients to mutate this field would enable privilege escalation.
+create trigger check_immutable_columns
+  before update on projects
+  for each row
+  execute function check_immutable_columns('name', 'tenant', 'creator');

--- a/internal/database/migrations/60_add_projects_immutable_trigger_test.go
+++ b/internal/database/migrations/60_add_projects_immutable_trigger_test.go
@@ -1,0 +1,146 @@
+/*
+Copyright (c) 2026 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package migrations
+
+import (
+	"context"
+	"errors"
+
+	"github.com/jackc/pgx/v5/pgconn"
+	. "github.com/onsi/ginkgo/v2/dsl/core"
+	. "github.com/onsi/gomega"
+)
+
+var _ = DescribeMigration("Add projects immutable trigger", func() {
+	insertTenant := func(ctx context.Context) {
+		_, err := conn.Exec(ctx,
+			`insert into tenants (id, name, tenant, creator, data)
+			 values ('test-tenant', 'test-tenant', 'system', 'system', '{}')
+			 on conflict do nothing`)
+		Expect(err).ToNot(HaveOccurred())
+	}
+
+	It("Adds an update trigger to the projects table", func(ctx context.Context) {
+		err := tool.Migrate(ctx, 60)
+		Expect(err).ToNot(HaveOccurred())
+
+		var count int
+		err = conn.QueryRow(ctx, `
+			select
+				count(*)
+			from
+				information_schema.triggers
+			where
+				trigger_name = 'check_immutable_columns' and
+				event_object_table = 'projects' and
+				action_timing = 'BEFORE' and
+				event_manipulation = 'UPDATE'
+		`).Scan(&count)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(count).To(Equal(1))
+	})
+
+	It("Prevents updating the name field", func(ctx context.Context) {
+		err := tool.Migrate(ctx, 60)
+		Expect(err).ToNot(HaveOccurred())
+		insertTenant(ctx)
+
+		_, err = conn.Exec(ctx,
+			`insert into projects (id, name, tenant, creator, data)
+			 values ('project-1', 'original-name', 'test-tenant', 'user1', '{}')`)
+		Expect(err).ToNot(HaveOccurred())
+
+		_, err = conn.Exec(ctx,
+			`update projects set name = 'new-name' where id = 'project-1'`)
+		Expect(err).To(HaveOccurred())
+		var pgErr *pgconn.PgError
+		Expect(errors.As(err, &pgErr)).To(BeTrue())
+		Expect(pgErr.Code).To(Equal("Z0001"))
+		Expect(pgErr.Message).To(ContainSubstring("column 'name'"))
+		Expect(pgErr.Message).To(ContainSubstring("immutable"))
+	})
+
+	It("Prevents updating the tenant field", func(ctx context.Context) {
+		err := tool.Migrate(ctx, 60)
+		Expect(err).ToNot(HaveOccurred())
+		insertTenant(ctx)
+
+		_, err = conn.Exec(ctx,
+			`insert into projects (id, name, tenant, creator, data)
+			 values ('project-2', 'my-project', 'test-tenant', 'user1', '{}')`)
+		Expect(err).ToNot(HaveOccurred())
+
+		_, err = conn.Exec(ctx,
+			`update projects set tenant = 'other-tenant' where id = 'project-2'`)
+		Expect(err).To(HaveOccurred())
+		var pgErr *pgconn.PgError
+		Expect(errors.As(err, &pgErr)).To(BeTrue())
+		Expect(pgErr.Code).To(Equal("Z0001"))
+		Expect(pgErr.Message).To(ContainSubstring("column 'tenant'"))
+		Expect(pgErr.Message).To(ContainSubstring("immutable"))
+	})
+
+	It("Prevents updating the creator field", func(ctx context.Context) {
+		err := tool.Migrate(ctx, 60)
+		Expect(err).ToNot(HaveOccurred())
+		insertTenant(ctx)
+
+		_, err = conn.Exec(ctx,
+			`insert into projects (id, name, tenant, creator, data)
+			 values ('project-3', 'my-project', 'test-tenant', 'original-user', '{}')`)
+		Expect(err).ToNot(HaveOccurred())
+
+		_, err = conn.Exec(ctx,
+			`update projects set creator = 'attacker-user' where id = 'project-3'`)
+		Expect(err).To(HaveOccurred())
+		var pgErr *pgconn.PgError
+		Expect(errors.As(err, &pgErr)).To(BeTrue())
+		Expect(pgErr.Code).To(Equal("Z0001"))
+		Expect(pgErr.Message).To(ContainSubstring("column 'creator'"))
+		Expect(pgErr.Message).To(ContainSubstring("immutable"))
+	})
+
+	It("Allows updating other fields", func(ctx context.Context) {
+		err := tool.Migrate(ctx, 60)
+		Expect(err).ToNot(HaveOccurred())
+		insertTenant(ctx)
+
+		_, err = conn.Exec(ctx,
+			`insert into projects (id, name, tenant, creator, data)
+			 values ('project-4', 'my-project', 'test-tenant', 'user1', '{"spec": {"title": "Old Title"}}')`)
+		Expect(err).ToNot(HaveOccurred())
+
+		_, err = conn.Exec(ctx,
+			`update projects set data = '{"spec": {"title": "New Title"}}'::jsonb where id = 'project-4'`)
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	It("Allows updating when immutable fields remain unchanged", func(ctx context.Context) {
+		err := tool.Migrate(ctx, 60)
+		Expect(err).ToNot(HaveOccurred())
+		insertTenant(ctx)
+
+		_, err = conn.Exec(ctx,
+			`insert into projects (id, name, tenant, creator, data)
+			 values ('project-5', 'my-project', 'test-tenant', 'user1', '{}')`)
+		Expect(err).ToNot(HaveOccurred())
+
+		_, err = conn.Exec(ctx,
+			`update projects
+			 set name = 'my-project', tenant = 'test-tenant', creator = 'user1',
+			     data = '{"spec": {"title": "Updated"}}'::jsonb
+			 where id = 'project-5'`)
+		Expect(err).ToNot(HaveOccurred())
+	})
+})

--- a/internal/idp/client.go
+++ b/internal/idp/client.go
@@ -83,11 +83,14 @@ type Client interface {
 	// CreateAuthorizationGroup creates a Keycloak organization group for authorization purposes.
 	// Organization groups are scoped to a specific organization and support hierarchical paths.
 	// Recommended path format: "/{project-name}/{viewers|managers}" for top-level projects.
-	CreateAuthorizationGroup(ctx context.Context, organizationName, groupName, groupPath string) error
+	// Returns the created group ID.
+	CreateAuthorizationGroup(ctx context.Context, organizationName, groupName, groupPath string) (string, error)
 	// DeleteAuthorizationGroup deletes a Keycloak organization group by ID.
 	DeleteAuthorizationGroup(ctx context.Context, organizationName, groupID string) error
 	// GetGroupIDByPath gets a Keycloak organization group ID by its path.
 	GetGroupIDByPath(ctx context.Context, organizationName, groupPath string) (string, error)
+	// AddUserToGroup adds a user to an organization group by group ID.
+	AddUserToGroup(ctx context.Context, organizationName, username, groupID string) error
 
 	// Identity Provider operations
 	// CreateIdentityProvider creates a new external identity provider at the realm level.

--- a/internal/idp/internal/idp/client_mock.go
+++ b/internal/idp/internal/idp/client_mock.go
@@ -13,6 +13,7 @@ import (
 	context "context"
 	reflect "reflect"
 
+	idp "github.com/osac-project/fulfillment-service/internal/idp"
 	gomock "go.uber.org/mock/gomock"
 )
 
@@ -41,21 +42,21 @@ func (m *MockClient) EXPECT() *MockClientMockRecorder {
 }
 
 // AddUserToGroup mocks base method.
-func (m *MockClient) AddUserToGroup(ctx context.Context, organizationName, username, groupID string) error {
+func (m *MockClient) AddUserToGroup(ctx context.Context, organizationName, userID, groupID string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "AddUserToGroup", ctx, organizationName, username, groupID)
+	ret := m.ctrl.Call(m, "AddUserToGroup", ctx, organizationName, userID, groupID)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // AddUserToGroup indicates an expected call of AddUserToGroup.
-func (mr *MockClientMockRecorder) AddUserToGroup(ctx, organizationName, username, groupID any) *gomock.Call {
+func (mr *MockClientMockRecorder) AddUserToGroup(ctx, organizationName, userID, groupID any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddUserToGroup", reflect.TypeOf((*MockClient)(nil).AddUserToGroup), ctx, organizationName, username, groupID)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddUserToGroup", reflect.TypeOf((*MockClient)(nil).AddUserToGroup), ctx, organizationName, userID, groupID)
 }
 
 // AssignClientRolesToUser mocks base method.
-func (m *MockClient) AssignClientRolesToUser(ctx context.Context, organizationName, userID, clientID string, roles []*Role) error {
+func (m *MockClient) AssignClientRolesToUser(ctx context.Context, organizationName, userID, clientID string, roles []*idp.Role) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AssignClientRolesToUser", ctx, organizationName, userID, clientID, roles)
 	ret0, _ := ret[0].(error)
@@ -97,7 +98,7 @@ func (mr *MockClientMockRecorder) AssignOrganizationAdminPermissions(ctx, organi
 }
 
 // AssignOrganizationRolesToUser mocks base method.
-func (m *MockClient) AssignOrganizationRolesToUser(ctx context.Context, organizationName, userID string, roles []*Role) error {
+func (m *MockClient) AssignOrganizationRolesToUser(ctx context.Context, organizationName, userID string, roles []*idp.Role) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AssignOrganizationRolesToUser", ctx, organizationName, userID, roles)
 	ret0, _ := ret[0].(error)
@@ -126,10 +127,10 @@ func (mr *MockClientMockRecorder) CreateAuthorizationGroup(ctx, organizationName
 }
 
 // CreateAuthorizationResource mocks base method.
-func (m *MockClient) CreateAuthorizationResource(ctx context.Context, resource *AuthorizationResource) (*AuthorizationResource, error) {
+func (m *MockClient) CreateAuthorizationResource(ctx context.Context, resource *idp.AuthorizationResource) (*idp.AuthorizationResource, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateAuthorizationResource", ctx, resource)
-	ret0, _ := ret[0].(*AuthorizationResource)
+	ret0, _ := ret[0].(*idp.AuthorizationResource)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -140,26 +141,11 @@ func (mr *MockClientMockRecorder) CreateAuthorizationResource(ctx, resource any)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateAuthorizationResource", reflect.TypeOf((*MockClient)(nil).CreateAuthorizationResource), ctx, resource)
 }
 
-// CreateIdentityProvider mocks base method.
-func (m *MockClient) CreateIdentityProvider(ctx context.Context, idp *IdentityProvider) (*IdentityProvider, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateIdentityProvider", ctx, idp)
-	ret0, _ := ret[0].(*IdentityProvider)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// CreateIdentityProvider indicates an expected call of CreateIdentityProvider.
-func (mr *MockClientMockRecorder) CreateIdentityProvider(ctx, idp any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateIdentityProvider", reflect.TypeOf((*MockClient)(nil).CreateIdentityProvider), ctx, idp)
-}
-
 // CreateOrganization mocks base method.
-func (m *MockClient) CreateOrganization(ctx context.Context, org *Organization) (*Organization, error) {
+func (m *MockClient) CreateOrganization(ctx context.Context, org *idp.Organization) (*idp.Organization, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateOrganization", ctx, org)
-	ret0, _ := ret[0].(*Organization)
+	ret0, _ := ret[0].(*idp.Organization)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -171,10 +157,10 @@ func (mr *MockClientMockRecorder) CreateOrganization(ctx, org any) *gomock.Call 
 }
 
 // CreateUser mocks base method.
-func (m *MockClient) CreateUser(ctx context.Context, organizationName string, user *User) (*User, error) {
+func (m *MockClient) CreateUser(ctx context.Context, organizationName string, user *idp.User) (*idp.User, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateUser", ctx, organizationName, user)
-	ret0, _ := ret[0].(*User)
+	ret0, _ := ret[0].(*idp.User)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -242,10 +228,10 @@ func (mr *MockClientMockRecorder) DeleteUser(ctx, organizationName, userID any) 
 }
 
 // GetAuthorizationResource mocks base method.
-func (m *MockClient) GetAuthorizationResource(ctx context.Context, resourceID string) (*AuthorizationResource, error) {
+func (m *MockClient) GetAuthorizationResource(ctx context.Context, resourceID string) (*idp.AuthorizationResource, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetAuthorizationResource", ctx, resourceID)
-	ret0, _ := ret[0].(*AuthorizationResource)
+	ret0, _ := ret[0].(*idp.AuthorizationResource)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -272,10 +258,10 @@ func (mr *MockClientMockRecorder) GetGroupIDByPath(ctx, organizationName, groupP
 }
 
 // GetIdentityProvider mocks base method.
-func (m *MockClient) GetIdentityProvider(ctx context.Context, alias string) (*IdentityProvider, error) {
+func (m *MockClient) GetIdentityProvider(ctx context.Context, alias string) (*idp.IdentityProvider, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetIdentityProvider", ctx, alias)
-	ret0, _ := ret[0].(*IdentityProvider)
+	ret0, _ := ret[0].(*idp.IdentityProvider)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -287,10 +273,10 @@ func (mr *MockClientMockRecorder) GetIdentityProvider(ctx, alias any) *gomock.Ca
 }
 
 // GetOrganization mocks base method.
-func (m *MockClient) GetOrganization(ctx context.Context, name string) (*Organization, error) {
+func (m *MockClient) GetOrganization(ctx context.Context, name string) (*idp.Organization, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetOrganization", ctx, name)
-	ret0, _ := ret[0].(*Organization)
+	ret0, _ := ret[0].(*idp.Organization)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -302,10 +288,10 @@ func (mr *MockClientMockRecorder) GetOrganization(ctx, name any) *gomock.Call {
 }
 
 // GetOrganizationIdentityProvider mocks base method.
-func (m *MockClient) GetOrganizationIdentityProvider(ctx context.Context, organizationName, alias string) (*IdentityProvider, error) {
+func (m *MockClient) GetOrganizationIdentityProvider(ctx context.Context, organizationName, alias string) (*idp.IdentityProvider, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetOrganizationIdentityProvider", ctx, organizationName, alias)
-	ret0, _ := ret[0].(*IdentityProvider)
+	ret0, _ := ret[0].(*idp.IdentityProvider)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -317,10 +303,10 @@ func (mr *MockClientMockRecorder) GetOrganizationIdentityProvider(ctx, organizat
 }
 
 // GetUser mocks base method.
-func (m *MockClient) GetUser(ctx context.Context, organizationName, userID string) (*User, error) {
+func (m *MockClient) GetUser(ctx context.Context, organizationName, userID string) (*idp.User, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetUser", ctx, organizationName, userID)
-	ret0, _ := ret[0].(*User)
+	ret0, _ := ret[0].(*idp.User)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -332,10 +318,10 @@ func (mr *MockClientMockRecorder) GetUser(ctx, organizationName, userID any) *go
 }
 
 // GetUserClientRoles mocks base method.
-func (m *MockClient) GetUserClientRoles(ctx context.Context, organizationName, userID, clientID string) ([]*Role, error) {
+func (m *MockClient) GetUserClientRoles(ctx context.Context, organizationName, userID, clientID string) ([]*idp.Role, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetUserClientRoles", ctx, organizationName, userID, clientID)
-	ret0, _ := ret[0].([]*Role)
+	ret0, _ := ret[0].([]*idp.Role)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -347,10 +333,10 @@ func (mr *MockClientMockRecorder) GetUserClientRoles(ctx, organizationName, user
 }
 
 // GetUserOrganizationRoles mocks base method.
-func (m *MockClient) GetUserOrganizationRoles(ctx context.Context, organizationName, userID string) ([]*Role, error) {
+func (m *MockClient) GetUserOrganizationRoles(ctx context.Context, organizationName, userID string) ([]*idp.Role, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetUserOrganizationRoles", ctx, organizationName, userID)
-	ret0, _ := ret[0].([]*Role)
+	ret0, _ := ret[0].([]*idp.Role)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -362,10 +348,10 @@ func (mr *MockClientMockRecorder) GetUserOrganizationRoles(ctx, organizationName
 }
 
 // ListAllIdentityProviders mocks base method.
-func (m *MockClient) ListAllIdentityProviders(ctx context.Context) ([]*IdentityProvider, error) {
+func (m *MockClient) ListAllIdentityProviders(ctx context.Context) ([]*idp.IdentityProvider, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListAllIdentityProviders", ctx)
-	ret0, _ := ret[0].([]*IdentityProvider)
+	ret0, _ := ret[0].([]*idp.IdentityProvider)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -377,10 +363,10 @@ func (mr *MockClientMockRecorder) ListAllIdentityProviders(ctx any) *gomock.Call
 }
 
 // ListClientRoles mocks base method.
-func (m *MockClient) ListClientRoles(ctx context.Context, organizationName, clientID string) ([]*Role, error) {
+func (m *MockClient) ListClientRoles(ctx context.Context, organizationName, clientID string) ([]*idp.Role, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListClientRoles", ctx, organizationName, clientID)
-	ret0, _ := ret[0].([]*Role)
+	ret0, _ := ret[0].([]*idp.Role)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -392,10 +378,10 @@ func (mr *MockClientMockRecorder) ListClientRoles(ctx, organizationName, clientI
 }
 
 // ListIdentityProviders mocks base method.
-func (m *MockClient) ListIdentityProviders(ctx context.Context, organizationName string) ([]*IdentityProvider, error) {
+func (m *MockClient) ListIdentityProviders(ctx context.Context, organizationName string) ([]*idp.IdentityProvider, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListIdentityProviders", ctx, organizationName)
-	ret0, _ := ret[0].([]*IdentityProvider)
+	ret0, _ := ret[0].([]*idp.IdentityProvider)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -407,10 +393,10 @@ func (mr *MockClientMockRecorder) ListIdentityProviders(ctx, organizationName an
 }
 
 // ListOrganizationRoles mocks base method.
-func (m *MockClient) ListOrganizationRoles(ctx context.Context, organizationName string) ([]*Role, error) {
+func (m *MockClient) ListOrganizationRoles(ctx context.Context, organizationName string) ([]*idp.Role, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListOrganizationRoles", ctx, organizationName)
-	ret0, _ := ret[0].([]*Role)
+	ret0, _ := ret[0].([]*idp.Role)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -422,10 +408,10 @@ func (mr *MockClientMockRecorder) ListOrganizationRoles(ctx, organizationName an
 }
 
 // ListUsers mocks base method.
-func (m *MockClient) ListUsers(ctx context.Context, organizationName string) ([]*User, error) {
+func (m *MockClient) ListUsers(ctx context.Context, organizationName string) ([]*idp.User, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListUsers", ctx, organizationName)
-	ret0, _ := ret[0].([]*User)
+	ret0, _ := ret[0].([]*idp.User)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -437,7 +423,7 @@ func (mr *MockClientMockRecorder) ListUsers(ctx, organizationName any) *gomock.C
 }
 
 // RemoveClientRolesFromUser mocks base method.
-func (m *MockClient) RemoveClientRolesFromUser(ctx context.Context, organizationName, userID, clientID string, roles []*Role) error {
+func (m *MockClient) RemoveClientRolesFromUser(ctx context.Context, organizationName, userID, clientID string, roles []*idp.Role) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RemoveClientRolesFromUser", ctx, organizationName, userID, clientID, roles)
 	ret0, _ := ret[0].(error)
@@ -451,7 +437,7 @@ func (mr *MockClientMockRecorder) RemoveClientRolesFromUser(ctx, organizationNam
 }
 
 // RemoveOrganizationRolesFromUser mocks base method.
-func (m *MockClient) RemoveOrganizationRolesFromUser(ctx context.Context, organizationName, userID string, roles []*Role) error {
+func (m *MockClient) RemoveOrganizationRolesFromUser(ctx context.Context, organizationName, userID string, roles []*idp.Role) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RemoveOrganizationRolesFromUser", ctx, organizationName, userID, roles)
 	ret0, _ := ret[0].(error)
@@ -462,4 +448,18 @@ func (m *MockClient) RemoveOrganizationRolesFromUser(ctx context.Context, organi
 func (mr *MockClientMockRecorder) RemoveOrganizationRolesFromUser(ctx, organizationName, userID, roles any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveOrganizationRolesFromUser", reflect.TypeOf((*MockClient)(nil).RemoveOrganizationRolesFromUser), ctx, organizationName, userID, roles)
+}
+
+// RemoveUserFromGroup mocks base method.
+func (m *MockClient) RemoveUserFromGroup(ctx context.Context, organizationName, userID, groupID string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RemoveUserFromGroup", ctx, organizationName, userID, groupID)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// RemoveUserFromGroup indicates an expected call of RemoveUserFromGroup.
+func (mr *MockClientMockRecorder) RemoveUserFromGroup(ctx, organizationName, userID, groupID any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveUserFromGroup", reflect.TypeOf((*MockClient)(nil).RemoveUserFromGroup), ctx, organizationName, userID, groupID)
 }

--- a/internal/idp/keycloak/authz_groups.go
+++ b/internal/idp/keycloak/authz_groups.go
@@ -16,11 +16,14 @@ package keycloak
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net/http"
 	"net/url"
 	"strings"
+
+	"github.com/osac-project/fulfillment-service/internal/apiclient"
 )
 
 // CreateAuthorizationGroup creates a Keycloak organization group for authorization purposes.
@@ -37,7 +40,7 @@ import (
 // Organization groups are scoped per organization, so paths can be simple and readable.
 // This method creates the full hierarchy if parent groups don't exist.
 // See https://www.keycloak.org/2026/04/org-groups for details.
-func (c *Client) CreateAuthorizationGroup(ctx context.Context, organizationName, groupName, groupPath string) error {
+func (c *Client) CreateAuthorizationGroup(ctx context.Context, organizationName, groupName, groupPath string) (string, error) {
 	c.logger.DebugContext(ctx, "Creating organization authorization group",
 		slog.String("organizationName", organizationName),
 		slog.String("groupName", groupName),
@@ -47,7 +50,7 @@ func (c *Client) CreateAuthorizationGroup(ctx context.Context, organizationName,
 	// Get the organization ID first
 	org, err := c.GetOrganization(ctx, organizationName)
 	if err != nil {
-		return fmt.Errorf("failed to get organization: %w", err)
+		return "", fmt.Errorf("failed to get organization: %w", err)
 	}
 
 	// Parse the path to create parent groups if needed
@@ -57,16 +60,23 @@ func (c *Client) CreateAuthorizationGroup(ctx context.Context, organizationName,
 	cache := make(map[string]string) // path -> groupID
 	err = c.ensureGroupHierarchyWithCache(ctx, org.ID, groupPath, cache)
 	if err != nil {
-		return fmt.Errorf("failed to ensure group hierarchy: %w", err)
+		return "", fmt.Errorf("failed to ensure group hierarchy: %w", err)
+	}
+
+	// Get the created group ID from the cache
+	groupID, ok := cache[groupPath]
+	if !ok {
+		return "", fmt.Errorf("group was created but ID not found in cache: %s", groupPath)
 	}
 
 	c.logger.DebugContext(ctx, "Created organization authorization group",
 		slog.String("organizationName", organizationName),
 		slog.String("groupName", groupName),
 		slog.String("groupPath", groupPath),
+		slog.String("groupID", groupID),
 	)
 
-	return nil
+	return groupID, nil
 }
 
 // DeleteAuthorizationGroup deletes a Keycloak organization group by ID.
@@ -130,7 +140,8 @@ func (c *Client) ensureGroupHierarchyWithCache(ctx context.Context, orgID, group
 		groupID, err := c.createOrganizationGroupWithParent(ctx, orgID, segment, parentID)
 		if err != nil {
 			// Check if it's a "already exists" error (409 conflict)
-			if strings.Contains(err.Error(), "already exists") || strings.Contains(err.Error(), "status=409") {
+			var apiErr *apiclient.APIError
+			if errors.As(err, &apiErr) && apiErr.StatusCode == http.StatusConflict {
 				// Group already exists, look up its ID using orgID directly
 				groupID, lookupErr := c.getGroupIDByPathWithOrgID(ctx, orgID, currentPath)
 				if lookupErr != nil {
@@ -268,4 +279,129 @@ func (c *Client) getGroupIDByPath(ctx context.Context, organizationName, groupPa
 	// Use getGroupIDByPathWithOrgID which lists all groups instead of using the search parameter.
 	// The search parameter is unreliable for recently-created groups.
 	return c.getGroupIDByPathWithOrgID(ctx, org.ID, groupPath)
+}
+
+// getUserIDByUsername looks up a user's UUID by their username.
+// Returns the user's UUID if found, or an error if not found or multiple matches exist.
+func (c *Client) getUserIDByUsername(ctx context.Context, username string) (string, error) {
+	// Use exact match to find the user by username
+	path := fmt.Sprintf("/admin/realms/%s/users?username=%s&exact=true",
+		url.PathEscape(c.realmName),
+		url.QueryEscape(username),
+	)
+
+	response, err := c.httpClient.DoRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return "", fmt.Errorf("failed to search for user: %w", err)
+	}
+	defer response.Body.Close()
+
+	var users []struct {
+		ID       string `json:"id"`
+		Username string `json:"username"`
+	}
+	if err := json.NewDecoder(response.Body).Decode(&users); err != nil {
+		return "", fmt.Errorf("failed to decode user search response: %w", err)
+	}
+
+	if len(users) == 0 {
+		return "", fmt.Errorf("user not found: %s", username)
+	}
+	if len(users) > 1 {
+		return "", fmt.Errorf("multiple users found for username: %s", username)
+	}
+
+	return users[0].ID, nil
+}
+
+// AddUserToGroup adds a user to an organization group by group ID.
+func (c *Client) AddUserToGroup(ctx context.Context, organizationName, username, groupID string) error {
+	c.logger.DebugContext(ctx, "Adding user to organization group",
+		slog.String("organizationName", organizationName),
+		slog.String("!username", username),
+		slog.String("groupID", groupID),
+	)
+
+	// Look up the user's UUID by username
+	userUUID, err := c.getUserIDByUsername(ctx, username)
+	if err != nil {
+		return fmt.Errorf("failed to lookup user UUID: %w", err)
+	}
+
+	c.logger.DebugContext(ctx, "Looked up user UUID",
+		slog.String("!username", username),
+		slog.String("!uuid", userUUID),
+	)
+
+	// Get the organization ID
+	org, err := c.GetOrganization(ctx, organizationName)
+	if err != nil {
+		return fmt.Errorf("failed to get organization: %w", err)
+	}
+
+	// First, ensure the user is a member of the organization
+	// This is required before we can add them to organization groups
+	err = c.ensureOrganizationMember(ctx, org.ID, userUUID)
+	if err != nil {
+		return fmt.Errorf("failed to ensure user is organization member: %w", err)
+	}
+
+	// Add the user to the organization group via the group's members endpoint
+	// PUT /admin/realms/{realm}/organizations/{orgId}/groups/{groupId}/members/{userId}
+	// The userId is in the path, not the body
+	path := fmt.Sprintf("/admin/realms/%s/organizations/%s/groups/%s/members/%s",
+		url.PathEscape(c.realmName),
+		url.PathEscape(org.ID),
+		url.PathEscape(groupID),
+		url.PathEscape(userUUID),
+	)
+
+	response, err := c.httpClient.DoRequest(ctx, http.MethodPut, path, nil)
+	if err != nil {
+		return fmt.Errorf("failed to add user to organization group: %w", err)
+	}
+	defer response.Body.Close()
+
+	c.logger.InfoContext(ctx, "Added user to organization group",
+		slog.String("organizationName", organizationName),
+		slog.String("!username", username),
+		slog.String("!uuid", userUUID),
+		slog.String("groupID", groupID),
+	)
+
+	return nil
+}
+
+// ensureOrganizationMember ensures a user is a member of an organization.
+// If they're already a member, this is a no-op. If not, adds them.
+func (c *Client) ensureOrganizationMember(ctx context.Context, orgID, userUUID string) error {
+	// Try to add the user as an organization member
+	// POST /admin/realms/{realm}/organizations/{org-id}/members
+	// Body is just the user UUID as a plain string
+	path := fmt.Sprintf("/admin/realms/%s/organizations/%s/members",
+		url.PathEscape(c.realmName),
+		url.PathEscape(orgID),
+	)
+
+	response, err := c.httpClient.DoRequest(ctx, http.MethodPost, path, userUUID)
+	if err != nil {
+		// Check if they're already a member (409 conflict)
+		var apiErr *apiclient.APIError
+		if errors.As(err, &apiErr) && apiErr.StatusCode == http.StatusConflict {
+			c.logger.DebugContext(ctx, "User already member of organization",
+				slog.String("!userUUID", userUUID),
+				slog.String("!orgID", orgID),
+			)
+			return nil
+		}
+		return fmt.Errorf("failed to add user to organization: %w", err)
+	}
+	defer response.Body.Close()
+
+	c.logger.DebugContext(ctx, "Added user to organization",
+		slog.String("!userUUID", userUUID),
+		slog.String("!orgID", orgID),
+	)
+
+	return nil
 }

--- a/internal/idp/keycloak/client_test.go
+++ b/internal/idp/keycloak/client_test.go
@@ -1931,8 +1931,9 @@ var _ = Describe("Keycloak Client", func() {
 
 				client = createTestClient(server.URL)
 
-				err := client.CreateAuthorizationGroup(ctx, "acme-corp", "viewers", "/web-app/viewers")
+				groupID, err := client.CreateAuthorizationGroup(ctx, "acme-corp", "viewers", "/web-app/viewers")
 				Expect(err).ToNot(HaveOccurred())
+				Expect(groupID).To(Equal(createdGroups["viewers"]))
 				Expect(createdGroups).To(HaveKey("web-app"))
 				Expect(createdGroups).To(HaveKey("viewers"))
 			})
@@ -1953,9 +1954,10 @@ var _ = Describe("Keycloak Client", func() {
 
 				client = createTestClient(server.URL)
 
-				err := client.CreateAuthorizationGroup(ctx, "nonexistent-org", "viewers", "/web-app/viewers")
+				groupID, err := client.CreateAuthorizationGroup(ctx, "nonexistent-org", "viewers", "/web-app/viewers")
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("failed to get organization"))
+				Expect(groupID).To(BeEmpty())
 			})
 
 			It("should handle 409 conflict by looking up existing group", func() {
@@ -2017,8 +2019,9 @@ var _ = Describe("Keycloak Client", func() {
 
 				client = createTestClient(server.URL)
 
-				err := client.CreateAuthorizationGroup(ctx, "acme-corp", "viewers", "/web-app/viewers")
+				groupID, err := client.CreateAuthorizationGroup(ctx, "acme-corp", "viewers", "/web-app/viewers")
 				Expect(err).ToNot(HaveOccurred())
+				Expect(groupID).To(Equal(createdGroups["viewers"]))
 				Expect(createdGroups).To(HaveKey("viewers"))
 			})
 		})

--- a/internal/idp/manager_test.go
+++ b/internal/idp/manager_test.go
@@ -258,8 +258,9 @@ func (m *mockClient) ListIdentityProviders(ctx context.Context, organizationName
 	return nil, nil
 }
 
-func (m *mockClient) CreateAuthorizationGroup(ctx context.Context, organizationName, groupName, groupPath string) error {
-	return nil
+func (m *mockClient) CreateAuthorizationGroup(ctx context.Context, organizationName, groupName, groupPath string) (string, error) {
+	// Return a fake group ID
+	return "test-group-id", nil
 }
 
 func (m *mockClient) DeleteAuthorizationGroup(ctx context.Context, organizationName, groupID string) error {
@@ -269,6 +270,11 @@ func (m *mockClient) DeleteAuthorizationGroup(ctx context.Context, organizationN
 func (m *mockClient) GetGroupIDByPath(ctx context.Context, organizationName, groupPath string) (string, error) {
 	// Return a fake group ID for testing
 	return "test-group-id", nil
+}
+
+func (m *mockClient) AddUserToGroup(ctx context.Context, organizationName, userID, groupID string) error {
+	// Stub for testing - no-op
+	return nil
 }
 
 var _ = Describe("OrganizationManager", func() {

--- a/internal/idp/resource_manager.go
+++ b/internal/idp/resource_manager.go
@@ -125,51 +125,113 @@ func (m *ResourceManager) getGroupIDByPath(ctx context.Context, organizationName
 // CreateProjectGroups creates Keycloak organization groups for a project.
 // Creates hierarchical groups: /{project-name}/viewers and /{project-name}/managers
 // These groups are used by Authorino OPA policies for authorization.
-func (m *ResourceManager) CreateProjectGroups(ctx context.Context, tenant, projectName string) error {
+// Returns the managers group ID for immediate use (avoids timing issues with group lookup).
+func (m *ResourceManager) CreateProjectGroups(ctx context.Context, tenant, projectName string) (string, error) {
+	if tenant == "" {
+		return "", fmt.Errorf("tenant is required")
+	}
+	if projectName == "" {
+		return "", fmt.Errorf("project name is required")
+	}
+
 	m.logger.DebugContext(ctx, "Creating project groups",
 		slog.String("tenant", tenant),
 		slog.String("project_name", projectName),
 	)
 
 	viewersGroupPath := fmt.Sprintf("/%s/%s", projectName, GroupNameViewers)
-	err := m.client.CreateAuthorizationGroup(ctx, tenant, GroupNameViewers, viewersGroupPath)
+	viewersGroupID, err := m.client.CreateAuthorizationGroup(ctx, tenant, GroupNameViewers, viewersGroupPath)
 	if err != nil {
-		return fmt.Errorf("failed to create viewers group: %w", err)
+		return "", fmt.Errorf("failed to create viewers group: %w", err)
 	}
 
 	m.logger.InfoContext(ctx, "Created project viewers group",
 		slog.String("group_path", viewersGroupPath),
+		slog.String("group_id", viewersGroupID),
 		slog.String("project_name", projectName),
 		slog.String("tenant", tenant),
 	)
 
 	managersGroupPath := fmt.Sprintf("/%s/%s", projectName, GroupNameManagers)
-	err = m.client.CreateAuthorizationGroup(ctx, tenant, GroupNameManagers, managersGroupPath)
+	managersGroupID, err := m.client.CreateAuthorizationGroup(ctx, tenant, GroupNameManagers, managersGroupPath)
 	if err != nil {
 		// Clean up viewers group on failure
-		viewersGroupID, getErr := m.getGroupIDByPath(ctx, tenant, viewersGroupPath)
-		if getErr != nil {
-			m.logger.ErrorContext(ctx, "Failed to get viewers group ID during rollback",
-				slog.String("group_path", viewersGroupPath),
-				slog.Any("get_error", getErr),
+		if cleanupErr := m.client.DeleteAuthorizationGroup(ctx, tenant, viewersGroupID); cleanupErr != nil {
+			m.logger.ErrorContext(ctx, "Failed to cleanup viewers group during rollback",
+				slog.String("group_id", viewersGroupID),
+				slog.Any("cleanup_error", cleanupErr),
 			)
-			return fmt.Errorf("failed to create managers group: %w (rollback also failed to lookup viewers group: %w)", err, getErr)
+			return "", fmt.Errorf("failed to create managers group: %w (rollback also failed: %w)", err, cleanupErr)
 		}
-		if viewersGroupID != "" {
-			if cleanupErr := m.client.DeleteAuthorizationGroup(ctx, tenant, viewersGroupID); cleanupErr != nil {
-				m.logger.ErrorContext(ctx, "Failed to cleanup viewers group during rollback",
-					slog.String("group_id", viewersGroupID),
-					slog.Any("cleanup_error", cleanupErr),
-				)
-				return fmt.Errorf("failed to create managers group: %w (rollback also failed: %w)", err, cleanupErr)
-			}
-		}
-		return fmt.Errorf("failed to create managers group: %w", err)
+		return "", fmt.Errorf("failed to create managers group: %w", err)
 	}
 
 	m.logger.InfoContext(ctx, "Created project managers group",
 		slog.String("group_path", managersGroupPath),
+		slog.String("group_id", managersGroupID),
 		slog.String("project_name", projectName),
+		slog.String("tenant", tenant),
+	)
+
+	return managersGroupID, nil
+}
+
+// AddUserToProjectGroup adds a user to a project group (viewers or managers).
+func (m *ResourceManager) AddUserToProjectGroup(ctx context.Context, tenant, projectName, username, groupType string) error {
+	if tenant == "" {
+		return fmt.Errorf("tenant is required")
+	}
+	if projectName == "" {
+		return fmt.Errorf("project name is required")
+	}
+	if username == "" {
+		return fmt.Errorf("username is required")
+	}
+	if groupType != GroupNameViewers && groupType != GroupNameManagers {
+		return fmt.Errorf("invalid group type %q, must be %q or %q", groupType, GroupNameViewers, GroupNameManagers)
+	}
+
+	groupPath := fmt.Sprintf("/%s/%s", projectName, groupType)
+	groupID, err := m.getGroupIDByPath(ctx, tenant, groupPath)
+	if err != nil {
+		return fmt.Errorf("failed to get group ID for %s: %w", groupPath, err)
+	}
+
+	if err = m.client.AddUserToGroup(ctx, tenant, username, groupID); err != nil {
+		return fmt.Errorf("failed to add user to group %s: %w", groupPath, err)
+	}
+
+	m.logger.InfoContext(ctx, "Added user to project group",
+		slog.String("group_path", groupPath),
+		slog.String("group_type", groupType),
+		slog.String("!username", username),
+		slog.String("project_name", projectName),
+		slog.String("tenant", tenant),
+	)
+
+	return nil
+}
+
+// AddUserToGroupByID adds a user to a group using the group ID directly.
+// This avoids timing issues with group lookup for recently created groups.
+func (m *ResourceManager) AddUserToGroupByID(ctx context.Context, tenant, username, groupID string) error {
+	if tenant == "" {
+		return fmt.Errorf("tenant is required")
+	}
+	if username == "" {
+		return fmt.Errorf("username is required")
+	}
+	if groupID == "" {
+		return fmt.Errorf("group ID is required")
+	}
+
+	if err := m.client.AddUserToGroup(ctx, tenant, username, groupID); err != nil {
+		return fmt.Errorf("failed to add user to group: %w", err)
+	}
+
+	m.logger.InfoContext(ctx, "Added user to group",
+		slog.String("group_id", groupID),
+		slog.String("!username", username),
 		slog.String("tenant", tenant),
 	)
 

--- a/internal/idp/resource_manager_test.go
+++ b/internal/idp/resource_manager_test.go
@@ -143,46 +143,132 @@ var _ = Describe("ResourceManager", func() {
 		It("should create hierarchical viewers and managers groups", func() {
 			mockClient.EXPECT().
 				CreateAuthorizationGroup(gomock.Any(), "test-org", GroupNameViewers, "/test-project/viewers").
-				Return(nil)
+				Return("viewers-group-id", nil)
 
 			mockClient.EXPECT().
 				CreateAuthorizationGroup(gomock.Any(), "test-org", GroupNameManagers, "/test-project/managers").
-				Return(nil)
+				Return("managers-group-id", nil)
 
-			err := manager.CreateProjectGroups(ctx, "test-org", "test-project")
+			managersID, err := manager.CreateProjectGroups(ctx, "test-org", "test-project")
 			Expect(err).ToNot(HaveOccurred())
+			Expect(managersID).To(Equal("managers-group-id"))
 		})
 
 		It("should rollback viewers group when managers group creation fails", func() {
 			mockClient.EXPECT().
 				CreateAuthorizationGroup(gomock.Any(), "test-org", GroupNameViewers, "/test-project/viewers").
-				Return(nil)
+				Return("viewers-group-id", nil)
 
 			mockClient.EXPECT().
 				CreateAuthorizationGroup(gomock.Any(), "test-org", GroupNameManagers, "/test-project/managers").
-				Return(errors.New("keycloak error"))
-
-			mockClient.EXPECT().
-				GetGroupIDByPath(gomock.Any(), "test-org", "/test-project/viewers").
-				Return("viewers-group-id", nil)
+				Return("", errors.New("keycloak error"))
 
 			mockClient.EXPECT().
 				DeleteAuthorizationGroup(gomock.Any(), "test-org", "viewers-group-id").
 				Return(nil)
 
-			err := manager.CreateProjectGroups(ctx, "test-org", "test-project")
+			managersID, err := manager.CreateProjectGroups(ctx, "test-org", "test-project")
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("failed to create managers group"))
+			Expect(managersID).To(BeEmpty())
 		})
 
 		It("should return error when viewers group creation fails", func() {
 			mockClient.EXPECT().
 				CreateAuthorizationGroup(gomock.Any(), "test-org", GroupNameViewers, "/test-project/viewers").
-				Return(errors.New("keycloak error"))
+				Return("", errors.New("keycloak error"))
 
-			err := manager.CreateProjectGroups(ctx, "test-org", "test-project")
+			managersID, err := manager.CreateProjectGroups(ctx, "test-org", "test-project")
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("failed to create viewers group"))
+			Expect(managersID).To(BeEmpty())
+		})
+	})
+
+	Describe("AddUserToProjectGroup", func() {
+		var manager *ResourceManager
+
+		BeforeEach(func() {
+			var err error
+			manager, err = NewResourceManager().
+				SetLogger(logger).
+				SetClient(mockClient).
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("should add user to managers group", func() {
+			mockClient.EXPECT().
+				GetGroupIDByPath(gomock.Any(), "test-org", "/test-project/managers").
+				Return("managers-group-id", nil)
+
+			mockClient.EXPECT().
+				AddUserToGroup(gomock.Any(), "test-org", "user-123", "managers-group-id").
+				Return(nil)
+
+			err := manager.AddUserToProjectGroup(ctx, "test-org", "test-project", "user-123", GroupNameManagers)
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("should add user to viewers group", func() {
+			mockClient.EXPECT().
+				GetGroupIDByPath(gomock.Any(), "test-org", "/test-project/viewers").
+				Return("viewers-group-id", nil)
+
+			mockClient.EXPECT().
+				AddUserToGroup(gomock.Any(), "test-org", "user-456", "viewers-group-id").
+				Return(nil)
+
+			err := manager.AddUserToProjectGroup(ctx, "test-org", "test-project", "user-456", GroupNameViewers)
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("should return error when tenant is empty", func() {
+			err := manager.AddUserToProjectGroup(ctx, "", "test-project", "user-123", GroupNameManagers)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("tenant is required"))
+		})
+
+		It("should return error when project name is empty", func() {
+			err := manager.AddUserToProjectGroup(ctx, "test-org", "", "user-123", GroupNameManagers)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("project name is required"))
+		})
+
+		It("should return error when username is empty", func() {
+			err := manager.AddUserToProjectGroup(ctx, "test-org", "test-project", "", GroupNameManagers)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("username is required"))
+		})
+
+		It("should return error for invalid group type", func() {
+			err := manager.AddUserToProjectGroup(ctx, "test-org", "test-project", "user-123", "invalid-group")
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("invalid group type"))
+		})
+
+		It("should return error when group lookup fails", func() {
+			mockClient.EXPECT().
+				GetGroupIDByPath(gomock.Any(), "test-org", "/test-project/managers").
+				Return("", errors.New("group not found"))
+
+			err := manager.AddUserToProjectGroup(ctx, "test-org", "test-project", "user-123", GroupNameManagers)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("failed to get group ID"))
+		})
+
+		It("should return error when adding user to group fails", func() {
+			mockClient.EXPECT().
+				GetGroupIDByPath(gomock.Any(), "test-org", "/test-project/managers").
+				Return("managers-group-id", nil)
+
+			mockClient.EXPECT().
+				AddUserToGroup(gomock.Any(), "test-org", "user-123", "managers-group-id").
+				Return(errors.New("keycloak error"))
+
+			err := manager.AddUserToProjectGroup(ctx, "test-org", "test-project", "user-123", GroupNameManagers)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("failed to add user to group"))
 		})
 	})
 })

--- a/internal/servers/private_projects_server_test.go
+++ b/internal/servers/private_projects_server_test.go
@@ -16,6 +16,8 @@ package servers
 import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	grpccodes "google.golang.org/grpc/codes"
+	grpcstatus "google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/fieldmaskpb"
 
 	privatev1 "github.com/osac-project/fulfillment-service/internal/api/osac/private/v1"
@@ -328,5 +330,102 @@ var _ = Describe("Private projects server", func() {
 		updateResp, err := privateServer.Update(ctx, updateReq)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(updateResp.Object.Spec.Description).To(HaveValue(Equal("Updated description")))
+	})
+
+	It("Rejects update of the name of a project", func() {
+		createResponse, err := privateServer.Create(ctx, privatev1.ProjectsCreateRequest_builder{
+			Object: privatev1.Project_builder{
+				Metadata: privatev1.Metadata_builder{
+					Name:   "my-project",
+					Tenant: "my-tenant",
+				}.Build(),
+			}.Build(),
+		}.Build())
+		Expect(err).ToNot(HaveOccurred())
+		object := createResponse.GetObject()
+		id := object.GetId()
+		updateResponse, err := privateServer.Update(ctx, privatev1.ProjectsUpdateRequest_builder{
+			Object: privatev1.Project_builder{
+				Id: id,
+				Metadata: privatev1.Metadata_builder{
+					Name: "your-project",
+				}.Build(),
+			}.Build(),
+			UpdateMask: &fieldmaskpb.FieldMask{
+				Paths: []string{"metadata.name"},
+			},
+		}.Build())
+		Expect(err).To(HaveOccurred())
+		Expect(updateResponse).To(BeNil())
+		status, ok := grpcstatus.FromError(err)
+		Expect(ok).To(BeTrue())
+		Expect(status.Code()).To(Equal(grpccodes.InvalidArgument))
+		Expect(status.Message()).To(Equal(
+			"field 'metadata.name' is immutable",
+		))
+	})
+
+	It("Rejects update of the tenant of a project", func() {
+		createResponse, err := privateServer.Create(ctx, privatev1.ProjectsCreateRequest_builder{
+			Object: privatev1.Project_builder{
+				Metadata: privatev1.Metadata_builder{
+					Name:   "my-project",
+					Tenant: "my-tenant",
+				}.Build(),
+			}.Build(),
+		}.Build())
+		Expect(err).ToNot(HaveOccurred())
+		object := createResponse.GetObject()
+		id := object.GetId()
+		updateResponse, err := privateServer.Update(ctx, privatev1.ProjectsUpdateRequest_builder{
+			Object: privatev1.Project_builder{
+				Id: id,
+				Metadata: privatev1.Metadata_builder{
+					Tenant: "your-tenant",
+				}.Build(),
+			}.Build(),
+			UpdateMask: &fieldmaskpb.FieldMask{
+				Paths: []string{"metadata.tenant"},
+			},
+		}.Build())
+		Expect(err).To(HaveOccurred())
+		Expect(updateResponse).To(BeNil())
+		status, ok := grpcstatus.FromError(err)
+		Expect(ok).To(BeTrue())
+		Expect(status.Code()).To(Equal(grpccodes.InvalidArgument))
+		Expect(status.Message()).To(Equal(
+			"field 'metadata.tenant' is immutable",
+		))
+	})
+
+	It("Silently ignores update of the creator of a project", func() {
+		createResponse, err := privateServer.Create(ctx, privatev1.ProjectsCreateRequest_builder{
+			Object: privatev1.Project_builder{
+				Metadata: privatev1.Metadata_builder{
+					Name:   "my-project",
+					Tenant: "my-tenant",
+				}.Build(),
+			}.Build(),
+		}.Build())
+		Expect(err).ToNot(HaveOccurred())
+		object := createResponse.GetObject()
+		id := object.GetId()
+		originalCreator := object.GetMetadata().GetCreator()
+
+		// Attempt to update creator - should be silently ignored
+		updateResponse, err := privateServer.Update(ctx, privatev1.ProjectsUpdateRequest_builder{
+			Object: privatev1.Project_builder{
+				Id: id,
+				Metadata: privatev1.Metadata_builder{
+					Creator: "attacker-user",
+				}.Build(),
+			}.Build(),
+			UpdateMask: &fieldmaskpb.FieldMask{
+				Paths: []string{"metadata.creator"},
+			},
+		}.Build())
+		Expect(err).ToNot(HaveOccurred())
+		Expect(updateResponse).ToNot(BeNil())
+		Expect(updateResponse.Object.GetMetadata().GetCreator()).To(Equal(originalCreator))
 	})
 })


### PR DESCRIPTION
# Description
The user who creates a Project should be added to the `manager` group of that project group on Keycloak automatically.

# Testing

- [x] Ran integration test:
    - Created org with tenant admin, logged in as tenant admin and created project. Confirmed on keycloak console that the user is part of `managers` group automatically


Assisted-by: Claude Code <noreply@anthropic.com>

/cc @jhernand 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Assigns the project creator to the project’s managers group when a project is activated (non-blocking on failure).
  * Adds support for assigning users to project authorization groups (viewers/managers), including adding users by direct group ID.

* **Improvements**
  * More reliable authorization-group provisioning using created group IDs, with safer rollback when managers-group creation fails.
  * Improved handling of “already exists” group scenarios to ensure correct group targeting.

* **Tests**
  * Updated unit tests for deterministic group-ID behavior and expanded success/failure coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->