### PR TITLE
OSAC-1546: Harden the hubs table

### DIFF
--- a/internal/cmd/cli/create/hub/create_hub_cmd.go
+++ b/internal/cmd/cli/create/hub/create_hub_cmd.go
@@ -37,11 +37,18 @@ func Cmd() *cobra.Command {
 	}
 	flags := result.Flags()
 	flags.StringVar(
-		&runner.id,
+		&runner.name,
+		"name",
+		"",
+		nameFlagHelp,
+	)
+	flags.StringVar(
+		&runner.name,
 		"id",
 		"",
 		idFlagHelp,
 	)
+	flags.MarkDeprecated("id", "use '--name' instead")
 	flags.StringVar(
 		&runner.kubeconfig,
 		"kubeconfig",
@@ -59,7 +66,7 @@ func Cmd() *cobra.Command {
 
 type runnerContext struct {
 	console    *terminal.Console
-	id         string
+	name       string
 	kubeconfig string
 	namespace  string
 }
@@ -78,11 +85,8 @@ func (c *runnerContext) run(cmd *cobra.Command, args []string) error {
 	}
 
 	// Check the parameters:
-	if c.id == "" {
-		return fmt.Errorf("identifier is required")
-	}
-	if c.namespace == "" {
-		return fmt.Errorf("namespace name is required")
+	if c.name == "" {
+		return fmt.Errorf("hub name is required, use the '--name' flag")
 	}
 	if c.kubeconfig == "" {
 		return fmt.Errorf("kubeconfig file is required")
@@ -109,7 +113,9 @@ func (c *runnerContext) run(cmd *cobra.Command, args []string) error {
 
 	// Prepare the hub:
 	hub := privatev1.Hub_builder{
-		Id: c.id,
+		Metadata: privatev1.Metadata_builder{
+			Name: c.name,
+		}.Build(),
 		Spec: privatev1.HubSpec_builder{
 			Kubeconfig: kubeconfig,
 			Namespace:  c.namespace,
@@ -126,7 +132,7 @@ func (c *runnerContext) run(cmd *cobra.Command, args []string) error {
 
 	// Display the result:
 	hub = response.Object
-	c.console.Infof(ctx, "Created hub `%s`.\n", hub.GetId())
+	c.console.Infof(ctx, "Created hub `%s`.\n", hub.GetMetadata().GetName())
 
 	return nil
 }
@@ -137,8 +143,12 @@ const longHelp = `
 Create a hub.
 `
 
+const nameFlagHelp = `
+_NAME_ - Name of the hub.
+`
+
 const idFlagHelp = `
-_ID_ - Unique identifier of the hub.
+Deprecated alternative for the '--name' flag.
 `
 
 const kubeconfigFlagHelp = `

--- a/internal/database/database_tool.go
+++ b/internal/database/database_tool.go
@@ -575,12 +575,16 @@ func (t *tool) listArchiveTables(ctx context.Context, pool *pgxpool.Pool) (resul
 }
 
 // checkObjectTable performs all consistency checks for a single object table: verifies that it has the expected columns
-// with the correct types, a primary key on 'id', a tenant foreign key, and a corresponding archive table. Returns the
-// number of issues found.
+// with the correct types, a primary key, a tenant foreign key, and a corresponding archive table. Returns the number
+// of issues found.
 func (t *tool) checkObjectTable(ctx context.Context, pool *pgxpool.Pool, table string) int {
 	issues := 0
 	issues += t.checkColumns(ctx, pool, table, toolObjectColumns)
-	issues += t.checkPrimaryKey(ctx, pool, table)
+	if slices.Contains(hardenedTables, table) {
+		issues += t.checkPrimaryKey(ctx, pool, table, "tenant", "name")
+	} else {
+		issues += t.checkPrimaryKey(ctx, pool, table, "id")
+	}
 	issues += t.checkTenantForeignKey(ctx, pool, table)
 	issues += t.checkTableExists(ctx, pool, "archived_"+table)
 	return issues
@@ -634,9 +638,9 @@ func (t *tool) checkColumns(ctx context.Context, pool *pgxpool.Pool, table strin
 	return issues
 }
 
-// checkPrimaryKey verifies that the given table has a primary key constraint on the 'id' column. Returns the number
-// of issues found.
-func (t *tool) checkPrimaryKey(ctx context.Context, pool *pgxpool.Pool, table string) int {
+// checkPrimaryKey verifies that the given table has a primary key constraint covering all the specified columns.
+// Returns the number of issues found.
+func (t *tool) checkPrimaryKey(ctx context.Context, pool *pgxpool.Pool, table string, columns ...string) int {
 	var count int
 	row := pool.QueryRow(
 		ctx,
@@ -655,8 +659,9 @@ func (t *tool) checkPrimaryKey(ctx context.Context, pool *pgxpool.Pool, table st
 			n.nspname = 'public' and
 			c.relname = $1 and
 			con.contype = 'p' and
-			a.attname = 'id'`,
+			a.attname = any($2)`,
 		table,
+		columns,
 	)
 	err := row.Scan(&count)
 	if err != nil {
@@ -668,11 +673,12 @@ func (t *tool) checkPrimaryKey(ctx context.Context, pool *pgxpool.Pool, table st
 		)
 		return 1
 	}
-	if count != 1 {
+	if count != len(columns) {
 		t.logger.ErrorContext(
 			ctx,
-			"Object table is missing the primary key on 'id' column",
+			"Object table primary key doesn't match expected columns",
 			slog.String("table", table),
+			slog.Any("expected", columns),
 		)
 		return 1
 	}
@@ -883,4 +889,10 @@ var toolArchivedColumns = map[string]string{
 	"name":               "text",
 	"tenant":             "text",
 	"version":            "integer",
+}
+
+// hardenedTables lists tables whose primary key has been changed from the default single-column 'id' to the composite
+// (tenant, name) pair. More tables will be hardened in the future following the same pattern.
+var hardenedTables = []string{
+	"hubs",
 }

--- a/internal/database/migrations/56_harden_hubs_table.up.sql
+++ b/internal/database/migrations/56_harden_hubs_table.up.sql
@@ -1,0 +1,36 @@
+--
+-- Copyright (c) 2026 Red Hat Inc.
+--
+-- Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+-- the License. You may obtain a copy of the License at
+--
+--   http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+-- an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+-- specific language governing permissions and limitations under the License.
+--
+
+-- This migration hardens the hubs table. Hubs are infrastructure-level resources that must always belong to the shared
+-- tenant, so any hub previously assigned to another tenant is reassigned. It also backfills the name column for hubs
+-- that don't have one yet (copying the identifier), switches the primary key from 'id' to the composite (tenant, name),
+-- keeps 'id' as a unique column, and attaches the immutable-columns trigger so that the id, name and tenant columns
+-- cannot be changed after creation.
+
+-- Move all hubs to the shared tenant:
+update hubs set tenant = 'shared' where tenant != 'shared';
+
+-- Backfill the name column for hubs that have an empty name:
+update hubs set name = id where name = '';
+
+-- Replace the primary key: drop the single-column key on 'id' and add a composite key on (tenant, name). The 'id'
+-- column is preserved as unique so that lookups by identifier continue to work efficiently.
+alter table hubs drop constraint hubs_pkey;
+alter table hubs add primary key (tenant, name);
+alter table hubs add constraint hubs_id_unique unique (id);
+
+-- Attach the trigger to the hubs table to enforce immutability of the id, name and tenant columns:
+create trigger check_immutable_columns
+  before update on hubs
+  for each row
+  execute function check_immutable_columns('id', 'name', 'tenant');

--- a/internal/database/migrations/56_harden_hubs_table_test.go
+++ b/internal/database/migrations/56_harden_hubs_table_test.go
@@ -1,0 +1,215 @@
+/*
+Copyright (c) 2026 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package migrations
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2/dsl/core"
+	. "github.com/onsi/gomega"
+
+	"github.com/osac-project/fulfillment-service/internal/auth"
+)
+
+var _ = DescribeMigration("Harden hubs table", func() {
+	It("Moves all hubs to the shared tenant", func(ctx context.Context) {
+		// Create an additional tenant so the foreign key constraint is satisfied:
+		_, err := conn.Exec(ctx, `
+			insert into organizations (id, name, tenant, creator, data)
+			values ('my-tenant', 'my-tenant', 'my-tenant', 'shared', '{}')
+		`)
+		Expect(err).ToNot(HaveOccurred())
+
+		// Insert a hub with a non-shared tenant before the migration:
+		_, err = conn.Exec(ctx,
+			`insert into hubs (id, tenant, data) values ('my-hub', 'my-tenant', '{}')`,
+		)
+		Expect(err).ToNot(HaveOccurred())
+
+		// Run the migration:
+		err = tool.Migrate(ctx, 56)
+		Expect(err).ToNot(HaveOccurred())
+
+		// Verify that the hub now belongs to the shared tenant:
+		var tenant string
+		err = conn.QueryRow(ctx, `select tenant from hubs where id = 'my-hub'`).Scan(&tenant)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(tenant).To(Equal(auth.SharedTenant))
+	})
+
+	It("Copies the identifier to the name for hubs with an empty name", func(ctx context.Context) {
+		// Insert a hub without a name (defaults to empty string):
+		_, err := conn.Exec(ctx,
+			`insert into hubs (id, tenant, data) values ('hub-no-name', 'shared', '{}')`,
+		)
+		Expect(err).ToNot(HaveOccurred())
+
+		// Insert a hub that already has a name:
+		_, err = conn.Exec(ctx,
+			`insert into hubs (id, name, tenant, data) values ('hub-with-name', 'my-hub', 'shared', '{}')`,
+		)
+		Expect(err).ToNot(HaveOccurred())
+
+		// Run the migration:
+		err = tool.Migrate(ctx, 56)
+		Expect(err).ToNot(HaveOccurred())
+
+		// The hub that had no name should now use its id as the name:
+		var name string
+		err = conn.QueryRow(ctx, `select name from hubs where id = 'hub-no-name'`).Scan(&name)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(name).To(Equal("hub-no-name"))
+
+		// The hub that already had a name should keep it:
+		err = conn.QueryRow(ctx, `select name from hubs where id = 'hub-with-name'`).Scan(&name)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(name).To(Equal("my-hub"))
+	})
+
+	It("Creates a composite primary key on (tenant, name)", func(ctx context.Context) {
+		// Insert a hub before the migration:
+		_, err := conn.Exec(ctx,
+			`insert into hubs (id, name, tenant, data) values ('hub-1', 'hub-1', 'shared', '{}')`,
+		)
+		Expect(err).ToNot(HaveOccurred())
+
+		// Run the migration:
+		err = tool.Migrate(ctx, 56)
+		Expect(err).ToNot(HaveOccurred())
+
+		// Verify the primary key is on (tenant, name):
+		var columns []string
+		rows, err := conn.Query(ctx, `
+			select
+				a.attname
+			from
+				pg_constraint con
+			join
+				pg_class c on c.oid = con.conrelid
+			join
+				pg_attribute a on a.attrelid = c.oid and a.attnum = any(con.conkey)
+			where
+				c.relname = 'hubs' and
+				con.contype = 'p'
+		`)
+		Expect(err).ToNot(HaveOccurred())
+		defer rows.Close()
+		for rows.Next() {
+			var col string
+			err = rows.Scan(&col)
+			Expect(err).ToNot(HaveOccurred())
+			columns = append(columns, col)
+		}
+		Expect(rows.Err()).ToNot(HaveOccurred())
+		Expect(columns).To(ConsistOf("tenant", "name"))
+	})
+
+	It("Makes the id column unique but not a primary key", func(ctx context.Context) {
+		err := tool.Migrate(ctx, 56)
+		Expect(err).ToNot(HaveOccurred())
+
+		// Verify the unique constraint exists on id:
+		var count int
+		err = conn.QueryRow(ctx, `
+			select
+				count(*)
+			from
+				pg_constraint con
+			join
+				pg_class c on c.oid = con.conrelid
+			join
+				pg_attribute a on a.attrelid = c.oid and a.attnum = any(con.conkey)
+			where
+				c.relname = 'hubs' and
+				con.contype = 'u' and
+				a.attname = 'id'
+		`).Scan(&count)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(count).To(Equal(1))
+	})
+
+	It("Adds an immutable-columns trigger to the hubs table", func(ctx context.Context) {
+		err := tool.Migrate(ctx, 56)
+		Expect(err).ToNot(HaveOccurred())
+
+		var count int
+		err = conn.QueryRow(ctx, `
+			select
+				count(*)
+			from
+				pg_trigger t
+			join
+				pg_class c on c.oid = t.tgrelid
+			where
+				t.tgname = 'check_immutable_columns' and
+				c.relname = 'hubs'
+		`).Scan(&count)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(count).To(Equal(1))
+	})
+
+	It("Rejects updates to the tenant column", func(ctx context.Context) {
+		// Insert a hub before the migration:
+		_, err := conn.Exec(ctx,
+			`insert into hubs (id, tenant, data) values ('hub-immutable', 'shared', '{}')`,
+		)
+		Expect(err).ToNot(HaveOccurred())
+
+		// Run the migration:
+		err = tool.Migrate(ctx, 56)
+		Expect(err).ToNot(HaveOccurred())
+
+		// Attempt to change the tenant, which should be rejected by the trigger:
+		_, err = conn.Exec(ctx,
+			`update hubs set tenant = 'system' where id = 'hub-immutable'`,
+		)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("immutable"))
+	})
+
+	It("Rejects duplicate (tenant, name) pairs", func(ctx context.Context) {
+		// Insert a hub before the migration:
+		_, err := conn.Exec(ctx,
+			`insert into hubs (id, name, tenant, data) values ('hub-1', 'my-hub', 'shared', '{}')`,
+		)
+		Expect(err).ToNot(HaveOccurred())
+
+		// Run the migration:
+		err = tool.Migrate(ctx, 56)
+		Expect(err).ToNot(HaveOccurred())
+
+		// Try to insert another hub with the same tenant and name but different id:
+		_, err = conn.Exec(ctx,
+			`insert into hubs (id, name, tenant, data) values ('hub-2', 'my-hub', 'shared', '{}')`,
+		)
+		Expect(err).To(HaveOccurred())
+	})
+
+	It("Rejects duplicate id values", func(ctx context.Context) {
+		err := tool.Migrate(ctx, 56)
+		Expect(err).ToNot(HaveOccurred())
+
+		// Insert a hub:
+		_, err = conn.Exec(ctx,
+			`insert into hubs (id, name, tenant, data) values ('hub-1', 'hub-a', 'shared', '{}')`,
+		)
+		Expect(err).ToNot(HaveOccurred())
+
+		// Try to insert another hub with the same id but a different name:
+		_, err = conn.Exec(ctx,
+			`insert into hubs (id, name, tenant, data) values ('hub-1', 'hub-b', 'shared', '{}')`,
+		)
+		Expect(err).To(HaveOccurred())
+	})
+})

--- a/internal/servers/private_hubs_server.go
+++ b/internal/servers/private_hubs_server.go
@@ -19,6 +19,8 @@ import (
 	"log/slog"
 
 	"github.com/prometheus/client_golang/prometheus"
+	grpccodes "google.golang.org/grpc/codes"
+	grpcstatus "google.golang.org/grpc/status"
 
 	privatev1 "github.com/osac-project/fulfillment-service/internal/api/osac/private/v1"
 	"github.com/osac-project/fulfillment-service/internal/auth"
@@ -119,6 +121,46 @@ func (s *PrivateHubsServer) Get(ctx context.Context,
 
 func (s *PrivateHubsServer) Create(ctx context.Context,
 	request *privatev1.HubsCreateRequest) (response *privatev1.HubsCreateResponse, err error) {
+	// For hubs the name is mandatory:
+	object := request.GetObject()
+	metadata := object.GetMetadata()
+	name := metadata.GetName()
+	if name == "" {
+		err = grpcstatus.Errorf(
+			grpccodes.InvalidArgument,
+			"field 'metadata.name' is mandatory",
+		)
+		return
+	}
+
+	// For hubs the identifier must be empty or equal to the name. If it is empty it will be set to the name.
+	id := object.GetId()
+	if id != "" && id != name {
+		err = grpcstatus.Errorf(
+			grpccodes.InvalidArgument,
+			"field 'id' must be empty or equal to field 'metadata.name'",
+		)
+		return
+	}
+	if id == "" {
+		object.SetId(name)
+	}
+
+	// Hubs must always belong to the shared tenant. If the caller didn't specify a tenant we default to 'shared'.
+	// If they specified anything else we reject the request.
+	tenant := metadata.GetTenant()
+	if tenant != "" && tenant != auth.SharedTenant {
+		err = grpcstatus.Errorf(
+			grpccodes.InvalidArgument,
+			"field 'metadata.tenant' must be empty or '%s'",
+			auth.SharedTenant,
+		)
+		return
+	}
+	if tenant == "" {
+		metadata.SetTenant(auth.SharedTenant)
+	}
+
 	err = s.generic.Create(ctx, request, &response)
 	return
 }

--- a/internal/servers/private_hubs_server_test.go
+++ b/internal/servers/private_hubs_server_test.go
@@ -18,9 +18,13 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	grpccodes "google.golang.org/grpc/codes"
+	grpcstatus "google.golang.org/grpc/status"
 	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/fieldmaskpb"
 
 	privatev1 "github.com/osac-project/fulfillment-service/internal/api/osac/private/v1"
+	"github.com/osac-project/fulfillment-service/internal/auth"
 )
 
 var _ = Describe("Private hubs server", func() {
@@ -82,6 +86,9 @@ var _ = Describe("Private hubs server", func() {
 		It("Creates object", func() {
 			response, err := server.Create(ctx, privatev1.HubsCreateRequest_builder{
 				Object: privatev1.Hub_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name: "my-hub",
+					}.Build(),
 					Spec: privatev1.HubSpec_builder{
 						Kubeconfig: []byte("my_config"),
 						Namespace:  "my_ns",
@@ -92,7 +99,7 @@ var _ = Describe("Private hubs server", func() {
 			Expect(response).ToNot(BeNil())
 			object := response.GetObject()
 			Expect(object).ToNot(BeNil())
-			Expect(object.GetId()).ToNot(BeEmpty())
+			Expect(object.GetId()).To(Equal("my-hub"))
 		})
 
 		It("List objects", func() {
@@ -101,6 +108,9 @@ var _ = Describe("Private hubs server", func() {
 			for i := range count {
 				_, err := server.Create(ctx, privatev1.HubsCreateRequest_builder{
 					Object: privatev1.Hub_builder{
+						Metadata: privatev1.Metadata_builder{
+							Name: fmt.Sprintf("my-hub-%d", i),
+						}.Build(),
 						Spec: privatev1.HubSpec_builder{
 							Kubeconfig: []byte(fmt.Sprintf("my_config_%d", i)),
 							Namespace:  fmt.Sprintf("my_ns_%d", i),
@@ -124,6 +134,9 @@ var _ = Describe("Private hubs server", func() {
 			for i := range count {
 				_, err := server.Create(ctx, privatev1.HubsCreateRequest_builder{
 					Object: privatev1.Hub_builder{
+						Metadata: privatev1.Metadata_builder{
+							Name: fmt.Sprintf("my-hub-%d", i),
+						}.Build(),
 						Spec: privatev1.HubSpec_builder{
 							Kubeconfig: []byte(fmt.Sprintf("my_config_%d", i)),
 							Namespace:  fmt.Sprintf("my_ns_%d", i),
@@ -147,6 +160,9 @@ var _ = Describe("Private hubs server", func() {
 			for i := range count {
 				_, err := server.Create(ctx, privatev1.HubsCreateRequest_builder{
 					Object: privatev1.Hub_builder{
+						Metadata: privatev1.Metadata_builder{
+							Name: fmt.Sprintf("my-hub-%d", i),
+						}.Build(),
 						Spec: privatev1.HubSpec_builder{
 							Kubeconfig: []byte(fmt.Sprintf("my_config_%d", i)),
 							Namespace:  fmt.Sprintf("my_ns_%d", i),
@@ -171,6 +187,9 @@ var _ = Describe("Private hubs server", func() {
 			for i := range count {
 				response, err := server.Create(ctx, privatev1.HubsCreateRequest_builder{
 					Object: privatev1.Hub_builder{
+						Metadata: privatev1.Metadata_builder{
+							Name: fmt.Sprintf("my-hub-%d", i),
+						}.Build(),
 						Spec: privatev1.HubSpec_builder{
 							Kubeconfig: []byte(fmt.Sprintf("my_config_%d", i)),
 							Namespace:  fmt.Sprintf("my_ns_%d", i),
@@ -196,6 +215,9 @@ var _ = Describe("Private hubs server", func() {
 			// Create the object:
 			createResponse, err := server.Create(ctx, privatev1.HubsCreateRequest_builder{
 				Object: privatev1.Hub_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name: "my-hub",
+					}.Build(),
 					Spec: privatev1.HubSpec_builder{
 						Kubeconfig: []byte("my_config"),
 						Namespace:  "my_ns",
@@ -216,6 +238,9 @@ var _ = Describe("Private hubs server", func() {
 			// Create the object:
 			createResponse, err := server.Create(ctx, privatev1.HubsCreateRequest_builder{
 				Object: privatev1.Hub_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name: "my-hub",
+					}.Build(),
 					Spec: privatev1.HubSpec_builder{
 						Kubeconfig: []byte("my_config"),
 						Namespace:  "my_ns",
@@ -234,6 +259,12 @@ var _ = Describe("Private hubs server", func() {
 						Namespace:  "your_ns",
 					}.Build(),
 				}.Build(),
+				UpdateMask: &fieldmaskpb.FieldMask{
+					Paths: []string{
+						"spec.kubeconfig",
+						"spec.namespace",
+					},
+				},
 			}.Build())
 			Expect(err).ToNot(HaveOccurred())
 			Expect(updateResponse.GetObject().GetSpec().GetKubeconfig()).To(Equal([]byte("your_config")))
@@ -253,6 +284,7 @@ var _ = Describe("Private hubs server", func() {
 			createResponse, err := server.Create(ctx, privatev1.HubsCreateRequest_builder{
 				Object: privatev1.Hub_builder{
 					Metadata: privatev1.Metadata_builder{
+						Name:       "my-hub",
 						Finalizers: []string{"a"},
 					}.Build(),
 					Spec: privatev1.HubSpec_builder{
@@ -276,6 +308,178 @@ var _ = Describe("Private hubs server", func() {
 			}.Build())
 			Expect(err).ToNot(HaveOccurred())
 			Expect(getResponse.GetObject().GetMetadata().GetDeletionTimestamp()).ToNot(BeNil())
+		})
+
+		It("Rejects creation when name is not provided", func() {
+			response, err := server.Create(ctx, privatev1.HubsCreateRequest_builder{
+				Object: privatev1.Hub_builder{
+					Spec: privatev1.HubSpec_builder{
+						Kubeconfig: []byte("my_config"),
+						Namespace:  "my_ns",
+					}.Build(),
+				}.Build(),
+			}.Build())
+			Expect(err).To(HaveOccurred())
+			Expect(response).To(BeNil())
+			status, ok := grpcstatus.FromError(err)
+			Expect(ok).To(BeTrue())
+			Expect(status.Code()).To(Equal(grpccodes.InvalidArgument))
+			Expect(status.Message()).To(Equal(
+				"field 'metadata.name' is mandatory",
+			))
+		})
+
+		It("Uses the name as the identifier", func() {
+			response, err := server.Create(ctx, privatev1.HubsCreateRequest_builder{
+				Object: privatev1.Hub_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name: "my-hub",
+					}.Build(),
+					Spec: privatev1.HubSpec_builder{
+						Kubeconfig: []byte("my_config"),
+						Namespace:  "my_ns",
+					}.Build(),
+				}.Build(),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+			Expect(response).ToNot(BeNil())
+			Expect(response.GetObject().GetId()).To(Equal("my-hub"))
+			Expect(response.GetObject().GetMetadata().GetName()).To(Equal("my-hub"))
+		})
+
+		It("Accepts matching identifier and name", func() {
+			response, err := server.Create(ctx, privatev1.HubsCreateRequest_builder{
+				Object: privatev1.Hub_builder{
+					Id: "my-hub",
+					Metadata: privatev1.Metadata_builder{
+						Name: "my-hub",
+					}.Build(),
+					Spec: privatev1.HubSpec_builder{
+						Kubeconfig: []byte("my_config"),
+						Namespace:  "my_ns",
+					}.Build(),
+				}.Build(),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+			Expect(response).ToNot(BeNil())
+			Expect(response.GetObject().GetId()).To(Equal("my-hub"))
+			Expect(response.GetObject().GetMetadata().GetName()).To(Equal("my-hub"))
+		})
+
+		It("Rejects creation when identifier and name differ", func() {
+			response, err := server.Create(ctx, privatev1.HubsCreateRequest_builder{
+				Object: privatev1.Hub_builder{
+					Id: "my-hub",
+					Metadata: privatev1.Metadata_builder{
+						Name: "other-hub",
+					}.Build(),
+					Spec: privatev1.HubSpec_builder{
+						Kubeconfig: []byte("my_config"),
+						Namespace:  "my_ns",
+					}.Build(),
+				}.Build(),
+			}.Build())
+			Expect(err).To(HaveOccurred())
+			Expect(response).To(BeNil())
+			status, ok := grpcstatus.FromError(err)
+			Expect(ok).To(BeTrue())
+			Expect(status.Code()).To(Equal(grpccodes.InvalidArgument))
+			Expect(status.Message()).To(Equal(
+				"field 'id' must be empty or equal to field 'metadata.name'",
+			))
+		})
+
+		It("Rejects creation of a hub with a duplicate name", func() {
+			// Create the first hub:
+			_, err := server.Create(ctx, privatev1.HubsCreateRequest_builder{
+				Object: privatev1.Hub_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name: "my-hub",
+					}.Build(),
+					Spec: privatev1.HubSpec_builder{
+						Kubeconfig: []byte("my_config"),
+						Namespace:  "my_ns",
+					}.Build(),
+				}.Build(),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+
+			// Try to create a second hub with the same name:
+			response, err := server.Create(ctx, privatev1.HubsCreateRequest_builder{
+				Object: privatev1.Hub_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name: "my-hub",
+					}.Build(),
+					Spec: privatev1.HubSpec_builder{
+						Kubeconfig: []byte("other_config"),
+						Namespace:  "other_ns",
+					}.Build(),
+				}.Build(),
+			}.Build())
+			Expect(err).To(HaveOccurred())
+			Expect(response).To(BeNil())
+			status, ok := grpcstatus.FromError(err)
+			Expect(ok).To(BeTrue())
+			Expect(status.Code()).To(Equal(grpccodes.AlreadyExists))
+		})
+
+		It("Defaults tenant to 'shared' when not specified", func() {
+			response, err := server.Create(ctx, privatev1.HubsCreateRequest_builder{
+				Object: privatev1.Hub_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name: "my-hub",
+					}.Build(),
+					Spec: privatev1.HubSpec_builder{
+						Kubeconfig: []byte("my_config"),
+						Namespace:  "my_ns",
+					}.Build(),
+				}.Build(),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+			Expect(response).ToNot(BeNil())
+			Expect(response.GetObject().GetMetadata().GetTenant()).To(Equal(auth.SharedTenant))
+		})
+
+		It("Accepts explicit 'shared' tenant", func() {
+			response, err := server.Create(ctx, privatev1.HubsCreateRequest_builder{
+				Object: privatev1.Hub_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name:   "my-hub",
+						Tenant: auth.SharedTenant,
+					}.Build(),
+					Spec: privatev1.HubSpec_builder{
+						Kubeconfig: []byte("my_config"),
+						Namespace:  "my_ns",
+					}.Build(),
+				}.Build(),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+			Expect(response).ToNot(BeNil())
+			Expect(response.GetObject().GetMetadata().GetTenant()).To(Equal(auth.SharedTenant))
+		})
+
+		It("Rejects creation with a non-shared tenant", func() {
+			response, err := server.Create(ctx, privatev1.HubsCreateRequest_builder{
+				Object: privatev1.Hub_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name:   "my-hub",
+						Tenant: "other-tenant",
+					}.Build(),
+					Spec: privatev1.HubSpec_builder{
+						Kubeconfig: []byte("my_config"),
+						Namespace:  "my_ns",
+					}.Build(),
+				}.Build(),
+			}.Build())
+			Expect(err).To(HaveOccurred())
+			Expect(response).To(BeNil())
+			status, ok := grpcstatus.FromError(err)
+			Expect(ok).To(BeTrue())
+			Expect(status.Code()).To(Equal(grpccodes.InvalidArgument))
+			Expect(status.Message()).To(Equal(fmt.Sprintf(
+				"field 'metadata.tenant' must be empty or '%s'",
+				auth.SharedTenant,
+			)))
 		})
 	})
 })

--- a/it/it_tool.go
+++ b/it/it_tool.go
@@ -2098,7 +2098,9 @@ func (t *Tool) registerHub(ctx context.Context) error {
 	// Create the hub:
 	_, err = hubsClient.Create(ctx, privatev1.HubsCreateRequest_builder{
 		Object: privatev1.Hub_builder{
-			Id: hubId,
+			Metadata: privatev1.Metadata_builder{
+				Name: hubName,
+			}.Build(),
 			Spec: privatev1.HubSpec_builder{
 				Kubeconfig: hubKcBytes,
 				Namespace:  hubNamespace,
@@ -2280,7 +2282,7 @@ const (
 )
 
 // Name and namespace of the hub:
-const hubId = "local"
+const hubName = "local"
 const hubNamespace = "osac-operator-system"
 
 // Image details:


### PR DESCRIPTION
## Summary

- Enforce that hubs always belong to the `shared` tenant and that their name equals their
  identifier, both in the `PrivateHubsServer.Create` method and via a database migration that
  backfills existing data and switches the primary key to `(tenant, name)`.
- Add an immutable-columns trigger to prevent changes to the `id`, `name` and `tenant` columns
  after creation, and a unique constraint on `id` so DAO lookups remain efficient.
- Update the schema checker to support hardened tables, the CLI `create hub` command to use a
  `--name` flag (deprecating `--id`), and the integration test helper to match the new API.

## Test plan

- [x] Unit tests pass (`ginkgo run -r internal` -- 961 specs, 0 failures)
- [x] Migration tests pass (`ginkgo run internal/database/migrations` -- 87 specs, 0 failures)
- [x] Schema consistency test passes (`ginkgo run --focus="Is consistent" internal/database`)
- [x] Integration tests pass (`ginkgo run it`)

Related: https://redhat.atlassian.net/browse/OSAC-1546

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Hub CLI command now requires the `--name` flag as the primary identifier; the `--id` flag is deprecated
  * Added validation for hub creation to ensure required fields and prevent duplicate names

* **Chores**
  * Database schema hardened with enhanced integrity controls to prevent modification of hub identifiers after creation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->