### PR TITLE
OSAC-1621: Add Keycloak functions to create a new IDP

### DIFF
--- a/internal/idp/client.go
+++ b/internal/idp/client.go
@@ -90,6 +90,10 @@ type Client interface {
 	GetGroupIDByPath(ctx context.Context, organizationName, groupPath string) (string, error)
 
 	// Identity Provider operations
+	// CreateIdentityProvider creates a new external identity provider at the realm level.
+	// The IdP is created but not yet assigned to any organization.
+	CreateIdentityProvider(ctx context.Context, idp *IdentityProvider) (*IdentityProvider, error)
+
 	// GetIdentityProvider retrieves an external identity provider configuration by alias at the realm level.
 	// This returns the IdP without verifying organization assignment.
 	GetIdentityProvider(ctx context.Context, alias string) (*IdentityProvider, error)

--- a/internal/idp/client_mock.go
+++ b/internal/idp/client_mock.go
@@ -125,6 +125,21 @@ func (mr *MockClientMockRecorder) CreateAuthorizationResource(ctx, resource any)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateAuthorizationResource", reflect.TypeOf((*MockClient)(nil).CreateAuthorizationResource), ctx, resource)
 }
 
+// CreateIdentityProvider mocks base method.
+func (m *MockClient) CreateIdentityProvider(ctx context.Context, idp *IdentityProvider) (*IdentityProvider, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreateIdentityProvider", ctx, idp)
+	ret0, _ := ret[0].(*IdentityProvider)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CreateIdentityProvider indicates an expected call of CreateIdentityProvider.
+func (mr *MockClientMockRecorder) CreateIdentityProvider(ctx, idp any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateIdentityProvider", reflect.TypeOf((*MockClient)(nil).CreateIdentityProvider), ctx, idp)
+}
+
 // CreateOrganization mocks base method.
 func (m *MockClient) CreateOrganization(ctx context.Context, org *Organization) (*Organization, error) {
 	m.ctrl.T.Helper()

--- a/internal/idp/keycloak/client.go
+++ b/internal/idp/keycloak/client.go
@@ -756,6 +756,36 @@ func (c *Client) DeleteAuthorizationResource(ctx context.Context, resourceID str
 	return nil
 }
 
+// CreateIdentityProvider creates a new identity provider at the realm level.
+func (c *Client) CreateIdentityProvider(ctx context.Context, idpProvider *idp.IdentityProvider) (*idp.IdentityProvider, error) {
+	if idpProvider == nil {
+		return nil, fmt.Errorf("identity provider is nil")
+	}
+	c.logger.InfoContext(ctx, "Creating identity provider",
+		slog.String("realm", c.realmName),
+		slog.String("alias", idpProvider.Alias),
+		slog.String("type", idpProvider.Type),
+	)
+
+	path := fmt.Sprintf("/admin/realms/%s/identity-provider/instances", url.PathEscape(c.realmName))
+
+	kcIdp := toKeycloakIdentityProvider(idpProvider)
+
+	response, err := c.httpClient.DoRequest(ctx, http.MethodPost, path, kcIdp)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create identity provider: %w", err)
+	}
+	defer response.Body.Close()
+
+	// Keycloak returns 201 Created with the created object in the response body
+	var createdKcIdp keycloakIdentityProvider
+	if err := json.NewDecoder(response.Body).Decode(&createdKcIdp); err != nil {
+		return nil, fmt.Errorf("failed to decode created identity provider response: %w", err)
+	}
+
+	return fromKeycloakIdentityProvider(&createdKcIdp), nil
+}
+
 // GetIdentityProvider retrieves an identity provider configuration by alias at the realm level.
 func (c *Client) GetIdentityProvider(ctx context.Context, alias string) (*idp.IdentityProvider, error) {
 	c.logger.InfoContext(ctx, "Getting identity provider",

--- a/internal/idp/keycloak/client_test.go
+++ b/internal/idp/keycloak/client_test.go
@@ -1406,6 +1406,130 @@ var _ = Describe("Keycloak Client", func() {
 	})
 
 	Describe("Identity Provider Operations", func() {
+		Describe("CreateIdentityProvider", func() {
+			It("creates an identity provider in Keycloak", func() {
+				var receivedIdp *keycloakIdentityProvider
+				server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					if r.Method == http.MethodPost && r.URL.Path == "/admin/realms/osac/identity-provider/instances" {
+						// Create request
+						receivedIdp = &keycloakIdentityProvider{}
+						err := json.NewDecoder(r.Body).Decode(receivedIdp)
+						if err != nil {
+							http.Error(w, err.Error(), http.StatusBadRequest)
+							return
+						}
+
+						// Return the created IdP
+						response := keycloakIdentityProvider{
+							Alias:       receivedIdp.Alias,
+							DisplayName: receivedIdp.DisplayName,
+							InternalID:  "idp-uuid-123",
+							ProviderID:  receivedIdp.ProviderID,
+							Enabled:     receivedIdp.Enabled,
+							Config:      receivedIdp.Config,
+						}
+						w.Header().Set("Content-Type", "application/json")
+						w.WriteHeader(http.StatusCreated)
+						if err := json.NewEncoder(w).Encode(response); err != nil {
+							http.Error(w, err.Error(), http.StatusInternalServerError)
+							return
+						}
+						return
+					}
+					w.WriteHeader(http.StatusNotFound)
+				}))
+
+				client = createTestClient(server.URL)
+
+				idpProvider := &idp.IdentityProvider{
+					Alias:       "corporate-ldap",
+					DisplayName: "Corporate LDAP",
+					Type:        "ldap",
+					Enabled:     true,
+					Config: map[string]string{
+						"connectionUrl": "ldap://ldap.example.com:389",
+						"bindDn":        "cn=admin,dc=example,dc=com",
+					},
+				}
+				createdIdp, err := client.CreateIdentityProvider(ctx, idpProvider)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(receivedIdp).ToNot(BeNil(), "server handler should have set receivedIdp")
+				Expect(receivedIdp.Alias).To(Equal("corporate-ldap"))
+				Expect(receivedIdp.ProviderID).To(Equal("ldap"))
+				Expect(createdIdp).ToNot(BeNil())
+				Expect(createdIdp.Alias).To(Equal("corporate-ldap"))
+				Expect(createdIdp.DisplayName).To(Equal("Corporate LDAP"))
+				Expect(createdIdp.Type).To(Equal("ldap"))
+				Expect(createdIdp.Enabled).To(BeTrue())
+				Expect(createdIdp.Config).To(HaveKeyWithValue("connectionUrl", "ldap://ldap.example.com:389"))
+			})
+
+			It("creates an OIDC identity provider", func() {
+				server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					if r.Method == http.MethodPost && r.URL.Path == "/admin/realms/osac/identity-provider/instances" {
+						var receivedIdp keycloakIdentityProvider
+						json.NewDecoder(r.Body).Decode(&receivedIdp)
+
+						response := keycloakIdentityProvider{
+							Alias:       receivedIdp.Alias,
+							DisplayName: receivedIdp.DisplayName,
+							InternalID:  "idp-uuid-456",
+							ProviderID:  receivedIdp.ProviderID,
+							Enabled:     receivedIdp.Enabled,
+							Config:      receivedIdp.Config,
+						}
+						w.Header().Set("Content-Type", "application/json")
+						w.WriteHeader(http.StatusCreated)
+						if err := json.NewEncoder(w).Encode(response); err != nil {
+							http.Error(w, err.Error(), http.StatusInternalServerError)
+							return
+						}
+						return
+					}
+					w.WriteHeader(http.StatusNotFound)
+				}))
+
+				client = createTestClient(server.URL)
+
+				idpProvider := &idp.IdentityProvider{
+					Alias:       "google-sso",
+					DisplayName: "Google SSO",
+					Type:        "oidc",
+					Enabled:     true,
+					Config: map[string]string{
+						"authorizationUrl": "https://accounts.google.com/o/oauth2/v2/auth",
+						"tokenUrl":         "https://oauth2.googleapis.com/token",
+						"clientId":         "my-client-id",
+						"clientSecret":     "my-client-secret",
+					},
+				}
+				createdIdp, err := client.CreateIdentityProvider(ctx, idpProvider)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(createdIdp).ToNot(BeNil())
+				Expect(createdIdp.Alias).To(Equal("google-sso"))
+				Expect(createdIdp.Type).To(Equal("oidc"))
+				Expect(createdIdp.Config).To(HaveKeyWithValue("authorizationUrl", "https://accounts.google.com/o/oauth2/v2/auth"))
+			})
+
+			It("returns an error when creation fails", func() {
+				server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					w.WriteHeader(http.StatusConflict)
+					w.Write([]byte(`{"errorMessage":"Identity Provider with alias already exists"}`))
+				}))
+
+				client = createTestClient(server.URL)
+
+				idpProvider := &idp.IdentityProvider{
+					Alias:   "existing-idp",
+					Type:    "ldap",
+					Enabled: true,
+				}
+				_, err := client.CreateIdentityProvider(ctx, idpProvider)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("failed to create identity provider"))
+			})
+		})
+
 		Describe("GetIdentityProvider", func() {
 			It("retrieves an identity provider by alias", func() {
 				server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/idp/keycloak/types.go
+++ b/internal/idp/keycloak/types.go
@@ -264,12 +264,26 @@ func fromKeycloakAuthorizationResource(kcResource *keycloakAuthorizationResource
 // keycloakIdentityProvider represents an external identity provider configuration in Keycloak.
 // Identity providers are configured at the realm level and can be linked to specific organizations.
 type keycloakIdentityProvider struct {
-	Alias       string            `json:"alias,omitempty"`
+	Alias       string            `json:"alias"`
 	DisplayName string            `json:"displayName,omitempty"`
 	InternalID  string            `json:"internalId,omitempty"`
-	ProviderID  string            `json:"providerId,omitempty"` // "ldap", "oidc", "saml", etc.
-	Enabled     bool              `json:"enabled,omitempty"`
+	ProviderID  string            `json:"providerId"`
+	Enabled     bool              `json:"enabled"`
 	Config      map[string]string `json:"config,omitempty"` // Provider-specific configuration
+}
+
+func toKeycloakIdentityProvider(idpProvider *idp.IdentityProvider) *keycloakIdentityProvider {
+	if idpProvider == nil {
+		return nil
+	}
+
+	return &keycloakIdentityProvider{
+		Alias:       idpProvider.Alias,
+		DisplayName: idpProvider.DisplayName,
+		ProviderID:  idpProvider.Type,
+		Enabled:     idpProvider.Enabled,
+		Config:      idpProvider.Config,
+	}
 }
 
 func fromKeycloakIdentityProvider(kcIdp *keycloakIdentityProvider) *idp.IdentityProvider {

--- a/internal/idp/manager_test.go
+++ b/internal/idp/manager_test.go
@@ -238,6 +238,10 @@ func (m *mockClient) DeleteAuthorizationResource(ctx context.Context, resourceID
 }
 
 // Identity Provider stub methods
+func (m *mockClient) CreateIdentityProvider(ctx context.Context, idp *IdentityProvider) (*IdentityProvider, error) {
+	return idp, nil
+}
+
 func (m *mockClient) GetIdentityProvider(ctx context.Context, alias string) (*IdentityProvider, error) {
 	return nil, nil
 }


### PR DESCRIPTION
# Description

These functions will later be used by the IDP controller to create the IDP in keycloak.

# Testing

- [x] go build succeeds
- [x] go unit tests pass

Assisted-by: Claude Code <noreply@anthropic.com>

/cc @jhernand 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ability to create identity providers with support for multiple authentication types including LDAP and OIDC, featuring comprehensive validation and conflict detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->