### PR TITLE
NO-ISSUE: Use GITHUB_REF_NAME instead of git describe in publish-charts

### DIFF
--- a/.github/workflows/publish-charts.yaml
+++ b/.github/workflows/publish-charts.yaml
@@ -38,8 +38,8 @@ jobs:
         export registry="ghcr.io"
         echo "${{ secrets.GITHUB_TOKEN }}" | helm registry login --username "${{ github.actor }}" --password-stdin "${registry}"
 
-        # Get the git version:
-        export git_version="$(git describe --tags)"
+        # Get the git version from the tag that triggered the workflow:
+        export git_version="${GITHUB_REF_NAME}"
 
         # Update the image reference in the chart:
         export app_version="${git_version}"


### PR DESCRIPTION
## Summary
- Replace `git describe --tags` with `GITHUB_REF_NAME` in the publish-charts workflow
- `git describe --tags` returns the nearest tag by walking commit history — when two tags point to the same commit, it picks the older one, causing the chart to be published with the wrong version
- `GITHUB_REF_NAME` is the exact tag that triggered the workflow, so the chart version always matches the pushed tag