### PR TITLE
OSAC-1359: add create and describe instancetype CLI commands

### DIFF
--- a/internal/cmd/cli/create/create_cmd.go
+++ b/internal/cmd/cli/create/create_cmd.go
@@ -32,6 +32,7 @@ import (
 	"github.com/osac-project/fulfillment-service/internal/cmd/cli/create/cluster"
 	"github.com/osac-project/fulfillment-service/internal/cmd/cli/create/computeinstance"
 	"github.com/osac-project/fulfillment-service/internal/cmd/cli/create/hub"
+	"github.com/osac-project/fulfillment-service/internal/cmd/cli/create/instancetype"
 	"github.com/osac-project/fulfillment-service/internal/cmd/cli/create/publicip"
 	"github.com/osac-project/fulfillment-service/internal/cmd/cli/create/publicipattachment"
 	"github.com/osac-project/fulfillment-service/internal/cmd/cli/create/securitygroup"
@@ -56,6 +57,7 @@ func Cmd() *cobra.Command {
 	result.AddCommand(cluster.Cmd())
 	result.AddCommand(computeinstance.Cmd())
 	result.AddCommand(hub.Cmd())
+	result.AddCommand(instancetype.Cmd())
 	result.AddCommand(publicip.Cmd())
 	result.AddCommand(publicipattachment.Cmd())
 	result.AddCommand(virtualnetwork.Cmd())

--- a/internal/cmd/cli/create/instancetype/create_instancetype_cmd.go
+++ b/internal/cmd/cli/create/instancetype/create_instancetype_cmd.go
@@ -28,13 +28,13 @@ import (
 func Cmd() *cobra.Command {
 	runner := &runnerContext{}
 	result := &cobra.Command{
-		Use:     "instancetype",
-		Aliases: []string{string(proto.MessageName((*privatev1.InstanceType)(nil)))},
+		Use:                   "instancetype",
+		Aliases:               []string{string(proto.MessageName((*privatev1.InstanceType)(nil)))},
 		Short:                 shortHelp,
 		Long:                  longHelp,
 		DisableFlagsInUseLine: true,
 		Args:                  cobra.NoArgs,
-		RunE:    runner.run,
+		RunE:                  runner.run,
 	}
 	flags := result.Flags()
 	flags.StringVar(

--- a/internal/cmd/cli/create/instancetype/create_instancetype_cmd.go
+++ b/internal/cmd/cli/create/instancetype/create_instancetype_cmd.go
@@ -1,0 +1,166 @@
+/*
+Copyright (c) 2025 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package instancetype
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"google.golang.org/protobuf/proto"
+
+	privatev1 "github.com/osac-project/fulfillment-service/internal/api/osac/private/v1"
+	"github.com/osac-project/fulfillment-service/internal/config"
+	"github.com/osac-project/fulfillment-service/internal/terminal"
+)
+
+// Cmd creates the command to create an instance type.
+func Cmd() *cobra.Command {
+	runner := &runnerContext{}
+	result := &cobra.Command{
+		Use:     "instancetype",
+		Aliases: []string{string(proto.MessageName((*privatev1.InstanceType)(nil)))},
+		Short:                 shortHelp,
+		Long:                  longHelp,
+		DisableFlagsInUseLine: true,
+		Args:                  cobra.NoArgs,
+		RunE:    runner.run,
+	}
+	flags := result.Flags()
+	flags.StringVar(
+		&runner.name,
+		"name",
+		"",
+		nameFlagHelp,
+	)
+	flags.Int32Var(
+		&runner.cores,
+		"cores",
+		0,
+		coresFlagHelp,
+	)
+	flags.Int32Var(
+		&runner.memoryGiB,
+		"memory-gib",
+		0,
+		memoryGibFlagHelp,
+	)
+	flags.StringVar(
+		&runner.description,
+		"description",
+		"",
+		descriptionFlagHelp,
+	)
+	return result
+}
+
+type runnerContext struct {
+	console     *terminal.Console
+	name        string
+	cores       int32
+	memoryGiB   int32
+	description string
+}
+
+func (c *runnerContext) run(cmd *cobra.Command, args []string) error {
+	// Get the context:
+	ctx := cmd.Context()
+
+	// Get the console:
+	c.console = terminal.ConsoleFromContext(ctx)
+
+	// Get the configuration:
+	cfg := config.SettingsFromContext(ctx)
+	if !cfg.Armed() {
+		return fmt.Errorf("there is no configuration, run the 'login' command")
+	}
+
+	// Check the parameters:
+	if c.name == "" {
+		return fmt.Errorf("name is required")
+	}
+	if c.cores <= 0 {
+		return fmt.Errorf("cores must be greater than zero")
+	}
+	if c.memoryGiB <= 0 {
+		return fmt.Errorf("memory-gib must be greater than zero")
+	}
+
+	// Create the gRPC connection from the configuration:
+	conn, err := cfg.Connect(ctx, cmd.Flags())
+	if err != nil {
+		return fmt.Errorf("failed to create gRPC connection: %w", err)
+	}
+	defer conn.Close()
+
+	// Create the client:
+	client := privatev1.NewInstanceTypesClient(conn)
+
+	// Prepare the instance type:
+	instanceType := privatev1.InstanceType_builder{
+		Id: c.name,
+		Metadata: privatev1.Metadata_builder{
+			Name: c.name,
+		}.Build(),
+		Spec: privatev1.InstanceTypeSpec_builder{
+			Cores:       c.cores,
+			MemoryGib:   c.memoryGiB,
+			Description: c.description,
+		}.Build(),
+	}.Build()
+
+	// Create the instance type:
+	response, err := client.Create(ctx, privatev1.InstanceTypesCreateRequest_builder{
+		Object: instanceType,
+	}.Build())
+	if err != nil {
+		return fmt.Errorf("failed to create instance type: %w", err)
+	}
+
+	// Display the result:
+	c.console.Infof(ctx, "Created instance type '%s'.\n", response.GetObject().GetId())
+
+	return nil
+}
+
+const shortHelp = `Create an instance type.`
+
+const longHelp = `
+Create an instance type.
+
+An instance type defines a pre-configured compute bundle (CPU cores, memory) that can be referenced
+by name when creating compute instances. Instance types are managed by Cloud Provider Admins.
+
+To create an instance type:
+
+{{ bt 3 }}shell
+{{ binary }} create instancetype --name standard-4-16 --cores 4 --memory-gib 16 --description 'Balanced compute'
+{{ bt 3 }}
+`
+
+const nameFlagHelp = `
+_NAME_ - Name of the instance type. Must be a unique, human-readable identifier
+(e.g., {{ bt }}standard-4-16{{ bt }}).
+`
+
+const coresFlagHelp = `
+_CORES_ - Number of CPU cores for this instance type. Must be greater than zero.
+`
+
+const memoryGibFlagHelp = `
+_MEMORY_ - Amount of memory in GiB for this instance type. Must be greater than zero.
+`
+
+const descriptionFlagHelp = `
+_DESCRIPTION_ - Human friendly description of the instance type.
+`

--- a/internal/cmd/cli/create/instancetype/create_instancetype_cmd_test.go
+++ b/internal/cmd/cli/create/instancetype/create_instancetype_cmd_test.go
@@ -1,0 +1,63 @@
+/*
+Copyright (c) 2025 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package instancetype
+
+import (
+	. "github.com/onsi/ginkgo/v2/dsl/core"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Create instancetype flag registration", func() {
+	It("should create command without error", func() {
+		cmd := Cmd()
+		Expect(cmd).NotTo(BeNil())
+		Expect(cmd.Use).To(Equal("instancetype"))
+	})
+
+	It("should register --name flag", func() {
+		cmd := Cmd()
+		cmd.SetOut(GinkgoWriter)
+		cmd.SetErr(GinkgoWriter)
+		flag := cmd.Flags().Lookup("name")
+		Expect(flag).NotTo(BeNil())
+		Expect(flag.Usage).To(ContainSubstring("Name"))
+	})
+
+	It("should register --cores flag", func() {
+		cmd := Cmd()
+		cmd.SetOut(GinkgoWriter)
+		cmd.SetErr(GinkgoWriter)
+		flag := cmd.Flags().Lookup("cores")
+		Expect(flag).NotTo(BeNil())
+		Expect(flag.Usage).To(ContainSubstring("cores"))
+	})
+
+	It("should register --memory-gib flag", func() {
+		cmd := Cmd()
+		cmd.SetOut(GinkgoWriter)
+		cmd.SetErr(GinkgoWriter)
+		flag := cmd.Flags().Lookup("memory-gib")
+		Expect(flag).NotTo(BeNil())
+		Expect(flag.Usage).To(ContainSubstring("memory"))
+	})
+
+	It("should register --description flag", func() {
+		cmd := Cmd()
+		cmd.SetOut(GinkgoWriter)
+		cmd.SetErr(GinkgoWriter)
+		flag := cmd.Flags().Lookup("description")
+		Expect(flag).NotTo(BeNil())
+		Expect(flag.Usage).To(ContainSubstring("description"))
+	})
+})

--- a/internal/cmd/cli/create/instancetype/create_instancetype_suite_test.go
+++ b/internal/cmd/cli/create/instancetype/create_instancetype_suite_test.go
@@ -1,0 +1,26 @@
+/*
+Copyright (c) 2025 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package instancetype
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestCreateInstancetype(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Create instancetype command")
+}

--- a/internal/cmd/cli/describe/describe_cmd.go
+++ b/internal/cmd/cli/describe/describe_cmd.go
@@ -19,6 +19,7 @@ import (
 	"github.com/osac-project/fulfillment-service/internal/cmd/cli/describe/baremetalinstance"
 	"github.com/osac-project/fulfillment-service/internal/cmd/cli/describe/cluster"
 	"github.com/osac-project/fulfillment-service/internal/cmd/cli/describe/computeinstance"
+	"github.com/osac-project/fulfillment-service/internal/cmd/cli/describe/instancetype"
 	"github.com/osac-project/fulfillment-service/internal/cmd/cli/describe/networkclass"
 	"github.com/osac-project/fulfillment-service/internal/cmd/cli/describe/publicip"
 	"github.com/osac-project/fulfillment-service/internal/cmd/cli/describe/publicipattachment"
@@ -36,6 +37,7 @@ func Cmd() *cobra.Command {
 	result.AddCommand(baremetalinstance.Cmd())
 	result.AddCommand(cluster.Cmd())
 	result.AddCommand(computeinstance.Cmd())
+	result.AddCommand(instancetype.Cmd())
 	result.AddCommand(networkclass.Cmd())
 	result.AddCommand(publicip.Cmd())
 	result.AddCommand(publicipattachment.Cmd())

--- a/internal/cmd/cli/describe/instancetype/describe_instancetype_cmd.go
+++ b/internal/cmd/cli/describe/instancetype/describe_instancetype_cmd.go
@@ -1,0 +1,152 @@
+/*
+Copyright (c) 2025 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package instancetype
+
+import (
+	"fmt"
+	"io"
+	"strings"
+	"text/tabwriter"
+	"time"
+
+	"github.com/spf13/cobra"
+	"google.golang.org/protobuf/proto"
+
+	publicv1 "github.com/osac-project/fulfillment-service/internal/api/osac/public/v1"
+	"github.com/osac-project/fulfillment-service/internal/cmd/cli/lookup"
+	"github.com/osac-project/fulfillment-service/internal/config"
+	"github.com/osac-project/fulfillment-service/internal/terminal"
+)
+
+// Cmd creates the command to describe an instance type.
+func Cmd() *cobra.Command {
+	runner := &runnerContext{}
+	result := &cobra.Command{
+		Use:                   "instancetype [FLAG...] ID|NAME",
+		Aliases:               []string{"instancetypes"},
+		Short:                 shortHelp,
+		Long:                  longHelp,
+		DisableFlagsInUseLine: true,
+		Args:                  cobra.ExactArgs(1),
+		RunE:                  runner.run,
+	}
+	return result
+}
+
+type runnerContext struct {
+	console *terminal.Console
+}
+
+func (c *runnerContext) run(cmd *cobra.Command, args []string) error {
+	ref := args[0]
+
+	// Get the context:
+	ctx := cmd.Context()
+
+	// Get the console:
+	c.console = terminal.ConsoleFromContext(ctx)
+
+	// Get the configuration:
+	cfg := config.SettingsFromContext(ctx)
+	if !cfg.Armed() {
+		return fmt.Errorf("there is no configuration, run the 'login' command")
+	}
+
+	// Create the gRPC connection from the configuration:
+	conn, err := cfg.Connect(ctx, cmd.Flags())
+	if err != nil {
+		return fmt.Errorf("failed to create gRPC connection: %w", err)
+	}
+	defer conn.Close()
+
+	// Create the client:
+	client := publicv1.NewInstanceTypesClient(conn)
+
+	// Find the instance type:
+	matched, err := lookup.Find(ref, "instance type", func(filter string, limit int32) ([]*publicv1.InstanceType, error) {
+		resp, err := client.List(ctx, publicv1.InstanceTypesListRequest_builder{
+			Filter: proto.String(filter),
+			Limit:  proto.Int32(limit),
+		}.Build())
+		if err != nil {
+			return nil, fmt.Errorf("failed to describe instance type: %w", err)
+		}
+		return resp.GetItems(), nil
+	})
+	if err != nil {
+		return err
+	}
+
+	// Display the result:
+	renderInstanceType(c.console, matched)
+
+	return nil
+}
+
+func renderInstanceType(w io.Writer, it *publicv1.InstanceType) {
+	writer := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
+
+	// Base fields (always shown):
+	fmt.Fprintf(writer, "Name:\t%s\n", it.GetMetadata().GetName())
+
+	spec := it.GetSpec()
+	if spec != nil {
+		fmt.Fprintf(writer, "Cores:\t%d\n", spec.GetCores())
+		fmt.Fprintf(writer, "Memory (GiB):\t%d\n", spec.GetMemoryGib())
+
+		// State with prefix stripping (D-02):
+		state := strings.TrimPrefix(spec.GetState().String(), "INSTANCE_TYPE_STATE_")
+		fmt.Fprintf(writer, "State:\t%s\n", state)
+
+		// Description (only when non-empty):
+		if desc := spec.GetDescription(); desc != "" {
+			fmt.Fprintf(writer, "Description:\t%s\n", desc)
+		}
+	}
+
+	// Conditional deprecation section (D-01):
+	if dep := spec.GetDeprecation(); dep != nil {
+		hasContent := dep.GetReplacement() != "" ||
+			dep.GetDeprecationTimestamp() != nil ||
+			dep.GetObsolescenceTimestamp() != nil
+		if hasContent {
+			if dep.GetReplacement() != "" {
+				fmt.Fprintf(writer, "Replacement:\t%s\n", dep.GetReplacement())
+			}
+			if ts := dep.GetDeprecationTimestamp(); ts != nil {
+				fmt.Fprintf(writer, "Deprecated At:\t%s\n", ts.AsTime().Format(time.RFC3339))
+			}
+			if ts := dep.GetObsolescenceTimestamp(); ts != nil {
+				fmt.Fprintf(writer, "Obsolete At:\t%s\n", ts.AsTime().Format(time.RFC3339))
+			}
+		}
+	}
+
+	writer.Flush()
+}
+
+const shortHelp = `Describe an instance type.`
+
+const longHelp = `
+Describe an instance type.
+
+Displays detailed information about an instance type, including its compute configuration (cores,
+memory), lifecycle state, and deprecation details if applicable.
+
+To describe an instance type by name:
+
+{{ bt 3 }}shell
+{{ binary }} describe instancetype standard-4-16
+{{ bt 3 }}
+`

--- a/internal/cmd/cli/describe/instancetype/describe_instancetype_cmd.go
+++ b/internal/cmd/cli/describe/instancetype/describe_instancetype_cmd.go
@@ -113,22 +113,22 @@ func renderInstanceType(w io.Writer, it *publicv1.InstanceType) {
 		if desc := spec.GetDescription(); desc != "" {
 			fmt.Fprintf(writer, "Description:\t%s\n", desc)
 		}
-	}
 
-	// Conditional deprecation section (D-01):
-	if dep := spec.GetDeprecation(); dep != nil {
-		hasContent := dep.GetReplacement() != "" ||
-			dep.GetDeprecationTimestamp() != nil ||
-			dep.GetObsolescenceTimestamp() != nil
-		if hasContent {
-			if dep.GetReplacement() != "" {
-				fmt.Fprintf(writer, "Replacement:\t%s\n", dep.GetReplacement())
-			}
-			if ts := dep.GetDeprecationTimestamp(); ts != nil {
-				fmt.Fprintf(writer, "Deprecated At:\t%s\n", ts.AsTime().Format(time.RFC3339))
-			}
-			if ts := dep.GetObsolescenceTimestamp(); ts != nil {
-				fmt.Fprintf(writer, "Obsolete At:\t%s\n", ts.AsTime().Format(time.RFC3339))
+		// Conditional deprecation section (D-01):
+		if dep := spec.GetDeprecation(); dep != nil {
+			hasContent := dep.GetReplacement() != "" ||
+				dep.GetDeprecationTimestamp() != nil ||
+				dep.GetObsolescenceTimestamp() != nil
+			if hasContent {
+				if dep.GetReplacement() != "" {
+					fmt.Fprintf(writer, "Replacement:\t%s\n", dep.GetReplacement())
+				}
+				if ts := dep.GetDeprecationTimestamp(); ts != nil {
+					fmt.Fprintf(writer, "Deprecated At:\t%s\n", ts.AsTime().Format(time.RFC3339))
+				}
+				if ts := dep.GetObsolescenceTimestamp(); ts != nil {
+					fmt.Fprintf(writer, "Obsolete At:\t%s\n", ts.AsTime().Format(time.RFC3339))
+				}
 			}
 		}
 	}

--- a/internal/cmd/cli/describe/instancetype/describe_instancetype_cmd_test.go
+++ b/internal/cmd/cli/describe/instancetype/describe_instancetype_cmd_test.go
@@ -1,0 +1,151 @@
+/*
+Copyright (c) 2025 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package instancetype
+
+import (
+	"bytes"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2/dsl/core"
+	. "github.com/onsi/gomega"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	publicv1 "github.com/osac-project/fulfillment-service/internal/api/osac/public/v1"
+)
+
+func formatInstanceType(it *publicv1.InstanceType) string {
+	var buf bytes.Buffer
+	renderInstanceType(&buf, it)
+	return buf.String()
+}
+
+var _ = Describe("Rendering tests", func() {
+	It("should display all base fields for ACTIVE type", func() {
+		it := publicv1.InstanceType_builder{
+			Id: "standard-4-16",
+			Metadata: publicv1.Metadata_builder{
+				Name: "standard-4-16",
+			}.Build(),
+			Spec: publicv1.InstanceTypeSpec_builder{
+				Cores:       4,
+				MemoryGib:   16,
+				Description: "Balanced compute",
+				State:       publicv1.InstanceTypeState_INSTANCE_TYPE_STATE_ACTIVE,
+			}.Build(),
+		}.Build()
+		output := formatInstanceType(it)
+		Expect(output).To(ContainSubstring("standard-4-16"))
+		Expect(output).To(ContainSubstring("4"))
+		Expect(output).To(ContainSubstring("16"))
+		Expect(output).To(ContainSubstring("ACTIVE"))
+		Expect(output).To(ContainSubstring("Balanced compute"))
+		Expect(output).NotTo(ContainSubstring("INSTANCE_TYPE_STATE_"))
+		Expect(output).NotTo(ContainSubstring("Replacement:"))
+		Expect(output).NotTo(ContainSubstring("Deprecated At:"))
+		Expect(output).NotTo(ContainSubstring("Obsolete At:"))
+	})
+
+	It("should strip INSTANCE_TYPE_STATE_ prefix from state", func() {
+		it := publicv1.InstanceType_builder{
+			Id: "deprecated-2-8",
+			Metadata: publicv1.Metadata_builder{
+				Name: "deprecated-2-8",
+			}.Build(),
+			Spec: publicv1.InstanceTypeSpec_builder{
+				Cores:     2,
+				MemoryGib: 8,
+				State:     publicv1.InstanceTypeState_INSTANCE_TYPE_STATE_DEPRECATED,
+			}.Build(),
+		}.Build()
+		output := formatInstanceType(it)
+		Expect(output).To(ContainSubstring("DEPRECATED"))
+		Expect(output).NotTo(ContainSubstring("INSTANCE_TYPE_STATE_"))
+	})
+
+	It("should show deprecation section when deprecation data exists", func() {
+		depTime := time.Date(2026, 6, 10, 17, 21, 0, 0, time.UTC)
+		obsTime := time.Date(2026, 12, 31, 0, 0, 0, 0, time.UTC)
+		it := publicv1.InstanceType_builder{
+			Id: "old-4-16",
+			Metadata: publicv1.Metadata_builder{
+				Name: "old-4-16",
+			}.Build(),
+			Spec: publicv1.InstanceTypeSpec_builder{
+				Cores:     4,
+				MemoryGib: 16,
+				State:     publicv1.InstanceTypeState_INSTANCE_TYPE_STATE_DEPRECATED,
+				Deprecation: publicv1.InstanceTypeDeprecation_builder{
+					Replacement:           "standard-8-32",
+					DeprecationTimestamp:  timestamppb.New(depTime),
+					ObsolescenceTimestamp: timestamppb.New(obsTime),
+				}.Build(),
+			}.Build(),
+		}.Build()
+		output := formatInstanceType(it)
+		Expect(output).To(MatchRegexp(`Replacement:\s+standard-8-32`))
+		Expect(output).To(MatchRegexp(`Deprecated At:\s+2026-06-10T17:21:00Z`))
+		Expect(output).To(MatchRegexp(`Obsolete At:\s+2026-12-31T00:00:00Z`))
+	})
+
+	It("should omit deprecation section for ACTIVE type without deprecation data", func() {
+		it := publicv1.InstanceType_builder{
+			Id: "active-8-32",
+			Metadata: publicv1.Metadata_builder{
+				Name: "active-8-32",
+			}.Build(),
+			Spec: publicv1.InstanceTypeSpec_builder{
+				Cores:     8,
+				MemoryGib: 32,
+				State:     publicv1.InstanceTypeState_INSTANCE_TYPE_STATE_ACTIVE,
+			}.Build(),
+		}.Build()
+		output := formatInstanceType(it)
+		Expect(output).NotTo(ContainSubstring("Replacement:"))
+		Expect(output).NotTo(ContainSubstring("Deprecated At:"))
+		Expect(output).NotTo(ContainSubstring("Obsolete At:"))
+	})
+
+	It("should omit description when empty", func() {
+		it := publicv1.InstanceType_builder{
+			Id: "no-desc-2-4",
+			Metadata: publicv1.Metadata_builder{
+				Name: "no-desc-2-4",
+			}.Build(),
+			Spec: publicv1.InstanceTypeSpec_builder{
+				Cores:     2,
+				MemoryGib: 4,
+				State:     publicv1.InstanceTypeState_INSTANCE_TYPE_STATE_ACTIVE,
+			}.Build(),
+		}.Build()
+		output := formatInstanceType(it)
+		Expect(output).NotTo(ContainSubstring("Description:"))
+	})
+
+	It("should show description when present", func() {
+		it := publicv1.InstanceType_builder{
+			Id: "highmem-4-64",
+			Metadata: publicv1.Metadata_builder{
+				Name: "highmem-4-64",
+			}.Build(),
+			Spec: publicv1.InstanceTypeSpec_builder{
+				Cores:       4,
+				MemoryGib:   64,
+				Description: "High memory",
+				State:       publicv1.InstanceTypeState_INSTANCE_TYPE_STATE_ACTIVE,
+			}.Build(),
+		}.Build()
+		output := formatInstanceType(it)
+		Expect(output).To(MatchRegexp(`Description:\s+High memory`))
+	})
+})

--- a/internal/cmd/cli/describe/instancetype/describe_instancetype_suite_test.go
+++ b/internal/cmd/cli/describe/instancetype/describe_instancetype_suite_test.go
@@ -1,0 +1,26 @@
+/*
+Copyright (c) 2025 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package instancetype
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestDescribeInstancetype(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Describe instancetype command")
+}


### PR DESCRIPTION
## Summary
- Add `create instancetype` CLI command with `--name`, `--cores`, `--memory-gib`, `--description` flags using the private API for admin-only creation
- Add `describe instancetype` CLI command using the public API with `lookup.Find`, rendering base fields (name, cores, memory, state, description) and conditional deprecation data (replacement, deprecated at, obsolete at)
- State display strips `INSTANCE_TYPE_STATE_` prefix; timestamps formatted as RFC3339
- Both commands registered in their parent command routers with Ginkgo test suites (5 + 6 specs)

## Test plan
- [x] `go build ./...` passes
- [x] `ginkgo run internal/cmd/cli/create/instancetype` — 5 specs pass (flag registration)
- [x] `ginkgo run internal/cmd/cli/describe/instancetype` — 6 specs pass (rendering: base fields, state stripping, conditional deprecation, RFC3339 timestamps, description presence/absence)
- [x] `ginkgo run -r internal` — full unit test suite passes (no regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `create instancetype` CLI command to create instance types with `--name`, `--cores`, `--memory-gib`, and `--description`.
  * Added `describe instancetype` CLI command to display instance type details by ID or name, including cores, memory, state, description, and conditional deprecation info with RFC3339 timestamps.
* **Tests**
  * Added Ginkgo/Gomega coverage for `create instancetype` flag/usage behavior and `describe instancetype` output rendering (state formatting, description, and deprecation sections).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->