### PR TITLE
OSAC-1679: Add GitHub Actions e2e job

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -1,0 +1,38 @@
+---
+name: E2E Tests
+
+on:
+  pull_request:
+    branches: [main]
+  workflow_dispatch: {}
+
+jobs:
+  build-pr-image:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    outputs:
+      image: ${{ steps.meta.outputs.image }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set image metadata
+        id: meta
+        run: |
+          IMAGE="ghcr.io/osac-project/fulfillment-service:pr-${{ github.event.pull_request.number || github.run_id }}"
+          echo "image=${IMAGE}" >> "$GITHUB_OUTPUT"
+
+      - name: Build and push PR image
+        run: |
+          echo "${{ secrets.GITHUB_TOKEN }}" | podman login ghcr.io -u "${{ github.actor }}" --password-stdin
+          podman build -t "${{ steps.meta.outputs.image }}" -f Containerfile .
+          podman push "${{ steps.meta.outputs.image }}"
+
+  e2e:
+    needs: build-pr-image
+    uses: osac-project/osac-test-infra/.github/workflows/e2e.yml@main
+    with:
+      component-image: ${{ needs.build-pr-image.outputs.image }}
+      component-image-name: ghcr.io/osac-project/fulfillment-service


### PR DESCRIPTION
## Summary
- Add `e2e-test.yml` caller workflow for PR-triggered E2E testing via GitHub Actions
- Builds PR image on `ubuntu-latest`, pushes to GHCR with `pr-<number>` tag
- Calls shared `e2e.yml` from `osac-test-infra` with component image override
- Supports `workflow_dispatch` for manual execution

**Depends on:** osac-project/osac-test-infra PR ([OSAC-1678](https://redhat.atlassian.net/browse/OSAC-1678)) for the `component-image` input on `e2e.yml`

## Jira
- [OSAC-1679](https://redhat.atlassian.net/browse/OSAC-1679)

## Test plan
- [ ] Verify workflow triggers on PR to main
- [ ] Verify PR image builds and pushes to GHCR
- [ ] Verify e2e workflow is invoked with correct component-image override