### PR TITLE
NO-ISSUE: Increase probe timeouts and failure thresholds in Helm charts

### DIFF
--- a/charts/service/templates/console-proxy/deployment.yaml
+++ b/charts/service/templates/console-proxy/deployment.yaml
@@ -101,6 +101,8 @@ spec:
             - --grpc-server-timeout=1s
           initialDelaySeconds: 5
           periodSeconds: 10
+          timeoutSeconds: 5
+          failureThreshold: 5
         readinessProbe:
           exec:
             command:
@@ -112,3 +114,5 @@ spec:
             - --grpc-server-timeout=1s
           initialDelaySeconds: 5
           periodSeconds: 10
+          timeoutSeconds: 5
+          failureThreshold: 5

--- a/charts/service/templates/controller/deployment.yaml
+++ b/charts/service/templates/controller/deployment.yaml
@@ -159,6 +159,8 @@ spec:
             - --grpc-server-timeout=1s
           initialDelaySeconds: 5
           periodSeconds: 10
+          timeoutSeconds: 5
+          failureThreshold: 5
         readinessProbe:
           exec:
             command:
@@ -170,4 +172,6 @@ spec:
             - --grpc-server-timeout=1s
           initialDelaySeconds: 5
           periodSeconds: 10
+          timeoutSeconds: 5
+          failureThreshold: 5
         {{ end }}

--- a/charts/service/templates/grpc-server/deployment.yaml
+++ b/charts/service/templates/grpc-server/deployment.yaml
@@ -158,6 +158,8 @@ spec:
             - --grpc-server-timeout=1s
           initialDelaySeconds: 5
           periodSeconds: 10
+          timeoutSeconds: 5
+          failureThreshold: 5
         readinessProbe:
           exec:
             command:
@@ -169,4 +171,6 @@ spec:
             - --grpc-server-timeout=1s
           initialDelaySeconds: 5
           periodSeconds: 10
+          timeoutSeconds: 5
+          failureThreshold: 5
         {{ end }}

--- a/charts/service/templates/ingress-proxy/deployment.yaml
+++ b/charts/service/templates/ingress-proxy/deployment.yaml
@@ -61,9 +61,13 @@ spec:
             port: 8002
           initialDelaySeconds: 5
           periodSeconds: 10
+          timeoutSeconds: 5
+          failureThreshold: 5
         livenessProbe:
           httpGet:
             path: /healthz
             port: 8002
           initialDelaySeconds: 10
           periodSeconds: 15
+          timeoutSeconds: 5
+          failureThreshold: 5

--- a/charts/service/templates/rest-gateway/deployment.yaml
+++ b/charts/service/templates/rest-gateway/deployment.yaml
@@ -92,6 +92,8 @@ spec:
             scheme: HTTPS
           initialDelaySeconds: 5
           periodSeconds: 10
+          timeoutSeconds: 5
+          failureThreshold: 5
         readinessProbe:
           httpGet:
             path: /healthz
@@ -99,4 +101,6 @@ spec:
             scheme: HTTPS
           initialDelaySeconds: 5
           periodSeconds: 10
+          timeoutSeconds: 5
+          failureThreshold: 5
         {{ end }}


### PR DESCRIPTION
## Summary

- Sets `timeoutSeconds: 5` and `failureThreshold: 5` on all liveness and readiness probes across every Helm chart deployment template (grpc-server, rest-gateway, controller, console-proxy, ingress-proxy).
- Under CPU/IO pressure on single-node clusters the exec-based probes can exceed the default 1s timeout, causing the headless Service to drop pod IPs and Envoy to return "no healthy upstream" errors.
- With these values baked into the chart, the [`patch-grpc-probes.yaml`](https://github.com/osac-project/osac-installer/blob/main/charts/osac/templates/hooks/patch-grpc-probes.yaml) post-install hook in osac-installer is no longer needed and can be removed.

## Test plan

- [ ] Deploy the chart on a single-node kind/OpenShift cluster and verify the probes use the new timeout and threshold values.
- [ ] Confirm the `osac-patch-grpc-probes` hook job can be removed from osac-installer without regressions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated health check configurations across service deployments to adjust timeout and failure threshold parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->