### PR TITLE
OSAC-1644: Make emergency service accounts configurable

### DIFF
--- a/charts/service/templates/grpc-server/deployment.yaml
+++ b/charts/service/templates/grpc-server/deployment.yaml
@@ -125,6 +125,7 @@ spec:
         - --grpc-listener-tls-crt=/etc/fulfillment-grpc-server/tls/tls.crt
         - --grpc-listener-tls-key=/etc/fulfillment-grpc-server/tls/tls.key
         - --grpc-authn-trusted-token-issuers={{ required "auth.issuerUrl is required" .Values.auth.issuerUrl }}
+        - --emergency-service-accounts={{ join "," .Values.auth.emergencyServiceAccounts }}
         - --grpc-authn-type=external
         - --grpc-authn-external-address=authorino-authorino-authorization:50051
         - --tenancy-logic=default

--- a/charts/service/values.yaml
+++ b/charts/service/values.yaml
@@ -80,6 +80,12 @@ auth:
   # identifier is in an `id` key but the credential parameter name is `client-id`.
   controllerCredentials:
 
+  # List of names of Kubernetes service accounts that are allowed to access the private API with administrator
+  # permissions. These are intended only for emergency situations, for example when the regular authentication
+  # mechanisms are not working. The service accounts are expected to be in the namespace where the service is deployed.
+  emergencyServiceAccounts:
+  - admin
+
 # Logging configuration:
 log:
 

--- a/internal/auth/grpc_authz_interceptor.go
+++ b/internal/auth/grpc_authz_interceptor.go
@@ -31,6 +31,7 @@ import (
 	"google.golang.org/grpc/metadata"
 	grpcstatus "google.golang.org/grpc/status"
 	"google.golang.org/protobuf/proto"
+	"k8s.io/apimachinery/pkg/util/validation"
 
 	"github.com/osac-project/fulfillment-service/internal/collections"
 	k8sfiles "github.com/osac-project/fulfillment-service/internal/kubernetes/files"
@@ -47,10 +48,11 @@ type MetadataFetcher func(ctx context.Context, id string) (tenant, project strin
 // using an embedded Rego policy evaluated with the OPA library. Don't create instances of this type directly, use the
 // NewGrpcAuthzInterceptor function instead.
 type GrpcAuthzInterceptorBuilder struct {
-	logger           *slog.Logger
-	anonymousMethods []string
-	inputCallback    func(ctx context.Context, input map[string]any) error
-	metadataFetcher  MetadataFetcher
+	logger                   *slog.Logger
+	anonymousMethods         []string
+	inputCallback            func(ctx context.Context, input map[string]any) error
+	metadataFetcher          MetadataFetcher
+	emergencyServiceAccounts []string
 }
 
 // GrpcAuthzInterceptor is a gRPC interceptor that evaluates an embedded Rego policy for authorization. It reads the
@@ -104,6 +106,15 @@ func (b *GrpcAuthzInterceptorBuilder) SetMetadataFetcher(value MetadataFetcher) 
 	return b
 }
 
+// AddEmergencyServiceAccounts adds Kubernetes service account names that are allowed to access the private API with
+// administrator permissions. These are intended only for emergency situations, for example when the regular
+// authentication mechanisms are not working.
+func (b *GrpcAuthzInterceptorBuilder) AddEmergencyServiceAccounts(
+	values ...string) *GrpcAuthzInterceptorBuilder {
+	b.emergencyServiceAccounts = append(b.emergencyServiceAccounts, values...)
+	return b
+}
+
 // Build uses the data stored in the builder to create and configure a new interceptor.
 func (b *GrpcAuthzInterceptorBuilder) Build() (result *GrpcAuthzInterceptor, err error) {
 	if b.logger == nil {
@@ -141,9 +152,29 @@ func (b *GrpcAuthzInterceptorBuilder) Build() (result *GrpcAuthzInterceptor, err
 		}
 	}
 
+	// Validate and build the full Kubernetes service account names for the emergency accounts:
+	emergencyServiceAccounts := make([]any, 0, len(b.emergencyServiceAccounts))
+	for _, emergencyServiceAccount := range b.emergencyServiceAccounts {
+		emergencyServiceAccount = strings.TrimSpace(emergencyServiceAccount)
+		errs := validation.IsDNS1123Subdomain(emergencyServiceAccount)
+		if len(errs) > 0 {
+			err = fmt.Errorf(
+				"emergency service account name '%s' is not a valid Kubernetes service account name",
+				emergencyServiceAccount,
+			)
+			return
+		}
+
+		emergencyServiceAccountName := fmt.Sprintf(
+			"system:serviceaccount:%s:%s",
+			nsName, emergencyServiceAccount,
+		)
+		emergencyServiceAccounts = append(emergencyServiceAccounts, emergencyServiceAccountName)
+	}
+
 	// Build external data for the policy:
 	policyData := inmem.NewFromObject(map[string]any{
-		"namespace": nsName,
+		"emergency_service_accounts": emergencyServiceAccounts,
 	})
 
 	// Prepare the Rego query by compiling the embedded policy once. The query evaluates all exported variables in

--- a/internal/auth/grpc_authz_interceptor_test.go
+++ b/internal/auth/grpc_authz_interceptor_test.go
@@ -48,6 +48,51 @@ var _ = Describe("Rego authorization interceptor", func() {
 			Expect(err.Error()).To(ContainSubstring("logger is mandatory"))
 			Expect(interceptor).To(BeNil())
 		})
+
+		It("Rejects empty emergency service account name", func() {
+			_, err := NewGrpcAuthzInterceptor().
+				SetLogger(logger).
+				AddEmergencyServiceAccounts("").
+				Build()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("not a valid Kubernetes service account name"))
+		})
+
+		It("Rejects whitespace-only emergency service account name", func() {
+			_, err := NewGrpcAuthzInterceptor().
+				SetLogger(logger).
+				AddEmergencyServiceAccounts("  ").
+				Build()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("not a valid Kubernetes service account name"))
+		})
+
+		It("Rejects emergency service account name with colon", func() {
+			_, err := NewGrpcAuthzInterceptor().
+				SetLogger(logger).
+				AddEmergencyServiceAccounts("system:admin").
+				Build()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("not a valid Kubernetes service account name"))
+		})
+
+		It("Rejects emergency service account name with uppercase", func() {
+			_, err := NewGrpcAuthzInterceptor().
+				SetLogger(logger).
+				AddEmergencyServiceAccounts("Admin").
+				Build()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("not a valid Kubernetes service account name"))
+		})
+
+		It("Rejects emergency service account name starting with hyphen", func() {
+			_, err := NewGrpcAuthzInterceptor().
+				SetLogger(logger).
+				AddEmergencyServiceAccounts("-admin").
+				Build()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("not a valid Kubernetes service account name"))
+		})
 	})
 
 	Describe("Permission checks", func() {
@@ -132,6 +177,12 @@ var _ = Describe("Rego authorization interceptor", func() {
 				AddAnonymousMethodRegex(`^/grpc\.health\.v1\.Health/.*$`).
 				AddAnonymousMethodRegex(`^/grpc\.reflection\.v1\.ServerReflection/.*$`).
 				AddAnonymousMethodRegex(`^/osac\.public\.v1\.Capabilities/.*$`).
+				AddEmergencyServiceAccounts(
+					"admin",
+					"osac-operator",
+					"osac-operator-controller-manager",
+					"template-publisher",
+				).
 				Build()
 			Expect(err).ToNot(HaveOccurred())
 		})
@@ -249,6 +300,10 @@ var _ = Describe("Rego authorization interceptor", func() {
 			),
 			Entry(
 				"Controller manager",
+				"osac", "osac-operator",
+			),
+			Entry(
+				"Alternative controller manager",
 				"osac", "osac-operator-controller-manager",
 			),
 		)

--- a/internal/auth/policies/authz.rego
+++ b/internal/auth/policies/authz.rego
@@ -18,20 +18,9 @@ import rego.v1
 default allow := false
 
 # Emergency service accounts are Kubernetes service accounts that are allowed to act as administrators in case of
-# emergency situations where it isn't possible to get a valid JWT token from the identity provider.
-#
-# TODO: The 'template-publisher' 'osac-operator' and 'osac-operator-controller-manager' service accounts are used by the
-# template publisher and by the OSAC operator. That assumes that they are in the same Kubernetes clusters, which is
-# wrong, but we need it for now. They should be replaced with Keycloak service accounts.
-emergency_service_account_names := {
-  "admin",
-  "osac-operator",
-  "osac-operator-controller-manager",
-  "template-publisher",
-}
-emergency_service_accounts contains sprintf("system:serviceaccount:%s:%s", [data.namespace, name]) if {
-  some name in emergency_service_account_names
-}
+# emergency situations where it isn't possible to get a valid JWT token from the identity provider. The full service
+# account names are provided via the external data passed to the policy.
+emergency_service_accounts := {name | some name in data.emergency_service_accounts}
 
 # Admin service accounts are service accounts that are allowed to act as administrators.
 admin_service_accounts := {

--- a/internal/cmd/service/start/grpcserver/start_grpc_server_cmd.go
+++ b/internal/cmd/service/start/grpcserver/start_grpc_server_cmd.go
@@ -147,6 +147,17 @@ func Cmd() *cobra.Command {
 		"",
 		tokenIssuerFlagHelp,
 	)
+	flags.StringSliceVar(
+		&runner.args.emergencyServiceAccounts,
+		"emergency-service-accounts",
+		[]string{
+			"admin",
+			"osac-operator",
+			"osac-operator-controller-manager",
+			"template-publisher",
+		},
+		emergencyServiceAccountsFlagHelp,
+	)
 	network.AddGrpcKeepaliveFlags(flags)
 	return command
 }
@@ -156,15 +167,16 @@ type runnerContext struct {
 	logger *slog.Logger
 	flags  *pflag.FlagSet
 	args   struct {
-		caFiles             []string
-		authType            string
-		externalAuthAddress string
-		trustedTokenIssuers []string
-		tenancyLogic        string
-		tokenSignerCrt      string
-		tokenSignerKey      string
-		tokenEncryptionCrt  string
-		tokenIssuer         string
+		caFiles                  []string
+		authType                 string
+		externalAuthAddress      string
+		trustedTokenIssuers      []string
+		tenancyLogic             string
+		tokenSignerCrt           string
+		tokenSignerKey           string
+		tokenEncryptionCrt       string
+		tokenIssuer              string
+		emergencyServiceAccounts []string
 	}
 }
 
@@ -302,6 +314,7 @@ func (c *runnerContext) run(cmd *cobra.Command, argv []string) error { //nolint:
 		SetLogger(c.logger).
 		AddAnonymousMethodRegex(anonymousMethodsRegex).
 		SetMetadataFetcher(metadataFetcher).
+		AddEmergencyServiceAccounts(c.args.emergencyServiceAccounts...).
 		Build()
 	if err != nil {
 		return fmt.Errorf("failed to create Rego authorization interceptor: %w", err)
@@ -1358,4 +1371,10 @@ of the token recipient. Used to encrypt the JWE envelope of issued tokens.
 const tokenIssuerFlagHelp = `
 _URL_ - Issuer URL for JWT tokens. Used as the iss claim. Token
 consumers derive the JWKS endpoint as <issuer>/.well-known/jwks.json.
+`
+
+const emergencyServiceAccountsFlagHelp = `
+_NAMES_ - Comma-separated list of Kubernetes service account names that are allowed to access the private API with
+administrator permissions. These are intended only for emergency situations, for example when the regular authentication
+mechanisms are not working. The service accounts are expected to be in the namespace where the service is deployed.
 `


### PR DESCRIPTION
## Summary

- Makes the list of emergency Kubernetes service accounts configurable instead of hardcoded in the Rego policy.
- Adds a new `--emergency-service-accounts` CLI flag (comma-separated names) and a corresponding `auth.emergencyServiceAccounts` Helm value (defaulting to `["admin"]`).
- The `GrpcAuthzInterceptorBuilder` gains an `AddEmergencyServiceAccounts` method that builds full `system:serviceaccount:<ns>:<name>` strings and passes them to the Rego policy as external data.

## Test plan

- [x] Existing unit tests updated to pass emergency service account names explicitly and all 192 auth tests pass.
- [x] Deploy with custom `auth.emergencyServiceAccounts` values and verify only the listed accounts get admin access.

Related: https://redhat.atlassian.net/browse/OSAC-1644

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable “emergency” Kubernetes service accounts with administrator access to the private API.
  * Introduced `--emergency-service-accounts` (comma-separated) with sensible defaults, plus Helm setting `auth.emergencyServiceAccounts`.
* **Security / Authorization**
  * Authorization now matches the full Kubernetes service account identities provided in the configuration, rejecting invalid names.
* **Tests**
  * Expanded test coverage for valid/invalid emergency service account values and updated authorization expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->