### PR TITLE
OSAC-899: add --windows flag and OS column to CLI compute instances

### DIFF
--- a/internal/cmd/cli/create/computeinstance/create_compute_instance_cmd.go
+++ b/internal/cmd/cli/create/computeinstance/create_compute_instance_cmd.go
@@ -150,6 +150,12 @@ func Cmd() *cobra.Command {
 		nil,
 		networkAttachmentFlagHelp,
 	)
+	flags.BoolVar(
+		&runner.args.windows,
+		"windows",
+		false,
+		windowsFlagHelp,
+	)
 
 	result.MarkFlagsMutuallyExclusive("catalog-item", "template")
 	result.MarkFlagsOneRequired("catalog-item", "template")
@@ -173,6 +179,7 @@ type runnerContext struct {
 		runStrategy             string
 		userData                string
 		networkAttachments      []string
+		windows                 bool
 	}
 	logger                 *slog.Logger
 	console                *terminal.Console
@@ -723,6 +730,9 @@ func (c *runnerContext) buildSpec(templateID string,
 	if c.args.userData != "" {
 		spec.UserData = new(c.args.userData)
 	}
+	if c.args.windows {
+		spec.IsWindows = new(true)
+	}
 	if err := c.applyNetworkingFlags(&spec); err != nil {
 		return nil, err
 	}
@@ -868,6 +878,9 @@ func (c *runnerContext) buildSpecFromCatalogItem(catalogItemID string) (*publicv
 	}
 	if c.args.userData != "" {
 		spec.UserData = new(c.args.userData)
+	}
+	if c.args.windows {
+		spec.IsWindows = new(true)
 	}
 	if err := c.applyNetworkingFlags(&spec); err != nil {
 		return nil, err
@@ -1021,4 +1034,8 @@ _SPEC_ - Per-NIC network attachment. The value can be a plain subnet ID, or a
 comma-separated specification in the format
 {{ bt }}subnet=ID[,security-groups=ID,ID...]{{ bt }}. Can be
 specified multiple times to attach multiple NICs.
+`
+
+const windowsFlagHelp = `
+_[BOOLEAN]_ - Create a Windows VM. Defaults to {{ bt }}false{{ bt }} (Linux VM).
 `

--- a/internal/cmd/cli/create/computeinstance/create_compute_instance_cmd_test.go
+++ b/internal/cmd/cli/create/computeinstance/create_compute_instance_cmd_test.go
@@ -71,6 +71,25 @@ var _ = Describe("buildSpec", func() {
 		}.Build()
 		Expect(proto.Equal(spec, want)).To(BeTrue(), "spec should equal expected spec")
 	})
+
+	It("should set IsWindows when windows flag is true", func() {
+		c := &runnerContext{}
+		c.args.windows = true
+		spec, err := c.buildSpec("tmpl", nil)
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(spec.IsWindows).NotTo(BeNil())
+		Expect(*spec.IsWindows).To(BeTrue())
+	})
+
+	It("should leave IsWindows nil when windows flag is false", func() {
+		c := &runnerContext{}
+		c.args.windows = false
+		spec, err := c.buildSpec("tmpl", nil)
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(spec.IsWindows).To(BeNil())
+	})
 })
 
 var _ = Describe("buildSpecFromCatalogItem", func() {
@@ -106,6 +125,25 @@ var _ = Describe("buildSpecFromCatalogItem", func() {
 		c.args.networkAttachments = []string{"subnet=a,foo=bar"}
 		_, err := c.buildSpecFromCatalogItem("cat-003")
 		Expect(err).To(HaveOccurred())
+	})
+
+	It("should set IsWindows when windows flag is true", func() {
+		c := &runnerContext{}
+		c.args.windows = true
+		spec, err := c.buildSpecFromCatalogItem("cat-004")
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(spec.IsWindows).NotTo(BeNil())
+		Expect(*spec.IsWindows).To(BeTrue())
+	})
+
+	It("should leave IsWindows nil when windows flag is false", func() {
+		c := &runnerContext{}
+		c.args.windows = false
+		spec, err := c.buildSpecFromCatalogItem("cat-005")
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(spec.IsWindows).To(BeNil())
 	})
 })
 
@@ -143,6 +181,15 @@ var _ = Describe("Create computeinstance flag registration", func() {
 		flag := cmd.Flags().Lookup("template")
 		Expect(flag).NotTo(BeNil())
 		Expect(flag.Shorthand).To(Equal("t"))
+	})
+
+	It("should register --windows flag with default value false", func() {
+		cmd := Cmd()
+		cmd.SetOut(GinkgoWriter)
+		cmd.SetErr(GinkgoWriter)
+		flag := cmd.Flags().Lookup("windows")
+		Expect(flag).NotTo(BeNil())
+		Expect(flag.DefValue).To(Equal("false"))
 	})
 })
 

--- a/internal/rendering/tables/osac.private.v1.ComputeInstance.yaml
+++ b/internal/rendering/tables/osac.private.v1.ComputeInstance.yaml
@@ -24,6 +24,9 @@ columns:
   type: osac.private.v1.ComputeInstanceTemplate
   lookup: true
 
+- header: OS
+  value: "has(this.spec.is_windows) && this.spec.is_windows ? 'windows' : 'linux'"
+
 - header: STATE
   value: this.status.state
   type: osac.private.v1.ComputeInstanceState

--- a/internal/rendering/tables/osac.public.v1.ComputeInstance.yaml
+++ b/internal/rendering/tables/osac.public.v1.ComputeInstance.yaml
@@ -26,6 +26,9 @@ columns:
   type: osac.public.v1.ComputeInstanceTemplate
   lookup: true
 
+- header: OS
+  value: "has(this.spec.is_windows) && this.spec.is_windows ? 'windows' : 'linux'"
+
 - header: STATE
   value: this.status.state
   type: osac.public.v1.ComputeInstanceState


### PR DESCRIPTION
Add Windows VM support to the CLI by introducing a `--windows` flag for compute instance creation and an OS column in table output.

Users need to provision Windows VMs through the same OSAC CLI workflow used for Linux VMs, with the guest OS type visible in listings.

- Add `--windows` boolean flag to the create compute-instance command
- Set `IsWindows` on the compute instance spec when the flag is provided
- Apply the flag in both template-based and catalog-item-based creation paths
- Add an OS column to public and private compute instance table definitions, displaying "windows" or "linux" based on the `is_windows` spec field

Unit tests added for the `--windows` flag: flag registration, spec building with the flag enabled and disabled, covering both template and catalog-item creation paths.

Assisted-by: Claude Code <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--windows` flag to create Windows-based compute instances (Linux is the default)
  * Display tables now include an OS column showing the operating system (Windows or Linux) for each compute instance

<!-- end of auto-generated comment: release notes by coderabbit.ai -->