### PR TITLE
NO-ISSUE: Add `build` command to `dev.py`

### DIFF
--- a/dev.py
+++ b/dev.py
@@ -33,6 +33,7 @@ def cli():
     """
 
 # Add the commands:
+cli.add_command(dev.build)
 cli.add_command(dev.lint)
 cli.add_command(dev.setup)
 

--- a/dev/__init__.py
+++ b/dev/__init__.py
@@ -13,6 +13,7 @@
 # specific language governing permissions and limitations under the License.
 #
 
+from .build import *
 from .formatter import *
 from .lint import *
 from .setup import *

--- a/dev/build.py
+++ b/dev/build.py
@@ -1,0 +1,65 @@
+# -*- coding: utf-8 -*-
+
+#
+# Copyright (c) 2026 Red Hat Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+# the License. You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+import logging
+
+import click
+
+from . import commands
+from . import dirs
+
+
+@click.group(invoke_without_command=True)
+@click.pass_context
+def build(ctx) -> None:
+    """
+    Builds the project artifacts. When no sub-command is specified it defaults to building the binaries.
+    """
+    if ctx.invoked_subcommand is None:
+        ctx.invoke(binaries)
+
+
+@build.command()
+def binaries() -> None:
+    """
+    Builds the Go binaries for each sub-directory of the cmd directory.
+    """
+    project_dir = dirs.project()
+    cmd_dir = project_dir / "cmd"
+    bin_dir = project_dir / "bin"
+    bin_dir.mkdir(parents=True, exist_ok=True)
+    for cmd_subdir in sorted(cmd_dir.iterdir()):
+        if not cmd_subdir.is_dir():
+            continue
+        bin_name = cmd_subdir.name
+        bin_file = bin_dir / bin_name
+        logging.info(f"Building binary '{bin_name}'")
+        commands.run([
+            "go", "build",
+            "-o", f"{bin_file.relative_to(project_dir)}",
+            f"./{cmd_subdir.relative_to(project_dir)}",
+        ])
+
+
+@build.command()
+def images() -> None:
+    """
+    Builds the container image using podman.
+    """
+    logging.info("Building container image")
+    commands.run([
+        "podman", "build",
+        ".",
+    ])

--- a/dev/commands.py
+++ b/dev/commands.py
@@ -32,6 +32,7 @@ def run(
     """
     Runs the given command.
     """
+    kwargs.setdefault("cwd", dirs.project())
     args = resolve(args)
     cmd = ' '.join(map(shlex.quote, args))
     logging.debug(f"Running command '{cmd}'")
@@ -46,6 +47,7 @@ def eval(
     """
     Runs the given command and returns the exit code and the text that it writes to the standard output.
     """
+    kwargs.setdefault("cwd", dirs.project())
     args = resolve(args)
     cmd = ' '.join(map(shlex.quote, args))
     logging.debug(f"Evaluating command '{cmd}'")


### PR DESCRIPTION
## Summary

- Adds a `build` command group to `dev.py` with `binaries` and `images` sub-commands.
- `build binaries` discovers sub-directories of `cmd/` and runs `go build` for each, placing outputs in `bin/`.
- `build images` runs `podman build .` to build the container image.

## Test plan

- Run `dev build binaries` and verify binaries appear in `bin/`.
- Run `dev build images` and verify podman builds the image.
- Run `dev build` with no sub-command and verify it defaults to building binaries.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new development build command to the CLI, including subcommands to build binaries and container images.
  * Binary builds now auto-discover command directories and produce executables in the output directory.
* **Improvements**
  * Updated command execution helpers to use the project directory as the default working location when none is provided.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->