### PR TITLE
OSAC-1157: Mark it/charts as integration-test only

### DIFF
--- a/it/charts/README.md
+++ b/it/charts/README.md
@@ -1,0 +1,15 @@
+# Integration test Helm charts
+
+Charts in this directory are for **integration testing only**. They are deployed
+by the fulfillment-service `it/` Ginkgo suite and must not be used for production
+installations.
+
+For production PostgreSQL, deploy an in-cluster database via an operator
+(CloudNativePG, Crunchy PGO, or Zalando) as documented in
+[`docs/INSTALL.md`](../../docs/INSTALL.md).
+
+| Chart | Purpose |
+|-------|---------|
+| `postgres/` | Single-replica PostgreSQL with TLS for integration tests |
+| `keycloak/` | Keycloak instance for integration tests |
+| `prometheus/` | Prometheus monitoring stack for integration tests |

--- a/it/charts/prometheus/Chart.yaml
+++ b/it/charts/prometheus/Chart.yaml
@@ -13,7 +13,7 @@
 
 apiVersion: v2
 name: prometheus
-description: A Helm chart for Prometheus for use in the OSAC project
+description: A Helm chart for Prometheus for use in OSAC development and testing environments (not for production)
 type: application
 version: 0.0.0
 appVersion: "3.10.0"


### PR DESCRIPTION
## Summary

- Add `it/charts/README.md` documenting that charts under `it/charts/` are for integration testing only
- Update prometheus `Chart.yaml` description to match postgres/keycloak test-only wording
- Production PostgreSQL uses in-cluster operators per `docs/INSTALL.md`

## Persona impact (runtime)

| Persona | Impact | Manner |
|---------|--------|--------|
| **Cloud Infrastructure Admin** | Indirect | README points production path to `INSTALL.md` |
| **Cloud Provider Admin** | None direct | No admin UI/API change |
| **Tenant Admin** | None direct | No change |
| **Tenant User** | None direct | No change |

## Project contributor impact (open source)

| Stakeholder | Impact | Manner |
|-------------|--------|--------|
| **OSAC developer** | Indirect | `it/charts/postgres` still exists for local/integration use but marked test-only; not callable from `setup.sh` |
| **CI maintainer** | Direct | `it/it_tool.go` still deploys `it/charts/postgres` for Ginkgo integration tests — presubmit path unchanged; production-grade E2E migration is follow-up |
| **OSS contributor (non–Red Hat)** | Indirect | Clearer test-only boundaries in README; production path documented in INSTALL.md |

## Jira

[OSAC-1157](https://issues.redhat.com/browse/OSAC-1157)

## Related

Related: osac-installer#327

## Test plan

- [x] `pre-commit run --files it/charts/README.md it/charts/prometheus/Chart.yaml -c .pre-commit-config-ci.yaml`
- [ ] CI check-pull-request passes

## Acceptance Criteria

- [x] AC-4: `it/` charts clearly marked as test-only (README + Chart.yaml)

## Open questions (stakeholder-scoped)

1. **CI maintainer:** Should `it_tool.go` migrate off `it/charts/postgres` to production-grade Postgres (ticket author intent), or remain test-only with README warnings?
