### PR TITLE
OSAC-1550: rename sshKey to sshPublicKey in AAP template parameters

### DIFF
--- a/internal/controllers/baremetalinstance/baremetalinstance_reconciler_function.go
+++ b/internal/controllers/baremetalinstance/baremetalinstance_reconciler_function.go
@@ -508,7 +508,7 @@ func (t *task) mutateBMI(ctx context.Context, object *bmfov1alpha1.BareMetalInst
 
 	params := map[string]string{}
 	if t.bareMetalInstance.GetSpec().HasSshPublicKey() {
-		params["sshKey"] = t.bareMetalInstance.GetSpec().GetSshPublicKey()
+		params["sshPublicKey"] = t.bareMetalInstance.GetSpec().GetSshPublicKey()
 	}
 	if t.userDataSecretName != "" {
 		params["userDataSecret"] = t.userDataSecretName

--- a/internal/controllers/baremetalinstance/baremetalinstance_reconciler_function_test.go
+++ b/internal/controllers/baremetalinstance/baremetalinstance_reconciler_function_test.go
@@ -197,7 +197,7 @@ var _ = Describe("mutateBMI", func() {
 		Expect(obj.Spec.RunStrategy).To(Equal(bmfov1alpha1.RunStrategyUnspecified))
 	})
 
-	It("should include sshKey and userDataSecret in templateParameters", func() {
+	It("should include sshPublicKey and userDataSecret in templateParameters", func() {
 		catalogItemsClient := defaultFakeCatalogItemsClient()
 
 		t := &task{
@@ -221,13 +221,13 @@ var _ = Describe("mutateBMI", func() {
 
 		var params map[string]string
 		Expect(json.Unmarshal([]byte(obj.Spec.TemplateParameters), &params)).To(Succeed())
-		Expect(params["sshKey"]).To(Equal("ssh-ed25519 AAAA... test@example.com"))
+		Expect(params["sshPublicKey"]).To(Equal("ssh-ed25519 AAAA... test@example.com"))
 		Expect(params["userDataSecret"]).To(Equal("bmi-test-user-data"))
 	})
 
-	It("should include only sshKey when no user data", func() {
+	It("should include only sshPublicKey when no user data", func() {
 		catalogItemsClient := defaultFakeCatalogItemsClient()
-		sshKey := "ssh-ed25519 AAAA... test@example.com"
+		sshPublicKey := "ssh-ed25519 AAAA... test@example.com"
 
 		t := &task{
 			r: &function{
@@ -238,7 +238,7 @@ var _ = Describe("mutateBMI", func() {
 				Id: "bmi-test",
 				Spec: privatev1.BareMetalInstanceSpec_builder{
 					CatalogItem:  "catalog-1",
-					SshPublicKey: new(sshKey),
+					SshPublicKey: new(sshPublicKey),
 				}.Build(),
 			}.Build(),
 		}
@@ -249,8 +249,8 @@ var _ = Describe("mutateBMI", func() {
 
 		var params map[string]string
 		Expect(json.Unmarshal([]byte(obj.Spec.TemplateParameters), &params)).To(Succeed())
-		Expect(params).To(HaveKey("sshKey"))
-		Expect(params["sshKey"]).To(Equal(sshKey))
+		Expect(params).To(HaveKey("sshPublicKey"))
+		Expect(params["sshPublicKey"]).To(Equal(sshPublicKey))
 		Expect(params).ToNot(HaveKey("userDataSecret"))
 	})
 


### PR DESCRIPTION
## Summary

- Rename the AAP template parameter key from `sshKey` to `sshPublicKey` in the BareMetalInstance reconciler
- Update all corresponding test assertions and descriptions

Follows up on the review comment from PR #738: https://github.com/osac-project/fulfillment-service/pull/738#discussion_r3452900297

## Test plan

- [x] `ginkgo run internal/controllers/baremetalinstance` — 36/36 tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Corrected the SSH credential template parameter name for BareMetalInstance to use `sshPublicKey` instead of `sshKey`, ensuring public keys are passed under the expected parameter key.

* **Tests**
  * Updated BareMetalInstance test cases to assert `sshPublicKey` is used and to verify related template parameter behavior (including user data presence/absence).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->