### PR TITLE
NO-ISSUE: Document Python, uv, and the dev.py script

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,11 @@ To work with this project you will need the following tools:
 - [jq](https://jqlang.org) - Used by some of the commands in this document.
 - [kind](https://kind.sigs.k8s.io) - Used to create Kubernetes clusters for integration tests.
 - [helm](https://helm.sh/) - Used by default to deploy the service during integration tests.
+- [Python](https://www.python.org) - Used to run the `dev.py` script for development tasks like linting.
+- [uv](https://docs.astral.sh/uv) - Used to run the `dev.py` script without manually managing Python dependencies.
+
+See [dev/README.md](dev/README.md) for more information about the `dev.py` script and how to extend
+it with new commands.
 
 ## Building the binaries
 

--- a/dev/README.md
+++ b/dev/README.md
@@ -6,6 +6,30 @@ generating code, running tests with specific options, or installing a tool), it 
 new command or sub-command in the `dev/` Python package rather than as a standalone shell script or
 a Makefile target.
 
+## Running the script
+
+The recommended way to run the `dev.py` script is through [uv](https://docs.astral.sh/uv), which
+automatically manages the Python virtual environment and dependencies. For example, to run the
+linter:
+
+```shell
+uv run dev.py lint
+```
+
+Since `uv run dev.py` is a common prefix, it is convenient to create a shell alias:
+
+```shell
+alias dev='uv run dev.py'
+```
+
+With this alias in place the same command becomes:
+
+```shell
+dev lint
+```
+
+## Package structure
+
 The `dev/` package is organized as follows:
 
 - `dev.py` - Entry point that registers all commands via Click.


### PR DESCRIPTION
## Summary

- Add Python and uv to the list of required development tools in the main README, with a link
  to `dev/README.md` for further details.
- Add a "Running the script" section to `dev/README.md` explaining how to use `uv run dev.py`,
  with a recommendation to create a `dev` shell alias for convenience.

## Test plan

- Documentation-only change, no code modified.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the setup requirements to include Python and `uv`.
  * Added guidance on where to learn more about the development script and how to extend it with new commands.
  * Expanded the development guide with instructions for running the script, including example commands and an optional shell alias.
  * Added a section header to better organize the package layout explanation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->