### PR TITLE
OSAC-1621: Wire up IDP controllers

### DIFF
--- a/internal/cmd/service/start/controller/start_controller_cmd.go
+++ b/internal/cmd/service/start/controller/start_controller_cmd.go
@@ -44,6 +44,7 @@ import (
 	"github.com/osac-project/fulfillment-service/internal/controllers/baremetalinstance"
 	"github.com/osac-project/fulfillment-service/internal/controllers/cluster"
 	"github.com/osac-project/fulfillment-service/internal/controllers/computeinstance"
+	"github.com/osac-project/fulfillment-service/internal/controllers/identityprovider"
 	"github.com/osac-project/fulfillment-service/internal/controllers/project"
 	"github.com/osac-project/fulfillment-service/internal/controllers/publicip"
 	"github.com/osac-project/fulfillment-service/internal/controllers/publicipattachment"
@@ -850,6 +851,43 @@ func (r *runnerContext) run(cmd *cobra.Command, argv []string) error { //nolint:
 			r.logger.InfoContext(
 				ctx,
 				"Project reconciler failed",
+				slog.Any("error", err),
+			)
+		}
+	}()
+
+	// Create the identity provider reconciler:
+	r.logger.InfoContext(ctx, "Creating identity provider reconciler")
+	identityProviderReconcilerFunction, err := identityprovider.NewFunction().
+		SetLogger(r.logger).
+		SetConnection(r.client).
+		SetIdpClient(idpClient).
+		Build()
+	if err != nil {
+		return fmt.Errorf("failed to create identity provider reconciler function: %w", err)
+	}
+	identityProviderReconciler, err := controllers.NewReconciler[*privatev1.IdentityProvider]().
+		SetLogger(r.logger).
+		SetName("identity_provider").
+		SetClient(r.client).
+		SetFunction(identityProviderReconcilerFunction.Run).
+		SetEventFilter("has(event.identity_provider)").
+		SetHealthReporter(healthAggregator).
+		Build()
+	if err != nil {
+		return fmt.Errorf("failed to create identity provider reconciler: %w", err)
+	}
+
+	// Start the identity provider reconciler:
+	r.logger.InfoContext(ctx, "Starting identity provider reconciler")
+	go func() {
+		err := identityProviderReconciler.Start(ctx)
+		if err == nil || errors.Is(err, context.Canceled) {
+			r.logger.InfoContext(ctx, "Identity provider reconciler finished")
+		} else {
+			r.logger.InfoContext(
+				ctx,
+				"Identity provider reconciler failed",
 				slog.Any("error", err),
 			)
 		}

--- a/internal/controllers/identityprovider/identity_provider_reconciler_function.go
+++ b/internal/controllers/identityprovider/identity_provider_reconciler_function.go
@@ -1,0 +1,294 @@
+/*
+Copyright (c) 2026 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package identityprovider
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"slices"
+
+	"google.golang.org/grpc"
+	"google.golang.org/protobuf/proto"
+
+	privatev1 "github.com/osac-project/fulfillment-service/internal/api/osac/private/v1"
+	"github.com/osac-project/fulfillment-service/internal/auth"
+	"github.com/osac-project/fulfillment-service/internal/controllers/finalizers"
+	"github.com/osac-project/fulfillment-service/internal/idp"
+	"github.com/osac-project/fulfillment-service/internal/masks"
+)
+
+// FunctionBuilder contains the data needed to build instances of the reconciler function.
+type FunctionBuilder struct {
+	logger     *slog.Logger
+	connection *grpc.ClientConn
+	idpClient  idp.Client
+}
+
+// NewFunction creates a builder that can be used to configure and create reconciler functions.
+func NewFunction() *FunctionBuilder {
+	return &FunctionBuilder{}
+}
+
+// SetLogger sets the logger that the reconciler will use to write log messages.
+func (b *FunctionBuilder) SetLogger(value *slog.Logger) *FunctionBuilder {
+	b.logger = value
+	return b
+}
+
+// SetConnection sets the gRPC connection that the reconciler will use to communicate with the API server.
+func (b *FunctionBuilder) SetConnection(value *grpc.ClientConn) *FunctionBuilder {
+	b.connection = value
+	return b
+}
+
+// SetIdpClient sets the IDP client that the reconciler will use to manage identity providers.
+func (b *FunctionBuilder) SetIdpClient(value idp.Client) *FunctionBuilder {
+	b.idpClient = value
+	return b
+}
+
+// Build uses the data stored in the builder to create and configure a new reconciler function.
+func (b *FunctionBuilder) Build() (result *function, err error) {
+	if b.logger == nil {
+		err = errors.New("logger is mandatory")
+		return
+	}
+	if b.connection == nil {
+		err = errors.New("connection is mandatory")
+		return
+	}
+	if b.idpClient == nil {
+		err = errors.New("IDP client is mandatory")
+		return
+	}
+
+	result = &function{
+		logger:                  b.logger,
+		identityProvidersClient: privatev1.NewIdentityProvidersClient(b.connection),
+		idpClient:               b.idpClient,
+		maskCalculator:          masks.NewCalculator().Build(),
+	}
+	return
+}
+
+// function is the implementation of the reconciler function.
+type function struct {
+	logger                  *slog.Logger
+	identityProvidersClient privatev1.IdentityProvidersClient
+	idpClient               idp.Client
+	maskCalculator          *masks.Calculator
+}
+
+// Run executes the reconciliation logic for the given identity provider.
+func (r *function) Run(ctx context.Context, identityProvider *privatev1.IdentityProvider) error {
+	oldIdp := proto.Clone(identityProvider).(*privatev1.IdentityProvider)
+
+	task := &task{
+		r:                r,
+		identityProvider: identityProvider,
+	}
+
+	var err error
+	if identityProvider.HasMetadata() && identityProvider.GetMetadata().HasDeletionTimestamp() {
+		err = task.delete(ctx)
+	} else {
+		err = task.update(ctx)
+	}
+	if err != nil {
+		return err
+	}
+
+	updateMask := r.maskCalculator.Calculate(oldIdp, identityProvider)
+
+	if len(updateMask.GetPaths()) > 0 {
+		_, err = r.identityProvidersClient.Update(ctx, privatev1.IdentityProvidersUpdateRequest_builder{
+			Object:     identityProvider,
+			UpdateMask: updateMask,
+		}.Build())
+	}
+
+	return err
+}
+
+// task contains the data needed to reconcile a single identity provider.
+type task struct {
+	r                *function
+	identityProvider *privatev1.IdentityProvider
+}
+
+// update performs the reconciliation logic for creating or updating an identity provider.
+func (t *task) update(ctx context.Context) error {
+	if t.addFinalizer() {
+		return nil
+	}
+
+	if err := t.validateTenant(); err != nil {
+		return err
+	}
+
+	t.setDefaults()
+
+	state := t.identityProvider.GetStatus().GetPhase()
+
+	// Skip reconciliation for terminal error state
+	if state == privatev1.IdentityProviderPhase_IDENTITY_PROVIDER_PHASE_ERROR {
+		return nil
+	}
+
+	// For ready identity providers, no updates are needed
+	if state == privatev1.IdentityProviderPhase_IDENTITY_PROVIDER_PHASE_READY {
+		return nil
+	}
+
+	// Identity provider is UNSPECIFIED or UNKNOWN, perform initial sync to IDP
+	return t.syncToIDP(ctx)
+}
+
+// syncToIDP synchronizes the identity provider to the IDP backend (Keycloak).
+func (t *task) syncToIDP(ctx context.Context) error {
+	// Build the IDP provider object from the spec
+	// Use tenant-prefixed alias to ensure uniqueness across tenants in Keycloak
+	alias := fmt.Sprintf("%s-%s", t.identityProvider.GetMetadata().GetTenant(), t.identityProvider.GetMetadata().GetName())
+	idpProvider := &idp.IdentityProvider{
+		Alias:       alias,
+		DisplayName: t.identityProvider.GetSpec().GetTitle(),
+		Type:        t.determineProviderType(),
+		Enabled:     t.identityProvider.GetSpec().GetEnabled(),
+		Config:      t.buildConfig(),
+	}
+
+	createdIdp, err := t.r.idpClient.CreateIdentityProvider(ctx, idpProvider)
+	if err != nil {
+		t.identityProvider.GetStatus().SetPhase(privatev1.IdentityProviderPhase_IDENTITY_PROVIDER_PHASE_ERROR)
+		t.identityProvider.GetStatus().SetMessage(fmt.Sprintf("Identity provider creation in IDP failed: %v", err))
+		return nil
+	}
+
+	t.identityProvider.GetStatus().SetPhase(privatev1.IdentityProviderPhase_IDENTITY_PROVIDER_PHASE_READY)
+	t.identityProvider.GetStatus().SetMessage(fmt.Sprintf("Identity provider created successfully with alias: %s", createdIdp.Alias))
+
+	t.r.logger.DebugContext(ctx, "Identity provider synced to IDP",
+		slog.String("identity_provider_id", t.identityProvider.GetId()),
+		slog.String("alias", createdIdp.Alias),
+	)
+
+	return nil
+}
+
+// determineProviderType returns the provider type based on which config is set.
+func (t *task) determineProviderType() string {
+	spec := t.identityProvider.GetSpec()
+	if spec.HasLdap() {
+		return "ldap"
+	}
+	if spec.HasOidc() {
+		return "oidc"
+	}
+	return ""
+}
+
+// buildConfig builds the provider-specific configuration map.
+func (t *task) buildConfig() map[string]string {
+	config := make(map[string]string)
+	spec := t.identityProvider.GetSpec()
+
+	if ldap := spec.GetLdap(); ldap != nil {
+		config["connectionUrl"] = ldap.GetConnectionUrl()
+		config["bindDn"] = ldap.GetBindDn()
+		config["bindCredential"] = ldap.GetBindCredential()
+		config["usersDn"] = ldap.GetUsersDn()
+	}
+
+	if oidc := spec.GetOidc(); oidc != nil {
+		config["authorizationUrl"] = oidc.GetAuthorizationUrl()
+		config["tokenUrl"] = oidc.GetTokenUrl()
+		config["clientId"] = oidc.GetClientId()
+		config["clientSecret"] = oidc.GetClientSecret()
+		config["issuer"] = oidc.GetIssuer()
+	}
+
+	return config
+}
+
+// validateTenant verifies that the identity provider has a valid tenant assigned.
+// Identity providers must belong to a specific organization tenant, not "shared" or "system".
+func (t *task) validateTenant() error {
+	if !t.identityProvider.HasMetadata() || t.identityProvider.GetMetadata().GetTenant() == "" {
+		return errors.New("Identity provider must have a tenant assigned") //nolint:staticcheck // ST1005: Identity provider is an API resource name
+	}
+	tenant := t.identityProvider.GetMetadata().GetTenant()
+	if tenant == auth.SharedTenant || tenant == auth.SystemTenant {
+		return fmt.Errorf("Identity provider cannot belong to '%s' tenant - must be scoped to a specific organization", tenant) //nolint:staticcheck // ST1005: Identity provider is an API resource name
+	}
+	return nil
+}
+
+// setDefaults sets default values for the identity provider.
+func (t *task) setDefaults() {
+	if !t.identityProvider.HasStatus() {
+		t.identityProvider.SetStatus(&privatev1.IdentityProviderStatus{})
+	}
+	if t.identityProvider.GetStatus().GetPhase() == privatev1.IdentityProviderPhase_IDENTITY_PROVIDER_PHASE_UNSPECIFIED {
+		t.identityProvider.GetStatus().SetPhase(privatev1.IdentityProviderPhase_IDENTITY_PROVIDER_PHASE_UNKNOWN)
+	}
+}
+
+// addFinalizer adds the controller finalizer to the identity provider if not already present.
+// Returns true if the finalizer was added (indicating the update should be saved immediately).
+func (t *task) addFinalizer() bool {
+	if !t.identityProvider.HasMetadata() {
+		t.identityProvider.SetMetadata(&privatev1.Metadata{})
+	}
+	list := t.identityProvider.GetMetadata().GetFinalizers()
+	if !slices.Contains(list, finalizers.Controller) {
+		list = append(list, finalizers.Controller)
+		t.identityProvider.GetMetadata().SetFinalizers(list)
+		return true
+	}
+	return false
+}
+
+// removeFinalizer removes the controller finalizer from the identity provider.
+func (t *task) removeFinalizer() {
+	if !t.identityProvider.HasMetadata() {
+		return
+	}
+	list := t.identityProvider.GetMetadata().GetFinalizers()
+	if slices.Contains(list, finalizers.Controller) {
+		list = slices.DeleteFunc(list, func(item string) bool {
+			return item == finalizers.Controller
+		})
+		t.identityProvider.GetMetadata().SetFinalizers(list)
+	}
+}
+
+// delete performs the deletion cleanup for an identity provider.
+func (t *task) delete(ctx context.Context) error {
+	// Skip if not in ready state (not synced to IDP yet)
+	if t.identityProvider.GetStatus().GetPhase() != privatev1.IdentityProviderPhase_IDENTITY_PROVIDER_PHASE_READY {
+		t.removeFinalizer()
+		return nil
+	}
+
+	// TODO: Add DeleteIdentityProvider method to idp.Client interface and implement deletion
+	// For now, we just remove the finalizer to allow the object to be deleted from the database
+	t.r.logger.WarnContext(ctx, "Identity provider deletion from IDP not yet implemented",
+		slog.String("identity_provider_id", t.identityProvider.GetId()),
+	)
+
+	t.removeFinalizer()
+	return nil
+}

--- a/internal/controllers/identityprovider/identity_provider_reconciler_function_test.go
+++ b/internal/controllers/identityprovider/identity_provider_reconciler_function_test.go
@@ -1,0 +1,761 @@
+/*
+Copyright (c) 2026 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package identityprovider
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"go.uber.org/mock/gomock"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	privatev1 "github.com/osac-project/fulfillment-service/internal/api/osac/private/v1"
+	"github.com/osac-project/fulfillment-service/internal/controllers/finalizers"
+	"github.com/osac-project/fulfillment-service/internal/idp"
+)
+
+var _ = Describe("Finalizer Management", func() {
+	It("should add finalizer on first call", func() {
+		identityProvider := privatev1.IdentityProvider_builder{
+			Metadata: privatev1.Metadata_builder{
+				Finalizers: []string{},
+			}.Build(),
+		}.Build()
+
+		task := &task{
+			identityProvider: identityProvider,
+		}
+
+		added := task.addFinalizer()
+		Expect(added).To(BeTrue())
+		Expect(identityProvider.GetMetadata().GetFinalizers()).To(ContainElement(finalizers.Controller))
+	})
+
+	It("should not add finalizer if already present", func() {
+		identityProvider := privatev1.IdentityProvider_builder{
+			Metadata: privatev1.Metadata_builder{
+				Finalizers: []string{finalizers.Controller},
+			}.Build(),
+		}.Build()
+
+		task := &task{
+			identityProvider: identityProvider,
+		}
+
+		added := task.addFinalizer()
+		Expect(added).To(BeFalse())
+		Expect(identityProvider.GetMetadata().GetFinalizers()).To(HaveLen(1))
+	})
+
+	It("should return immediately after adding finalizer", func() {
+		identityProvider := privatev1.IdentityProvider_builder{
+			Metadata: privatev1.Metadata_builder{
+				Name:   "test-idp",
+				Tenant: "tenant-1",
+			}.Build(),
+		}.Build()
+
+		task := &task{
+			identityProvider: identityProvider,
+		}
+
+		err := task.update(context.Background())
+		Expect(err).ToNot(HaveOccurred())
+
+		Expect(identityProvider.GetMetadata().GetFinalizers()).To(ContainElement(finalizers.Controller))
+		Expect(identityProvider.HasStatus()).To(BeFalse())
+	})
+
+	It("should initialize metadata when adding finalizer if not present", func() {
+		identityProvider := privatev1.IdentityProvider_builder{}.Build()
+
+		task := &task{
+			identityProvider: identityProvider,
+		}
+
+		added := task.addFinalizer()
+		Expect(added).To(BeTrue())
+		Expect(identityProvider.HasMetadata()).To(BeTrue())
+		Expect(identityProvider.GetMetadata().GetFinalizers()).To(ContainElement(finalizers.Controller))
+	})
+})
+
+var _ = Describe("Default Values", func() {
+	It("should set default status if missing", func() {
+		identityProvider := privatev1.IdentityProvider_builder{}.Build()
+
+		task := &task{
+			identityProvider: identityProvider,
+		}
+
+		task.setDefaults()
+		Expect(identityProvider.HasStatus()).To(BeTrue())
+		Expect(identityProvider.GetStatus().GetPhase()).To(Equal(privatev1.IdentityProviderPhase_IDENTITY_PROVIDER_PHASE_UNKNOWN))
+	})
+
+	It("should set default phase if unspecified", func() {
+		identityProvider := privatev1.IdentityProvider_builder{
+			Status: privatev1.IdentityProviderStatus_builder{}.Build(),
+		}.Build()
+
+		task := &task{
+			identityProvider: identityProvider,
+		}
+
+		task.setDefaults()
+		Expect(identityProvider.GetStatus().GetPhase()).To(Equal(privatev1.IdentityProviderPhase_IDENTITY_PROVIDER_PHASE_UNKNOWN))
+	})
+
+	It("should not override existing phase", func() {
+		identityProvider := privatev1.IdentityProvider_builder{
+			Status: privatev1.IdentityProviderStatus_builder{
+				Phase: privatev1.IdentityProviderPhase_IDENTITY_PROVIDER_PHASE_READY,
+			}.Build(),
+		}.Build()
+
+		task := &task{
+			identityProvider: identityProvider,
+		}
+
+		task.setDefaults()
+		Expect(identityProvider.GetStatus().GetPhase()).To(Equal(privatev1.IdentityProviderPhase_IDENTITY_PROVIDER_PHASE_READY))
+	})
+})
+
+var _ = Describe("Tenant Validation", func() {
+	It("should succeed when tenant is set to a valid organization", func() {
+		identityProvider := privatev1.IdentityProvider_builder{
+			Metadata: privatev1.Metadata_builder{
+				Tenant: "my-org",
+			}.Build(),
+		}.Build()
+
+		task := &task{
+			identityProvider: identityProvider,
+		}
+
+		err := task.validateTenant()
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	It("should fail when tenant is empty", func() {
+		identityProvider := privatev1.IdentityProvider_builder{
+			Metadata: privatev1.Metadata_builder{}.Build(),
+		}.Build()
+
+		task := &task{
+			identityProvider: identityProvider,
+		}
+
+		err := task.validateTenant()
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("must have a tenant assigned"))
+	})
+
+	It("should fail when metadata is missing", func() {
+		identityProvider := privatev1.IdentityProvider_builder{}.Build()
+
+		task := &task{
+			identityProvider: identityProvider,
+		}
+
+		err := task.validateTenant()
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("must have a tenant assigned"))
+	})
+
+	It("should fail when tenant is 'shared'", func() {
+		identityProvider := privatev1.IdentityProvider_builder{
+			Metadata: privatev1.Metadata_builder{
+				Tenant: "shared",
+			}.Build(),
+		}.Build()
+
+		task := &task{
+			identityProvider: identityProvider,
+		}
+
+		err := task.validateTenant()
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("cannot belong to 'shared' tenant"))
+	})
+
+	It("should fail when tenant is 'system'", func() {
+		identityProvider := privatev1.IdentityProvider_builder{
+			Metadata: privatev1.Metadata_builder{
+				Tenant: "system",
+			}.Build(),
+		}.Build()
+
+		task := &task{
+			identityProvider: identityProvider,
+		}
+
+		err := task.validateTenant()
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("cannot belong to 'system' tenant"))
+	})
+})
+
+var _ = Describe("Provider Type Detection", func() {
+	It("should return ldap for LDAP config", func() {
+		identityProvider := privatev1.IdentityProvider_builder{
+			Spec: privatev1.IdentityProviderSpec_builder{
+				Ldap: privatev1.LdapConfig_builder{
+					ConnectionUrl: "ldap://example.com",
+				}.Build(),
+			}.Build(),
+		}.Build()
+
+		task := &task{
+			identityProvider: identityProvider,
+		}
+
+		providerType := task.determineProviderType()
+		Expect(providerType).To(Equal("ldap"))
+	})
+
+	It("should return oidc for OIDC config", func() {
+		identityProvider := privatev1.IdentityProvider_builder{
+			Spec: privatev1.IdentityProviderSpec_builder{
+				Oidc: privatev1.OidcConfig_builder{
+					Issuer: "https://example.com",
+				}.Build(),
+			}.Build(),
+		}.Build()
+
+		task := &task{
+			identityProvider: identityProvider,
+		}
+
+		providerType := task.determineProviderType()
+		Expect(providerType).To(Equal("oidc"))
+	})
+
+	It("should return empty string when no config is set", func() {
+		identityProvider := privatev1.IdentityProvider_builder{
+			Spec: privatev1.IdentityProviderSpec_builder{}.Build(),
+		}.Build()
+
+		task := &task{
+			identityProvider: identityProvider,
+		}
+
+		providerType := task.determineProviderType()
+		Expect(providerType).To(BeEmpty())
+	})
+
+	It("should prioritize LDAP when both configs are set", func() {
+		identityProvider := privatev1.IdentityProvider_builder{
+			Spec: privatev1.IdentityProviderSpec_builder{
+				Ldap: privatev1.LdapConfig_builder{
+					ConnectionUrl: "ldap://example.com",
+				}.Build(),
+				Oidc: privatev1.OidcConfig_builder{
+					Issuer: "https://example.com",
+				}.Build(),
+			}.Build(),
+		}.Build()
+
+		task := &task{
+			identityProvider: identityProvider,
+		}
+
+		providerType := task.determineProviderType()
+		Expect(providerType).To(Equal("ldap"))
+	})
+})
+
+var _ = Describe("Config Building", func() {
+	It("should build LDAP config correctly", func() {
+		identityProvider := privatev1.IdentityProvider_builder{
+			Spec: privatev1.IdentityProviderSpec_builder{
+				Ldap: privatev1.LdapConfig_builder{
+					ConnectionUrl:  "ldap://example.com:389",
+					BindDn:         "cn=admin,dc=example,dc=com",
+					BindCredential: "secret",
+					UsersDn:        "ou=users,dc=example,dc=com",
+				}.Build(),
+			}.Build(),
+		}.Build()
+
+		task := &task{
+			identityProvider: identityProvider,
+		}
+
+		config := task.buildConfig()
+		Expect(config).To(HaveKeyWithValue("connectionUrl", "ldap://example.com:389"))
+		Expect(config).To(HaveKeyWithValue("bindDn", "cn=admin,dc=example,dc=com"))
+		Expect(config).To(HaveKeyWithValue("bindCredential", "secret"))
+		Expect(config).To(HaveKeyWithValue("usersDn", "ou=users,dc=example,dc=com"))
+	})
+
+	It("should build OIDC config correctly", func() {
+		identityProvider := privatev1.IdentityProvider_builder{
+			Spec: privatev1.IdentityProviderSpec_builder{
+				Oidc: privatev1.OidcConfig_builder{
+					AuthorizationUrl: "https://example.com/auth",
+					TokenUrl:         "https://example.com/token",
+					ClientId:         "client-123",
+					ClientSecret:     "secret-456",
+					Issuer:           "https://example.com",
+				}.Build(),
+			}.Build(),
+		}.Build()
+
+		task := &task{
+			identityProvider: identityProvider,
+		}
+
+		config := task.buildConfig()
+		Expect(config).To(HaveKeyWithValue("authorizationUrl", "https://example.com/auth"))
+		Expect(config).To(HaveKeyWithValue("tokenUrl", "https://example.com/token"))
+		Expect(config).To(HaveKeyWithValue("clientId", "client-123"))
+		Expect(config).To(HaveKeyWithValue("clientSecret", "secret-456"))
+		Expect(config).To(HaveKeyWithValue("issuer", "https://example.com"))
+	})
+
+	It("should return empty config when no provider is configured", func() {
+		identityProvider := privatev1.IdentityProvider_builder{
+			Spec: privatev1.IdentityProviderSpec_builder{}.Build(),
+		}.Build()
+
+		task := &task{
+			identityProvider: identityProvider,
+		}
+
+		config := task.buildConfig()
+		Expect(config).To(BeEmpty())
+	})
+})
+
+var _ = Describe("IDP Sync", func() {
+	var (
+		ctrl       *gomock.Controller
+		mockClient *idp.MockClient
+		reconciler *function
+	)
+
+	BeforeEach(func() {
+		ctrl = gomock.NewController(GinkgoT())
+		mockClient = idp.NewMockClient(ctrl)
+
+		reconciler = &function{
+			logger:    logger,
+			idpClient: mockClient,
+		}
+	})
+
+	AfterEach(func() {
+		ctrl.Finish()
+	})
+
+	It("should sync identity provider to IDP successfully with LDAP config", func() {
+		identityProvider := privatev1.IdentityProvider_builder{
+			Id: "idp-123",
+			Metadata: privatev1.Metadata_builder{
+				Name:       "corporate-ldap",
+				Tenant:     "tenant-1",
+				Finalizers: []string{finalizers.Controller},
+			}.Build(),
+			Spec: privatev1.IdentityProviderSpec_builder{
+				Title:   "Corporate LDAP",
+				Enabled: true,
+				Ldap: privatev1.LdapConfig_builder{
+					ConnectionUrl:  "ldap://ldap.example.com:389",
+					BindDn:         "cn=admin,dc=example,dc=com",
+					BindCredential: "secret",
+					UsersDn:        "ou=users,dc=example,dc=com",
+				}.Build(),
+			}.Build(),
+		}.Build()
+
+		mockClient.EXPECT().
+			CreateIdentityProvider(gomock.Any(), gomock.Any()).
+			DoAndReturn(func(ctx context.Context, idpProvider *idp.IdentityProvider) (*idp.IdentityProvider, error) {
+				Expect(idpProvider.Alias).To(Equal("tenant-1-corporate-ldap"))
+				Expect(idpProvider.DisplayName).To(Equal("Corporate LDAP"))
+				Expect(idpProvider.Type).To(Equal("ldap"))
+				Expect(idpProvider.Enabled).To(BeTrue())
+				Expect(idpProvider.Config).To(HaveKeyWithValue("connectionUrl", "ldap://ldap.example.com:389"))
+				Expect(idpProvider.Config).To(HaveKeyWithValue("bindDn", "cn=admin,dc=example,dc=com"))
+				return idpProvider, nil
+			}).
+			Times(1)
+
+		task := &task{
+			r:                reconciler,
+			identityProvider: identityProvider,
+		}
+
+		err := task.update(ctx)
+		Expect(err).ToNot(HaveOccurred())
+
+		Expect(identityProvider.GetStatus().GetPhase()).To(Equal(privatev1.IdentityProviderPhase_IDENTITY_PROVIDER_PHASE_READY))
+		Expect(identityProvider.GetStatus().GetMessage()).To(ContainSubstring("Identity provider created successfully"))
+		Expect(identityProvider.GetStatus().GetMessage()).To(ContainSubstring("tenant-1-corporate-ldap"))
+	})
+
+	It("should sync identity provider with OIDC config", func() {
+		identityProvider := privatev1.IdentityProvider_builder{
+			Id: "idp-456",
+			Metadata: privatev1.Metadata_builder{
+				Name:       "google-sso",
+				Tenant:     "tenant-2",
+				Finalizers: []string{finalizers.Controller},
+			}.Build(),
+			Spec: privatev1.IdentityProviderSpec_builder{
+				Title:   "Google SSO",
+				Enabled: true,
+				Oidc: privatev1.OidcConfig_builder{
+					AuthorizationUrl: "https://accounts.google.com/o/oauth2/auth",
+					TokenUrl:         "https://oauth2.googleapis.com/token",
+					ClientId:         "client-123",
+					ClientSecret:     "secret-456",
+					Issuer:           "https://accounts.google.com",
+				}.Build(),
+			}.Build(),
+		}.Build()
+
+		mockClient.EXPECT().
+			CreateIdentityProvider(gomock.Any(), gomock.Any()).
+			DoAndReturn(func(ctx context.Context, idpProvider *idp.IdentityProvider) (*idp.IdentityProvider, error) {
+				Expect(idpProvider.Alias).To(Equal("tenant-2-google-sso"))
+				Expect(idpProvider.DisplayName).To(Equal("Google SSO"))
+				Expect(idpProvider.Type).To(Equal("oidc"))
+				Expect(idpProvider.Enabled).To(BeTrue())
+				Expect(idpProvider.Config).To(HaveKeyWithValue("issuer", "https://accounts.google.com"))
+				return idpProvider, nil
+			}).
+			Times(1)
+
+		task := &task{
+			r:                reconciler,
+			identityProvider: identityProvider,
+		}
+
+		err := task.update(ctx)
+		Expect(err).ToNot(HaveOccurred())
+
+		Expect(identityProvider.GetStatus().GetPhase()).To(Equal(privatev1.IdentityProviderPhase_IDENTITY_PROVIDER_PHASE_READY))
+	})
+
+	It("should use tenant-prefixed alias", func() {
+		identityProvider := privatev1.IdentityProvider_builder{
+			Metadata: privatev1.Metadata_builder{
+				Name:       "test-idp",
+				Tenant:     "my-tenant",
+				Finalizers: []string{finalizers.Controller},
+			}.Build(),
+			Spec: privatev1.IdentityProviderSpec_builder{
+				Title:   "Test IDP",
+				Enabled: true,
+				Ldap: privatev1.LdapConfig_builder{
+					ConnectionUrl: "ldap://example.com",
+				}.Build(),
+			}.Build(),
+		}.Build()
+
+		mockClient.EXPECT().
+			CreateIdentityProvider(gomock.Any(), gomock.Any()).
+			DoAndReturn(func(ctx context.Context, idpProvider *idp.IdentityProvider) (*idp.IdentityProvider, error) {
+				Expect(idpProvider.Alias).To(Equal("my-tenant-test-idp"))
+				return idpProvider, nil
+			}).
+			Times(1)
+
+		task := &task{
+			r:                reconciler,
+			identityProvider: identityProvider,
+		}
+
+		err := task.update(ctx)
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	It("should set ERROR state on IDP creation failure", func() {
+		identityProvider := privatev1.IdentityProvider_builder{
+			Metadata: privatev1.Metadata_builder{
+				Name:       "test-ldap",
+				Tenant:     "tenant-1",
+				Finalizers: []string{finalizers.Controller},
+			}.Build(),
+			Spec: privatev1.IdentityProviderSpec_builder{
+				Title: "Test LDAP",
+				Ldap: privatev1.LdapConfig_builder{
+					ConnectionUrl: "ldap://example.com",
+				}.Build(),
+			}.Build(),
+		}.Build()
+
+		mockClient.EXPECT().
+			CreateIdentityProvider(gomock.Any(), gomock.Any()).
+			Return(nil, fmt.Errorf("IDP connection timeout")).
+			Times(1)
+
+		task := &task{
+			r:                reconciler,
+			identityProvider: identityProvider,
+		}
+
+		err := task.update(ctx)
+		Expect(err).ToNot(HaveOccurred())
+
+		Expect(identityProvider.GetStatus().GetPhase()).To(Equal(privatev1.IdentityProviderPhase_IDENTITY_PROVIDER_PHASE_ERROR))
+		Expect(identityProvider.GetStatus().GetMessage()).To(ContainSubstring("Identity provider creation in IDP failed"))
+		Expect(identityProvider.GetStatus().GetMessage()).To(ContainSubstring("IDP connection timeout"))
+	})
+
+	It("should not return error on IDP failure", func() {
+		identityProvider := privatev1.IdentityProvider_builder{
+			Metadata: privatev1.Metadata_builder{
+				Name:       "test-idp",
+				Tenant:     "tenant-1",
+				Finalizers: []string{finalizers.Controller},
+			}.Build(),
+			Spec: privatev1.IdentityProviderSpec_builder{
+				Ldap: privatev1.LdapConfig_builder{
+					ConnectionUrl: "ldap://example.com",
+				}.Build(),
+			}.Build(),
+		}.Build()
+
+		mockClient.EXPECT().
+			CreateIdentityProvider(gomock.Any(), gomock.Any()).
+			Return(nil, fmt.Errorf("identity provider already exists")).
+			Times(1)
+
+		task := &task{
+			r:                reconciler,
+			identityProvider: identityProvider,
+		}
+
+		err := task.update(ctx)
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	It("should sync disabled identity provider", func() {
+		identityProvider := privatev1.IdentityProvider_builder{
+			Metadata: privatev1.Metadata_builder{
+				Name:       "disabled-ldap",
+				Tenant:     "tenant-1",
+				Finalizers: []string{finalizers.Controller},
+			}.Build(),
+			Spec: privatev1.IdentityProviderSpec_builder{
+				Title:   "Disabled LDAP",
+				Enabled: false,
+				Ldap: privatev1.LdapConfig_builder{
+					ConnectionUrl: "ldap://example.com",
+				}.Build(),
+			}.Build(),
+		}.Build()
+
+		mockClient.EXPECT().
+			CreateIdentityProvider(gomock.Any(), gomock.Any()).
+			DoAndReturn(func(ctx context.Context, idpProvider *idp.IdentityProvider) (*idp.IdentityProvider, error) {
+				Expect(idpProvider.Enabled).To(BeFalse())
+				return idpProvider, nil
+			}).
+			Times(1)
+
+		task := &task{
+			r:                reconciler,
+			identityProvider: identityProvider,
+		}
+
+		err := task.update(ctx)
+		Expect(err).ToNot(HaveOccurred())
+
+		Expect(identityProvider.GetStatus().GetPhase()).To(Equal(privatev1.IdentityProviderPhase_IDENTITY_PROVIDER_PHASE_READY))
+	})
+})
+
+var _ = Describe("Skip Reconciliation", func() {
+	It("should skip reconciliation for ready identity providers", func() {
+		identityProvider := privatev1.IdentityProvider_builder{
+			Metadata: privatev1.Metadata_builder{
+				Tenant:     "my-org",
+				Finalizers: []string{finalizers.Controller},
+			}.Build(),
+			Status: privatev1.IdentityProviderStatus_builder{
+				Phase: privatev1.IdentityProviderPhase_IDENTITY_PROVIDER_PHASE_READY,
+			}.Build(),
+		}.Build()
+
+		task := &task{
+			identityProvider: identityProvider,
+		}
+
+		err := task.update(context.Background())
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	It("should skip reconciliation for error state identity providers", func() {
+		identityProvider := privatev1.IdentityProvider_builder{
+			Metadata: privatev1.Metadata_builder{
+				Tenant:     "my-org",
+				Finalizers: []string{finalizers.Controller},
+			}.Build(),
+			Status: privatev1.IdentityProviderStatus_builder{
+				Phase:   privatev1.IdentityProviderPhase_IDENTITY_PROVIDER_PHASE_ERROR,
+				Message: "Previous sync failed",
+			}.Build(),
+		}.Build()
+
+		task := &task{
+			identityProvider: identityProvider,
+		}
+
+		err := task.update(context.Background())
+		Expect(err).ToNot(HaveOccurred())
+	})
+})
+
+var _ = Describe("Deletion", func() {
+	var (
+		ctrl       *gomock.Controller
+		mockClient *idp.MockClient
+		reconciler *function
+	)
+
+	BeforeEach(func() {
+		ctrl = gomock.NewController(GinkgoT())
+		mockClient = idp.NewMockClient(ctrl)
+
+		reconciler = &function{
+			logger:    logger,
+			idpClient: mockClient,
+		}
+	})
+
+	AfterEach(func() {
+		ctrl.Finish()
+	})
+
+	It("should remove finalizer when identity provider not synced", func() {
+		deletionTimestamp := timestamppb.New(time.Now())
+		identityProvider := privatev1.IdentityProvider_builder{
+			Metadata: privatev1.Metadata_builder{
+				Name:              "test-idp",
+				Finalizers:        []string{finalizers.Controller},
+				DeletionTimestamp: deletionTimestamp,
+			}.Build(),
+			Status: privatev1.IdentityProviderStatus_builder{
+				Phase: privatev1.IdentityProviderPhase_IDENTITY_PROVIDER_PHASE_UNKNOWN,
+			}.Build(),
+		}.Build()
+
+		task := &task{
+			r:                reconciler,
+			identityProvider: identityProvider,
+		}
+
+		err := task.delete(ctx)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(identityProvider.GetMetadata().GetFinalizers()).ToNot(ContainElement(finalizers.Controller))
+	})
+
+	It("should remove finalizer when in ERROR state", func() {
+		deletionTimestamp := timestamppb.New(time.Now())
+		identityProvider := privatev1.IdentityProvider_builder{
+			Metadata: privatev1.Metadata_builder{
+				Name:              "test-idp",
+				Finalizers:        []string{finalizers.Controller},
+				DeletionTimestamp: deletionTimestamp,
+			}.Build(),
+			Status: privatev1.IdentityProviderStatus_builder{
+				Phase: privatev1.IdentityProviderPhase_IDENTITY_PROVIDER_PHASE_ERROR,
+			}.Build(),
+		}.Build()
+
+		task := &task{
+			r:                reconciler,
+			identityProvider: identityProvider,
+		}
+
+		err := task.delete(ctx)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(identityProvider.GetMetadata().GetFinalizers()).ToNot(ContainElement(finalizers.Controller))
+	})
+
+	It("should log warning when deleting READY identity provider", func() {
+		deletionTimestamp := timestamppb.New(time.Now())
+		identityProvider := privatev1.IdentityProvider_builder{
+			Id: "idp-123",
+			Metadata: privatev1.Metadata_builder{
+				Name:              "test-idp",
+				Finalizers:        []string{finalizers.Controller},
+				DeletionTimestamp: deletionTimestamp,
+			}.Build(),
+			Status: privatev1.IdentityProviderStatus_builder{
+				Phase: privatev1.IdentityProviderPhase_IDENTITY_PROVIDER_PHASE_READY,
+			}.Build(),
+		}.Build()
+
+		task := &task{
+			r:                reconciler,
+			identityProvider: identityProvider,
+		}
+
+		err := task.delete(ctx)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(identityProvider.GetMetadata().GetFinalizers()).ToNot(ContainElement(finalizers.Controller))
+	})
+
+	It("should remove finalizer when called", func() {
+		identityProvider := privatev1.IdentityProvider_builder{
+			Metadata: privatev1.Metadata_builder{
+				Finalizers: []string{finalizers.Controller, "other-finalizer"},
+			}.Build(),
+		}.Build()
+
+		task := &task{
+			identityProvider: identityProvider,
+		}
+
+		task.removeFinalizer()
+		Expect(identityProvider.GetMetadata().GetFinalizers()).ToNot(ContainElement(finalizers.Controller))
+		Expect(identityProvider.GetMetadata().GetFinalizers()).To(ContainElement("other-finalizer"))
+	})
+
+	It("should handle removal when finalizer not present", func() {
+		identityProvider := privatev1.IdentityProvider_builder{
+			Metadata: privatev1.Metadata_builder{
+				Finalizers: []string{"other-finalizer"},
+			}.Build(),
+		}.Build()
+
+		task := &task{
+			identityProvider: identityProvider,
+		}
+
+		task.removeFinalizer()
+		Expect(identityProvider.GetMetadata().GetFinalizers()).To(HaveLen(1))
+		Expect(identityProvider.GetMetadata().GetFinalizers()).To(ContainElement("other-finalizer"))
+	})
+
+	It("should handle removal when metadata is not present", func() {
+		identityProvider := privatev1.IdentityProvider_builder{}.Build()
+
+		task := &task{
+			identityProvider: identityProvider,
+		}
+
+		task.removeFinalizer()
+		Expect(identityProvider.HasMetadata()).To(BeFalse())
+	})
+})

--- a/internal/controllers/identityprovider/identity_provider_suite_test.go
+++ b/internal/controllers/identityprovider/identity_provider_suite_test.go
@@ -1,0 +1,41 @@
+/*
+Copyright (c) 2026 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package identityprovider
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var (
+	ctx    context.Context
+	logger *slog.Logger
+)
+
+func TestIdentityProvider(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Identity Provider Suite")
+}
+
+var _ = BeforeSuite(func() {
+	ctx = context.Background()
+	logger = slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{
+		Level: slog.LevelDebug,
+	}))
+})


### PR DESCRIPTION
# Description
The controllers will reconcile the IDP objects and call associated APIs to create the IDP in Keycloak.

Currently, these changes target creating an IDP. Update and Delete will be implemented in later patches.

# Testing

- [x] unit tests pass
- [x] go build passes
- [x] integration test
    - Created integration environment with changes
    - Created IDP (see below)
    - Verified it was created in Keycloak console and we're able to see it using the CLI
    - Verified Phase ready

```yaml
"@type": "type.googleapis.com/osac.private.v1.IdentityProvider"
metadata:
  name: "test-oidc"
  tenant: "test-org"
spec:
  title: "Test OIDC"
  enabled: true
  oidc:
    authorizationUrl: "https://oidc.example.com/authorize"
    tokenUrl: "https://oidc.example.com/token"
    clientId: "test-client"
    clientSecret: "secret"
    issuer: "https://oidc.example.com"
```

Status after creation
```yaml
  status:
    message: 'Identity provider created successfully with alias: test-org-test-oidc'
    phase: IDENTITY_PROVIDER_PHASE_READY
```

Assisted-by: Claude Code <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added management of Identity Provider resources with an always-on reconciler.
  * Automatically synchronizes identity providers to the backend for LDAP and OIDC, including update masking and tenant/provider validation.
  * Enhances lifecycle handling with finalizers plus status/phase defaults for missing or unspecified values.
* **Tests**
  * Added a Ginkgo/Gomega test suite covering task routing (update/delete), finalizer behavior, validation rules, config generation, update masking, and reconciliation skip conditions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->