### PR TITLE
NO-ISSUE: Use `go.mod` hash in Ginkgo cache key

### DIFF
--- a/.github/actions/setup-go/action.yaml
+++ b/.github/actions/setup-go/action.yaml
@@ -26,7 +26,7 @@ runs:
   - id: ginkgo-cache
     uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5
     with:
-      key: ginkgo
+      key: ginkgo-${{ hashFiles('go.mod') }}
       path: ~/go/bin/ginkgo
   - if: steps.ginkgo-cache.outputs.cache-hit != 'true'
     shell: bash


### PR DESCRIPTION
## Summary

- The Ginkgo binary cache in the `setup-go` action used a static key (`ginkgo`), so it was never
  invalidated when the Ginkgo dependency version changed in `go.mod`.
- Include a hash of `go.mod` in the cache key so the installed binary stays in sync with the
  version of the Ginkgo library actually used for tests.

## Test plan

- Verify the CI `setup-go` action correctly caches and invalidates the Ginkgo binary when `go.mod`
  changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved cache handling for Go-based workflows so cached data is refreshed more reliably when dependencies change.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->