### PR TITLE
OSAC-204: Render IdentityProviders in the CLI

### DIFF
--- a/internal/rendering/tables/osac.private.v1.IdentityProvider.yaml
+++ b/internal/rendering/tables/osac.private.v1.IdentityProvider.yaml
@@ -1,0 +1,20 @@
+#
+# Copyright (c) 2026 Red Hat Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+# the License. You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+columns:
+
+- header: ID
+  value: this.id
+
+- header: NAME
+  value: "has(this.metadata.name)? this.metadata.name: '-'"

--- a/internal/rendering/tables/osac.public.v1.IdentityProvider.yaml
+++ b/internal/rendering/tables/osac.public.v1.IdentityProvider.yaml
@@ -1,0 +1,20 @@
+#
+# Copyright (c) 2026 Red Hat Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+# the License. You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+columns:
+
+- header: ID
+  value: this.id
+
+- header: NAME
+  value: "has(this.metadata.name)? this.metadata.name: '-'"


### PR DESCRIPTION
# Testing

- [x] Created IDP using yaml below and ran `./osac get identityprovider` successfully with output:
```sh
$ ./osac get identityprovider
ID                                    DELETING  NAME
019ed779-bab3-7c52-b874-a197273654c7  -         test-ldap
```

```yaml
"@type": "type.googleapis.com/osac.private.v1.IdentityProvider"
metadata:
  name: "test-ldap"
spec:
  title: "Test LDAP"
  enabled: true
  ldap:
    connectionUrl: "ldap://ldap.example.com:389"
    bindDn: "cn=admin,dc=example,dc=com"
    bindCredential: "secret"
    usersDn: "ou=users,dc=example,dc=com"
```

Assisted-by: Claude Code <noreply@anthropic.com>

/cc @jhernand 