### PR TITLE
OSAC-1393: Add CLI integration tests for authentication and error handling

### DIFF
--- a/it/it_cli_auth_test.go
+++ b/it/it_cli_auth_test.go
@@ -1,0 +1,106 @@
+/*
+Copyright (c) 2026 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package it
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("CLI Authentication", Label("cli", "auth"), func() {
+	var homeDir string
+
+	BeforeEach(func() {
+		var err error
+		homeDir, err = tool.NewCLIHomeDir()
+		Expect(err).ToNot(HaveOccurred())
+		DeferCleanup(func() {
+			os.RemoveAll(homeDir)
+		})
+	})
+
+	It("Login with password flow succeeds", func(ctx context.Context) {
+		_, _, exitCode := tool.LoginCLI(ctx, homeDir, adminUsername, adminsPassword)
+		Expect(exitCode).To(Equal(0), "login should succeed")
+
+		// Verify that subsequent commands work with the stored credentials
+		_, _, exitCode = tool.RunCLI(ctx, homeDir, "get", "computeinstance")
+		Expect(exitCode).To(Equal(0), "get should succeed after login")
+	})
+
+	It("Login with client credentials flow succeeds", func(ctx context.Context) {
+		_, _, exitCode := tool.RunCLI(ctx, homeDir,
+			"login", "https://"+externalServiceAddr,
+			"--flow=credentials",
+			"--client-id="+controllerClientId,
+			"--client-secret="+tool.Secret(),
+			"--insecure",
+		)
+		Expect(exitCode).To(Equal(0), "client credentials login should succeed")
+
+		// Verify that subsequent commands work with the stored credentials
+		_, _, exitCode = tool.RunCLI(ctx, homeDir, "get", "computeinstance")
+		Expect(exitCode).To(Equal(0), "get should succeed after client credentials login")
+	})
+
+	It("Login with invalid credentials fails", func(ctx context.Context) {
+		_, stderr, exitCode := tool.LoginCLI(ctx, homeDir, adminUsername, "wrong-password")
+		Expect(exitCode).ToNot(Equal(0), "login with wrong password should fail")
+		Expect(stderr).To(ContainSubstring("invalid_grant"), "should report invalid credentials")
+
+		// Verify that no valid configuration was saved
+		_, _, exitCode = tool.RunCLI(ctx, homeDir, "get", "computeinstance")
+		Expect(exitCode).ToNot(Equal(0), "commands should fail after failed login")
+	})
+
+	It("Logout clears stored credentials", func(ctx context.Context) {
+		// First login successfully
+		_, _, exitCode := tool.LoginCLI(ctx, homeDir, adminUsername, adminsPassword)
+		Expect(exitCode).To(Equal(0), "login should succeed")
+
+		// Verify commands work
+		_, _, exitCode = tool.RunCLI(ctx, homeDir, "get", "computeinstance")
+		Expect(exitCode).To(Equal(0), "get should succeed after login")
+
+		// Logout
+		_, _, exitCode = tool.RunCLI(ctx, homeDir, "logout")
+		Expect(exitCode).To(Equal(0), "logout should succeed")
+
+		// Verify commands fail after logout
+		_, stderr, exitCode := tool.RunCLI(ctx, homeDir, "get", "computeinstance")
+		Expect(exitCode).ToNot(Equal(0), "commands should fail after logout")
+		Expect(stderr).To(ContainSubstring("there is no configuration"))
+	})
+
+	It("Corrupted configuration produces a clear error", func(ctx context.Context) {
+		// Write a malformed config.json to verify the CLI handles it gracefully
+		configDir := filepath.Join(homeDir, ".config", "osac")
+		err := os.MkdirAll(configDir, 0700)
+		Expect(err).ToNot(HaveOccurred())
+		configFile := filepath.Join(configDir, "config.json")
+		err = os.WriteFile(configFile, []byte(`{not valid json`), 0600)
+		Expect(err).ToNot(HaveOccurred())
+
+		// The CLI should fail with a clear error, not a panic
+		_, stderr, exitCode := tool.RunCLI(ctx, homeDir, "get", "computeinstance")
+		Expect(exitCode).ToNot(Equal(0), "commands with corrupted config should fail")
+		Expect(stderr).ToNot(BeEmpty(), "should produce an error message")
+		Expect(stderr).ToNot(ContainSubstring("runtime error"), "should not panic")
+		Expect(stderr).ToNot(ContainSubstring("goroutine"), "should not dump stack trace")
+	})
+})

--- a/it/it_cli_auth_test.go
+++ b/it/it_cli_auth_test.go
@@ -30,7 +30,8 @@ var _ = Describe("CLI Authentication", Label("cli", "auth"), func() {
 		homeDir, err = tool.NewCLIHomeDir()
 		Expect(err).ToNot(HaveOccurred())
 		DeferCleanup(func() {
-			os.RemoveAll(homeDir)
+			err := os.RemoveAll(homeDir)
+			Expect(err).ToNot(HaveOccurred())
 		})
 	})
 

--- a/it/it_cli_errors_test.go
+++ b/it/it_cli_errors_test.go
@@ -29,7 +29,8 @@ var _ = Describe("CLI Error Handling", Label("cli", "errors"), func() {
 		homeDir, err = tool.NewCLIHomeDir()
 		Expect(err).ToNot(HaveOccurred())
 		DeferCleanup(func() {
-			os.RemoveAll(homeDir)
+			err := os.RemoveAll(homeDir)
+			Expect(err).ToNot(HaveOccurred())
 		})
 	})
 

--- a/it/it_cli_errors_test.go
+++ b/it/it_cli_errors_test.go
@@ -1,0 +1,69 @@
+/*
+Copyright (c) 2026 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package it
+
+import (
+	"context"
+	"os"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("CLI Error Handling", Label("cli", "errors"), func() {
+	var homeDir string
+
+	BeforeEach(func() {
+		var err error
+		homeDir, err = tool.NewCLIHomeDir()
+		Expect(err).ToNot(HaveOccurred())
+		DeferCleanup(func() {
+			os.RemoveAll(homeDir)
+		})
+	})
+
+	It("Command without login shows configuration error", func(ctx context.Context) {
+		// Run a command without any prior login — homeDir has no stored credentials
+		stdout, stderr, exitCode := tool.RunCLI(ctx, homeDir, "get", "computeinstance")
+		Expect(exitCode).ToNot(Equal(0), "command without login should fail")
+
+		combinedOutput := stdout + stderr
+		Expect(combinedOutput).To(ContainSubstring("there is no configuration"))
+	})
+
+	It("Unknown resource type shows a helpful error", func(ctx context.Context) {
+		// Login first so we have valid credentials
+		_, _, exitCode := tool.LoginCLI(ctx, homeDir, adminUsername, adminsPassword)
+		Expect(exitCode).To(Equal(0), "login should succeed")
+
+		// Try to get an unknown resource type
+		stdout, _, exitCode := tool.RunCLI(ctx, homeDir, "get", "nonexistentresource")
+		Expect(exitCode).To(Equal(0), "unknown resource type renders help and exits 0")
+		Expect(stdout).To(ContainSubstring("There is no object named"))
+	})
+
+	It("Version command does not crash", func(ctx context.Context) {
+		// osac version should print CLI version info without crashing,
+		// even without a server connection
+		stdout, stderr, exitCode := tool.RunCLI(ctx, homeDir, "version")
+		combinedOutput := stdout + stderr
+
+		// The command should not panic — any exit code is acceptable as long as
+		// there is meaningful output and no stack trace
+		Expect(combinedOutput).ToNot(BeEmpty(), "version should produce output")
+		Expect(combinedOutput).ToNot(ContainSubstring("runtime error"), "version should not panic")
+		Expect(combinedOutput).ToNot(ContainSubstring("goroutine"), "version should not produce a stack trace")
+		_ = exitCode
+	})
+})

--- a/it/it_tool.go
+++ b/it/it_tool.go
@@ -2166,7 +2166,7 @@ func (t *Tool) NewCLIHomeDir() (string, error) {
 // for credential isolation. Returns stdout, stderr, and the process exit code.
 func (t *Tool) RunCLI(ctx context.Context, homeDir string, args ...string) (stdout, stderr string, exitCode int) {
 	cmd := exec.CommandContext(ctx, t.cliBinaryPath, args...)
-	cmd.Env = append(os.Environ(), "HOME="+homeDir)
+	cmd.Env = cliEnv(homeDir)
 	cmd.Dir = t.projectDir
 	var outBuf, errBuf bytes.Buffer
 	cmd.Stdout = &outBuf
@@ -2183,7 +2183,7 @@ func (t *Tool) RunCLI(ctx context.Context, homeDir string, args ...string) (stdo
 	}
 	t.logger.DebugContext(ctx, "CLI command completed",
 		slog.String("binary", t.cliBinaryPath),
-		slog.Any("args", args),
+		slog.Any("args", redactCLIArgs(args)),
 		slog.Int("exitCode", exitCode),
 	)
 	return outBuf.String(), errBuf.String(), exitCode
@@ -2193,9 +2193,7 @@ func (t *Tool) RunCLI(ctx context.Context, homeDir string, args ...string) (stdo
 // override. Each entry in extraEnv should be in "KEY=VALUE" format. Use "KEY=" to unset a variable.
 func (t *Tool) RunCLIWithEnv(ctx context.Context, homeDir string, extraEnv []string, args ...string) (stdout, stderr string, exitCode int) {
 	cmd := exec.CommandContext(ctx, t.cliBinaryPath, args...)
-	env := append(os.Environ(), "HOME="+homeDir)
-	env = append(env, extraEnv...)
-	cmd.Env = env
+	cmd.Env = append(cliEnv(homeDir), extraEnv...)
 	cmd.Dir = t.projectDir
 	var outBuf, errBuf bytes.Buffer
 	cmd.Stdout = &outBuf
@@ -2212,10 +2210,45 @@ func (t *Tool) RunCLIWithEnv(ctx context.Context, homeDir string, extraEnv []str
 	}
 	t.logger.DebugContext(ctx, "CLI command completed",
 		slog.String("binary", t.cliBinaryPath),
-		slog.Any("args", args),
+		slog.Any("args", redactCLIArgs(args)),
 		slog.Int("exitCode", exitCode),
 	)
 	return outBuf.String(), errBuf.String(), exitCode
+}
+
+// cliEnv builds a sandboxed environment for CLI subprocess execution. It inherits the host
+// environment but strips HOME, OSAC_CONFIG, and OSAC_CACHE to prevent leaking host state
+// into the isolated test HOME directory.
+func cliEnv(homeDir string) []string {
+	env := make([]string, 0, len(os.Environ())+2)
+	for _, kv := range os.Environ() {
+		if strings.HasPrefix(kv, "HOME=") ||
+			strings.HasPrefix(kv, "OSAC_CONFIG=") ||
+			strings.HasPrefix(kv, "OSAC_CACHE=") {
+			continue
+		}
+		env = append(env, kv)
+	}
+	env = append(env,
+		"HOME="+homeDir,
+		"OSAC_CONFIG="+filepath.Join(homeDir, ".config", "osac"),
+	)
+	return env
+}
+
+// redactCLIArgs returns a copy of args with sensitive flag values masked.
+func redactCLIArgs(args []string) []string {
+	out := make([]string, len(args))
+	copy(out, args)
+	for i, a := range out {
+		switch {
+		case strings.HasPrefix(a, "--password="):
+			out[i] = "--password=<redacted>"
+		case strings.HasPrefix(a, "--client-secret="):
+			out[i] = "--client-secret=<redacted>"
+		}
+	}
+	return out
 }
 
 // LoginCLI authenticates the CLI using the password flow against the external API with the

--- a/it/it_tool.go
+++ b/it/it_tool.go
@@ -115,6 +115,7 @@ type Tool struct {
 	externalView  *ToolView
 	secret        string
 	jqTool        *jq.Tool
+	cliBinaryPath string
 }
 
 // ToolView contains the gRPC connections and HTTP clients that can be used to connect to the cluster. This is a
@@ -319,6 +320,12 @@ func (t *Tool) Setup(ctx context.Context) error {
 
 	// Build the container image:
 	imageRef, err := t.buildImage(ctx)
+	if err != nil {
+		return err
+	}
+
+	// Build the CLI binary:
+	err = t.buildCLI(ctx)
 	if err != nil {
 		return err
 	}
@@ -2115,6 +2122,112 @@ func (t *Tool) registerHub(ctx context.Context) error {
 		return fmt.Errorf("failed to create hub: %w", err)
 	}
 	return nil
+}
+
+// buildCLI builds the osac CLI binary and stores its path for use in CLI integration tests.
+func (t *Tool) buildCLI(ctx context.Context) error {
+	t.logger.DebugContext(ctx, "Building CLI binary")
+	t.cliBinaryPath = filepath.Join(t.tmpDir, "osac")
+	buildCmd, err := testing.NewCommand().
+		SetLogger(t.logger).
+		SetHome(t.projectDir).
+		SetDir(t.projectDir).
+		SetName("go").
+		SetArgs("build", "-o", t.cliBinaryPath, "./cmd/osac").
+		Build()
+	if err != nil {
+		return fmt.Errorf("failed to create command to build CLI: %w", err)
+	}
+	err = buildCmd.Execute(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to build CLI binary: %w", err)
+	}
+	return nil
+}
+
+// CLIBinaryPath returns the path to the built osac CLI binary.
+func (t *Tool) CLIBinaryPath() string {
+	return t.cliBinaryPath
+}
+
+// Secret returns the shared secret used for passwords and credentials in the test environment.
+func (t *Tool) Secret() string {
+	return t.secret
+}
+
+// NewCLIHomeDir creates an isolated temporary directory suitable for use as a HOME directory
+// during CLI tests. Each test should call this to get credential isolation. The caller is
+// responsible for cleaning up the directory (typically via DeferCleanup).
+func (t *Tool) NewCLIHomeDir() (string, error) {
+	return os.MkdirTemp("", "*.cli-home")
+}
+
+// RunCLI executes the osac CLI binary with the given arguments and a custom HOME directory
+// for credential isolation. Returns stdout, stderr, and the process exit code.
+func (t *Tool) RunCLI(ctx context.Context, homeDir string, args ...string) (stdout, stderr string, exitCode int) {
+	cmd := exec.CommandContext(ctx, t.cliBinaryPath, args...)
+	cmd.Env = append(os.Environ(), "HOME="+homeDir)
+	cmd.Dir = t.projectDir
+	var outBuf, errBuf bytes.Buffer
+	cmd.Stdout = &outBuf
+	cmd.Stderr = &errBuf
+	err := cmd.Run()
+	exitCode = 0
+	if err != nil {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			exitCode = exitErr.ExitCode()
+		} else {
+			exitCode = -1
+		}
+	}
+	t.logger.DebugContext(ctx, "CLI command completed",
+		slog.String("binary", t.cliBinaryPath),
+		slog.Any("args", args),
+		slog.Int("exitCode", exitCode),
+	)
+	return outBuf.String(), errBuf.String(), exitCode
+}
+
+// RunCLIWithEnv executes the osac binary with additional environment variables beyond the HOME
+// override. Each entry in extraEnv should be in "KEY=VALUE" format. Use "KEY=" to unset a variable.
+func (t *Tool) RunCLIWithEnv(ctx context.Context, homeDir string, extraEnv []string, args ...string) (stdout, stderr string, exitCode int) {
+	cmd := exec.CommandContext(ctx, t.cliBinaryPath, args...)
+	env := append(os.Environ(), "HOME="+homeDir)
+	env = append(env, extraEnv...)
+	cmd.Env = env
+	cmd.Dir = t.projectDir
+	var outBuf, errBuf bytes.Buffer
+	cmd.Stdout = &outBuf
+	cmd.Stderr = &errBuf
+	err := cmd.Run()
+	exitCode = 0
+	if err != nil {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			exitCode = exitErr.ExitCode()
+		} else {
+			exitCode = -1
+		}
+	}
+	t.logger.DebugContext(ctx, "CLI command completed",
+		slog.String("binary", t.cliBinaryPath),
+		slog.Any("args", args),
+		slog.Int("exitCode", exitCode),
+	)
+	return outBuf.String(), errBuf.String(), exitCode
+}
+
+// LoginCLI authenticates the CLI using the password flow against the external API with the
+// given user credentials. The homeDir parameter provides credential isolation between tests.
+func (t *Tool) LoginCLI(ctx context.Context, homeDir, user, password string) (stdout, stderr string, exitCode int) {
+	return t.RunCLI(ctx, homeDir,
+		"login", fmt.Sprintf("https://%s", externalServiceAddr),
+		"--flow=password",
+		"--user="+user,
+		"--password="+password,
+		"--insecure",
+	)
 }
 
 func (t *Tool) Cleanup(ctx context.Context) error {

--- a/it/it_tool.go
+++ b/it/it_tool.go
@@ -2165,33 +2165,20 @@ func (t *Tool) NewCLIHomeDir() (string, error) {
 // RunCLI executes the osac CLI binary with the given arguments and a custom HOME directory
 // for credential isolation. Returns stdout, stderr, and the process exit code.
 func (t *Tool) RunCLI(ctx context.Context, homeDir string, args ...string) (stdout, stderr string, exitCode int) {
-	cmd := exec.CommandContext(ctx, t.cliBinaryPath, args...)
-	cmd.Env = cliEnv(homeDir)
-	cmd.Dir = t.projectDir
-	var outBuf, errBuf bytes.Buffer
-	cmd.Stdout = &outBuf
-	cmd.Stderr = &errBuf
-	err := cmd.Run()
-	exitCode = 0
-	if err != nil {
-		var exitErr *exec.ExitError
-		if errors.As(err, &exitErr) {
-			exitCode = exitErr.ExitCode()
-		} else {
-			exitCode = -1
-		}
-	}
-	t.logger.DebugContext(ctx, "CLI command completed",
-		slog.String("binary", t.cliBinaryPath),
-		slog.Any("args", redactCLIArgs(args)),
-		slog.Int("exitCode", exitCode),
-	)
-	return outBuf.String(), errBuf.String(), exitCode
+	return t.runCLI(ctx, homeDir, nil, args...)
 }
 
 // RunCLIWithEnv executes the osac binary with additional environment variables beyond the HOME
 // override. Each entry in extraEnv should be in "KEY=VALUE" format. Use "KEY=" to unset a variable.
 func (t *Tool) RunCLIWithEnv(ctx context.Context, homeDir string, extraEnv []string, args ...string) (stdout, stderr string, exitCode int) {
+	return t.runCLI(ctx, homeDir, extraEnv, args...)
+}
+
+// runCLI is the shared implementation for RunCLI and RunCLIWithEnv. We intentionally use
+// exec.CommandContext directly rather than testing.Command because the CLI tests need custom
+// environment sandboxing and explicit exit-code extraction for non-zero exits (expected
+// behavior, not errors).
+func (t *Tool) runCLI(ctx context.Context, homeDir string, extraEnv []string, args ...string) (stdout, stderr string, exitCode int) {
 	cmd := exec.CommandContext(ctx, t.cliBinaryPath, args...)
 	cmd.Env = append(cliEnv(homeDir), extraEnv...)
 	cmd.Dir = t.projectDir
@@ -2206,34 +2193,31 @@ func (t *Tool) RunCLIWithEnv(ctx context.Context, homeDir string, extraEnv []str
 			exitCode = exitErr.ExitCode()
 		} else {
 			exitCode = -1
+			t.logger.ErrorContext(ctx, "CLI command failed with unexpected error",
+				slog.String("binary", t.cliBinaryPath),
+				slog.Any("args", redactCLIArgs(args)),
+				slog.String("error", err.Error()),
+			)
 		}
 	}
 	t.logger.DebugContext(ctx, "CLI command completed",
 		slog.String("binary", t.cliBinaryPath),
 		slog.Any("args", redactCLIArgs(args)),
-		slog.Int("exitCode", exitCode),
+		slog.Int("code", exitCode),
 	)
 	return outBuf.String(), errBuf.String(), exitCode
 }
 
-// cliEnv builds a sandboxed environment for CLI subprocess execution. It inherits the host
-// environment but strips HOME, OSAC_CONFIG, and OSAC_CACHE to prevent leaking host state
-// into the isolated test HOME directory.
+// cliEnv builds a minimal sandboxed environment for CLI subprocess execution. Only the
+// variables strictly required by the CLI binary are set; everything else from the host
+// is excluded to guarantee full test isolation.
 func cliEnv(homeDir string) []string {
-	env := make([]string, 0, len(os.Environ())+2)
-	for _, kv := range os.Environ() {
-		if strings.HasPrefix(kv, "HOME=") ||
-			strings.HasPrefix(kv, "OSAC_CONFIG=") ||
-			strings.HasPrefix(kv, "OSAC_CACHE=") {
-			continue
-		}
-		env = append(env, kv)
+	return []string{
+		"HOME=" + homeDir,
+		"PATH=" + os.Getenv("PATH"),
+		"OSAC_CONFIG=" + filepath.Join(homeDir, ".config", "osac"),
+		"OSAC_CACHE=" + filepath.Join(homeDir, ".cache", "osac"),
 	}
-	env = append(env,
-		"HOME="+homeDir,
-		"OSAC_CONFIG="+filepath.Join(homeDir, ".config", "osac"),
-	)
-	return env
 }
 
 // redactCLIArgs returns a copy of args with sensitive flag values masked.


### PR DESCRIPTION
## Summary

- Add Phase 1 CLI integration tests that verify the `osac` binary as a subprocess against the Ginkgo integration test API server
- New test helpers in `it/it_tool.go`: `buildCLI()`, `RunCLI()`, `RunCLIWithEnv()`, `LoginCLI()`, `NewCLIHomeDir()`, `CLIBinaryPath()`, `Secret()`
- 8 new test scenarios covering authentication lifecycle and error handling

## Test Scenarios

### Authentication (`cli`, `auth` labels — 5 tests)
1. **Login with password flow** — verifies `osac login --flow=password` and subsequent commands
2. **Login with client credentials** — verifies `osac login --flow=credentials` with controller client
3. **Invalid credentials** — verifies proper error reporting (`invalid_grant`)
4. **Logout** — verifies credential clearing and subsequent command failure
5. **Corrupted configuration** — verifies graceful error handling (no panic/stack trace)

### Error Handling (`cli`, `errors` labels — 3 tests)
6. **Command without login** — verifies "there is no configuration" error
7. **Unknown resource type** — verifies helpful "There is no object named" message
8. **Version command stability** — verifies no crash without server connection

## Test plan

- [x] `go vet ./it/` passes
- [x] All 8 CLI tests pass (`ginkgo run -v --label-filter="cli" it/`)
- [x] Full suite passes on `main`: 138/138
- [x] Full suite passes on this branch: 146/146 (138 existing + 8 new, zero regressions)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added end-to-end CLI authentication and error-handling coverage, including password login, client-credentials login, logout behavior, invalid-password failures, unknown-resource messaging, and corrupted config handling.
  * Added CLI test utilities to run the executable in isolated temporary home directories and reliably capture stdout/stderr and exit codes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->