### PR TITLE
OSAC-1794: Fix authn interceptor rejecting JWE tokens on anonymous methods

### DIFF
--- a/internal/auth/grpc_authn_interceptor.go
+++ b/internal/auth/grpc_authn_interceptor.go
@@ -161,13 +161,20 @@ func (s *grpcAuthnStream) SetTrailer(md metadata.MD) {
 }
 
 // authenticate extracts and validates the bearer token from the gRPC metadata, then stores the parsed token in the
-// context.
+// context. Anonymous methods skip authentication entirely, regardless of whether an authorization header is present.
+// This matches the behavior of the previous external auth interceptor and is required because some clients (e.g.
+// grpcurl) send non-JWT bearer tokens (such as JWE console tickets) on all requests, including anonymous methods
+// like reflection.
 func (i *GrpcAuthnInterceptor) authenticate(ctx context.Context, method string) (result context.Context, err error) {
+	if i.isAnonymous(method) {
+		result = ctx
+		return
+	}
 	values := metadata.ValueFromIncomingContext(ctx, Authorization)
 	length := len(values)
 	switch length {
 	case 0:
-		result, err = i.withoutHeader(ctx, method)
+		err = grpcstatus.Errorf(grpccodes.Unauthenticated, "method '%s' requires authentication", method)
 	case 1:
 		header := values[0]
 		result, err = i.withHeader(ctx, header)
@@ -192,16 +199,6 @@ func (i *GrpcAuthnInterceptor) withHeader(ctx context.Context, header string) (r
 		return
 	}
 	result = ContextWithToken(ctx, token)
-	return
-}
-
-func (i *GrpcAuthnInterceptor) withoutHeader(ctx context.Context, method string) (result context.Context,
-	err error) {
-	if i.isAnonymous(method) {
-		result = ctx
-		return
-	}
-	err = grpcstatus.Errorf(grpccodes.Unauthenticated, "method '%s' requires authentication", method)
 	return
 }
 

--- a/internal/auth/grpc_authn_interceptor_test.go
+++ b/internal/auth/grpc_authn_interceptor_test.go
@@ -230,12 +230,8 @@ var _ = Describe("Authentication interceptor behaviour", func() {
 		Expect(handled).To(BeTrue())
 	})
 
-	It("Rejects invalid token for anonymous method", func(ctx context.Context) {
-		errValidation := errors.New("my reason")
+	It("Ignores invalid token for anonymous method", func(ctx context.Context) {
 		jwtValidator := NewMockJwtValidator(ctrl)
-		jwtValidator.EXPECT().
-			Validate(gomock.Any(), gomock.Any()).
-			Return(nil, errValidation)
 		interceptor, err := NewGrpcAuthnInterceptor().
 			SetLogger(logger).
 			SetJwtValidator(jwtValidator).
@@ -252,35 +248,29 @@ var _ = Describe("Authentication interceptor behaviour", func() {
 				FullMethod: "/my_package/MyMethod",
 			},
 			func(ctx context.Context, req any) (any, error) {
+				stored := TokenFromContext(ctx)
+				Expect(stored).To(BeNil())
 				handled = true
 				return nil, nil
 			},
 		)
-		Expect(err).To(HaveOccurred())
-		status, ok := grpcstatus.FromError(err)
-		Expect(ok).To(BeTrue())
-		Expect(status.Code()).To(Equal(grpccodes.Unauthenticated))
-		Expect(status.Message()).To(Equal("my reason"))
-		Expect(handled).To(BeFalse())
+		Expect(err).ToNot(HaveOccurred())
+		Expect(handled).To(BeTrue())
 	})
 
-	It("Stores valid token for anonymous method", func(ctx context.Context) {
-		token := MakeTokenObject(nil, jwt.MapClaims{
-			"iss": issuerUrl,
-			"sub": "user-123",
-		})
-		bearer := token.Raw
+	It("Ignores valid token for anonymous method", func(ctx context.Context) {
 		jwtValidator := NewMockJwtValidator(ctrl)
-		jwtValidator.EXPECT().
-			Validate(gomock.Any(), bearer).
-			Return(token, nil)
 		interceptor, err := NewGrpcAuthnInterceptor().
 			SetLogger(logger).
 			SetJwtValidator(jwtValidator).
 			AddAnonymousMethodRegex(`^/my_package/.*$`).
 			Build()
 		Expect(err).ToNot(HaveOccurred())
-		ctx = metadata.NewIncomingContext(ctx, metadata.Pairs(Authorization, "Bearer "+bearer))
+		token := MakeTokenObject(nil, jwt.MapClaims{
+			"iss": issuerUrl,
+			"sub": "user-123",
+		})
+		ctx = metadata.NewIncomingContext(ctx, metadata.Pairs(Authorization, "Bearer "+token.Raw))
 		handled := false
 		_, err = interceptor.UnaryServer(
 			ctx,
@@ -290,7 +280,37 @@ var _ = Describe("Authentication interceptor behaviour", func() {
 			},
 			func(ctx context.Context, req any) (any, error) {
 				stored := TokenFromContext(ctx)
-				Expect(stored).To(BeIdenticalTo(token))
+				Expect(stored).To(BeNil())
+				handled = true
+				return nil, nil
+			},
+		)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(handled).To(BeTrue())
+	})
+
+	It("Ignores non-JWT authorization header for anonymous method", func(ctx context.Context) {
+		jwtValidator := NewMockJwtValidator(ctrl)
+		interceptor, err := NewGrpcAuthnInterceptor().
+			SetLogger(logger).
+			SetJwtValidator(jwtValidator).
+			AddAnonymousMethodRegex(`^/my_package/.*$`).
+			Build()
+		Expect(err).ToNot(HaveOccurred())
+		// JWE tokens have 5 dot-separated segments, which the JWT parser rejects.
+		// Anonymous methods must pass through regardless.
+		jweTicket := "header.key.iv.ciphertext.tag"
+		ctx = metadata.NewIncomingContext(ctx, metadata.Pairs(Authorization, "Bearer "+jweTicket))
+		handled := false
+		_, err = interceptor.UnaryServer(
+			ctx,
+			nil,
+			&grpc.UnaryServerInfo{
+				FullMethod: "/my_package/MyMethod",
+			},
+			func(ctx context.Context, req any) (any, error) {
+				stored := TokenFromContext(ctx)
+				Expect(stored).To(BeNil())
 				handled = true
 				return nil, nil
 			},


### PR DESCRIPTION
## Summary

The issue is demonstrated in https://github.com/osac-project/osac-test-infra/pull/97

- The built-in authn interceptor (added in 58c8ac44) validated the `Authorization` header even for anonymous methods like gRPC reflection and health checks. Clients such as `grpcurl` that send a bearer token on every request — including JWE console tickets — were rejected with "token is malformed" because the JWT parser cannot parse JWE's 5-segment format.
- Moved the `isAnonymous()` check to the top of `authenticate()`, before inspecting headers, so anonymous methods skip authentication entirely regardless of what headers are present. This restores the behavior of the previous `GrpcExternalAuthInterceptor`.
- Removed the now-unnecessary `withoutHeader()` method (its logic is inlined).

## Test plan

- [x] Updated "Rejects invalid token for anonymous method" -> "Ignores invalid token for anonymous method" (expects success)
- [x] Updated "Stores valid token for anonymous method" -> "Ignores valid token for anonymous method" (expects success, no token in context)
- [x] Added "Ignores non-JWT authorization header for anonymous method" (sends JWE-like 5-segment token, expects success)
- [x] All 66 test suites pass (`ginkgo run -r internal`)
- [x] Lint passes (`uv run dev.py lint`)
- [x] Verify console gRPC e2e tests pass with the updated image

Assisted-by: Claude <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Anonymous API calls now bypass authentication checks consistently, even if an authorization header is present.
  * Requests to anonymous methods no longer require a valid token and no longer place token data into the request context.
  * Non-JWT-style authorization values continue to pass through for anonymous methods without causing failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->