### PR TITLE
OSAC-1542: Add catalog item create subcommands to CLI

### DIFF
--- a/internal/cmd/cli/create/baremetalinstancecatalogitem/create_baremetal_instance_catalog_item_cmd.go
+++ b/internal/cmd/cli/create/baremetalinstancecatalogitem/create_baremetal_instance_catalog_item_cmd.go
@@ -1,0 +1,161 @@
+/*
+Copyright (c) 2026 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package baremetalinstancecatalogitem
+
+import (
+	"fmt"
+	"log/slog"
+
+	"github.com/spf13/cobra"
+	"google.golang.org/protobuf/proto"
+
+	publicv1 "github.com/osac-project/fulfillment-service/internal/api/osac/public/v1"
+	"github.com/osac-project/fulfillment-service/internal/config"
+	"github.com/osac-project/fulfillment-service/internal/logging"
+	"github.com/osac-project/fulfillment-service/internal/terminal"
+)
+
+func Cmd() *cobra.Command {
+	runner := &runnerContext{}
+	result := &cobra.Command{
+		Use:                   "baremetalinstancecatalogitem [FLAG...]",
+		Aliases:               []string{string(proto.MessageName((*publicv1.BareMetalInstanceCatalogItem)(nil)))},
+		Short:                 shortHelp,
+		Long:                  longHelp,
+		DisableFlagsInUseLine: true,
+		Args:                  cobra.NoArgs,
+		RunE:                  runner.run,
+	}
+	flags := result.Flags()
+	flags.StringVarP(
+		&runner.args.name,
+		"name",
+		"n",
+		"",
+		nameFlagHelp,
+	)
+	flags.StringVar(
+		&runner.args.title,
+		"title",
+		"",
+		titleFlagHelp,
+	)
+	flags.StringVar(
+		&runner.args.description,
+		"description",
+		"",
+		descriptionFlagHelp,
+	)
+	flags.StringVarP(
+		&runner.args.template,
+		"template",
+		"t",
+		"",
+		templateFlagHelp,
+	)
+	flags.BoolVar(
+		&runner.args.published,
+		"published",
+		false,
+		publishedFlagHelp,
+	)
+	result.MarkFlagRequired("template") //nolint:errcheck
+	return result
+}
+
+type runnerContext struct {
+	args struct {
+		name        string
+		title       string
+		description string
+		template    string
+		published   bool
+	}
+	logger  *slog.Logger
+	console *terminal.Console
+}
+
+func (c *runnerContext) run(cmd *cobra.Command, args []string) error {
+	ctx := cmd.Context()
+
+	c.logger = logging.LoggerFromContext(ctx)
+	c.console = terminal.ConsoleFromContext(ctx)
+
+	cfg := config.SettingsFromContext(ctx)
+	if !cfg.Armed() {
+		return fmt.Errorf("there is no configuration, run the 'login' command")
+	}
+
+	conn, err := cfg.Connect(ctx, cmd.Flags())
+	if err != nil {
+		return fmt.Errorf("failed to create gRPC connection: %w", err)
+	}
+	defer conn.Close()
+
+	client := publicv1.NewBareMetalInstanceCatalogItemsClient(conn)
+
+	catalogItem := publicv1.BareMetalInstanceCatalogItem_builder{
+		Metadata: publicv1.Metadata_builder{
+			Name: c.args.name,
+		}.Build(),
+		Title:       c.args.title,
+		Description: c.args.description,
+		Template:    c.args.template,
+		Published:   c.args.published,
+	}.Build()
+
+	response, err := client.Create(ctx, publicv1.BareMetalInstanceCatalogItemsCreateRequest_builder{
+		Object: catalogItem,
+	}.Build())
+	if err != nil {
+		return fmt.Errorf("failed to create bare metal instance catalog item: %w", err)
+	}
+
+	catalogItem = response.Object
+	c.console.Infof(ctx, "Created bare metal instance catalog item '%s'.\n", catalogItem.GetId())
+
+	return nil
+}
+
+const shortHelp = `Create a bare metal instance catalog item.`
+
+const longHelp = `
+Create a bare metal instance catalog item. A catalog item defines a curated
+bare metal instance offering that references an underlying bare metal
+instance template.
+
+To include field definitions, use {{ bt }}osac create -f{{ bt }} with a
+YAML file instead.
+`
+
+const nameFlagHelp = `
+_NAME_ - Name of the bare metal instance catalog item.
+`
+
+const titleFlagHelp = `
+_TITLE_ - Human-friendly short description, suitable for displaying in a
+single line.
+`
+
+const descriptionFlagHelp = `
+_TEXT_ - Human-friendly long description in Markdown format.
+`
+
+const templateFlagHelp = `
+_ID_ - Identifier of the underlying bare metal instance template.
+`
+
+const publishedFlagHelp = `
+_[BOOLEAN]_ - Whether this catalog item is published.
+`

--- a/internal/cmd/cli/create/clustercatalogitem/create_cluster_catalog_item_cmd.go
+++ b/internal/cmd/cli/create/clustercatalogitem/create_cluster_catalog_item_cmd.go
@@ -1,0 +1,160 @@
+/*
+Copyright (c) 2026 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package clustercatalogitem
+
+import (
+	"fmt"
+	"log/slog"
+
+	"github.com/spf13/cobra"
+	"google.golang.org/protobuf/proto"
+
+	publicv1 "github.com/osac-project/fulfillment-service/internal/api/osac/public/v1"
+	"github.com/osac-project/fulfillment-service/internal/config"
+	"github.com/osac-project/fulfillment-service/internal/logging"
+	"github.com/osac-project/fulfillment-service/internal/terminal"
+)
+
+func Cmd() *cobra.Command {
+	runner := &runnerContext{}
+	result := &cobra.Command{
+		Use:                   "clustercatalogitem [FLAG...]",
+		Aliases:               []string{string(proto.MessageName((*publicv1.ClusterCatalogItem)(nil)))},
+		Short:                 shortHelp,
+		Long:                  longHelp,
+		DisableFlagsInUseLine: true,
+		Args:                  cobra.NoArgs,
+		RunE:                  runner.run,
+	}
+	flags := result.Flags()
+	flags.StringVarP(
+		&runner.args.name,
+		"name",
+		"n",
+		"",
+		nameFlagHelp,
+	)
+	flags.StringVar(
+		&runner.args.title,
+		"title",
+		"",
+		titleFlagHelp,
+	)
+	flags.StringVar(
+		&runner.args.description,
+		"description",
+		"",
+		descriptionFlagHelp,
+	)
+	flags.StringVarP(
+		&runner.args.template,
+		"template",
+		"t",
+		"",
+		templateFlagHelp,
+	)
+	flags.BoolVar(
+		&runner.args.published,
+		"published",
+		false,
+		publishedFlagHelp,
+	)
+	result.MarkFlagRequired("template") //nolint:errcheck
+	return result
+}
+
+type runnerContext struct {
+	args struct {
+		name        string
+		title       string
+		description string
+		template    string
+		published   bool
+	}
+	logger  *slog.Logger
+	console *terminal.Console
+}
+
+func (c *runnerContext) run(cmd *cobra.Command, args []string) error {
+	ctx := cmd.Context()
+
+	c.logger = logging.LoggerFromContext(ctx)
+	c.console = terminal.ConsoleFromContext(ctx)
+
+	cfg := config.SettingsFromContext(ctx)
+	if !cfg.Armed() {
+		return fmt.Errorf("there is no configuration, run the 'login' command")
+	}
+
+	conn, err := cfg.Connect(ctx, cmd.Flags())
+	if err != nil {
+		return fmt.Errorf("failed to create gRPC connection: %w", err)
+	}
+	defer conn.Close()
+
+	client := publicv1.NewClusterCatalogItemsClient(conn)
+
+	catalogItem := publicv1.ClusterCatalogItem_builder{
+		Metadata: publicv1.Metadata_builder{
+			Name: c.args.name,
+		}.Build(),
+		Title:       c.args.title,
+		Description: c.args.description,
+		Template:    c.args.template,
+		Published:   c.args.published,
+	}.Build()
+
+	response, err := client.Create(ctx, publicv1.ClusterCatalogItemsCreateRequest_builder{
+		Object: catalogItem,
+	}.Build())
+	if err != nil {
+		return fmt.Errorf("failed to create cluster catalog item: %w", err)
+	}
+
+	catalogItem = response.Object
+	c.console.Infof(ctx, "Created cluster catalog item '%s'.\n", catalogItem.GetId())
+
+	return nil
+}
+
+const shortHelp = `Create a cluster catalog item.`
+
+const longHelp = `
+Create a cluster catalog item. A catalog item defines a curated cluster
+offering that references an underlying cluster template.
+
+To include field definitions, use {{ bt }}osac create -f{{ bt }} with a
+YAML file instead.
+`
+
+const nameFlagHelp = `
+_NAME_ - Name of the cluster catalog item.
+`
+
+const titleFlagHelp = `
+_TITLE_ - Human-friendly short description, suitable for displaying in a
+single line.
+`
+
+const descriptionFlagHelp = `
+_TEXT_ - Human-friendly long description in Markdown format.
+`
+
+const templateFlagHelp = `
+_ID_ - Identifier of the underlying cluster template.
+`
+
+const publishedFlagHelp = `
+_[BOOLEAN]_ - Whether this catalog item is published.
+`

--- a/internal/cmd/cli/create/computeinstancecatalogitem/create_compute_instance_catalog_item_cmd.go
+++ b/internal/cmd/cli/create/computeinstancecatalogitem/create_compute_instance_catalog_item_cmd.go
@@ -1,0 +1,161 @@
+/*
+Copyright (c) 2026 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package computeinstancecatalogitem
+
+import (
+	"fmt"
+	"log/slog"
+
+	"github.com/spf13/cobra"
+	"google.golang.org/protobuf/proto"
+
+	publicv1 "github.com/osac-project/fulfillment-service/internal/api/osac/public/v1"
+	"github.com/osac-project/fulfillment-service/internal/config"
+	"github.com/osac-project/fulfillment-service/internal/logging"
+	"github.com/osac-project/fulfillment-service/internal/terminal"
+)
+
+func Cmd() *cobra.Command {
+	runner := &runnerContext{}
+	result := &cobra.Command{
+		Use:                   "computeinstancecatalogitem [FLAG...]",
+		Aliases:               []string{string(proto.MessageName((*publicv1.ComputeInstanceCatalogItem)(nil)))},
+		Short:                 shortHelp,
+		Long:                  longHelp,
+		DisableFlagsInUseLine: true,
+		Args:                  cobra.NoArgs,
+		RunE:                  runner.run,
+	}
+	flags := result.Flags()
+	flags.StringVarP(
+		&runner.args.name,
+		"name",
+		"n",
+		"",
+		nameFlagHelp,
+	)
+	flags.StringVar(
+		&runner.args.title,
+		"title",
+		"",
+		titleFlagHelp,
+	)
+	flags.StringVar(
+		&runner.args.description,
+		"description",
+		"",
+		descriptionFlagHelp,
+	)
+	flags.StringVarP(
+		&runner.args.template,
+		"template",
+		"t",
+		"",
+		templateFlagHelp,
+	)
+	flags.BoolVar(
+		&runner.args.published,
+		"published",
+		false,
+		publishedFlagHelp,
+	)
+	result.MarkFlagRequired("template") //nolint:errcheck
+	return result
+}
+
+type runnerContext struct {
+	args struct {
+		name        string
+		title       string
+		description string
+		template    string
+		published   bool
+	}
+	logger  *slog.Logger
+	console *terminal.Console
+}
+
+func (c *runnerContext) run(cmd *cobra.Command, args []string) error {
+	ctx := cmd.Context()
+
+	c.logger = logging.LoggerFromContext(ctx)
+	c.console = terminal.ConsoleFromContext(ctx)
+
+	cfg := config.SettingsFromContext(ctx)
+	if !cfg.Armed() {
+		return fmt.Errorf("there is no configuration, run the 'login' command")
+	}
+
+	conn, err := cfg.Connect(ctx, cmd.Flags())
+	if err != nil {
+		return fmt.Errorf("failed to create gRPC connection: %w", err)
+	}
+	defer conn.Close()
+
+	client := publicv1.NewComputeInstanceCatalogItemsClient(conn)
+
+	catalogItem := publicv1.ComputeInstanceCatalogItem_builder{
+		Metadata: publicv1.Metadata_builder{
+			Name: c.args.name,
+		}.Build(),
+		Title:       c.args.title,
+		Description: c.args.description,
+		Template:    c.args.template,
+		Published:   c.args.published,
+	}.Build()
+
+	response, err := client.Create(ctx, publicv1.ComputeInstanceCatalogItemsCreateRequest_builder{
+		Object: catalogItem,
+	}.Build())
+	if err != nil {
+		return fmt.Errorf("failed to create compute instance catalog item: %w", err)
+	}
+
+	catalogItem = response.Object
+	c.console.Infof(ctx, "Created compute instance catalog item '%s'.\n", catalogItem.GetId())
+
+	return nil
+}
+
+const shortHelp = `Create a compute instance catalog item.`
+
+const longHelp = `
+Create a compute instance catalog item. A catalog item defines a curated
+compute instance offering that references an underlying compute instance
+template.
+
+To include field definitions, use {{ bt }}osac create -f{{ bt }} with a
+YAML file instead.
+`
+
+const nameFlagHelp = `
+_NAME_ - Name of the compute instance catalog item.
+`
+
+const titleFlagHelp = `
+_TITLE_ - Human-friendly short description, suitable for displaying in a
+single line.
+`
+
+const descriptionFlagHelp = `
+_TEXT_ - Human-friendly long description in Markdown format.
+`
+
+const templateFlagHelp = `
+_ID_ - Identifier of the underlying compute instance template.
+`
+
+const publishedFlagHelp = `
+_[BOOLEAN]_ - Whether this catalog item is published.
+`

--- a/internal/cmd/cli/create/create_cmd.go
+++ b/internal/cmd/cli/create/create_cmd.go
@@ -29,8 +29,11 @@ import (
 	"gopkg.in/yaml.v3"
 
 	"github.com/osac-project/fulfillment-service/internal/cmd/cli/create/baremetalinstance"
+	"github.com/osac-project/fulfillment-service/internal/cmd/cli/create/baremetalinstancecatalogitem"
 	"github.com/osac-project/fulfillment-service/internal/cmd/cli/create/cluster"
+	"github.com/osac-project/fulfillment-service/internal/cmd/cli/create/clustercatalogitem"
 	"github.com/osac-project/fulfillment-service/internal/cmd/cli/create/computeinstance"
+	"github.com/osac-project/fulfillment-service/internal/cmd/cli/create/computeinstancecatalogitem"
 	"github.com/osac-project/fulfillment-service/internal/cmd/cli/create/hub"
 	"github.com/osac-project/fulfillment-service/internal/cmd/cli/create/instancetype"
 	"github.com/osac-project/fulfillment-service/internal/cmd/cli/create/publicip"
@@ -54,8 +57,11 @@ func Cmd() *cobra.Command {
 		RunE:                  runner.run,
 	}
 	result.AddCommand(baremetalinstance.Cmd())
+	result.AddCommand(baremetalinstancecatalogitem.Cmd())
 	result.AddCommand(cluster.Cmd())
+	result.AddCommand(clustercatalogitem.Cmd())
 	result.AddCommand(computeinstance.Cmd())
+	result.AddCommand(computeinstancecatalogitem.Cmd())
 	result.AddCommand(hub.Cmd())
 	result.AddCommand(instancetype.Cmd())
 	result.AddCommand(publicip.Cmd())

--- a/internal/cmd/cli/create/create_cmd_test.go
+++ b/internal/cmd/cli/create/create_cmd_test.go
@@ -22,8 +22,11 @@ import (
 
 	privatev1 "github.com/osac-project/fulfillment-service/internal/api/osac/private/v1"
 	publicv1 "github.com/osac-project/fulfillment-service/internal/api/osac/public/v1"
+	"github.com/osac-project/fulfillment-service/internal/cmd/cli/create/baremetalinstancecatalogitem"
 	"github.com/osac-project/fulfillment-service/internal/cmd/cli/create/cluster"
+	"github.com/osac-project/fulfillment-service/internal/cmd/cli/create/clustercatalogitem"
 	"github.com/osac-project/fulfillment-service/internal/cmd/cli/create/computeinstance"
+	"github.com/osac-project/fulfillment-service/internal/cmd/cli/create/computeinstancecatalogitem"
 	"github.com/osac-project/fulfillment-service/internal/cmd/cli/create/hub"
 	"github.com/osac-project/fulfillment-service/internal/cmd/cli/create/publicip"
 	"github.com/osac-project/fulfillment-service/internal/cmd/cli/create/securitygroup"
@@ -38,8 +41,11 @@ var _ = Describe("Create command", func() {
 			expectedAlias := string(proto.MessageName(protoMsg))
 			Expect(cmd.Aliases).To(ContainElement(expectedAlias))
 		},
+		Entry("baremetalinstancecatalogitem", baremetalinstancecatalogitem.Cmd, (*publicv1.BareMetalInstanceCatalogItem)(nil)),
 		Entry("cluster", cluster.Cmd, (*publicv1.Cluster)(nil)),
+		Entry("clustercatalogitem", clustercatalogitem.Cmd, (*publicv1.ClusterCatalogItem)(nil)),
 		Entry("computeinstance", computeinstance.Cmd, (*publicv1.ComputeInstance)(nil)),
+		Entry("computeinstancecatalogitem", computeinstancecatalogitem.Cmd, (*publicv1.ComputeInstanceCatalogItem)(nil)),
 		Entry("hub", hub.Cmd, (*privatev1.Hub)(nil)),
 		Entry("publicip", publicip.Cmd, (*publicv1.PublicIP)(nil)),
 		Entry("virtualnetwork", virtualnetwork.Cmd, (*publicv1.VirtualNetwork)(nil)),
@@ -57,7 +63,7 @@ var _ = Describe("Create command", func() {
 				subcommandNames = append(subcommandNames, subcmd.Name())
 			}
 
-			Expect(subcommandNames).To(ContainElements("cluster", "computeinstance", "hub", "publicip", "publicipattachment", "virtualnetwork", "subnet", "securitygroup"))
+			Expect(subcommandNames).To(ContainElements("baremetalinstancecatalogitem", "cluster", "clustercatalogitem", "computeinstance", "computeinstancecatalogitem", "hub", "publicip", "publicipattachment", "virtualnetwork", "subnet", "securitygroup"))
 		})
 	})
 })


### PR DESCRIPTION
## [OSAC-1542](https://redhat.atlassian.net/browse/OSAC-1542): Add catalog item create subcommands to CLI

**Jira:** https://redhat.atlassian.net/browse/OSAC-1542

### Summary

The `osac create --help` output was missing catalog item subcommands. This adds `clustercatalogitem`, `computeinstancecatalogitem`, and `baremetalinstancecatalogitem` subcommands so users can create catalog items with dedicated flags instead of only via `osac create -f`.

### Changes

- **`internal/cmd/cli/create/clustercatalogitem/`** - New subcommand for creating cluster catalog items
- **`internal/cmd/cli/create/computeinstancecatalogitem/`** - New subcommand for creating compute instance catalog items
- **`internal/cmd/cli/create/baremetalinstancecatalogitem/`** - New subcommand for creating bare metal instance catalog items
- **`internal/cmd/cli/create/create_cmd.go`** - Register the three new subcommands
- **`internal/cmd/cli/create/create_cmd_test.go`** - Add alias and subcommand registration tests

Each subcommand accepts `--name`, `--title`, `--description`, `--template` (required), and `--published` flags. For `field_definitions`, users should use `osac create -f` with a YAML file.

### Testing

- **Unit tests:** 3 new alias entries and updated subcommand list assertion in existing test suite
- **Integration tests:** N/A - thin CLI wrappers over existing gRPC clients
- **Coverage:** Follows same pattern as other simple create subcommands (publicip, hub)

### Acceptance Criteria

- [x] `osac create --help` lists catalog item subcommands
- [x] Each subcommand accepts --name, --title, --description, --template, --published flags
- [x] `field_definitions` not exposed as flags (use `create -f` for that)
- [x] Each subcommand creates via public gRPC API


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new `create` CLI options for catalog items in bare metal instance, cluster, and compute instance workflows.
  * Each command now supports setting name, title, description, template, and published status, and reports the created item ID after success.

* **Tests**
  * Updated CLI coverage to include the new subcommands and their aliases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->