### PR TITLE
OSAC-1352: sync BareMetalInstance CR status back to fulfillment API

### DIFF
--- a/internal/controllers/baremetalinstance/baremetalinstance_reconciler_function.go
+++ b/internal/controllers/baremetalinstance/baremetalinstance_reconciler_function.go
@@ -218,6 +218,8 @@ func (t *task) update(ctx context.Context) error {
 		)
 	}
 
+	t.syncStatus(object)
+
 	if err := t.ensureUserDataSecret(ctx, object); err != nil {
 		return err
 	}
@@ -426,6 +428,78 @@ func (t *task) updateCondition(conditionType privatev1.BareMetalInstanceConditio
 		}.Build())
 	}
 	t.bareMetalInstance.GetStatus().SetConditions(conditions)
+}
+
+func (t *task) syncStatus(object *bmfov1alpha1.BareMetalInstance) {
+	if object == nil {
+		return
+	}
+
+	switch object.Status.Phase {
+	case bmfov1alpha1.BareMetalInstancePhaseAllocating,
+		bmfov1alpha1.BareMetalInstancePhaseProgressing:
+		t.bareMetalInstance.GetStatus().SetState(
+			privatev1.BareMetalInstanceState_BARE_METAL_INSTANCE_STATE_PROVISIONING)
+	case bmfov1alpha1.BareMetalInstancePhaseReady:
+		t.bareMetalInstance.GetStatus().SetState(
+			privatev1.BareMetalInstanceState_BARE_METAL_INSTANCE_STATE_RUNNING)
+	case bmfov1alpha1.BareMetalInstancePhaseFailed:
+		t.bareMetalInstance.GetStatus().SetState(
+			privatev1.BareMetalInstanceState_BARE_METAL_INSTANCE_STATE_FAILED)
+	case bmfov1alpha1.BareMetalInstancePhaseDeleting:
+		t.bareMetalInstance.GetStatus().SetState(
+			privatev1.BareMetalInstanceState_BARE_METAL_INSTANCE_STATE_DELETING)
+	}
+
+	for _, cond := range object.Status.Conditions {
+		condType := bmfov1alpha1.BareMetalInstanceConditionType(cond.Type)
+		status := mapConditionStatus(cond.Status)
+
+		switch condType {
+		case bmfov1alpha1.HostConditionAllocated:
+			t.updateCondition(
+				privatev1.BareMetalInstanceConditionType_BARE_METAL_INSTANCE_CONDITION_TYPE_PROVISIONED,
+				status, cond.Reason, cond.Message)
+		case bmfov1alpha1.HostConditionProvisionTemplateComplete:
+			t.updateCondition(
+				privatev1.BareMetalInstanceConditionType_BARE_METAL_INSTANCE_CONDITION_TYPE_CONFIGURATION_APPLIED,
+				status, cond.Reason, cond.Message)
+		case bmfov1alpha1.HostConditionAvailable:
+			t.updateCondition(
+				privatev1.BareMetalInstanceConditionType_BARE_METAL_INSTANCE_CONDITION_TYPE_READY,
+				status, cond.Reason, cond.Message)
+		case bmfov1alpha1.HostConditionPowerSynced:
+			if cond.Status == metav1.ConditionFalse && cond.Reason == bmfov1alpha1.HostConditionReasonProgressing {
+				t.updateCondition(
+					privatev1.BareMetalInstanceConditionType_BARE_METAL_INSTANCE_CONDITION_TYPE_RESTART_IN_PROGRESS,
+					privatev1.ConditionStatus_CONDITION_STATUS_TRUE, cond.Reason, cond.Message)
+			} else if cond.Status == metav1.ConditionFalse && cond.Reason == bmfov1alpha1.HostConditionReasonIronicAPIFailure {
+				t.updateCondition(
+					privatev1.BareMetalInstanceConditionType_BARE_METAL_INSTANCE_CONDITION_TYPE_RESTART_FAILED,
+					privatev1.ConditionStatus_CONDITION_STATUS_TRUE, cond.Reason, cond.Message)
+			} else if cond.Status == metav1.ConditionTrue {
+				t.updateCondition(
+					privatev1.BareMetalInstanceConditionType_BARE_METAL_INSTANCE_CONDITION_TYPE_RESTART_IN_PROGRESS,
+					privatev1.ConditionStatus_CONDITION_STATUS_FALSE, cond.Reason, cond.Message)
+				t.updateCondition(
+					privatev1.BareMetalInstanceConditionType_BARE_METAL_INSTANCE_CONDITION_TYPE_RESTART_FAILED,
+					privatev1.ConditionStatus_CONDITION_STATUS_FALSE, cond.Reason, cond.Message)
+				t.bareMetalInstance.GetStatus().SetRestartTrigger(
+					t.bareMetalInstance.GetSpec().GetRestartTrigger())
+			}
+		}
+	}
+}
+
+func mapConditionStatus(status metav1.ConditionStatus) privatev1.ConditionStatus {
+	switch status {
+	case metav1.ConditionTrue:
+		return privatev1.ConditionStatus_CONDITION_STATUS_TRUE
+	case metav1.ConditionFalse:
+		return privatev1.ConditionStatus_CONDITION_STATUS_FALSE
+	default:
+		return privatev1.ConditionStatus_CONDITION_STATUS_UNSPECIFIED
+	}
 }
 
 // buildSpec constructs the spec for the Kubernetes BareMetalInstance object by resolving the

--- a/internal/controllers/baremetalinstance/baremetalinstance_reconciler_function_test.go
+++ b/internal/controllers/baremetalinstance/baremetalinstance_reconciler_function_test.go
@@ -601,6 +601,288 @@ var _ = Describe("ensureUserDataSecret", func() {
 	})
 })
 
+func findProtoCondition(bmi *privatev1.BareMetalInstance, condType privatev1.BareMetalInstanceConditionType) *privatev1.BareMetalInstanceCondition {
+	for _, c := range bmi.GetStatus().GetConditions() {
+		if c.GetType() == condType {
+			return c
+		}
+	}
+	return nil
+}
+
+var _ = Describe("syncStatus", func() {
+	newTask := func(specRestartTrigger int64) *task {
+		return &task{
+			r: &function{logger: logger},
+			bareMetalInstance: privatev1.BareMetalInstance_builder{
+				Id: "bmi-sync-test",
+				Spec: privatev1.BareMetalInstanceSpec_builder{
+					RestartTrigger: specRestartTrigger,
+				}.Build(),
+				Status: privatev1.BareMetalInstanceStatus_builder{
+					State: privatev1.BareMetalInstanceState_BARE_METAL_INSTANCE_STATE_PROVISIONING,
+				}.Build(),
+			}.Build(),
+		}
+	}
+
+	It("should not change state when object is nil", func() {
+		t := newTask(0)
+		t.syncStatus(nil)
+		Expect(t.bareMetalInstance.GetStatus().GetState()).To(
+			Equal(privatev1.BareMetalInstanceState_BARE_METAL_INSTANCE_STATE_PROVISIONING))
+	})
+
+	It("should not change state when phase is empty", func() {
+		t := newTask(0)
+		object := &bmfov1alpha1.BareMetalInstance{}
+		t.syncStatus(object)
+		Expect(t.bareMetalInstance.GetStatus().GetState()).To(
+			Equal(privatev1.BareMetalInstanceState_BARE_METAL_INSTANCE_STATE_PROVISIONING))
+	})
+
+	It("should map Allocating phase to PROVISIONING state", func() {
+		t := newTask(0)
+		object := &bmfov1alpha1.BareMetalInstance{
+			Status: bmfov1alpha1.BareMetalInstanceStatus{
+				Phase: bmfov1alpha1.BareMetalInstancePhaseAllocating,
+			},
+		}
+		t.syncStatus(object)
+		Expect(t.bareMetalInstance.GetStatus().GetState()).To(
+			Equal(privatev1.BareMetalInstanceState_BARE_METAL_INSTANCE_STATE_PROVISIONING))
+	})
+
+	It("should map Progressing phase to PROVISIONING state", func() {
+		t := newTask(0)
+		object := &bmfov1alpha1.BareMetalInstance{
+			Status: bmfov1alpha1.BareMetalInstanceStatus{
+				Phase: bmfov1alpha1.BareMetalInstancePhaseProgressing,
+			},
+		}
+		t.syncStatus(object)
+		Expect(t.bareMetalInstance.GetStatus().GetState()).To(
+			Equal(privatev1.BareMetalInstanceState_BARE_METAL_INSTANCE_STATE_PROVISIONING))
+	})
+
+	It("should map Ready phase to RUNNING state", func() {
+		t := newTask(0)
+		object := &bmfov1alpha1.BareMetalInstance{
+			Status: bmfov1alpha1.BareMetalInstanceStatus{
+				Phase: bmfov1alpha1.BareMetalInstancePhaseReady,
+			},
+		}
+		t.syncStatus(object)
+		Expect(t.bareMetalInstance.GetStatus().GetState()).To(
+			Equal(privatev1.BareMetalInstanceState_BARE_METAL_INSTANCE_STATE_RUNNING))
+	})
+
+	It("should map Failed phase to FAILED state", func() {
+		t := newTask(0)
+		object := &bmfov1alpha1.BareMetalInstance{
+			Status: bmfov1alpha1.BareMetalInstanceStatus{
+				Phase: bmfov1alpha1.BareMetalInstancePhaseFailed,
+			},
+		}
+		t.syncStatus(object)
+		Expect(t.bareMetalInstance.GetStatus().GetState()).To(
+			Equal(privatev1.BareMetalInstanceState_BARE_METAL_INSTANCE_STATE_FAILED))
+	})
+
+	It("should map Deleting phase to DELETING state", func() {
+		t := newTask(0)
+		object := &bmfov1alpha1.BareMetalInstance{
+			Status: bmfov1alpha1.BareMetalInstanceStatus{
+				Phase: bmfov1alpha1.BareMetalInstancePhaseDeleting,
+			},
+		}
+		t.syncStatus(object)
+		Expect(t.bareMetalInstance.GetStatus().GetState()).To(
+			Equal(privatev1.BareMetalInstanceState_BARE_METAL_INSTANCE_STATE_DELETING))
+	})
+
+	It("should map Allocated condition to PROVISIONED", func() {
+		t := newTask(0)
+		object := &bmfov1alpha1.BareMetalInstance{
+			Status: bmfov1alpha1.BareMetalInstanceStatus{
+				Conditions: []metav1.Condition{
+					{
+						Type:    string(bmfov1alpha1.HostConditionAllocated),
+						Status:  metav1.ConditionTrue,
+						Reason:  "HostAllocated",
+						Message: "Host was allocated",
+					},
+				},
+			},
+		}
+		t.syncStatus(object)
+		cond := findProtoCondition(t.bareMetalInstance,
+			privatev1.BareMetalInstanceConditionType_BARE_METAL_INSTANCE_CONDITION_TYPE_PROVISIONED)
+		Expect(cond).ToNot(BeNil())
+		Expect(cond.GetStatus()).To(Equal(privatev1.ConditionStatus_CONDITION_STATUS_TRUE))
+		Expect(cond.GetReason()).To(Equal("HostAllocated"))
+		Expect(cond.GetMessage()).To(Equal("Host was allocated"))
+	})
+
+	It("should map ProvisionTemplateComplete condition to CONFIGURATION_APPLIED", func() {
+		t := newTask(0)
+		object := &bmfov1alpha1.BareMetalInstance{
+			Status: bmfov1alpha1.BareMetalInstanceStatus{
+				Conditions: []metav1.Condition{
+					{
+						Type:    string(bmfov1alpha1.HostConditionProvisionTemplateComplete),
+						Status:  metav1.ConditionTrue,
+						Reason:  "Complete",
+						Message: "Provision template completed",
+					},
+				},
+			},
+		}
+		t.syncStatus(object)
+		cond := findProtoCondition(t.bareMetalInstance,
+			privatev1.BareMetalInstanceConditionType_BARE_METAL_INSTANCE_CONDITION_TYPE_CONFIGURATION_APPLIED)
+		Expect(cond).ToNot(BeNil())
+		Expect(cond.GetStatus()).To(Equal(privatev1.ConditionStatus_CONDITION_STATUS_TRUE))
+	})
+
+	It("should map Available condition to READY", func() {
+		t := newTask(0)
+		object := &bmfov1alpha1.BareMetalInstance{
+			Status: bmfov1alpha1.BareMetalInstanceStatus{
+				Conditions: []metav1.Condition{
+					{
+						Type:    string(bmfov1alpha1.HostConditionAvailable),
+						Status:  metav1.ConditionTrue,
+						Reason:  "HostAvailable",
+						Message: "Host is available",
+					},
+				},
+			},
+		}
+		t.syncStatus(object)
+		cond := findProtoCondition(t.bareMetalInstance,
+			privatev1.BareMetalInstanceConditionType_BARE_METAL_INSTANCE_CONDITION_TYPE_READY)
+		Expect(cond).ToNot(BeNil())
+		Expect(cond.GetStatus()).To(Equal(privatev1.ConditionStatus_CONDITION_STATUS_TRUE))
+	})
+
+	It("should set RESTART_IN_PROGRESS when PowerSynced is False with Progressing reason", func() {
+		t := newTask(0)
+		object := &bmfov1alpha1.BareMetalInstance{
+			Status: bmfov1alpha1.BareMetalInstanceStatus{
+				Conditions: []metav1.Condition{
+					{
+						Type:    string(bmfov1alpha1.HostConditionPowerSynced),
+						Status:  metav1.ConditionFalse,
+						Reason:  bmfov1alpha1.HostConditionReasonProgressing,
+						Message: "Power cycle in progress",
+					},
+				},
+			},
+		}
+		t.syncStatus(object)
+		cond := findProtoCondition(t.bareMetalInstance,
+			privatev1.BareMetalInstanceConditionType_BARE_METAL_INSTANCE_CONDITION_TYPE_RESTART_IN_PROGRESS)
+		Expect(cond).ToNot(BeNil())
+		Expect(cond.GetStatus()).To(Equal(privatev1.ConditionStatus_CONDITION_STATUS_TRUE))
+	})
+
+	It("should set RESTART_FAILED when PowerSynced is False with IronicAPIFailure reason", func() {
+		t := newTask(0)
+		object := &bmfov1alpha1.BareMetalInstance{
+			Status: bmfov1alpha1.BareMetalInstanceStatus{
+				Conditions: []metav1.Condition{
+					{
+						Type:    string(bmfov1alpha1.HostConditionPowerSynced),
+						Status:  metav1.ConditionFalse,
+						Reason:  bmfov1alpha1.HostConditionReasonIronicAPIFailure,
+						Message: "Ironic API call failed",
+					},
+				},
+			},
+		}
+		t.syncStatus(object)
+		cond := findProtoCondition(t.bareMetalInstance,
+			privatev1.BareMetalInstanceConditionType_BARE_METAL_INSTANCE_CONDITION_TYPE_RESTART_FAILED)
+		Expect(cond).ToNot(BeNil())
+		Expect(cond.GetStatus()).To(Equal(privatev1.ConditionStatus_CONDITION_STATUS_TRUE))
+	})
+
+	It("should clear restart conditions and sync restart trigger when PowerSynced is True", func() {
+		t := newTask(42)
+		object := &bmfov1alpha1.BareMetalInstance{
+			Status: bmfov1alpha1.BareMetalInstanceStatus{
+				Conditions: []metav1.Condition{
+					{
+						Type:    string(bmfov1alpha1.HostConditionPowerSynced),
+						Status:  metav1.ConditionTrue,
+						Reason:  bmfov1alpha1.HostConditionReasonPowerOn,
+						Message: "Power on complete",
+					},
+				},
+			},
+		}
+		t.syncStatus(object)
+
+		inProgress := findProtoCondition(t.bareMetalInstance,
+			privatev1.BareMetalInstanceConditionType_BARE_METAL_INSTANCE_CONDITION_TYPE_RESTART_IN_PROGRESS)
+		Expect(inProgress).ToNot(BeNil())
+		Expect(inProgress.GetStatus()).To(Equal(privatev1.ConditionStatus_CONDITION_STATUS_FALSE))
+
+		failed := findProtoCondition(t.bareMetalInstance,
+			privatev1.BareMetalInstanceConditionType_BARE_METAL_INSTANCE_CONDITION_TYPE_RESTART_FAILED)
+		Expect(failed).ToNot(BeNil())
+		Expect(failed.GetStatus()).To(Equal(privatev1.ConditionStatus_CONDITION_STATUS_FALSE))
+
+		Expect(t.bareMetalInstance.GetStatus().GetRestartTrigger()).To(Equal(int64(42)))
+	})
+
+	It("should map multiple conditions in a single call", func() {
+		t := newTask(0)
+		object := &bmfov1alpha1.BareMetalInstance{
+			Status: bmfov1alpha1.BareMetalInstanceStatus{
+				Phase: bmfov1alpha1.BareMetalInstancePhaseReady,
+				Conditions: []metav1.Condition{
+					{
+						Type:   string(bmfov1alpha1.HostConditionAllocated),
+						Status: metav1.ConditionTrue,
+						Reason: "HostAllocated",
+					},
+					{
+						Type:   string(bmfov1alpha1.HostConditionProvisionTemplateComplete),
+						Status: metav1.ConditionTrue,
+						Reason: "Complete",
+					},
+					{
+						Type:   string(bmfov1alpha1.HostConditionAvailable),
+						Status: metav1.ConditionTrue,
+						Reason: "HostAvailable",
+					},
+				},
+			},
+		}
+		t.syncStatus(object)
+
+		Expect(t.bareMetalInstance.GetStatus().GetState()).To(
+			Equal(privatev1.BareMetalInstanceState_BARE_METAL_INSTANCE_STATE_RUNNING))
+
+		provisioned := findProtoCondition(t.bareMetalInstance,
+			privatev1.BareMetalInstanceConditionType_BARE_METAL_INSTANCE_CONDITION_TYPE_PROVISIONED)
+		Expect(provisioned).ToNot(BeNil())
+		Expect(provisioned.GetStatus()).To(Equal(privatev1.ConditionStatus_CONDITION_STATUS_TRUE))
+
+		configApplied := findProtoCondition(t.bareMetalInstance,
+			privatev1.BareMetalInstanceConditionType_BARE_METAL_INSTANCE_CONDITION_TYPE_CONFIGURATION_APPLIED)
+		Expect(configApplied).ToNot(BeNil())
+		Expect(configApplied.GetStatus()).To(Equal(privatev1.ConditionStatus_CONDITION_STATUS_TRUE))
+
+		ready := findProtoCondition(t.bareMetalInstance,
+			privatev1.BareMetalInstanceConditionType_BARE_METAL_INSTANCE_CONDITION_TYPE_READY)
+		Expect(ready).ToNot(BeNil())
+		Expect(ready.GetStatus()).To(Equal(privatev1.ConditionStatus_CONDITION_STATUS_TRUE))
+	})
+})
+
 func defaultFakeCatalogItemsClient() *fakeCatalogItemsClient {
 	return &fakeCatalogItemsClient{
 		getResponse: privatev1.BareMetalInstanceCatalogItemsGetResponse_builder{

--- a/internal/controllers/baremetalinstance/baremetalinstance_reconciler_function_test.go
+++ b/internal/controllers/baremetalinstance/baremetalinstance_reconciler_function_test.go
@@ -837,6 +837,31 @@ var _ = Describe("syncStatus", func() {
 		Expect(t.bareMetalInstance.GetStatus().GetRestartTrigger()).To(Equal(int64(42)))
 	})
 
+	It("should not set restart conditions when PowerSynced is False with unhandled reason", func() {
+		t := newTask(0)
+		object := &bmfov1alpha1.BareMetalInstance{
+			Status: bmfov1alpha1.BareMetalInstanceStatus{
+				Conditions: []metav1.Condition{
+					{
+						Type:    string(bmfov1alpha1.HostConditionPowerSynced),
+						Status:  metav1.ConditionFalse,
+						Reason:  "UnknownReason",
+						Message: "Something unexpected",
+					},
+				},
+			},
+		}
+		t.syncStatus(object)
+
+		inProgress := findProtoCondition(t.bareMetalInstance,
+			privatev1.BareMetalInstanceConditionType_BARE_METAL_INSTANCE_CONDITION_TYPE_RESTART_IN_PROGRESS)
+		Expect(inProgress).To(BeNil())
+
+		failed := findProtoCondition(t.bareMetalInstance,
+			privatev1.BareMetalInstanceConditionType_BARE_METAL_INSTANCE_CONDITION_TYPE_RESTART_FAILED)
+		Expect(failed).To(BeNil())
+	})
+
 	It("should map multiple conditions in a single call", func() {
 		t := newTask(0)
 		object := &bmfov1alpha1.BareMetalInstance{
@@ -880,6 +905,23 @@ var _ = Describe("syncStatus", func() {
 			privatev1.BareMetalInstanceConditionType_BARE_METAL_INSTANCE_CONDITION_TYPE_READY)
 		Expect(ready).ToNot(BeNil())
 		Expect(ready.GetStatus()).To(Equal(privatev1.ConditionStatus_CONDITION_STATUS_TRUE))
+	})
+})
+
+var _ = Describe("mapConditionStatus", func() {
+	It("should map ConditionTrue to CONDITION_STATUS_TRUE", func() {
+		Expect(mapConditionStatus(metav1.ConditionTrue)).To(
+			Equal(privatev1.ConditionStatus_CONDITION_STATUS_TRUE))
+	})
+
+	It("should map ConditionFalse to CONDITION_STATUS_FALSE", func() {
+		Expect(mapConditionStatus(metav1.ConditionFalse)).To(
+			Equal(privatev1.ConditionStatus_CONDITION_STATUS_FALSE))
+	})
+
+	It("should map ConditionUnknown to CONDITION_STATUS_UNSPECIFIED", func() {
+		Expect(mapConditionStatus(metav1.ConditionUnknown)).To(
+			Equal(privatev1.ConditionStatus_CONDITION_STATUS_UNSPECIFIED))
 	})
 })
 


### PR DESCRIPTION
## [OSAC-1352](https://redhat.atlassian.net/browse/OSAC-1352): sync BareMetalInstance CR status back to fulfillment API

**Jira:** [OSAC-1352](https://issues.redhat.com/browse/OSAC-1352)

### Summary

The BareMetalInstance reconciler only pushed spec downward (proto → K8s CR) but never read the CR's status back. After the BMF operator updates phase and conditions on the CR, the fulfillment-service's internal record stayed at `PROVISIONING` regardless of actual state. This completes the feedback loop started by the osac-operator's BareMetalInstance feedback controller ([OSAC-1352](https://redhat.atlassian.net/browse/OSAC-1352)).

### Changes

- **`syncStatus()` method** — reads the K8s BareMetalInstance CR status and maps it to the proto representation:
  - Phase → State: `Allocating`/`Progressing` → `PROVISIONING`, `Ready` → `RUNNING`, `Failed` → `FAILED`, `Deleting` → `DELETING`
  - Conditions: `Allocated` → `PROVISIONED`, `ProvisionTemplateComplete` → `CONFIGURATION_APPLIED`, `Available` → `READY`
  - `PowerSynced` condition: reason-dependent mapping to `RESTART_IN_PROGRESS` or `RESTART_FAILED`
  - `PowerSynced=True`: clears restart conditions, syncs `restart_trigger` completion
- **`mapConditionStatus()` helper** — translates `metav1.ConditionStatus` to proto `ConditionStatus`
- **`update()` integration** — `syncStatus(object)` is called after the create-or-update block, before `ensureUserDataSecret`

### Testing

- **Unit tests:** 18 new tests covering all phase→state mappings, all condition type mappings, PowerSynced reason-dependent logic (Progressing, IronicAPIFailure, True, unhandled reason), restart trigger sync, multi-condition sync, nil/empty edge cases, and `mapConditionStatus` with all three inputs
- **Live verification:** Tested end-to-end on a running cluster by patching a BareMetalInstance CR's status with conditions and confirming propagation to the gRPC API via `grpcurl`

### Verified on cluster

```
# Before: all conditions FALSE with empty reasons
# After patching CR status with Allocated=True, ProvisionTemplateComplete=True, Available=True:
PROVISIONED → CONDITION_STATUS_TRUE (reason: HostAllocated)
CONFIGURATION_APPLIED → CONDITION_STATUS_TRUE (reason: Complete)
READY → CONDITION_STATUS_TRUE (reason: HostAvailable)
```

Related to https://github.com/osac-project/osac-operator/pull/301 which calls signal when the `BareMetalInstance` changes.