### PR TITLE
OSAC-1346: add public gRPC servers and server wiring for bare metal instances

### DIFF
--- a/charts/service/templates/grpc-server/authconfig.yaml
+++ b/charts/service/templates/grpc-server/authconfig.yaml
@@ -196,6 +196,15 @@ spec:
               "/osac.public.v1.Clusters/Update",
               "/osac.public.v1.ClusterCatalogItems/Get",
               "/osac.public.v1.ClusterCatalogItems/List",
+              "/osac.public.v1.BareMetalInstanceCatalogItems/Get",
+              "/osac.public.v1.BareMetalInstanceCatalogItems/List",
+              "/osac.public.v1.BareMetalInstanceTemplates/Get",
+              "/osac.public.v1.BareMetalInstanceTemplates/List",
+              "/osac.public.v1.BareMetalInstances/Create",
+              "/osac.public.v1.BareMetalInstances/Delete",
+              "/osac.public.v1.BareMetalInstances/Get",
+              "/osac.public.v1.BareMetalInstances/List",
+              "/osac.public.v1.BareMetalInstances/Update",
               "/osac.public.v1.ComputeInstanceTemplates/Get",
               "/osac.public.v1.ComputeInstanceTemplates/List",
               "/osac.public.v1.ComputeInstances/Create",
@@ -245,6 +254,17 @@ spec:
               "/osac.public.v1.Roles/List",
               "/osac.public.v1.RoleBindings/Get",
               "/osac.public.v1.RoleBindings/List",
+            }
+          }
+
+          # Tenant admins can create and manage tenant-scoped bare metal catalog items.
+          # The application layer (generic server) enforces that the tenant field is set from caller identity.
+          allow if {
+            is_tenant_admin
+            grpc_method in {
+              "/osac.public.v1.BareMetalInstanceCatalogItems/Create",
+              "/osac.public.v1.BareMetalInstanceCatalogItems/Update",
+              "/osac.public.v1.BareMetalInstanceCatalogItems/Delete",
             }
           }
 

--- a/internal/cmd/cli/create/baremetalinstance/create_bare_metal_instance_cmd.go
+++ b/internal/cmd/cli/create/baremetalinstance/create_bare_metal_instance_cmd.go
@@ -1,0 +1,188 @@
+/*
+Copyright (c) 2025 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package baremetalinstance
+
+import (
+	"fmt"
+	"log/slog"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"google.golang.org/protobuf/proto"
+
+	publicv1 "github.com/osac-project/fulfillment-service/internal/api/osac/public/v1"
+	"github.com/osac-project/fulfillment-service/internal/config"
+	"github.com/osac-project/fulfillment-service/internal/logging"
+	"github.com/osac-project/fulfillment-service/internal/reflection"
+	"github.com/osac-project/fulfillment-service/internal/terminal"
+)
+
+func Cmd() *cobra.Command {
+	runner := &runnerContext{}
+	result := &cobra.Command{
+		Use:                   "baremetalinstance [FLAG...]",
+		Aliases:               []string{string(proto.MessageName((*publicv1.BareMetalInstance)(nil)))},
+		Short:                 shortHelp,
+		Long:                  longHelp,
+		DisableFlagsInUseLine: true,
+		Args:                  cobra.NoArgs,
+		RunE:                  runner.run,
+	}
+	flags := result.Flags()
+	flags.StringVarP(
+		&runner.args.name,
+		"name",
+		"n",
+		"",
+		nameFlagHelp,
+	)
+	flags.StringVar(
+		&runner.args.catalogItem,
+		"catalog-item",
+		"",
+		catalogItemFlagHelp,
+	)
+	flags.StringVar(
+		&runner.args.sshKey,
+		"ssh-key",
+		"",
+		sshKeyFlagHelp,
+	)
+	flags.StringVar(
+		&runner.args.userData,
+		"user-data",
+		"",
+		userDataFlagHelp,
+	)
+	flags.StringVar(
+		&runner.args.runStrategy,
+		"run-strategy",
+		"",
+		runStrategyFlagHelp,
+	)
+
+	if err := result.MarkFlagRequired("catalog-item"); err != nil {
+		panic(fmt.Sprintf("failed to mark catalog-item flag as required: %v", err))
+	}
+	return result
+}
+
+type runnerContext struct {
+	args struct {
+		name        string
+		catalogItem string
+		sshKey      string
+		userData    string
+		runStrategy string
+	}
+	logger *slog.Logger
+}
+
+func (c *runnerContext) run(cmd *cobra.Command, _ []string) error {
+	ctx := cmd.Context()
+	c.logger = logging.LoggerFromContext(ctx)
+	console := terminal.ConsoleFromContext(ctx)
+
+	cfg := config.SettingsFromContext(ctx)
+	if !cfg.Armed() {
+		return fmt.Errorf("there is no configuration, run the 'login' command")
+	}
+
+	conn, err := cfg.Connect(ctx, cmd.Flags())
+	if err != nil {
+		return fmt.Errorf("failed to create gRPC connection: %w", err)
+	}
+	defer conn.Close()
+
+	helper, err := reflection.NewHelper().
+		SetLogger(c.logger).
+		SetConnection(conn).
+		AddPackages(cfg.Packages()).
+		Build()
+	if err != nil {
+		return fmt.Errorf("failed to create reflection tool: %w", err)
+	}
+	console.SetHelper(helper)
+
+	spec := publicv1.BareMetalInstanceSpec_builder{
+		CatalogItem: c.args.catalogItem,
+	}
+	if c.args.sshKey != "" {
+		sshKey := c.args.sshKey
+		spec.SshKey = &sshKey
+	}
+	if c.args.userData != "" {
+		userData := c.args.userData
+		spec.UserData = &userData
+	}
+	if c.args.runStrategy != "" {
+		val, ok := publicv1.BareMetalInstanceRunStrategy_value["BARE_METAL_INSTANCE_RUN_STRATEGY_"+strings.ToUpper(c.args.runStrategy)]
+		if !ok {
+			return fmt.Errorf(
+				"unknown run strategy %q, valid values are Always and Halted",
+				c.args.runStrategy,
+			)
+		}
+		rs := publicv1.BareMetalInstanceRunStrategy(val)
+		spec.RunStrategy = &rs
+	}
+
+	bmi := publicv1.BareMetalInstance_builder{
+		Metadata: publicv1.Metadata_builder{
+			Name: c.args.name,
+		}.Build(),
+		Spec: spec.Build(),
+	}.Build()
+
+	client := publicv1.NewBareMetalInstancesClient(conn)
+	response, err := client.Create(ctx, publicv1.BareMetalInstancesCreateRequest_builder{
+		Object: bmi,
+	}.Build())
+	if err != nil {
+		return fmt.Errorf("failed to create bare metal instance: %w", err)
+	}
+
+	console.Infof(ctx, "Created bare metal instance '%s'.\n", response.GetObject().GetId())
+	return nil
+}
+
+const shortHelp = `Create a bare metal instance.`
+
+const longHelp = `
+Create a bare metal instance.
+`
+
+const nameFlagHelp = `
+_NAME_ - Name of the bare metal instance.
+`
+
+const catalogItemFlagHelp = `
+_ID_ - Catalog item identifier or name. Required.
+`
+
+const sshKeyFlagHelp = `
+_KEY_ - SSH public key injected into the OS at provisioning time. Must be a
+valid OpenSSH public key. Immutable after creation.
+`
+
+const userDataFlagHelp = `
+_DATA_ - User data passed to the OS at first boot (e.g. cloud-init).
+Maximum 64 KB. Immutable after creation.
+`
+
+const runStrategyFlagHelp = `
+_STRATEGY_ - Run strategy controlling the power state. Valid values are
+{{ bt }}Always{{ bt }} (keep powered on) and {{ bt }}Halted{{ bt }}
+(power off).
+`

--- a/internal/cmd/cli/create/create_cmd.go
+++ b/internal/cmd/cli/create/create_cmd.go
@@ -28,6 +28,7 @@ import (
 	"google.golang.org/protobuf/types/known/anypb"
 	"gopkg.in/yaml.v3"
 
+	"github.com/osac-project/fulfillment-service/internal/cmd/cli/create/baremetalinstance"
 	"github.com/osac-project/fulfillment-service/internal/cmd/cli/create/cluster"
 	"github.com/osac-project/fulfillment-service/internal/cmd/cli/create/computeinstance"
 	"github.com/osac-project/fulfillment-service/internal/cmd/cli/create/hub"
@@ -51,6 +52,7 @@ func Cmd() *cobra.Command {
 		Long:                  longHelp,
 		RunE:                  runner.run,
 	}
+	result.AddCommand(baremetalinstance.Cmd())
 	result.AddCommand(cluster.Cmd())
 	result.AddCommand(computeinstance.Cmd())
 	result.AddCommand(hub.Cmd())

--- a/internal/cmd/cli/describe/baremetalinstance/describe_baremetalinstance_cmd.go
+++ b/internal/cmd/cli/describe/baremetalinstance/describe_baremetalinstance_cmd.go
@@ -1,0 +1,103 @@
+/*
+Copyright (c) 2025 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package baremetalinstance
+
+import (
+	"fmt"
+	"io"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/spf13/cobra"
+	"google.golang.org/protobuf/proto"
+
+	publicv1 "github.com/osac-project/fulfillment-service/internal/api/osac/public/v1"
+	"github.com/osac-project/fulfillment-service/internal/cmd/cli/lookup"
+	"github.com/osac-project/fulfillment-service/internal/config"
+	"github.com/osac-project/fulfillment-service/internal/terminal"
+)
+
+func Cmd() *cobra.Command {
+	result := &cobra.Command{
+		Use:                   "baremetalinstance [FLAG...] ID|NAME",
+		Aliases:               []string{"baremetalinstances"},
+		Short:                 shortHelp,
+		Long:                  longHelp,
+		DisableFlagsInUseLine: true,
+		Args:                  cobra.ExactArgs(1),
+		RunE:                  run,
+	}
+	return result
+}
+
+func run(cmd *cobra.Command, args []string) error {
+	ref := args[0]
+	ctx := cmd.Context()
+	console := terminal.ConsoleFromContext(ctx)
+
+	cfg := config.SettingsFromContext(ctx)
+	if !cfg.Armed() {
+		return fmt.Errorf("there is no configuration, run the 'login' command")
+	}
+
+	conn, err := cfg.Connect(ctx, cmd.Flags())
+	if err != nil {
+		return fmt.Errorf("failed to create gRPC connection: %w", err)
+	}
+	defer conn.Close()
+
+	client := publicv1.NewBareMetalInstancesClient(conn)
+
+	matched, err := lookup.Find(ref, "bare metal instance", func(filter string, limit int32) ([]*publicv1.BareMetalInstance, error) {
+		resp, err := client.List(ctx, publicv1.BareMetalInstancesListRequest_builder{
+			Filter: proto.String(filter),
+			Limit:  proto.Int32(limit),
+		}.Build())
+		if err != nil {
+			return nil, fmt.Errorf("failed to describe bare metal instance: %w", err)
+		}
+		return resp.GetItems(), nil
+	})
+	if err != nil {
+		return err
+	}
+
+	renderBareMetalInstance(console, matched)
+	return nil
+}
+
+func renderBareMetalInstance(w io.Writer, bmi *publicv1.BareMetalInstance) {
+	writer := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
+	catalogItem := "-"
+	if bmi.Spec != nil {
+		if id := bmi.Spec.GetCatalogItem(); id != "" {
+			catalogItem = id
+		}
+	}
+	state := "-"
+	if bmi.Status != nil {
+		state = bmi.Status.State.String()
+		state = strings.TrimPrefix(state, "BARE_METAL_INSTANCE_STATE_")
+	}
+	fmt.Fprintf(writer, "ID:\t%s\n", bmi.Id)
+	fmt.Fprintf(writer, "Catalog Item:\t%s\n", catalogItem)
+	fmt.Fprintf(writer, "State:\t%s\n", state)
+	writer.Flush()
+}
+
+const shortHelp = `Describe a bare metal instance.`
+
+const longHelp = `
+Describe a bare metal instance.
+`

--- a/internal/cmd/cli/describe/describe_cmd.go
+++ b/internal/cmd/cli/describe/describe_cmd.go
@@ -16,6 +16,7 @@ package describe
 import (
 	"github.com/spf13/cobra"
 
+	"github.com/osac-project/fulfillment-service/internal/cmd/cli/describe/baremetalinstance"
 	"github.com/osac-project/fulfillment-service/internal/cmd/cli/describe/cluster"
 	"github.com/osac-project/fulfillment-service/internal/cmd/cli/describe/computeinstance"
 	"github.com/osac-project/fulfillment-service/internal/cmd/cli/describe/publicip"
@@ -31,6 +32,7 @@ func Cmd() *cobra.Command {
 		Short: shortHelp,
 		Long:  longHelp,
 	}
+	result.AddCommand(baremetalinstance.Cmd())
 	result.AddCommand(cluster.Cmd())
 	result.AddCommand(computeinstance.Cmd())
 	result.AddCommand(publicip.Cmd())

--- a/internal/cmd/service/start/grpcserver/start_grpc_server_cmd.go
+++ b/internal/cmd/service/start/grpcserver/start_grpc_server_cmd.go
@@ -662,6 +662,48 @@ func (c *runnerContext) run(cmd *cobra.Command, argv []string) error { //nolint:
 	}
 	privatev1.RegisterComputeInstancesServer(grpcServer, privateComputeInstancesServer)
 
+	// Create the bare metal instance templates server:
+	c.logger.InfoContext(ctx, "Creating bare metal instance templates server")
+	bareMetalInstanceTemplatesServer, err := servers.NewBareMetalInstanceTemplatesServer().
+		SetLogger(c.logger).
+		SetNotifier(notifier).
+		SetAttributionLogic(publicAttributionLogic).
+		SetTenancyLogic(tenancyLogic).
+		SetMetricsRegisterer(metricsRegisterer).
+		Build()
+	if err != nil {
+		return fmt.Errorf("failed to create bare metal instance templates server: %w", err)
+	}
+	publicv1.RegisterBareMetalInstanceTemplatesServer(grpcServer, bareMetalInstanceTemplatesServer)
+
+	// Create the bare metal instance catalog items server:
+	c.logger.InfoContext(ctx, "Creating bare metal instance catalog items server")
+	bareMetalInstanceCatalogItemsServer, err := servers.NewBareMetalInstanceCatalogItemsServer().
+		SetLogger(c.logger).
+		SetNotifier(notifier).
+		SetAttributionLogic(publicAttributionLogic).
+		SetTenancyLogic(tenancyLogic).
+		SetMetricsRegisterer(metricsRegisterer).
+		Build()
+	if err != nil {
+		return fmt.Errorf("failed to create bare metal instance catalog items server: %w", err)
+	}
+	publicv1.RegisterBareMetalInstanceCatalogItemsServer(grpcServer, bareMetalInstanceCatalogItemsServer)
+
+	// Create the bare metal instances server:
+	c.logger.InfoContext(ctx, "Creating bare metal instances server")
+	bareMetalInstancesServer, err := servers.NewBareMetalInstancesServer().
+		SetLogger(c.logger).
+		SetNotifier(notifier).
+		SetAttributionLogic(publicAttributionLogic).
+		SetTenancyLogic(tenancyLogic).
+		SetMetricsRegisterer(metricsRegisterer).
+		Build()
+	if err != nil {
+		return fmt.Errorf("failed to create bare metal instances server: %w", err)
+	}
+	publicv1.RegisterBareMetalInstancesServer(grpcServer, bareMetalInstancesServer)
+
 	// Create the private bare metal instance templates server:
 	c.logger.InfoContext(ctx, "Creating private bare metal instance templates server")
 	privateBareMetalInstanceTemplatesServer, err := servers.NewPrivateBareMetalInstanceTemplatesServer().

--- a/internal/rendering/tables/osac.private.v1.BareMetalInstance.yaml
+++ b/internal/rendering/tables/osac.private.v1.BareMetalInstance.yaml
@@ -1,0 +1,29 @@
+#
+# Copyright (c) 2025 Red Hat Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+# the License. You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+columns:
+
+- header: ID
+  value: this.id
+
+- header: NAME
+  value: "has(this.metadata.name)? this.metadata.name: '-'"
+
+- header: CATALOG ITEM
+  value: this.spec.catalog_item
+  type: osac.private.v1.BareMetalInstanceCatalogItem
+  lookup: true
+
+- header: STATE
+  value: this.status.state
+  type: osac.private.v1.BareMetalInstanceState

--- a/internal/rendering/tables/osac.private.v1.BareMetalInstance.yaml
+++ b/internal/rendering/tables/osac.private.v1.BareMetalInstance.yaml
@@ -27,3 +27,8 @@ columns:
 - header: STATE
   value: this.status.state
   type: osac.private.v1.BareMetalInstanceState
+
+- header: HUB
+  value: this.status.hub
+  type: osac.private.v1.Hub
+  lookup: true

--- a/internal/rendering/tables/osac.private.v1.BareMetalInstanceCatalogItem.yaml
+++ b/internal/rendering/tables/osac.private.v1.BareMetalInstanceCatalogItem.yaml
@@ -1,0 +1,29 @@
+#
+# Copyright (c) 2025 Red Hat Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+# the License. You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+columns:
+
+- header: ID
+  value: this.id
+
+- header: NAME
+  value: "has(this.metadata.name)? this.metadata.name: '-'"
+
+- header: TITLE
+  value: this.title
+
+- header: PUBLISHED
+  value: "this.published? 'true': 'false'"
+
+- header: TENANT
+  value: "this.tenant != ''? this.tenant: '-'"

--- a/internal/rendering/tables/osac.private.v1.BareMetalInstanceTemplate.yaml
+++ b/internal/rendering/tables/osac.private.v1.BareMetalInstanceTemplate.yaml
@@ -1,0 +1,23 @@
+#
+# Copyright (c) 2025 Red Hat Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+# the License. You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+columns:
+
+- header: ID
+  value: this.id
+
+- header: NAME
+  value: "has(this.metadata.name)? this.metadata.name: '-'"
+
+- header: TITLE
+  value: this.title

--- a/internal/rendering/tables/osac.public.v1.BareMetalInstance.yaml
+++ b/internal/rendering/tables/osac.public.v1.BareMetalInstance.yaml
@@ -1,0 +1,29 @@
+#
+# Copyright (c) 2025 Red Hat Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+# the License. You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+columns:
+
+- header: ID
+  value: this.id
+
+- header: NAME
+  value: "has(this.metadata.name)? this.metadata.name: '-'"
+
+- header: CATALOG ITEM
+  value: this.spec.catalog_item
+  type: osac.public.v1.BareMetalInstanceCatalogItem
+  lookup: true
+
+- header: STATE
+  value: this.status.state
+  type: osac.public.v1.BareMetalInstanceState

--- a/internal/rendering/tables/osac.public.v1.BareMetalInstanceCatalogItem.yaml
+++ b/internal/rendering/tables/osac.public.v1.BareMetalInstanceCatalogItem.yaml
@@ -1,0 +1,26 @@
+#
+# Copyright (c) 2025 Red Hat Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+# the License. You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+columns:
+
+- header: ID
+  value: this.id
+
+- header: NAME
+  value: "has(this.metadata.name)? this.metadata.name: '-'"
+
+- header: TITLE
+  value: this.title
+
+- header: PUBLISHED
+  value: "this.published? 'true': 'false'"

--- a/internal/rendering/tables/osac.public.v1.BareMetalInstanceTemplate.yaml
+++ b/internal/rendering/tables/osac.public.v1.BareMetalInstanceTemplate.yaml
@@ -1,0 +1,23 @@
+#
+# Copyright (c) 2025 Red Hat Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+# the License. You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+columns:
+
+- header: ID
+  value: this.id
+
+- header: NAME
+  value: "has(this.metadata.name)? this.metadata.name: '-'"
+
+- header: TITLE
+  value: this.title

--- a/internal/servers/baremetal_instance_catalog_items_server.go
+++ b/internal/servers/baremetal_instance_catalog_items_server.go
@@ -1,0 +1,324 @@
+/*
+Copyright (c) 2025 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package servers
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+
+	"github.com/prometheus/client_golang/prometheus"
+	grpccodes "google.golang.org/grpc/codes"
+	grpcstatus "google.golang.org/grpc/status"
+
+	privatev1 "github.com/osac-project/fulfillment-service/internal/api/osac/private/v1"
+	publicv1 "github.com/osac-project/fulfillment-service/internal/api/osac/public/v1"
+	"github.com/osac-project/fulfillment-service/internal/auth"
+	"github.com/osac-project/fulfillment-service/internal/database/dao"
+	"github.com/osac-project/fulfillment-service/internal/events"
+)
+
+type BareMetalInstanceCatalogItemsServerBuilder struct {
+	logger            *slog.Logger
+	notifier          events.Notifier
+	attributionLogic  auth.AttributionLogic
+	tenancyLogic      auth.TenancyLogic
+	metricsRegisterer prometheus.Registerer
+}
+
+var _ publicv1.BareMetalInstanceCatalogItemsServer = (*BareMetalInstanceCatalogItemsServer)(nil)
+
+type BareMetalInstanceCatalogItemsServer struct {
+	publicv1.UnimplementedBareMetalInstanceCatalogItemsServer
+
+	logger           *slog.Logger
+	referenceChecker catalogItemReferenceChecker
+	delegate         privatev1.BareMetalInstanceCatalogItemsServer
+	inMapper         *GenericMapper[*publicv1.BareMetalInstanceCatalogItem, *privatev1.BareMetalInstanceCatalogItem]
+	outMapper        *GenericMapper[*privatev1.BareMetalInstanceCatalogItem, *publicv1.BareMetalInstanceCatalogItem]
+}
+
+func NewBareMetalInstanceCatalogItemsServer() *BareMetalInstanceCatalogItemsServerBuilder {
+	return &BareMetalInstanceCatalogItemsServerBuilder{}
+}
+
+// SetLogger sets the logger to use. This is mandatory.
+func (b *BareMetalInstanceCatalogItemsServerBuilder) SetLogger(value *slog.Logger) *BareMetalInstanceCatalogItemsServerBuilder {
+	b.logger = value
+	return b
+}
+
+// SetNotifier sets the notifier to use. This is optional.
+func (b *BareMetalInstanceCatalogItemsServerBuilder) SetNotifier(value events.Notifier) *BareMetalInstanceCatalogItemsServerBuilder {
+	b.notifier = value
+	return b
+}
+
+// SetAttributionLogic sets the attribution logic to use. This is optional.
+func (b *BareMetalInstanceCatalogItemsServerBuilder) SetAttributionLogic(value auth.AttributionLogic) *BareMetalInstanceCatalogItemsServerBuilder {
+	b.attributionLogic = value
+	return b
+}
+
+// SetTenancyLogic sets the tenancy logic to use. This is mandatory.
+func (b *BareMetalInstanceCatalogItemsServerBuilder) SetTenancyLogic(value auth.TenancyLogic) *BareMetalInstanceCatalogItemsServerBuilder {
+	b.tenancyLogic = value
+	return b
+}
+
+// SetMetricsRegisterer sets the Prometheus registerer used to register the metrics for the underlying database
+// access objects. This is optional. If not set, no metrics will be recorded.
+func (b *BareMetalInstanceCatalogItemsServerBuilder) SetMetricsRegisterer(value prometheus.Registerer) *BareMetalInstanceCatalogItemsServerBuilder {
+	b.metricsRegisterer = value
+	return b
+}
+
+func (b *BareMetalInstanceCatalogItemsServerBuilder) Build() (result *BareMetalInstanceCatalogItemsServer, err error) {
+	if b.logger == nil {
+		err = errors.New("logger is mandatory")
+		return
+	}
+	if b.tenancyLogic == nil {
+		err = errors.New("tenancy logic is mandatory")
+		return
+	}
+
+	inMapper, err := NewGenericMapper[*publicv1.BareMetalInstanceCatalogItem, *privatev1.BareMetalInstanceCatalogItem]().
+		SetLogger(b.logger).
+		SetStrict(true).
+		Build()
+	if err != nil {
+		return
+	}
+	outMapper, err := NewGenericMapper[*privatev1.BareMetalInstanceCatalogItem, *publicv1.BareMetalInstanceCatalogItem]().
+		SetLogger(b.logger).
+		SetStrict(false).
+		Build()
+	if err != nil {
+		return
+	}
+
+	bareMetalInstancesDao, err := dao.NewGenericDAO[*privatev1.BareMetalInstance]().
+		SetLogger(b.logger).
+		SetTenancyLogic(b.tenancyLogic).
+		SetMetricsRegisterer(b.metricsRegisterer).
+		Build()
+	if err != nil {
+		return
+	}
+	referenceChecker := &daoReferenceChecker[*privatev1.BareMetalInstance]{resourceDao: bareMetalInstancesDao}
+
+	delegate, err := NewPrivateBareMetalInstanceCatalogItemsServer().
+		SetLogger(b.logger).
+		SetNotifier(b.notifier).
+		SetAttributionLogic(b.attributionLogic).
+		SetTenancyLogic(b.tenancyLogic).
+		SetMetricsRegisterer(b.metricsRegisterer).
+		SetReferenceChecker(referenceChecker).
+		Build()
+	if err != nil {
+		return
+	}
+
+	result = &BareMetalInstanceCatalogItemsServer{
+		logger:           b.logger,
+		referenceChecker: referenceChecker,
+		delegate:         delegate,
+		inMapper:         inMapper,
+		outMapper:        outMapper,
+	}
+	return
+}
+
+func (s *BareMetalInstanceCatalogItemsServer) List(ctx context.Context,
+	request *publicv1.BareMetalInstanceCatalogItemsListRequest) (response *publicv1.BareMetalInstanceCatalogItemsListResponse, err error) {
+	privateRequest := &privatev1.BareMetalInstanceCatalogItemsListRequest{}
+	privateRequest.SetOffset(request.GetOffset())
+	privateRequest.SetLimit(request.GetLimit())
+	composedFilter, err := s.addPublishedFilter(request.GetFilter())
+	if err != nil {
+		return nil, err
+	}
+	privateRequest.SetFilter(composedFilter)
+	privateRequest.SetOrder(request.GetOrder())
+
+	privateResponse, err := s.delegate.List(ctx, privateRequest)
+	if err != nil {
+		return nil, err
+	}
+
+	privateItems := privateResponse.GetItems()
+	publicItems := make([]*publicv1.BareMetalInstanceCatalogItem, len(privateItems))
+	for i, privateItem := range privateItems {
+		publicItem := &publicv1.BareMetalInstanceCatalogItem{}
+		err = s.outMapper.Copy(ctx, privateItem, publicItem)
+		if err != nil {
+			s.logger.ErrorContext(ctx, "Failed to map private bare metal instance catalog item to public",
+				slog.Any("error", err))
+			return nil, grpcstatus.Errorf(grpccodes.Internal, "failed to process bare metal instance catalog items")
+		}
+		publicItems[i] = publicItem
+	}
+
+	response = &publicv1.BareMetalInstanceCatalogItemsListResponse{}
+	response.SetSize(privateResponse.GetSize())
+	response.SetTotal(privateResponse.GetTotal())
+	response.SetItems(publicItems)
+	return
+}
+
+func (s *BareMetalInstanceCatalogItemsServer) Get(ctx context.Context,
+	request *publicv1.BareMetalInstanceCatalogItemsGetRequest) (response *publicv1.BareMetalInstanceCatalogItemsGetResponse, err error) {
+	privateRequest := &privatev1.BareMetalInstanceCatalogItemsGetRequest{}
+	privateRequest.SetId(request.GetId())
+
+	privateResponse, err := s.delegate.Get(ctx, privateRequest)
+	if err != nil {
+		return nil, err
+	}
+
+	if !privateResponse.GetObject().GetPublished() {
+		hasRef, refErr := s.referenceChecker.hasReference(ctx, request.GetId())
+		if refErr != nil {
+			return nil, refErr
+		}
+		if !hasRef {
+			return nil, grpcstatus.Errorf(grpccodes.NotFound, "catalog item not found")
+		}
+	}
+
+	publicCatalogItem := &publicv1.BareMetalInstanceCatalogItem{}
+	err = s.outMapper.Copy(ctx, privateResponse.GetObject(), publicCatalogItem)
+	if err != nil {
+		s.logger.ErrorContext(ctx, "Failed to map private bare metal instance catalog item to public",
+			slog.Any("error", err))
+		return nil, grpcstatus.Errorf(grpccodes.Internal, "failed to process bare metal instance catalog item")
+	}
+
+	response = &publicv1.BareMetalInstanceCatalogItemsGetResponse{}
+	response.SetObject(publicCatalogItem)
+	return
+}
+
+func (s *BareMetalInstanceCatalogItemsServer) Create(ctx context.Context,
+	request *publicv1.BareMetalInstanceCatalogItemsCreateRequest) (response *publicv1.BareMetalInstanceCatalogItemsCreateResponse, err error) {
+	publicCatalogItem := request.GetObject()
+	if publicCatalogItem == nil {
+		err = grpcstatus.Errorf(grpccodes.InvalidArgument, "object is mandatory")
+		return
+	}
+	privateCatalogItem := &privatev1.BareMetalInstanceCatalogItem{}
+	err = s.inMapper.Copy(ctx, publicCatalogItem, privateCatalogItem)
+	if err != nil {
+		s.logger.ErrorContext(ctx, "Failed to map public bare metal instance catalog item to private",
+			slog.Any("error", err))
+		err = grpcstatus.Errorf(grpccodes.Internal, "failed to process bare metal instance catalog item")
+		return
+	}
+
+	privateRequest := &privatev1.BareMetalInstanceCatalogItemsCreateRequest{}
+	privateRequest.SetObject(privateCatalogItem)
+	privateResponse, err := s.delegate.Create(ctx, privateRequest)
+	if err != nil {
+		return nil, err
+	}
+
+	createdPublicCatalogItem := &publicv1.BareMetalInstanceCatalogItem{}
+	err = s.outMapper.Copy(ctx, privateResponse.GetObject(), createdPublicCatalogItem)
+	if err != nil {
+		s.logger.ErrorContext(ctx, "Failed to map private bare metal instance catalog item to public",
+			slog.Any("error", err))
+		err = grpcstatus.Errorf(grpccodes.Internal, "failed to process bare metal instance catalog item")
+		return
+	}
+
+	response = &publicv1.BareMetalInstanceCatalogItemsCreateResponse{}
+	response.SetObject(createdPublicCatalogItem)
+	return
+}
+
+func (s *BareMetalInstanceCatalogItemsServer) Update(ctx context.Context,
+	request *publicv1.BareMetalInstanceCatalogItemsUpdateRequest) (response *publicv1.BareMetalInstanceCatalogItemsUpdateResponse, err error) {
+	publicCatalogItem := request.GetObject()
+	if publicCatalogItem == nil {
+		err = grpcstatus.Errorf(grpccodes.InvalidArgument, "object is mandatory")
+		return
+	}
+	id := publicCatalogItem.GetId()
+	if id == "" {
+		err = grpcstatus.Errorf(grpccodes.InvalidArgument, "object identifier is mandatory")
+		return
+	}
+
+	getRequest := &privatev1.BareMetalInstanceCatalogItemsGetRequest{}
+	getRequest.SetId(id)
+	getResponse, err := s.delegate.Get(ctx, getRequest)
+	if err != nil {
+		return nil, err
+	}
+	existingPrivateCatalogItem := getResponse.GetObject()
+
+	err = s.inMapper.Copy(ctx, publicCatalogItem, existingPrivateCatalogItem)
+	if err != nil {
+		s.logger.ErrorContext(ctx, "Failed to map public bare metal instance catalog item to private",
+			slog.Any("error", err))
+		err = grpcstatus.Errorf(grpccodes.Internal, "failed to process bare metal instance catalog item")
+		return
+	}
+
+	privateRequest := &privatev1.BareMetalInstanceCatalogItemsUpdateRequest{}
+	privateRequest.SetObject(existingPrivateCatalogItem)
+	privateRequest.SetLock(request.GetLock())
+	privateResponse, err := s.delegate.Update(ctx, privateRequest)
+	if err != nil {
+		return nil, err
+	}
+
+	updatedPublicCatalogItem := &publicv1.BareMetalInstanceCatalogItem{}
+	err = s.outMapper.Copy(ctx, privateResponse.GetObject(), updatedPublicCatalogItem)
+	if err != nil {
+		s.logger.ErrorContext(ctx, "Failed to map private bare metal instance catalog item to public",
+			slog.Any("error", err))
+		err = grpcstatus.Errorf(grpccodes.Internal, "failed to process bare metal instance catalog item")
+		return
+	}
+
+	response = &publicv1.BareMetalInstanceCatalogItemsUpdateResponse{}
+	response.SetObject(updatedPublicCatalogItem)
+	return
+}
+
+func (s *BareMetalInstanceCatalogItemsServer) Delete(ctx context.Context,
+	request *publicv1.BareMetalInstanceCatalogItemsDeleteRequest) (response *publicv1.BareMetalInstanceCatalogItemsDeleteResponse, err error) {
+	privateRequest := &privatev1.BareMetalInstanceCatalogItemsDeleteRequest{}
+	privateRequest.SetId(request.GetId())
+
+	_, err = s.delegate.Delete(ctx, privateRequest)
+	if err != nil {
+		return nil, err
+	}
+
+	response = &publicv1.BareMetalInstanceCatalogItemsDeleteResponse{}
+	return
+}
+
+func (s *BareMetalInstanceCatalogItemsServer) addPublishedFilter(filter string) (string, error) {
+	if filter == "" {
+		return "this.published", nil
+	}
+	if err := validateCELSyntax(filter); err != nil {
+		return "", grpcstatus.Errorf(grpccodes.InvalidArgument, "invalid filter: %v", err)
+	}
+	return "(" + filter + ") && this.published", nil
+}

--- a/internal/servers/baremetal_instance_catalog_items_server_test.go
+++ b/internal/servers/baremetal_instance_catalog_items_server_test.go
@@ -1,0 +1,287 @@
+/*
+Copyright (c) 2025 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package servers
+
+import (
+	"fmt"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	privatev1 "github.com/osac-project/fulfillment-service/internal/api/osac/private/v1"
+	publicv1 "github.com/osac-project/fulfillment-service/internal/api/osac/public/v1"
+)
+
+var _ = Describe("Bare metal instance catalog items server", func() {
+	Describe("Creation", func() {
+		It("Can be built if all the required parameters are set", func() {
+			server, err := NewBareMetalInstanceCatalogItemsServer().
+				SetLogger(logger).
+				SetAttributionLogic(attribution).
+				SetTenancyLogic(tenancy).
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(server).ToNot(BeNil())
+		})
+
+		It("Fails if logger is not set", func() {
+			server, err := NewBareMetalInstanceCatalogItemsServer().
+				SetAttributionLogic(attribution).
+				SetTenancyLogic(tenancy).
+				Build()
+			Expect(err).To(MatchError("logger is mandatory"))
+			Expect(server).To(BeNil())
+		})
+
+		It("Fails if tenancy logic is not set", func() {
+			server, err := NewBareMetalInstanceCatalogItemsServer().
+				SetLogger(logger).
+				SetAttributionLogic(attribution).
+				Build()
+			Expect(err).To(MatchError("tenancy logic is mandatory"))
+			Expect(server).To(BeNil())
+		})
+	})
+
+	Describe("Behaviour", func() {
+		var server *BareMetalInstanceCatalogItemsServer
+
+		BeforeEach(func() {
+			var err error
+			server, err = NewBareMetalInstanceCatalogItemsServer().
+				SetLogger(logger).
+				SetAttributionLogic(attribution).
+				SetTenancyLogic(tenancy).
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("Creates object", func() {
+			response, err := server.Create(ctx, publicv1.BareMetalInstanceCatalogItemsCreateRequest_builder{
+				Object: publicv1.BareMetalInstanceCatalogItem_builder{
+					Title:       "My BMI catalog item",
+					Description: "My description.",
+					Template:    "my-bmi-template-id",
+					Published:   true,
+				}.Build(),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+			Expect(response).ToNot(BeNil())
+			object := response.GetObject()
+			Expect(object).ToNot(BeNil())
+			Expect(object.GetId()).ToNot(BeEmpty())
+			Expect(object.GetTitle()).To(Equal("My BMI catalog item"))
+			Expect(object.GetTemplate()).To(Equal("my-bmi-template-id"))
+			Expect(object.GetPublished()).To(BeTrue())
+		})
+
+		It("Fails to create without an object", func() {
+			_, err := server.Create(ctx, publicv1.BareMetalInstanceCatalogItemsCreateRequest_builder{}.Build())
+			Expect(err).To(HaveOccurred())
+			s, ok := status.FromError(err)
+			Expect(ok).To(BeTrue())
+			Expect(s.Code()).To(Equal(codes.InvalidArgument))
+		})
+
+		It("Lists only published objects", func() {
+			const publishedCount = 3
+			for i := range publishedCount {
+				_, err := server.Create(ctx, publicv1.BareMetalInstanceCatalogItemsCreateRequest_builder{
+					Object: publicv1.BareMetalInstanceCatalogItem_builder{
+						Title:     fmt.Sprintf("Published item %d", i),
+						Template:  "my-bmi-template-id",
+						Published: true,
+					}.Build(),
+				}.Build())
+				Expect(err).ToNot(HaveOccurred())
+			}
+			_, err := server.Create(ctx, publicv1.BareMetalInstanceCatalogItemsCreateRequest_builder{
+				Object: publicv1.BareMetalInstanceCatalogItem_builder{
+					Title:     "Unpublished item",
+					Template:  "my-bmi-template-id",
+					Published: false,
+				}.Build(),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+
+			response, err := server.List(ctx, publicv1.BareMetalInstanceCatalogItemsListRequest_builder{}.Build())
+			Expect(err).ToNot(HaveOccurred())
+			Expect(response.GetItems()).To(HaveLen(publishedCount))
+			for _, item := range response.GetItems() {
+				Expect(item.GetPublished()).To(BeTrue())
+			}
+		})
+
+		It("Rejects an invalid filter", func() {
+			_, err := server.List(ctx, publicv1.BareMetalInstanceCatalogItemsListRequest_builder{
+				Filter: new("!!!invalid!!!"),
+			}.Build())
+			Expect(err).To(HaveOccurred())
+			s, ok := status.FromError(err)
+			Expect(ok).To(BeTrue())
+			Expect(s.Code()).To(Equal(codes.InvalidArgument))
+		})
+
+		It("Gets a published object", func() {
+			createResponse, err := server.Create(ctx, publicv1.BareMetalInstanceCatalogItemsCreateRequest_builder{
+				Object: publicv1.BareMetalInstanceCatalogItem_builder{
+					Title:     "Published item",
+					Template:  "my-bmi-template-id",
+					Published: true,
+				}.Build(),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+			id := createResponse.GetObject().GetId()
+
+			getResponse, err := server.Get(ctx, publicv1.BareMetalInstanceCatalogItemsGetRequest_builder{
+				Id: id,
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+			Expect(getResponse.GetObject().GetId()).To(Equal(id))
+		})
+
+		It("Returns not found for an unpublished object with no references", func() {
+			createResponse, err := server.Create(ctx, publicv1.BareMetalInstanceCatalogItemsCreateRequest_builder{
+				Object: publicv1.BareMetalInstanceCatalogItem_builder{
+					Title:     "Unpublished item",
+					Template:  "my-bmi-template-id",
+					Published: false,
+				}.Build(),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+			id := createResponse.GetObject().GetId()
+
+			_, err = server.Get(ctx, publicv1.BareMetalInstanceCatalogItemsGetRequest_builder{
+				Id: id,
+			}.Build())
+			Expect(err).To(HaveOccurred())
+			s, ok := status.FromError(err)
+			Expect(ok).To(BeTrue())
+			Expect(s.Code()).To(Equal(codes.NotFound))
+		})
+
+		It("Updates an object", func() {
+			createResponse, err := server.Create(ctx, publicv1.BareMetalInstanceCatalogItemsCreateRequest_builder{
+				Object: publicv1.BareMetalInstanceCatalogItem_builder{
+					Title:     "Original title",
+					Template:  "my-bmi-template-id",
+					Published: true,
+				}.Build(),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+			id := createResponse.GetObject().GetId()
+
+			updateResponse, err := server.Update(ctx, publicv1.BareMetalInstanceCatalogItemsUpdateRequest_builder{
+				Object: publicv1.BareMetalInstanceCatalogItem_builder{
+					Id:        id,
+					Title:     "Updated title",
+					Template:  "my-bmi-template-id",
+					Published: true,
+				}.Build(),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+			Expect(updateResponse.GetObject().GetTitle()).To(Equal("Updated title"))
+		})
+
+		It("Fails to update without an object", func() {
+			_, err := server.Update(ctx, publicv1.BareMetalInstanceCatalogItemsUpdateRequest_builder{}.Build())
+			Expect(err).To(HaveOccurred())
+			s, ok := status.FromError(err)
+			Expect(ok).To(BeTrue())
+			Expect(s.Code()).To(Equal(codes.InvalidArgument))
+		})
+
+		It("Fails to update without an object identifier", func() {
+			_, err := server.Update(ctx, publicv1.BareMetalInstanceCatalogItemsUpdateRequest_builder{
+				Object: publicv1.BareMetalInstanceCatalogItem_builder{}.Build(),
+			}.Build())
+			Expect(err).To(HaveOccurred())
+			s, ok := status.FromError(err)
+			Expect(ok).To(BeTrue())
+			Expect(s.Code()).To(Equal(codes.InvalidArgument))
+		})
+
+		It("Deletes an object", func() {
+			createResponse, err := server.Create(ctx, publicv1.BareMetalInstanceCatalogItemsCreateRequest_builder{
+				Object: publicv1.BareMetalInstanceCatalogItem_builder{
+					Title:     "Item to delete",
+					Template:  "my-bmi-template-id",
+					Published: true,
+				}.Build(),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+			id := createResponse.GetObject().GetId()
+
+			_, err = server.Delete(ctx, publicv1.BareMetalInstanceCatalogItemsDeleteRequest_builder{
+				Id: id,
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+
+			_, err = server.Get(ctx, publicv1.BareMetalInstanceCatalogItemsGetRequest_builder{
+				Id: id,
+			}.Build())
+			Expect(err).To(HaveOccurred())
+			s, ok := status.FromError(err)
+			Expect(ok).To(BeTrue())
+			Expect(s.Code()).To(Equal(codes.NotFound))
+		})
+
+		It("Fails to delete an object that is referenced by a bare metal instance", func() {
+			createResponse, err := server.Create(ctx, publicv1.BareMetalInstanceCatalogItemsCreateRequest_builder{
+				Object: publicv1.BareMetalInstanceCatalogItem_builder{
+					Title:     "Referenced item",
+					Template:  "my-bmi-template-id",
+					Published: true,
+				}.Build(),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+			catalogItemID := createResponse.GetObject().GetId()
+
+			instancesServer, err := NewPrivateBareMetalInstancesServer().
+				SetLogger(logger).
+				SetAttributionLogic(attribution).
+				SetTenancyLogic(tenancy).
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+			_, err = instancesServer.Create(ctx, privatev1.BareMetalInstancesCreateRequest_builder{
+				Object: privatev1.BareMetalInstance_builder{
+					Spec: privatev1.BareMetalInstanceSpec_builder{
+						CatalogItem: catalogItemID,
+					}.Build(),
+				}.Build(),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+
+			_, err = server.Delete(ctx, publicv1.BareMetalInstanceCatalogItemsDeleteRequest_builder{
+				Id: catalogItemID,
+			}.Build())
+			Expect(err).To(HaveOccurred())
+			s, ok := status.FromError(err)
+			Expect(ok).To(BeTrue())
+			Expect(s.Code()).To(Equal(codes.FailedPrecondition))
+		})
+
+		It("Returns not found for a nonexistent object", func() {
+			_, err := server.Get(ctx, publicv1.BareMetalInstanceCatalogItemsGetRequest_builder{
+				Id: "00000000-0000-0000-0000-000000000000",
+			}.Build())
+			Expect(err).To(HaveOccurred())
+			s, ok := status.FromError(err)
+			Expect(ok).To(BeTrue())
+			Expect(s.Code()).To(Equal(codes.NotFound))
+		})
+	})
+})

--- a/internal/servers/baremetal_instance_templates_server.go
+++ b/internal/servers/baremetal_instance_templates_server.go
@@ -1,0 +1,174 @@
+/*
+Copyright (c) 2025 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package servers
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+
+	"github.com/prometheus/client_golang/prometheus"
+	grpccodes "google.golang.org/grpc/codes"
+	grpcstatus "google.golang.org/grpc/status"
+
+	privatev1 "github.com/osac-project/fulfillment-service/internal/api/osac/private/v1"
+	publicv1 "github.com/osac-project/fulfillment-service/internal/api/osac/public/v1"
+	"github.com/osac-project/fulfillment-service/internal/auth"
+	"github.com/osac-project/fulfillment-service/internal/events"
+)
+
+type BareMetalInstanceTemplatesServerBuilder struct {
+	logger            *slog.Logger
+	notifier          events.Notifier
+	attributionLogic  auth.AttributionLogic
+	tenancyLogic      auth.TenancyLogic
+	metricsRegisterer prometheus.Registerer
+}
+
+var _ publicv1.BareMetalInstanceTemplatesServer = (*BareMetalInstanceTemplatesServer)(nil)
+
+type BareMetalInstanceTemplatesServer struct {
+	publicv1.UnimplementedBareMetalInstanceTemplatesServer
+
+	logger    *slog.Logger
+	delegate  privatev1.BareMetalInstanceTemplatesServer
+	outMapper *GenericMapper[*privatev1.BareMetalInstanceTemplate, *publicv1.BareMetalInstanceTemplate]
+}
+
+func NewBareMetalInstanceTemplatesServer() *BareMetalInstanceTemplatesServerBuilder {
+	return &BareMetalInstanceTemplatesServerBuilder{}
+}
+
+// SetLogger sets the logger to use. This is mandatory.
+func (b *BareMetalInstanceTemplatesServerBuilder) SetLogger(value *slog.Logger) *BareMetalInstanceTemplatesServerBuilder {
+	b.logger = value
+	return b
+}
+
+// SetNotifier sets the notifier to use. This is optional.
+func (b *BareMetalInstanceTemplatesServerBuilder) SetNotifier(value events.Notifier) *BareMetalInstanceTemplatesServerBuilder {
+	b.notifier = value
+	return b
+}
+
+// SetAttributionLogic sets the attribution logic to use. This is optional.
+func (b *BareMetalInstanceTemplatesServerBuilder) SetAttributionLogic(value auth.AttributionLogic) *BareMetalInstanceTemplatesServerBuilder {
+	b.attributionLogic = value
+	return b
+}
+
+// SetTenancyLogic sets the tenancy logic to use. This is mandatory.
+func (b *BareMetalInstanceTemplatesServerBuilder) SetTenancyLogic(value auth.TenancyLogic) *BareMetalInstanceTemplatesServerBuilder {
+	b.tenancyLogic = value
+	return b
+}
+
+// SetMetricsRegisterer sets the Prometheus registerer used to register the metrics for the underlying database
+// access objects. This is optional. If not set, no metrics will be recorded.
+func (b *BareMetalInstanceTemplatesServerBuilder) SetMetricsRegisterer(value prometheus.Registerer) *BareMetalInstanceTemplatesServerBuilder {
+	b.metricsRegisterer = value
+	return b
+}
+
+func (b *BareMetalInstanceTemplatesServerBuilder) Build() (result *BareMetalInstanceTemplatesServer, err error) {
+	if b.logger == nil {
+		err = errors.New("logger is mandatory")
+		return
+	}
+	if b.tenancyLogic == nil {
+		err = errors.New("tenancy logic is mandatory")
+		return
+	}
+
+	outMapper, err := NewGenericMapper[*privatev1.BareMetalInstanceTemplate, *publicv1.BareMetalInstanceTemplate]().
+		SetLogger(b.logger).
+		SetStrict(false).
+		Build()
+	if err != nil {
+		return
+	}
+
+	delegate, err := NewPrivateBareMetalInstanceTemplatesServer().
+		SetLogger(b.logger).
+		SetNotifier(b.notifier).
+		SetAttributionLogic(b.attributionLogic).
+		SetTenancyLogic(b.tenancyLogic).
+		SetMetricsRegisterer(b.metricsRegisterer).
+		Build()
+	if err != nil {
+		return
+	}
+
+	result = &BareMetalInstanceTemplatesServer{
+		logger:    b.logger,
+		delegate:  delegate,
+		outMapper: outMapper,
+	}
+	return
+}
+
+func (s *BareMetalInstanceTemplatesServer) List(ctx context.Context,
+	request *publicv1.BareMetalInstanceTemplatesListRequest) (response *publicv1.BareMetalInstanceTemplatesListResponse, err error) {
+	privateRequest := &privatev1.BareMetalInstanceTemplatesListRequest{}
+	privateRequest.SetOffset(request.GetOffset())
+	privateRequest.SetLimit(request.GetLimit())
+	privateRequest.SetFilter(request.GetFilter())
+
+	privateResponse, err := s.delegate.List(ctx, privateRequest)
+	if err != nil {
+		return nil, err
+	}
+
+	privateItems := privateResponse.GetItems()
+	publicItems := make([]*publicv1.BareMetalInstanceTemplate, len(privateItems))
+	for i, privateItem := range privateItems {
+		publicItem := &publicv1.BareMetalInstanceTemplate{}
+		err = s.outMapper.Copy(ctx, privateItem, publicItem)
+		if err != nil {
+			s.logger.ErrorContext(ctx, "Failed to map private bare metal instance template to public",
+				slog.Any("error", err))
+			return nil, grpcstatus.Errorf(grpccodes.Internal, "failed to process bare metal instance templates")
+		}
+		publicItems[i] = publicItem
+	}
+
+	response = &publicv1.BareMetalInstanceTemplatesListResponse{}
+	response.SetSize(privateResponse.GetSize())
+	response.SetTotal(privateResponse.GetTotal())
+	response.SetItems(publicItems)
+	return
+}
+
+func (s *BareMetalInstanceTemplatesServer) Get(ctx context.Context,
+	request *publicv1.BareMetalInstanceTemplatesGetRequest) (response *publicv1.BareMetalInstanceTemplatesGetResponse, err error) {
+	privateRequest := &privatev1.BareMetalInstanceTemplatesGetRequest{}
+	privateRequest.SetId(request.GetId())
+
+	privateResponse, err := s.delegate.Get(ctx, privateRequest)
+	if err != nil {
+		return nil, err
+	}
+
+	publicTemplate := &publicv1.BareMetalInstanceTemplate{}
+	err = s.outMapper.Copy(ctx, privateResponse.GetObject(), publicTemplate)
+	if err != nil {
+		s.logger.ErrorContext(ctx, "Failed to map private bare metal instance template to public",
+			slog.Any("error", err))
+		return nil, grpcstatus.Errorf(grpccodes.Internal, "failed to process bare metal instance template")
+	}
+
+	response = &publicv1.BareMetalInstanceTemplatesGetResponse{}
+	response.SetObject(publicTemplate)
+	return
+}

--- a/internal/servers/baremetal_instance_templates_server_test.go
+++ b/internal/servers/baremetal_instance_templates_server_test.go
@@ -1,0 +1,113 @@
+/*
+Copyright (c) 2025 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package servers
+
+import (
+	"fmt"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	privatev1 "github.com/osac-project/fulfillment-service/internal/api/osac/private/v1"
+	publicv1 "github.com/osac-project/fulfillment-service/internal/api/osac/public/v1"
+)
+
+var _ = Describe("Bare metal instance templates server", func() {
+	Describe("Creation", func() {
+		It("Can be built if all the required parameters are set", func() {
+			server, err := NewBareMetalInstanceTemplatesServer().
+				SetLogger(logger).
+				SetAttributionLogic(attribution).
+				SetTenancyLogic(tenancy).
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(server).ToNot(BeNil())
+		})
+
+		It("Fails if logger is not set", func() {
+			server, err := NewBareMetalInstanceTemplatesServer().
+				SetTenancyLogic(tenancy).
+				Build()
+			Expect(err).To(MatchError("logger is mandatory"))
+			Expect(server).To(BeNil())
+		})
+
+		It("Fails if tenancy logic is not set", func() {
+			server, err := NewBareMetalInstanceTemplatesServer().
+				SetLogger(logger).
+				Build()
+			Expect(err).To(MatchError("tenancy logic is mandatory"))
+			Expect(server).To(BeNil())
+		})
+	})
+
+	Describe("Behaviour", func() {
+		var (
+			server        *BareMetalInstanceTemplatesServer
+			privateServer *PrivateBareMetalInstanceTemplatesServer
+		)
+
+		BeforeEach(func() {
+			var err error
+			server, err = NewBareMetalInstanceTemplatesServer().
+				SetLogger(logger).
+				SetAttributionLogic(attribution).
+				SetTenancyLogic(tenancy).
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+
+			privateServer, err = NewPrivateBareMetalInstanceTemplatesServer().
+				SetLogger(logger).
+				SetAttributionLogic(attribution).
+				SetTenancyLogic(tenancy).
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("Lists objects", func() {
+			const count = 3
+			for i := range count {
+				_, err := privateServer.Create(ctx, privatev1.BareMetalInstanceTemplatesCreateRequest_builder{
+					Object: privatev1.BareMetalInstanceTemplate_builder{
+						Title: fmt.Sprintf("Template %d", i),
+					}.Build(),
+				}.Build())
+				Expect(err).ToNot(HaveOccurred())
+			}
+
+			response, err := server.List(ctx, publicv1.BareMetalInstanceTemplatesListRequest_builder{}.Build())
+			Expect(err).ToNot(HaveOccurred())
+			Expect(response.GetItems()).To(HaveLen(count))
+		})
+
+		It("Gets object", func() {
+			createResponse, err := privateServer.Create(ctx, privatev1.BareMetalInstanceTemplatesCreateRequest_builder{
+				Object: privatev1.BareMetalInstanceTemplate_builder{
+					Title:       "My template",
+					Description: "A test template.",
+				}.Build(),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+			id := createResponse.GetObject().GetId()
+
+			response, err := server.Get(ctx, publicv1.BareMetalInstanceTemplatesGetRequest_builder{
+				Id: id,
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+			Expect(response.GetObject().GetId()).To(Equal(id))
+			Expect(response.GetObject().GetTitle()).To(Equal("My template"))
+			Expect(response.GetObject().GetDescription()).To(Equal("A test template."))
+		})
+	})
+})

--- a/internal/servers/baremetal_instances_server.go
+++ b/internal/servers/baremetal_instances_server.go
@@ -1,0 +1,294 @@
+/*
+Copyright (c) 2025 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package servers
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+
+	"github.com/prometheus/client_golang/prometheus"
+	grpccodes "google.golang.org/grpc/codes"
+	grpcstatus "google.golang.org/grpc/status"
+
+	privatev1 "github.com/osac-project/fulfillment-service/internal/api/osac/private/v1"
+	publicv1 "github.com/osac-project/fulfillment-service/internal/api/osac/public/v1"
+	"github.com/osac-project/fulfillment-service/internal/auth"
+	"github.com/osac-project/fulfillment-service/internal/events"
+)
+
+type BareMetalInstancesServerBuilder struct {
+	logger            *slog.Logger
+	notifier          events.Notifier
+	attributionLogic  auth.AttributionLogic
+	tenancyLogic      auth.TenancyLogic
+	metricsRegisterer prometheus.Registerer
+}
+
+var _ publicv1.BareMetalInstancesServer = (*BareMetalInstancesServer)(nil)
+
+type BareMetalInstancesServer struct {
+	publicv1.UnimplementedBareMetalInstancesServer
+
+	logger    *slog.Logger
+	delegate  privatev1.BareMetalInstancesServer
+	inMapper  *GenericMapper[*publicv1.BareMetalInstance, *privatev1.BareMetalInstance]
+	outMapper *GenericMapper[*privatev1.BareMetalInstance, *publicv1.BareMetalInstance]
+}
+
+func NewBareMetalInstancesServer() *BareMetalInstancesServerBuilder {
+	return &BareMetalInstancesServerBuilder{}
+}
+
+// SetLogger sets the logger to use. This is mandatory.
+func (b *BareMetalInstancesServerBuilder) SetLogger(value *slog.Logger) *BareMetalInstancesServerBuilder {
+	b.logger = value
+	return b
+}
+
+// SetNotifier sets the notifier to use. This is optional.
+func (b *BareMetalInstancesServerBuilder) SetNotifier(value events.Notifier) *BareMetalInstancesServerBuilder {
+	b.notifier = value
+	return b
+}
+
+// SetAttributionLogic sets the attribution logic to use. This is optional.
+func (b *BareMetalInstancesServerBuilder) SetAttributionLogic(value auth.AttributionLogic) *BareMetalInstancesServerBuilder {
+	b.attributionLogic = value
+	return b
+}
+
+// SetTenancyLogic sets the tenancy logic to use. This is mandatory.
+func (b *BareMetalInstancesServerBuilder) SetTenancyLogic(value auth.TenancyLogic) *BareMetalInstancesServerBuilder {
+	b.tenancyLogic = value
+	return b
+}
+
+// SetMetricsRegisterer sets the Prometheus registerer used to register the metrics for the underlying database
+// access objects. This is optional. If not set, no metrics will be recorded.
+func (b *BareMetalInstancesServerBuilder) SetMetricsRegisterer(value prometheus.Registerer) *BareMetalInstancesServerBuilder {
+	b.metricsRegisterer = value
+	return b
+}
+
+func (b *BareMetalInstancesServerBuilder) Build() (result *BareMetalInstancesServer, err error) {
+	if b.logger == nil {
+		err = errors.New("logger is mandatory")
+		return
+	}
+	if b.tenancyLogic == nil {
+		err = errors.New("tenancy logic is mandatory")
+		return
+	}
+
+	inMapper, err := NewGenericMapper[*publicv1.BareMetalInstance, *privatev1.BareMetalInstance]().
+		SetLogger(b.logger).
+		SetStrict(true).
+		Build()
+	if err != nil {
+		return
+	}
+	outMapper, err := NewGenericMapper[*privatev1.BareMetalInstance, *publicv1.BareMetalInstance]().
+		SetLogger(b.logger).
+		SetStrict(false).
+		Build()
+	if err != nil {
+		return
+	}
+
+	delegate, err := NewPrivateBareMetalInstancesServer().
+		SetLogger(b.logger).
+		SetNotifier(b.notifier).
+		SetAttributionLogic(b.attributionLogic).
+		SetTenancyLogic(b.tenancyLogic).
+		SetMetricsRegisterer(b.metricsRegisterer).
+		Build()
+	if err != nil {
+		return
+	}
+
+	result = &BareMetalInstancesServer{
+		logger:    b.logger,
+		delegate:  delegate,
+		inMapper:  inMapper,
+		outMapper: outMapper,
+	}
+	return
+}
+
+func (s *BareMetalInstancesServer) List(ctx context.Context,
+	request *publicv1.BareMetalInstancesListRequest) (response *publicv1.BareMetalInstancesListResponse, err error) {
+	privateRequest := &privatev1.BareMetalInstancesListRequest{}
+	privateRequest.SetOffset(request.GetOffset())
+	privateRequest.SetLimit(request.GetLimit())
+	privateRequest.SetFilter(request.GetFilter())
+
+	privateResponse, err := s.delegate.List(ctx, privateRequest)
+	if err != nil {
+		return nil, err
+	}
+
+	privateItems := privateResponse.GetItems()
+	publicItems := make([]*publicv1.BareMetalInstance, len(privateItems))
+	for i, privateItem := range privateItems {
+		publicItem := &publicv1.BareMetalInstance{}
+		err = s.outMapper.Copy(ctx, privateItem, publicItem)
+		if err != nil {
+			s.logger.ErrorContext(ctx, "Failed to map private bare metal instance to public",
+				slog.Any("error", err))
+			return nil, grpcstatus.Errorf(grpccodes.Internal, "failed to process bare metal instances")
+		}
+		publicItems[i] = publicItem
+	}
+
+	response = &publicv1.BareMetalInstancesListResponse{}
+	response.SetSize(privateResponse.GetSize())
+	response.SetTotal(privateResponse.GetTotal())
+	response.SetItems(publicItems)
+	return
+}
+
+func (s *BareMetalInstancesServer) Get(ctx context.Context,
+	request *publicv1.BareMetalInstancesGetRequest) (response *publicv1.BareMetalInstancesGetResponse, err error) {
+	privateRequest := &privatev1.BareMetalInstancesGetRequest{}
+	privateRequest.SetId(request.GetId())
+
+	privateResponse, err := s.delegate.Get(ctx, privateRequest)
+	if err != nil {
+		return nil, err
+	}
+
+	publicBMI := &publicv1.BareMetalInstance{}
+	err = s.outMapper.Copy(ctx, privateResponse.GetObject(), publicBMI)
+	if err != nil {
+		s.logger.ErrorContext(ctx, "Failed to map private bare metal instance to public",
+			slog.Any("error", err))
+		return nil, grpcstatus.Errorf(grpccodes.Internal, "failed to process bare metal instance")
+	}
+
+	response = &publicv1.BareMetalInstancesGetResponse{}
+	response.SetObject(publicBMI)
+	return
+}
+
+func (s *BareMetalInstancesServer) Create(ctx context.Context,
+	request *publicv1.BareMetalInstancesCreateRequest) (response *publicv1.BareMetalInstancesCreateResponse, err error) {
+	publicBMI := request.GetObject()
+	if publicBMI == nil {
+		err = grpcstatus.Errorf(grpccodes.InvalidArgument, "object is mandatory")
+		return
+	}
+	privateBMI := &privatev1.BareMetalInstance{}
+	err = s.inMapper.Copy(ctx, publicBMI, privateBMI)
+	if err != nil {
+		s.logger.ErrorContext(ctx, "Failed to map public bare metal instance to private",
+			slog.Any("error", err))
+		err = grpcstatus.Errorf(grpccodes.Internal, "failed to process bare metal instance")
+		return
+	}
+
+	privateRequest := &privatev1.BareMetalInstancesCreateRequest{}
+	privateRequest.SetObject(privateBMI)
+	privateResponse, err := s.delegate.Create(ctx, privateRequest)
+	if err != nil {
+		return nil, err
+	}
+
+	createdPublicBMI := &publicv1.BareMetalInstance{}
+	err = s.outMapper.Copy(ctx, privateResponse.GetObject(), createdPublicBMI)
+	if err != nil {
+		s.logger.ErrorContext(ctx, "Failed to map private bare metal instance to public",
+			slog.Any("error", err))
+		err = grpcstatus.Errorf(grpccodes.Internal, "failed to process bare metal instance")
+		return
+	}
+
+	response = &publicv1.BareMetalInstancesCreateResponse{}
+	response.SetObject(createdPublicBMI)
+	return
+}
+
+func (s *BareMetalInstancesServer) Update(ctx context.Context,
+	request *publicv1.BareMetalInstancesUpdateRequest) (response *publicv1.BareMetalInstancesUpdateResponse, err error) {
+	publicBMI := request.GetObject()
+	if publicBMI == nil {
+		err = grpcstatus.Errorf(grpccodes.InvalidArgument, "object is mandatory")
+		return
+	}
+	id := publicBMI.GetId()
+	if id == "" {
+		err = grpcstatus.Errorf(grpccodes.InvalidArgument, "object identifier is mandatory")
+		return
+	}
+
+	// When there's a field mask, copy to a new private object and let the generic server handle the
+	// merge with the database object, which correctly applies field mask semantics.
+	var privateBMI *privatev1.BareMetalInstance
+	updateMask := request.GetUpdateMask()
+	if len(updateMask.GetPaths()) > 0 {
+		privateBMI = &privatev1.BareMetalInstance{}
+		privateBMI.SetId(id)
+	} else {
+		getRequest := &privatev1.BareMetalInstancesGetRequest{}
+		getRequest.SetId(id)
+		getResponse, err := s.delegate.Get(ctx, getRequest)
+		if err != nil {
+			return nil, err
+		}
+		privateBMI = getResponse.GetObject()
+	}
+	err = s.inMapper.Copy(ctx, publicBMI, privateBMI)
+	if err != nil {
+		s.logger.ErrorContext(ctx, "Failed to map public bare metal instance to private",
+			slog.Any("error", err))
+		err = grpcstatus.Errorf(grpccodes.Internal, "failed to process bare metal instance")
+		return
+	}
+
+	privateRequest := &privatev1.BareMetalInstancesUpdateRequest{}
+	privateRequest.SetObject(privateBMI)
+	privateRequest.SetUpdateMask(updateMask)
+	privateRequest.SetLock(request.GetLock())
+	privateResponse, err := s.delegate.Update(ctx, privateRequest)
+	if err != nil {
+		return nil, err
+	}
+
+	updatedPublicBMI := &publicv1.BareMetalInstance{}
+	err = s.outMapper.Copy(ctx, privateResponse.GetObject(), updatedPublicBMI)
+	if err != nil {
+		s.logger.ErrorContext(ctx, "Failed to map private bare metal instance to public",
+			slog.Any("error", err))
+		err = grpcstatus.Errorf(grpccodes.Internal, "failed to process bare metal instance")
+		return
+	}
+
+	response = &publicv1.BareMetalInstancesUpdateResponse{}
+	response.SetObject(updatedPublicBMI)
+	return
+}
+
+func (s *BareMetalInstancesServer) Delete(ctx context.Context,
+	request *publicv1.BareMetalInstancesDeleteRequest) (response *publicv1.BareMetalInstancesDeleteResponse, err error) {
+	privateRequest := &privatev1.BareMetalInstancesDeleteRequest{}
+	privateRequest.SetId(request.GetId())
+
+	_, err = s.delegate.Delete(ctx, privateRequest)
+	if err != nil {
+		return nil, err
+	}
+
+	response = &publicv1.BareMetalInstancesDeleteResponse{}
+	return
+}

--- a/internal/servers/baremetal_instances_server_test.go
+++ b/internal/servers/baremetal_instances_server_test.go
@@ -1,0 +1,254 @@
+/*
+Copyright (c) 2025 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package servers
+
+import (
+	"fmt"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/fieldmaskpb"
+
+	privatev1 "github.com/osac-project/fulfillment-service/internal/api/osac/private/v1"
+	publicv1 "github.com/osac-project/fulfillment-service/internal/api/osac/public/v1"
+)
+
+var _ = Describe("Bare metal instances server", func() {
+	Describe("Creation", func() {
+		It("Can be built if all the required parameters are set", func() {
+			server, err := NewBareMetalInstancesServer().
+				SetLogger(logger).
+				SetAttributionLogic(attribution).
+				SetTenancyLogic(tenancy).
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(server).ToNot(BeNil())
+		})
+
+		It("Fails if logger is not set", func() {
+			server, err := NewBareMetalInstancesServer().
+				SetAttributionLogic(attribution).
+				SetTenancyLogic(tenancy).
+				Build()
+			Expect(err).To(MatchError("logger is mandatory"))
+			Expect(server).To(BeNil())
+		})
+
+		It("Fails if tenancy logic is not set", func() {
+			server, err := NewBareMetalInstancesServer().
+				SetLogger(logger).
+				SetAttributionLogic(attribution).
+				Build()
+			Expect(err).To(MatchError("tenancy logic is mandatory"))
+			Expect(server).To(BeNil())
+		})
+	})
+
+	Describe("Behaviour", func() {
+		var (
+			server        *BareMetalInstancesServer
+			catalogItemID string
+		)
+
+		BeforeEach(func() {
+			var err error
+
+			// Seed a published catalog item.
+			catalogServer, err := NewPrivateBareMetalInstanceCatalogItemsServer().
+				SetLogger(logger).
+				SetAttributionLogic(attribution).
+				SetTenancyLogic(tenancy).
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+			catalogResp, err := catalogServer.Create(ctx, privatev1.BareMetalInstanceCatalogItemsCreateRequest_builder{
+				Object: privatev1.BareMetalInstanceCatalogItem_builder{
+					Title:     "Test catalog item",
+					Template:  "test-template",
+					Published: true,
+				}.Build(),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+			catalogItemID = catalogResp.GetObject().GetId()
+
+			server, err = NewBareMetalInstancesServer().
+				SetLogger(logger).
+				SetAttributionLogic(attribution).
+				SetTenancyLogic(tenancy).
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("Creates object", func() {
+			response, err := server.Create(ctx, publicv1.BareMetalInstancesCreateRequest_builder{
+				Object: publicv1.BareMetalInstance_builder{
+					Spec: publicv1.BareMetalInstanceSpec_builder{
+						CatalogItem: catalogItemID,
+					}.Build(),
+				}.Build(),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+			Expect(response.GetObject().GetId()).ToNot(BeEmpty())
+			Expect(response.GetObject().GetSpec().GetCatalogItem()).To(Equal(catalogItemID))
+		})
+
+		It("Fails to create without an object", func() {
+			_, err := server.Create(ctx, publicv1.BareMetalInstancesCreateRequest_builder{}.Build())
+			Expect(err).To(HaveOccurred())
+			s, ok := status.FromError(err)
+			Expect(ok).To(BeTrue())
+			Expect(s.Code()).To(Equal(codes.InvalidArgument))
+		})
+
+		It("Lists objects", func() {
+			const count = 3
+			for i := range count {
+				_, err := server.Create(ctx, publicv1.BareMetalInstancesCreateRequest_builder{
+					Object: publicv1.BareMetalInstance_builder{
+						Spec: publicv1.BareMetalInstanceSpec_builder{
+							CatalogItem: catalogItemID,
+						}.Build(),
+						Metadata: publicv1.Metadata_builder{
+							Name: fmt.Sprintf("bmi-%d", i),
+						}.Build(),
+					}.Build(),
+				}.Build())
+				Expect(err).ToNot(HaveOccurred())
+			}
+
+			response, err := server.List(ctx, publicv1.BareMetalInstancesListRequest_builder{}.Build())
+			Expect(err).ToNot(HaveOccurred())
+			Expect(response.GetItems()).To(HaveLen(count))
+		})
+
+		It("Gets object", func() {
+			createResponse, err := server.Create(ctx, publicv1.BareMetalInstancesCreateRequest_builder{
+				Object: publicv1.BareMetalInstance_builder{
+					Spec: publicv1.BareMetalInstanceSpec_builder{
+						CatalogItem: catalogItemID,
+					}.Build(),
+				}.Build(),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+			id := createResponse.GetObject().GetId()
+
+			getResponse, err := server.Get(ctx, publicv1.BareMetalInstancesGetRequest_builder{
+				Id: id,
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+			Expect(getResponse.GetObject().GetId()).To(Equal(id))
+			Expect(getResponse.GetObject().GetSpec().GetCatalogItem()).To(Equal(catalogItemID))
+		})
+
+		It("Updates mutable fields via field mask", func() {
+			createResponse, err := server.Create(ctx, publicv1.BareMetalInstancesCreateRequest_builder{
+				Object: publicv1.BareMetalInstance_builder{
+					Spec: publicv1.BareMetalInstanceSpec_builder{
+						CatalogItem: catalogItemID,
+						RunStrategy: new(publicv1.BareMetalInstanceRunStrategy_BARE_METAL_INSTANCE_RUN_STRATEGY_ALWAYS),
+					}.Build(),
+				}.Build(),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+			id := createResponse.GetObject().GetId()
+
+			updateResponse, err := server.Update(ctx, publicv1.BareMetalInstancesUpdateRequest_builder{
+				Object: publicv1.BareMetalInstance_builder{
+					Id: id,
+					Spec: publicv1.BareMetalInstanceSpec_builder{
+						RunStrategy: new(publicv1.BareMetalInstanceRunStrategy_BARE_METAL_INSTANCE_RUN_STRATEGY_HALTED),
+					}.Build(),
+				}.Build(),
+				UpdateMask: &fieldmaskpb.FieldMask{
+					Paths: []string{"spec.run_strategy"},
+				},
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+			Expect(updateResponse.GetObject().GetSpec().GetRunStrategy()).To(
+				Equal(publicv1.BareMetalInstanceRunStrategy_BARE_METAL_INSTANCE_RUN_STRATEGY_HALTED))
+		})
+
+		It("Fails to update without an object", func() {
+			_, err := server.Update(ctx, publicv1.BareMetalInstancesUpdateRequest_builder{}.Build())
+			Expect(err).To(HaveOccurred())
+			s, ok := status.FromError(err)
+			Expect(ok).To(BeTrue())
+			Expect(s.Code()).To(Equal(codes.InvalidArgument))
+		})
+
+		It("Fails to update without an object identifier", func() {
+			_, err := server.Update(ctx, publicv1.BareMetalInstancesUpdateRequest_builder{
+				Object: publicv1.BareMetalInstance_builder{}.Build(),
+			}.Build())
+			Expect(err).To(HaveOccurred())
+			s, ok := status.FromError(err)
+			Expect(ok).To(BeTrue())
+			Expect(s.Code()).To(Equal(codes.InvalidArgument))
+		})
+
+		It("Rejects update that changes immutable catalog_item", func() {
+			createResponse, err := server.Create(ctx, publicv1.BareMetalInstancesCreateRequest_builder{
+				Object: publicv1.BareMetalInstance_builder{
+					Spec: publicv1.BareMetalInstanceSpec_builder{
+						CatalogItem: catalogItemID,
+					}.Build(),
+				}.Build(),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+			id := createResponse.GetObject().GetId()
+
+			_, err = server.Update(ctx, publicv1.BareMetalInstancesUpdateRequest_builder{
+				Object: publicv1.BareMetalInstance_builder{
+					Id: id,
+					Spec: publicv1.BareMetalInstanceSpec_builder{
+						CatalogItem: "different-catalog-item",
+					}.Build(),
+				}.Build(),
+				UpdateMask: &fieldmaskpb.FieldMask{
+					Paths: []string{"spec.catalog_item"},
+				},
+			}.Build())
+			Expect(err).To(HaveOccurred())
+			s, ok := status.FromError(err)
+			Expect(ok).To(BeTrue())
+			Expect(s.Code()).To(Equal(codes.InvalidArgument))
+		})
+
+		It("Deletes object", func() {
+			createResponse, err := server.Create(ctx, publicv1.BareMetalInstancesCreateRequest_builder{
+				Object: publicv1.BareMetalInstance_builder{
+					Spec: publicv1.BareMetalInstanceSpec_builder{
+						CatalogItem: catalogItemID,
+					}.Build(),
+				}.Build(),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+			id := createResponse.GetObject().GetId()
+
+			_, err = server.Delete(ctx, publicv1.BareMetalInstancesDeleteRequest_builder{
+				Id: id,
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+
+			_, err = server.Get(ctx, publicv1.BareMetalInstancesGetRequest_builder{
+				Id: id,
+			}.Build())
+			Expect(err).To(HaveOccurred())
+			s, ok := status.FromError(err)
+			Expect(ok).To(BeTrue())
+			Expect(s.Code()).To(Equal(codes.NotFound))
+		})
+	})
+})


### PR DESCRIPTION
## Summary

- Implements thin public wrappers over the private bare metal servers: `BareMetalInstanceTemplatesServer` (List/Get only, per EP), `BareMetalInstanceCatalogItemsServer` (full CRUD with published-visibility enforcement and tenant scoping on Create), and `BareMetalInstancesServer` (full CRUD with field-mask-aware Update)
- Registers all three public servers in the main gRPC setup alongside the existing private servers
- Adds unit tests for all three servers covering CRUD, published-visibility filter, immutability enforcement, and reference-blocked deletion

## Jira

https://redhat.atlassian.net/browse/OSAC-1346

## Test plan

- [x] `ginkgo run internal/servers` — 979/979 passed
- [x] `go build ./...` — clean
- [x] `gofmt -s -w .` — no drift

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added CLI command to create bare metal instances with configurable options (name, catalog item, SSH key, user data, run strategy).
  * Added CLI command to describe and retrieve bare metal instance details.
  * Introduced new gRPC API services for bare metal instance management, including templates and catalog items with full CRUD operations.

* **Security**
  * Extended authorization policies to control access to bare metal instance operations, including tenant-admin-only creation and management of catalog items.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->