### PR TITLE
NO-ISSUE: Enforce implementation_strategy immutability on VirtualNetwork and PublicIPPool

### DIFF
--- a/internal/servers/private_public_ip_pools_server.go
+++ b/internal/servers/private_public_ip_pools_server.go
@@ -164,9 +164,16 @@ func (s *PrivatePublicIPPoolsServer) Update(ctx context.Context,
 		return
 	}
 
-	err = validateUpdate(request.GetObject(), getResponse.GetObject())
+	existing := getResponse.GetObject()
+
+	err = validateUpdate(request.GetObject(), existing)
 	if err != nil {
 		return
+	}
+
+	// Preserve immutable implementation_strategy from existing object.
+	if request.GetObject().GetSpec() != nil && existing.GetSpec() != nil {
+		request.GetObject().GetSpec().SetImplementationStrategy(existing.GetSpec().GetImplementationStrategy())
 	}
 
 	err = s.generic.Update(ctx, request, &response)
@@ -233,6 +240,12 @@ func validateUpdate(newPool *privatev1.PublicIPPool, existing *privatev1.PublicI
 	if newCIDRs := spec.GetCidrs(); len(newCIDRs) > 0 && !cidrSlicesEqual(newCIDRs, existing.GetSpec().GetCidrs()) {
 		return grpcstatus.Errorf(grpccodes.InvalidArgument,
 			"field 'spec.cidrs' is immutable and cannot be changed after creation")
+	}
+
+	if newStrategy := spec.GetImplementationStrategy(); newStrategy != "" && newStrategy != existing.GetSpec().GetImplementationStrategy() {
+		return grpcstatus.Errorf(grpccodes.InvalidArgument,
+			"field 'spec.implementation_strategy' is immutable and cannot be changed from '%s' to '%s'",
+			existing.GetSpec().GetImplementationStrategy(), newStrategy)
 	}
 
 	return nil

--- a/internal/servers/private_public_ip_pools_server_test.go
+++ b/internal/servers/private_public_ip_pools_server_test.go
@@ -891,6 +891,89 @@ var _ = Describe("Private public IP pools server", func() {
 			})
 		})
 
+		Context("implementation_strategy immutability on Update", func() {
+			It("rejects changing implementation_strategy", func() {
+				createResponse, err := poolsServer.Create(ctx, privatev1.PublicIPPoolsCreateRequest_builder{
+					Object: privatev1.PublicIPPool_builder{
+						Spec: privatev1.PublicIPPoolSpec_builder{
+							Cidrs:                  []string{"10.0.0.0/24"},
+							IpFamily:               privatev1.IPFamily_IP_FAMILY_IPV4,
+							ImplementationStrategy: "metallb-l2",
+						}.Build(),
+					}.Build(),
+				}.Build())
+				Expect(err).ToNot(HaveOccurred())
+				id := createResponse.GetObject().GetId()
+
+				_, err = poolsServer.Update(ctx, privatev1.PublicIPPoolsUpdateRequest_builder{
+					Object: privatev1.PublicIPPool_builder{
+						Id: id,
+						Spec: privatev1.PublicIPPoolSpec_builder{
+							ImplementationStrategy: "different-strategy",
+						}.Build(),
+					}.Build(),
+				}.Build())
+				Expect(err).To(HaveOccurred())
+				status, ok := grpcstatus.FromError(err)
+				Expect(ok).To(BeTrue())
+				Expect(status.Code()).To(Equal(grpccodes.InvalidArgument))
+				Expect(err.Error()).To(ContainSubstring("implementation_strategy"))
+				Expect(err.Error()).To(ContainSubstring("immutable"))
+			})
+
+			It("allows same implementation_strategy on Update", func() {
+				createResponse, err := poolsServer.Create(ctx, privatev1.PublicIPPoolsCreateRequest_builder{
+					Object: privatev1.PublicIPPool_builder{
+						Spec: privatev1.PublicIPPoolSpec_builder{
+							Cidrs:                  []string{"10.0.0.0/24"},
+							IpFamily:               privatev1.IPFamily_IP_FAMILY_IPV4,
+							ImplementationStrategy: "metallb-l2",
+						}.Build(),
+					}.Build(),
+				}.Build())
+				Expect(err).ToNot(HaveOccurred())
+				id := createResponse.GetObject().GetId()
+
+				_, err = poolsServer.Update(ctx, privatev1.PublicIPPoolsUpdateRequest_builder{
+					Object: privatev1.PublicIPPool_builder{
+						Id: id,
+						Spec: privatev1.PublicIPPoolSpec_builder{
+							ImplementationStrategy: "metallb-l2",
+						}.Build(),
+					}.Build(),
+				}.Build())
+				Expect(err).ToNot(HaveOccurred())
+			})
+
+			It("preserves implementation_strategy when omitted in Update", func() {
+				createResponse, err := poolsServer.Create(ctx, privatev1.PublicIPPoolsCreateRequest_builder{
+					Object: privatev1.PublicIPPool_builder{
+						Spec: privatev1.PublicIPPoolSpec_builder{
+							Cidrs:                  []string{"10.0.0.0/24"},
+							IpFamily:               privatev1.IPFamily_IP_FAMILY_IPV4,
+							ImplementationStrategy: "metallb-l2",
+						}.Build(),
+					}.Build(),
+				}.Build())
+				Expect(err).ToNot(HaveOccurred())
+				id := createResponse.GetObject().GetId()
+
+				updateResponse, err := poolsServer.Update(ctx, privatev1.PublicIPPoolsUpdateRequest_builder{
+					Object: privatev1.PublicIPPool_builder{
+						Id: id,
+						Metadata: privatev1.Metadata_builder{
+							Name: "renamed-pool",
+						}.Build(),
+					}.Build(),
+					UpdateMask: &fieldmaskpb.FieldMask{
+						Paths: []string{"metadata.name"},
+					},
+				}.Build())
+				Expect(err).ToNot(HaveOccurred())
+				Expect(updateResponse.GetObject().GetSpec().GetImplementationStrategy()).To(Equal("metallb-l2"))
+			})
+		})
+
 		Context("Unit tests for capacity calculation helpers", func() {
 			DescribeTable("calculateCIDRCapacity",
 				func(cidr string, family privatev1.IPFamily, expected int64) {

--- a/internal/servers/private_virtual_networks_server.go
+++ b/internal/servers/private_virtual_networks_server.go
@@ -176,7 +176,7 @@ func (s *PrivateVirtualNetworksServer) Update(ctx context.Context,
 		return
 	}
 
-	// Preserve implementation_strategy from existing object (it's immutable)
+	// Preserve immutable implementation_strategy from existing object.
 	if request.GetObject().GetSpec() != nil && existingVN.GetSpec() != nil {
 		request.GetObject().GetSpec().SetImplementationStrategy(existingVN.GetSpec().GetImplementationStrategy())
 	}
@@ -275,6 +275,13 @@ func validateImmutableFields(newVN *privatev1.VirtualNetwork, existingVN *privat
 		return grpcstatus.Errorf(grpccodes.InvalidArgument,
 			"field 'spec.network_class' is immutable and cannot be changed from '%s' to '%s'",
 			existingSpec.GetNetworkClass(), newSpec.GetNetworkClass())
+	}
+
+	// Check immutable implementation_strategy field.
+	if newStrategy := newSpec.GetImplementationStrategy(); newStrategy != "" && newStrategy != existingSpec.GetImplementationStrategy() {
+		return grpcstatus.Errorf(grpccodes.InvalidArgument,
+			"field 'spec.implementation_strategy' is immutable and cannot be changed from '%s' to '%s'",
+			existingSpec.GetImplementationStrategy(), newStrategy)
 	}
 
 	// VN-VAL-11, VN-VAL-12: Preserve and check immutable CIDR fields.

--- a/internal/servers/private_virtual_networks_server_test.go
+++ b/internal/servers/private_virtual_networks_server_test.go
@@ -714,6 +714,96 @@ var _ = Describe("Private virtual networks server", func() {
 			})
 		})
 
+		Context("implementation_strategy immutability on Update", func() {
+			It("rejects changing implementation_strategy", func() {
+				existing := privatev1.VirtualNetwork_builder{
+					Spec: privatev1.VirtualNetworkSpec_builder{
+						Region:                 "us-west-1",
+						NetworkClass:           "test-class",
+						Ipv4Cidr:               new("10.0.0.0/16"),
+						ImplementationStrategy: "strategy-a",
+					}.Build(),
+				}.Build()
+
+				updated := privatev1.VirtualNetwork_builder{
+					Spec: privatev1.VirtualNetworkSpec_builder{
+						Region:                 "us-west-1",
+						NetworkClass:           "test-class",
+						Ipv4Cidr:               new("10.0.0.0/16"),
+						ImplementationStrategy: "strategy-b",
+					}.Build(),
+				}.Build()
+
+				_, err := server.validateVirtualNetwork(ctx, updated, existing)
+				Expect(err).To(HaveOccurred())
+				status, ok := grpcstatus.FromError(err)
+				Expect(ok).To(BeTrue())
+				Expect(status.Code()).To(Equal(grpccodes.InvalidArgument))
+				Expect(err.Error()).To(ContainSubstring("implementation_strategy"))
+				Expect(err.Error()).To(ContainSubstring("immutable"))
+			})
+
+			It("allows same implementation_strategy on Update", func() {
+				nc := createNetworkClass(ctx, privatev1.NetworkClassState_NETWORK_CLASS_STATE_READY)
+
+				existing := privatev1.VirtualNetwork_builder{
+					Spec: privatev1.VirtualNetworkSpec_builder{
+						Region:                 "us-west-1",
+						NetworkClass:           nc.GetId(),
+						Ipv4Cidr:               new("10.0.0.0/16"),
+						ImplementationStrategy: "test-strategy",
+					}.Build(),
+				}.Build()
+
+				updated := privatev1.VirtualNetwork_builder{
+					Spec: privatev1.VirtualNetworkSpec_builder{
+						Region:                 "us-west-1",
+						NetworkClass:           nc.GetId(),
+						Ipv4Cidr:               new("10.0.0.0/16"),
+						ImplementationStrategy: "test-strategy",
+					}.Build(),
+				}.Build()
+
+				_, err := server.validateVirtualNetwork(ctx, updated, existing)
+				Expect(err).ToNot(HaveOccurred())
+			})
+
+			It("preserves implementation_strategy when omitted in Update (round-trip)", func() {
+				nc := createNetworkClass(ctx, privatev1.NetworkClassState_NETWORK_CLASS_STATE_READY)
+
+				createResponse, err := server.Create(ctx, privatev1.VirtualNetworksCreateRequest_builder{
+					Object: privatev1.VirtualNetwork_builder{
+						Metadata: privatev1.Metadata_builder{
+							Tenant: auth.SharedTenant,
+						}.Build(),
+						Spec: privatev1.VirtualNetworkSpec_builder{
+							Ipv4Cidr:     new("10.0.0.0/16"),
+							NetworkClass: nc.GetId(),
+							Region:       "us-west-1",
+						}.Build(),
+					}.Build(),
+				}.Build())
+				Expect(err).ToNot(HaveOccurred())
+				created := createResponse.GetObject()
+				Expect(created.GetSpec().GetImplementationStrategy()).To(Equal("test-strategy"))
+
+				updateResponse, err := server.Update(ctx, privatev1.VirtualNetworksUpdateRequest_builder{
+					Object: privatev1.VirtualNetwork_builder{
+						Id: created.GetId(),
+						Metadata: privatev1.Metadata_builder{
+							Name: "renamed-vn",
+						}.Build(),
+						Spec: privatev1.VirtualNetworkSpec_builder{
+							NetworkClass: nc.GetId(),
+							Region:       "us-west-1",
+						}.Build(),
+					}.Build(),
+				}.Build())
+				Expect(err).ToNot(HaveOccurred())
+				Expect(updateResponse.GetObject().GetSpec().GetImplementationStrategy()).To(Equal("test-strategy"))
+			})
+		})
+
 		Context("VN-VAL-11: IPv4 CIDR immutability on Update", func() {
 			It("prevents ipv4_cidr field modification", func() {
 				// Fake NetworkClass: immutability check for NC fires before the NC reference lookup


### PR DESCRIPTION
## Summary

- Adds explicit `InvalidArgument` validation rejecting changes to `spec.implementation_strategy` on `VirtualNetwork` and `PublicIPPool` updates.
- Silently preserves the existing value when the field is omitted from an update request, preventing accidental erasure.
- Adds tests for rejection, no-op same-value, and round-trip preservation on both resources.

## Test plan

- [x] `ginkgo run internal/servers --focus="implementation_strategy immutability"`