### PR TITLE
OSAC-1552: Reject creation when required editable field has no value

### DIFF
--- a/internal/servers/catalog_item_validation.go
+++ b/internal/servers/catalog_item_validation.go
@@ -113,6 +113,10 @@ func applyFieldDefinitions(
 					}
 				}
 			} else {
+				if defaultVal == nil {
+					return grpcstatus.Errorf(grpccodes.InvalidArgument,
+						"field '%s' is required but no value was provided and no default is defined", path)
+				}
 				if err := applyDefault(specMap, path, defaultVal); err != nil {
 					return err
 				}

--- a/internal/servers/catalog_item_validation_test.go
+++ b/internal/servers/catalog_item_validation_test.go
@@ -37,8 +37,9 @@ var _ = Describe("applyFieldDefinitions", func() {
 	})
 
 	It("accepts editable field with no default when user provides value", func() {
+		pullSecret := "my-secret"
 		spec := &privatev1.ClusterSpec{
-			PullSecret: strPtr("my-secret"),
+			PullSecret: &pullSecret,
 		}
 		fieldDefs := []*privatev1.FieldDefinition{{
 			Path:     "pull_secret",
@@ -64,8 +65,9 @@ var _ = Describe("applyFieldDefinitions", func() {
 	})
 
 	It("overrides user value with default for non-editable field", func() {
+		userValue := "user-value"
 		spec := &privatev1.ClusterSpec{
-			PullSecret: strPtr("user-value"),
+			PullSecret: &userValue,
 		}
 		defaultVal, err := structpb.NewValue("admin-value")
 		Expect(err).ToNot(HaveOccurred())
@@ -80,17 +82,42 @@ var _ = Describe("applyFieldDefinitions", func() {
 	})
 
 	It("returns no error for empty field definitions", func() {
+		pullSecret := "my-secret"
 		spec := &privatev1.ClusterSpec{
-			PullSecret: strPtr("my-secret"),
+			PullSecret: &pullSecret,
 		}
 		err := applyFieldDefinitions(spec, nil)
 		Expect(err).ToNot(HaveOccurred())
 	})
-})
 
-func strPtr(s string) *string {
-	return &s
-}
+	It("rejects when any required field is missing among multiple fields", func() {
+		sshKey := "my-ssh-key"
+		spec := &privatev1.ClusterSpec{
+			SshPublicKey: &sshKey,
+		}
+		defaultRelease, err := structpb.NewValue("4.16")
+		Expect(err).ToNot(HaveOccurred())
+		fieldDefs := []*privatev1.FieldDefinition{
+			{
+				Path:     "release_image",
+				Editable: true,
+				Default:  defaultRelease,
+			},
+			{
+				Path:     "pull_secret",
+				Editable: true,
+			},
+			{
+				Path:     "ssh_public_key",
+				Editable: true,
+			},
+		}
+		err = applyFieldDefinitions(spec, fieldDefs)
+		Expect(err).To(HaveOccurred())
+		Expect(status.Code(err)).To(Equal(codes.InvalidArgument))
+		Expect(err.Error()).To(ContainSubstring("pull_secret"))
+	})
+})
 
 var _ = Describe("addPublishedFilter", func() {
 	var server *ClusterCatalogItemsServer

--- a/internal/servers/catalog_item_validation_test.go
+++ b/internal/servers/catalog_item_validation_test.go
@@ -18,7 +18,79 @@ import (
 	. "github.com/onsi/gomega"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/structpb"
+
+	privatev1 "github.com/osac-project/fulfillment-service/internal/api/osac/private/v1"
 )
+
+var _ = Describe("applyFieldDefinitions", func() {
+	It("rejects editable field with no default and no user value", func() {
+		spec := &privatev1.ClusterSpec{}
+		fieldDefs := []*privatev1.FieldDefinition{{
+			Path:     "pull_secret",
+			Editable: true,
+		}}
+		err := applyFieldDefinitions(spec, fieldDefs)
+		Expect(err).To(HaveOccurred())
+		Expect(status.Code(err)).To(Equal(codes.InvalidArgument))
+		Expect(err.Error()).To(ContainSubstring("pull_secret"))
+	})
+
+	It("accepts editable field with no default when user provides value", func() {
+		spec := &privatev1.ClusterSpec{
+			PullSecret: strPtr("my-secret"),
+		}
+		fieldDefs := []*privatev1.FieldDefinition{{
+			Path:     "pull_secret",
+			Editable: true,
+		}}
+		err := applyFieldDefinitions(spec, fieldDefs)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(spec.GetPullSecret()).To(Equal("my-secret"))
+	})
+
+	It("applies default for editable field when user provides no value", func() {
+		spec := &privatev1.ClusterSpec{}
+		defaultVal, err := structpb.NewValue("default-secret")
+		Expect(err).ToNot(HaveOccurred())
+		fieldDefs := []*privatev1.FieldDefinition{{
+			Path:     "pull_secret",
+			Editable: true,
+			Default:  defaultVal,
+		}}
+		err = applyFieldDefinitions(spec, fieldDefs)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(spec.GetPullSecret()).To(Equal("default-secret"))
+	})
+
+	It("overrides user value with default for non-editable field", func() {
+		spec := &privatev1.ClusterSpec{
+			PullSecret: strPtr("user-value"),
+		}
+		defaultVal, err := structpb.NewValue("admin-value")
+		Expect(err).ToNot(HaveOccurred())
+		fieldDefs := []*privatev1.FieldDefinition{{
+			Path:     "pull_secret",
+			Editable: false,
+			Default:  defaultVal,
+		}}
+		err = applyFieldDefinitions(spec, fieldDefs)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(spec.GetPullSecret()).To(Equal("admin-value"))
+	})
+
+	It("returns no error for empty field definitions", func() {
+		spec := &privatev1.ClusterSpec{
+			PullSecret: strPtr("my-secret"),
+		}
+		err := applyFieldDefinitions(spec, nil)
+		Expect(err).ToNot(HaveOccurred())
+	})
+})
+
+func strPtr(s string) *string {
+	return &s
+}
 
 var _ = Describe("addPublishedFilter", func() {
 	var server *ClusterCatalogItemsServer


### PR DESCRIPTION
## [OSAC-1552](https://redhat.atlassian.net/browse/OSAC-1552): Reject creation when required editable field has no value

**Jira:** https://redhat.atlassian.net/browse/OSAC-1552

### Summary

When a catalog item defines an editable field with no default value (e.g., `pull_secret`), and the user creates a cluster or compute instance without providing that field, the server now rejects the request immediately with `InvalidArgument`. Previously, the request was silently accepted and failed later during AAP provisioning with a confusing error.

### Changes

- **`internal/servers/catalog_item_validation.go`** - In `applyFieldDefinitions()`, when an editable field has no default and the user provides no value, return `InvalidArgument` with a message identifying the missing field
- **`internal/servers/catalog_item_validation_test.go`** - Added 5 unit tests for `applyFieldDefinitions` covering: rejection of missing required fields, acceptance of user-provided values, default application, non-editable field override, and empty field definitions

### Testing

- **Unit tests:** 5 new tests for `applyFieldDefinitions` behavioral contracts
- **Integration tests:** N/A - shared validation function, no component interaction changes
- **Coverage:** All new code paths covered through public interface tests

### Acceptance Criteria

- [x] Server rejects cluster/compute instance creation with `InvalidArgument` when a required editable field is missing
- [x] Error message clearly identifies which field is missing
- [x] Existing clusters with defaults or user-provided values are unaffected
- [x] Unit tests cover: editable+no default+no user value (rejected), editable+no default+user provides value (accepted), editable+default+no user value (default applied)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation to properly enforce required editable fields. Fields without default values now correctly return an error if not provided by the user, preventing silent failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->