### PR TITLE
NO-ISSUE: post debug command on PR when Prow E2E fails

### DIFF
--- a/.github/workflows/e2e-failure-comment.yaml
+++ b/.github/workflows/e2e-failure-comment.yaml
@@ -1,0 +1,69 @@
+#
+# Copyright (c) 2025 Red Hat Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License. You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License
+# is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+# or implied. See the License for the specific language governing permissions and limitations under
+# the License.
+#
+
+name: E2E failure comment
+
+on:
+  status:
+
+permissions:
+  pull-requests: write
+
+jobs:
+  comment:
+    name: Post debug command on PR
+    if: >-
+      github.event.state == 'failure' &&
+      startsWith(github.event.context, 'ci/prow/e2e-')
+    runs-on: ubuntu-latest
+    steps:
+
+    - name: Find PR for commit
+      id: pr
+      env:
+        GH_TOKEN: ${{ github.token }}
+      run: |
+        PR_NUMBER=$(gh api \
+          "repos/${{ github.repository }}/commits/${{ github.event.commit.sha }}/pulls" \
+          --jq '.[0].number // empty')
+        echo "number=${PR_NUMBER}" >> "$GITHUB_OUTPUT"
+
+    - name: Post comment
+      if: steps.pr.outputs.number != ''
+      env:
+        GH_TOKEN: ${{ github.token }}
+        PR_NUMBER: ${{ steps.pr.outputs.number }}
+        CONTEXT: ${{ github.event.context }}
+        TARGET_URL: ${{ github.event.target_url }}
+      run: |
+        REPO_NAME=$(echo "${{ github.repository }}" | cut -d/ -f2)
+
+        # Skip if we already posted a comment for this exact job URL
+        EXISTING=$(gh api "repos/${{ github.repository }}/issues/${PR_NUMBER}/comments" \
+          --jq "[.[] | select(.body | contains(\"${TARGET_URL}\"))] | length")
+        if [ "${EXISTING}" != "0" ]; then
+          echo "Comment already exists for this job, skipping"
+          exit 0
+        fi
+
+        gh pr comment "${PR_NUMBER}" --repo "${{ github.repository }}" --body "$(cat <<EOF
+        E2E test \`${CONTEXT}\` failed. [View job](${TARGET_URL})
+
+        To investigate, run the \`/debug-e2e\` skill in [Claude Code](https://claude.ai/code) from the \`osac-workspace\` repo:
+
+        \`\`\`
+        /debug-e2e ${TARGET_URL}
+        \`\`\`
+        EOF
+        )"


### PR DESCRIPTION
## Summary
- Adds a GitHub Actions workflow that triggers when a Prow E2E status check fails on a PR
- Posts a comment with the `/debug-e2e` skill command and Prow job URL so developers can quickly investigate
- Includes deduplication — won't post the same comment twice on retest
- This is a proof of concept on fulfillment-service; can be rolled out to other repos later

## Example comment posted

> E2E test `ci/prow/e2e-vmaas` failed. [View job](https://prow.ci.openshift.org/view/gs/...)
>
> To investigate, run the `/debug-e2e` skill in [Claude Code](https://claude.ai/code) from the `osac-workspace` repo:
>
> ```
> /debug-e2e https://prow.ci.openshift.org/view/gs/...
> ```

## Test plan
- [ ] Merge to main, then trigger a Prow E2E failure on a test PR to verify the comment is posted
- [ ] Verify deduplication by retesting — second failure should not post a duplicate comment

🤖 Generated with [Claude Code](https://claude.com/claude-code)