### PR TITLE
NO-ISSUE: Add audience validation to JWT validator

### DIFF
--- a/internal/cmd/service/start/grpcserver/start_grpc_server_cmd.go
+++ b/internal/cmd/service/start/grpcserver/start_grpc_server_cmd.go
@@ -293,7 +293,12 @@ func (c *runnerContext) run(cmd *cobra.Command, argv []string) error { //nolint:
 	jwtValidator, err := auth.NewJwtValidator().
 		SetLogger(c.logger).
 		SetJwksCache(jwksCache).
-		SetExpirationLeeway(5 * time.Second).
+		SetExpirationLeeway(5*time.Second).
+		AddAudiences(
+			auth.Audience,
+			"https://kubernetes.default.svc",
+			"https://kubernetes.default.svc.cluster.local",
+		).
 		Build()
 	if err != nil {
 		return fmt.Errorf("failed to create JWT validator: %w", err)


### PR DESCRIPTION
## Summary

- Enable `aud` (audience) claim validation in the JWT validator, as recommended by
  [RFC 8725](https://datatracker.ietf.org/doc/html/rfc8725#section-3.9) (JSON Web Token Best
  Current Practices). The accepted audiences are the fulfillment service's own identifier and the
  two standard Kubernetes API server URLs used by service account tokens.
- This was previously omitted because the Keycloak instance used by end-to-end tests was not
  configured to include the correct audience. That configuration has now been fixed.

## Test plan

- [ ] Verify existing unit tests pass (`ginkgo run -r internal`)
- [ ] Verify end-to-end tests pass with the updated Keycloak configuration

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved gRPC JWT authentication validation to support Kubernetes service audiences, ensuring proper token verification in Kubernetes-based deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->