### PR TITLE
OSAC-1628: Make `externalHostname` and `internalHostname` mandatory

### DIFF
--- a/charts/service/README.md
+++ b/charts/service/README.md
@@ -21,30 +21,33 @@ $ helm install fulfillment-service ./charts/service -n osac --create-namespace
 
 The following table lists the configurable parameters of the chart and their default values:
 
-| Parameter                  | Description                                                        | Default                                                        |
-|----------------------------|--------------------------------------------------------------------|----------------------------------------------------------------|
-| `variant`                  | Deployment variant (`kind` or `openshift`)                         | `kind`                                                         |
-| `certs.issuerRef.kind`     | Kind of _cert-manager_ issuer                                      | `ClusterIssuer`                                                |
-| `certs.issuerRef.name`     | Name of _cert-manager_ issuer                                      | None                                                           |
-| `certs.caBundle.configMap` | Name of configmap containing trusted CA certificates in PEM format | Required                                                       |
-| `externalHostname`         | Hostname used to access the public API from outside the cluster (see note below) | None                                                |
-| `internalHostname`         | Hostname used to access both the public and private APIs (see note below)        | None                                                |
-| `auth.issuerUrl`           | OAuth issuer URL for authentication                                | `https://keycloak.keycloak.svc.cluster.local:8000/realms/osac` |
-| `log.level`                | Log level for all components (debug, info, warn, error)            | `info`                                                         |
-| `log.headers`              | Enable logging of HTTP/gRPC headers                                | `false`                                                        |
-| `log.bodies`               | Enable logging of HTTP/gRPC request and response bodies            | `false`                                                        |
-| `images.service`           | Fulfillment service container image                                | `ghcr.io/osac/fulfillment-service:main`                        |
-| `images.envoy`             | Envoy proxy container image                                        | `docker.io/envoyproxy/envoy:v1.37.1`                           |
-| `database.connection`      | List of sources for database connection parameters (see below)     | `[]`                                                           |
+| Parameter                  | Description                                                                       | Default                                                        |
+|----------------------------|-----------------------------------------------------------------------------------|----------------------------------------------------------------|
+| `variant`                  | Deployment variant (`kind` or `openshift`)                                        | `kind`                                                         |
+| `certs.issuerRef.kind`     | Kind of _cert-manager_ issuer                                                     | `ClusterIssuer`                                                |
+| `certs.issuerRef.name`     | Name of _cert-manager_ issuer                                                     | None                                                           |
+| `certs.caBundle.configMap` | Name of configmap containing trusted CA certificates in PEM format                | Required                                                       |
+| `externalHostname`         | Hostname used to access the public API via the external network                   | Required                                                       |
+| `internalHostname`         | Hostname used to access both the public and private APIs via the internal network | Required                                                       |
+| `auth.issuerUrl`           | OAuth issuer URL for authentication                                               | `https://keycloak.keycloak.svc.cluster.local:8000/realms/osac` |
+| `log.level`                | Log level for all components (debug, info, warn, error)                           | `info`                                                         |
+| `log.headers`              | Enable logging of HTTP/gRPC headers                                               | `false`                                                        |
+| `log.bodies`               | Enable logging of HTTP/gRPC request and response bodies                           | `false`                                                        |
+| `images.service`           | Fulfillment service container image                                               | `ghcr.io/osac/fulfillment-service:main`                        |
+| `images.envoy`             | Envoy proxy container image                                                       | `docker.io/envoyproxy/envoy:v1.37.1`                           |
+| `database.connection`      | List of sources for database connection parameters (see below)                    | `[]`                                                           |
 
-**Note on `internalHostname`:** The internal API exposes both the public and private APIs. The
-administrator is responsible for ensuring that this hostname is accessible only from the internal
-network and not accessible to regular users. This isn't strictly required because access is subject
-to authentication and authorization (regular users won't be authorized to use the private API), but
-it is good practice to restrict network-level access as an additional layer of defense. When
-`internalHostname` is not set, no Route (OpenShift) or TLSRoute (Kind) will be created for the
-internal API, allowing the administrator to manually configure ingress with custom settings such as
-a dedicated load balancer or a specific IP address.
+**Note on hostnames:** Both `externalHostname` and `internalHostname` are required because TLS
+certificates must be generated with the correct host names.
+
+The recommended deployment uses two networks. The external network is intended for regular users and
+only gives access to the public API via `externalHostname`. The internal network gives access to
+both the public and private APIs via `internalHostname`. The internal network should be restricted so
+that only the administrators of the system can access it. In a typical environment this would be a
+network confined to the physical infrastructure of the cloud provider, while the external network
+would be publicly reachable. Restricting access to the internal network is not strictly required
+because the private API is protected by authentication and authorization, but it is good practice to
+add network-level isolation as an additional layer of defense.
 
 ### Example custom values
 

--- a/charts/service/templates/_helpers.tpl
+++ b/charts/service/templates/_helpers.tpl
@@ -12,40 +12,29 @@ specific language governing permissions and limitations under the License.
 */}}
 
 {{/*
-Generate the hostname for the fulfillment API. If .Values.externalHostname is set, use it; otherwise, use the default
-Kubernetes service hostname based on the release namespace.
+Return the hostname for the fulfillment API. Fails if 'externalHostname' is not set.
 */}}
 {{- define "fulfillment-api.hostname" -}}
-{{- if .Values.externalHostname -}}
-{{- .Values.externalHostname -}}
-{{- else -}}
-{{- printf "fulfillment-api.%s.svc.cluster.local" .Release.Namespace -}}
-{{- end -}}
+{{- required "externalHostname is required" .Values.externalHostname -}}
 {{- end -}}
 
 {{/*
 Generate the token issuer URL for JWT signing and JWKS discovery.
 
-On OpenShift with an external hostname, a Route provides TLS passthrough on
-port 443, so the URL omits the port. In all other cases (kind variant, or no
-external hostname) traffic goes directly to the Kubernetes Service on port 8000.
+On OpenShift a Route provides TLS passthrough on port 443, so the URL omits the port. In the kind
+variant traffic goes directly to the Kubernetes Service on port 8000.
 */}}
 {{- define "fulfillment-api.tokenIssuerUrl" -}}
-{{- if and (eq .Values.variant "openshift") .Values.externalHostname -}}
-https://{{ .Values.externalHostname }}
+{{- if eq .Values.variant "openshift" -}}
+https://{{ include "fulfillment-api.hostname" . }}
 {{- else -}}
 https://{{ include "fulfillment-api.hostname" . }}:8000
 {{- end -}}
 {{- end -}}
 
 {{/*
-Generate the hostname for the fulfillment internal API. If .Values.internalHostname is set, use it; otherwise, use the
-default Kubernetes service hostname based on the release namespace.
+Return the hostname for the fulfillment internal API. Fails if 'internalHostname' is not set.
 */}}
 {{- define "fulfillment-internal-api.hostname" -}}
-{{- if .Values.internalHostname -}}
-{{- .Values.internalHostname -}}
-{{- else -}}
-{{- printf "fulfillment-internal-api.%s.svc.cluster.local" .Release.Namespace -}}
-{{- end -}}
+{{- required "internalHostname is required" .Values.internalHostname -}}
 {{- end -}}

--- a/charts/service/templates/ingress-proxy/certificate.yaml
+++ b/charts/service/templates/ingress-proxy/certificate.yaml
@@ -28,12 +28,8 @@ spec:
   - fulfillment-internal-api
   - fulfillment-internal-api.{{ .Release.Namespace }}
   - fulfillment-internal-api.{{ .Release.Namespace }}.svc.cluster.local
-{{- if .Values.externalHostname }}
-  - {{ .Values.externalHostname | quote}}
-{{- end }}
-{{- if .Values.internalHostname }}
-  - {{ .Values.internalHostname | quote}}
-{{- end }}
+  - {{ include "fulfillment-api.hostname" . | quote }}
+  - {{ include "fulfillment-internal-api.hostname" . | quote }}
   secretName: fulfillment-api-tls
   privateKey:
     rotationPolicy: Always

--- a/charts/service/templates/route.yaml
+++ b/charts/service/templates/route.yaml
@@ -27,7 +27,6 @@ spec:
   tls:
     termination: passthrough
 
-{{ if .Values.internalHostname }}
 ---
 apiVersion: route.openshift.io/v1
 kind: Route
@@ -35,7 +34,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   name: fulfillment-internal-api
 spec:
-  host: {{ .Values.internalHostname }}
+  host: {{ include "fulfillment-internal-api.hostname" . }}
   to:
     kind: Service
     name: fulfillment-internal-api
@@ -43,7 +42,6 @@ spec:
     targetPort: internal-api
   tls:
     termination: passthrough
-{{ end }}
 
 {{ end }}
 
@@ -67,7 +65,6 @@ spec:
     - name: fulfillment-api
       port: 8000
 
-{{ if .Values.internalHostname }}
 ---
 apiVersion: gateway.networking.k8s.io/v1alpha3
 kind: TLSRoute
@@ -87,6 +84,5 @@ spec:
   - backendRefs:
     - name: fulfillment-internal-api
       port: 8001
-{{ end }}
 
 {{ end }}

--- a/charts/service/values.yaml
+++ b/charts/service/values.yaml
@@ -32,19 +32,17 @@ certs:
   caBundle:
     configMap:
 
-# This defines the hostname used to access the public API from outside the cluster. The default is to use the hostname
-# of the Kubernetes service. For example, if the application is deployed in a namespace named 'osac' then the default
-# hostname will be 'fulfillment-api.osac.svc.cluster.local'.
+# Hostname for the external network, which gives regular users access to the public API. This value is required because
+# the TLS certificates need to be generated with the correct host names. In a typical environment the external network
+# is publicly reachable.
 externalHostname:
 
-# This defines the hostname used to access both the public and private APIs from outside the cluster. It is typically
-# accessible only from the administrator's internal network. The default is to use the hostname of the Kubernetes
-# service. For example, if the application is deployed in a namespace named 'osac' then the default hostname will be
-# 'fulfillment-internal-api.osac.svc.cluster.local'.
-#
-# The administrator is responsible for ensuring that this hostname is accessible only from the internal network and not
-# accessible to regular users. This isn't strictly required because access is subject to authentication and
-# authorization, but it is good practice to restrict network-level access as an additional layer of defense.
+# Hostname for the internal network, which gives administrators access to both the public and private APIs. This value
+# is required because the TLS certificates need to be generated with the correct host names. The internal network should
+# be restricted so that only administrators can reach it. In a typical environment this would be a network confined to
+# the physical infrastructure of the cloud provider. Restricting access is not strictly required because the private API
+# is protected by authentication and authorization, but it is good practice to add network-level isolation as an
+# additional layer of defense.
 internalHostname:
 
 # Authentication and authorization configuration:

--- a/internal/auth/auth_rules_test.go
+++ b/internal/auth/auth_rules_test.go
@@ -64,6 +64,8 @@ var _ = Describe("Authorization rules", Ordered, func() {
 		// Create a temporary values file:
 		valuesFile := filepath.Join(tmpDir, "values.yaml")
 		valuesData := map[string]any{
+			"internalHostname": "internal.example.com",
+			"externalHostname": "external.example.com",
 			"certs": map[string]any{
 				"issuerRef": map[string]any{
 					"name": "my-ca",


### PR DESCRIPTION
## Summary

- Make `externalHostname` and `internalHostname` required Helm values instead of falling back to
  auto-generated Kubernetes service hostnames. The defaults only worked in integration tests and
  cannot work in real deployments because TLS certificates must include the correct host names.
- Replace fallback logic with Helm's `required` function for immediate, clear failures.
- Remove conditionals guarding the internal API Route/TLSRoute since the value is always present.

## Test plan

- [ ] Verify `helm template` fails with a clear error when either hostname is omitted.
- [ ] Verify `helm template` succeeds when both hostnames are provided.
- [ ] Run integration tests (`ginkgo run it`) to confirm they still pass (they already set both values explicitly).

Related: https://redhat.atlassian.net/browse/OSAC-1628

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated configuration guidance to state that both external and internal hostname values must be correct to generate TLS certificates.
  * Added clearer “note on hostnames” messaging and emphasized network isolation as defense-in-depth for internal APIs.

* **Chores**
  * External and internal hostname settings are now required at deployment time.
  * Internal and public routing/certificate generation now consistently use the configured hostname values across variants.

* **Tests**
  * Updated manifest rendering tests to include both hostname values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->