### PR TITLE
OSAC-420: Add kube-root-ca to console-proxy CA pool

### DIFF
--- a/charts/service/templates/console-proxy/deployment.yaml
+++ b/charts/service/templates/console-proxy/deployment.yaml
@@ -30,7 +30,6 @@ spec:
       labels:
         app: fulfillment-console-proxy
     spec:
-      automountServiceAccountToken: false
       securityContext:
         runAsNonRoot: true
         seccompProfile:

--- a/internal/cmd/service/start/consoleproxy/start_console_proxy_cmd.go
+++ b/internal/cmd/service/start/consoleproxy/start_console_proxy_cmd.go
@@ -126,6 +126,7 @@ func (c *runnerContext) run(cmd *cobra.Command, argv []string) error {
 	caPool, err := network.NewCertPool().
 		SetLogger(c.logger).
 		AddSystemFiles(true).
+		AddKubernetesFiles(true).
 		AddFiles(c.args.caFiles...).
 		Build()
 	if err != nil {

--- a/manifests/base/console-proxy/deployment.yaml
+++ b/manifests/base/console-proxy/deployment.yaml
@@ -25,7 +25,6 @@ spec:
       labels:
         app: fulfillment-console-proxy
     spec:
-      automountServiceAccountToken: false
       securityContext:
         runAsNonRoot: true
         seccompProfile:


### PR DESCRIPTION
The console-proxy dials the kube-apiserver to proxy KubeVirt VM console
WebSocket connections. The deployment had automountServiceAccountToken
set to false, so the cluster CA at /var/run/secrets was unavailable,
causing x509 verification failures.

Remove automountServiceAccountToken: false and add
AddKubernetesFiles(true) to the CA pool builder so the proxy
automatically loads the cluster CA from the service account mount.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated console-proxy service deployment configuration to mount and utilize the Kubernetes-provided root CA certificate for certificate validation. Changes include adding volume definitions sourced from a ConfigMap, configuring read-only container mounts at a specified path, and updating service arguments to reference the CA certificate path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->