### PR TITLE
OSAC-1809: enforce timestamp-based naming for new database migrations

### DIFF
--- a/internal/database/database_migrations_test.go
+++ b/internal/database/database_migrations_test.go
@@ -87,7 +87,7 @@ var _ = Describe("Migrations", func() {
 		legacyPattern := regexp.MustCompile(`^(\d{1,4})_[a-z][a-z0-9_]*[a-z0-9]\.(up|down)\.sql$`)
 		timestampPattern := regexp.MustCompile(`^(\d{14})_[a-z][a-z0-9_]*[a-z0-9]\.(up|down)\.sql$`)
 
-		const lastSequentialMigration = 63
+		const lastSequentialMigration = 76
 
 		var violations []string
 		for _, file := range files {

--- a/internal/database/database_migrations_test.go
+++ b/internal/database/database_migrations_test.go
@@ -84,15 +84,40 @@ var _ = Describe("Migrations", func() {
 		Expect(err).ToNot(HaveOccurred())
 		Expect(files).ToNot(BeEmpty())
 
-		pattern := regexp.MustCompile(`^(\d+)_[a-z][a-z0-9_]*[a-z0-9]\.(up|down)\.sql$`)
+		legacyPattern := regexp.MustCompile(`^(\d{1,4})_[a-z][a-z0-9_]*[a-z0-9]\.(up|down)\.sql$`)
+		timestampPattern := regexp.MustCompile(`^(\d{14})_[a-z][a-z0-9_]*[a-z0-9]\.(up|down)\.sql$`)
+
+		const lastSequentialMigration = 63
+
 		var violations []string
 		for _, file := range files {
 			base := filepath.Base(file)
-			if !pattern.MatchString(base) {
-				violations = append(violations, base)
+
+			parts := strings.SplitN(base, "_", 2)
+			if len(parts) < 2 {
+				violations = append(violations, fmt.Sprintf("%s: cannot parse prefix", base))
+				continue
+			}
+			n, err := strconv.Atoi(parts[0])
+			if err != nil {
+				violations = append(violations, fmt.Sprintf("%s: prefix is not a number", base))
+				continue
+			}
+
+			if n <= lastSequentialMigration {
+				if !legacyPattern.MatchString(base) {
+					violations = append(violations, fmt.Sprintf("%s: legacy migration must match N_description.(up|down).sql", base))
+				}
+			} else {
+				if !timestampPattern.MatchString(base) {
+					violations = append(violations, fmt.Sprintf(
+						"%s: new migrations (> %d) must use timestamp format YYYYMMDDHHMMSS_description.(up|down).sql — "+
+							"generate with: date +%%Y%%m%%d%%H%%M%%S",
+						base, lastSequentialMigration))
+				}
 			}
 		}
-		Expect(violations).To(BeEmpty(), "migration filenames violate naming convention: %v", violations)
+		Expect(violations).To(BeEmpty(), "migration filenames violate naming convention:\n%s", strings.Join(violations, "\n"))
 	})
 
 	It("Has an up-to-date migrations hash", func() {
@@ -132,35 +157,4 @@ var _ = Describe("Migrations", func() {
 		}
 	})
 
-	It("Has no unexpected gaps in migration numbering", func() {
-		files, err := filepath.Glob("migrations/*.up.sql")
-		Expect(err).ToNot(HaveOccurred())
-		Expect(files).ToNot(BeEmpty())
-
-		knownGaps := map[int]bool{18: true}
-
-		present := map[int]bool{}
-		maxNum := 0
-		for _, file := range files {
-			base := filepath.Base(file)
-			parts := strings.SplitN(base, "_", 2)
-			if len(parts) < 2 {
-				continue
-			}
-			n, err := strconv.Atoi(parts[0])
-			Expect(err).ToNot(HaveOccurred(), "failed to parse migration number from %s", base)
-			present[n] = true
-			if n > maxNum {
-				maxNum = n
-			}
-		}
-
-		var gaps []int
-		for i := 0; i <= maxNum; i++ {
-			if !present[i] && !knownGaps[i] {
-				gaps = append(gaps, i)
-			}
-		}
-		Expect(gaps).To(BeEmpty(), "unexpected gaps in migration numbering: %v", gaps)
-	})
 })

--- a/internal/database/migrations/README.md
+++ b/internal/database/migrations/README.md
@@ -30,8 +30,7 @@ This forces one of them to renumber after the other's PR merges.
 Timestamp prefixes (`YYYYMMDDHHMMSS`) eliminate this problem — two
 developers would need to generate the prefix at the exact same second
 to collide. This is the same approach used by
-[assisted-service](https://github.com/openshift/assisted-service/tree/master/internal/migrations)
-and Rails ActiveRecord migrations.
+[assisted-service](https://github.com/openshift/assisted-service/tree/master/internal/migrations).
 
 ## Legacy migrations
 

--- a/internal/database/migrations/README.md
+++ b/internal/database/migrations/README.md
@@ -34,13 +34,13 @@ to collide. This is the same approach used by
 
 ## Legacy migrations
 
-Migrations 0–63 use the original sequential numbering. They are kept
+Migrations 0–76 use the original sequential numbering. They are kept
 as-is to avoid breaking deployed databases that track the current
-version in `schema_migrations`. Since `20260625... > 63`, golang-migrate
+version in `schema_migrations`. Since `20260625... > 76`, golang-migrate
 orders them correctly after the legacy files.
 
 ## CI enforcement
 
 The unit test in `database_migrations_test.go` enforces that any
-migration with a number > 63 uses the 14-digit timestamp format. PRs
+migration with a number > 76 uses the 14-digit timestamp format. PRs
 with incorrectly named migration files will fail CI.

--- a/internal/database/migrations/README.md
+++ b/internal/database/migrations/README.md
@@ -1,0 +1,46 @@
+# Database Migrations
+
+## Adding a new migration
+
+1. Generate a timestamp prefix:
+   ```bash
+   date +%Y%m%d%H%M%S
+   ```
+2. Create your migration file(s):
+   - `<timestamp>_<description>.up.sql` (required)
+   - `<timestamp>_<description>.down.sql` (optional)
+3. Description must be `snake_case`, starting with a verb (`add_`, `create_`, `drop_`, `rename_`, `migrate_`).
+
+Example:
+```bash
+# Generate prefix
+$ date +%Y%m%d%H%M%S
+20260625143022
+
+# Create the file
+$ touch internal/database/migrations/20260625143022_add_storage_class_column.up.sql
+```
+
+## Why timestamps?
+
+Sequential numbering (`54_`, `55_`, ...) caused collisions when two PRs
+independently claimed the same next number. With `strict: false` on
+branch protection (required to avoid tide retest loops), both PRs could
+merge without git detecting a conflict, breaking the service at startup.
+
+Timestamp prefixes (`YYYYMMDDHHMMSS`) make collisions practically
+impossible — two developers would need to create a migration at the
+exact same second.
+
+## Legacy migrations
+
+Migrations 0–63 use the original sequential numbering. They are kept
+as-is to avoid breaking deployed databases that track the current
+version in `schema_migrations`. Since `20260625... > 63`, golang-migrate
+orders them correctly after the legacy files.
+
+## CI enforcement
+
+The unit test in `database_migrations_test.go` enforces that any
+migration with a number > 63 uses the 14-digit timestamp format. PRs
+with incorrectly named migration files will fail CI.

--- a/internal/database/migrations/README.md
+++ b/internal/database/migrations/README.md
@@ -23,14 +23,15 @@ $ touch internal/database/migrations/20260625143022_add_storage_class_column.up.
 
 ## Why timestamps?
 
-Sequential numbering (`54_`, `55_`, ...) caused collisions when two PRs
-independently claimed the same next number. With `strict: false` on
-branch protection (required to avoid tide retest loops), both PRs could
-merge without git detecting a conflict, breaking the service at startup.
+With sequential numbering (`64_`, `65_`, ...), two developers
+independently adding migrations will both pick the same next number.
+This forces one of them to renumber after the other's PR merges.
 
-Timestamp prefixes (`YYYYMMDDHHMMSS`) make collisions practically
-impossible — two developers would need to create a migration at the
-exact same second.
+Timestamp prefixes (`YYYYMMDDHHMMSS`) eliminate this problem — two
+developers would need to generate the prefix at the exact same second
+to collide. This is the same approach used by
+[assisted-service](https://github.com/openshift/assisted-service/tree/master/internal/migrations)
+and Rails ActiveRecord migrations.
 
 ## Legacy migrations
 


### PR DESCRIPTION
## Summary

- Enforce timestamp-based naming (`YYYYMMDDHHMMSS_description.up.sql`) for all new migrations (number > 63) to eliminate migration number collisions between concurrent PRs
- Keep existing sequential migrations (0–63) as-is since deployed databases track versions in `schema_migrations`
- Remove the gap-detection test (not applicable for timestamp naming)
- Add migrations README documenting the convention and usage

## Motivation

With sequential numbering, two developers independently adding migrations will both pick the next number (e.g. `64`). This requires one of them to renumber after the other's PR merges. Timestamp prefixes (`YYYYMMDDHHMMSS`) make collisions practically impossible — two developers would need to generate the prefix at the exact same second. This is the same approach used by [assisted-service](https://github.com/openshift/assisted-service/tree/master/internal/migrations).

## Test plan

- [x] All existing migration tests pass (suffix, duplicates, naming convention, hash)
- [ ] Verify a new migration file with sequential naming (e.g. `64_foo.up.sql`) fails the naming convention test
- [ ] Verify a new migration file with timestamp naming (e.g. `20260625143022_foo.up.sql`) passes

Jira: [OSAC-1809](https://redhat.atlassian.net/browse/OSAC-1809)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified database migration naming rules and added step-by-step guidance for creating new migration files.
  * Documented both legacy sequential and newer timestamp-based migration formats.

* **Tests**
  * Strengthened migration filename validation with more detailed error reporting.
  * Removed the check for gaps in the sequential migration number range.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->