### PR TITLE
OSAC-1795: use proto reflection for --watch to support all event types

### DIFF
--- a/internal/cmd/cli/edit/edit_cmd.go
+++ b/internal/cmd/cli/edit/edit_cmd.go
@@ -28,8 +28,11 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/reflect/protoreflect"
 	"gopkg.in/yaml.v3"
 
+	privatev1 "github.com/osac-project/fulfillment-service/internal/api/osac/private/v1"
+	publicv1 "github.com/osac-project/fulfillment-service/internal/api/osac/public/v1"
 	"github.com/osac-project/fulfillment-service/internal/config"
 	"github.com/osac-project/fulfillment-service/internal/logging"
 	"github.com/osac-project/fulfillment-service/internal/reflection"
@@ -239,7 +242,9 @@ func (c *runnerContext) run(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	c.showWatchSuggestion(ctx, updated)
+	if c.isWatchable() {
+		c.showWatchSuggestion(ctx, updated)
+	}
 
 	return nil
 }
@@ -271,6 +276,26 @@ func (c *runnerContext) findEditor(ctx context.Context) string {
 func (c *runnerContext) update(ctx context.Context, object proto.Message) (result proto.Message, err error) {
 	result, err = c.helper.Update(ctx, object)
 	return
+}
+
+func (c *runnerContext) isWatchable() bool {
+	objectFullName := c.helper.Descriptor().FullName()
+	for _, eventDesc := range []protoreflect.MessageDescriptor{
+		(&publicv1.Event{}).ProtoReflect().Descriptor(),
+		(&privatev1.Event{}).ProtoReflect().Descriptor(),
+	} {
+		payloadOneof := eventDesc.Oneofs().ByName("payload")
+		if payloadOneof == nil {
+			continue
+		}
+		for i := 0; i < payloadOneof.Fields().Len(); i++ {
+			field := payloadOneof.Fields().Get(i)
+			if field.Message() != nil && field.Message().FullName() == objectFullName {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 func (c *runnerContext) showWatchSuggestion(ctx context.Context, object proto.Message) {

--- a/internal/cmd/cli/edit/edit_cmd_test.go
+++ b/internal/cmd/cli/edit/edit_cmd_test.go
@@ -19,6 +19,7 @@ import (
 	"log/slog"
 
 	. "github.com/onsi/ginkgo/v2/dsl/core"
+	. "github.com/onsi/ginkgo/v2/dsl/table"
 	. "github.com/onsi/gomega"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
@@ -82,6 +83,29 @@ var _ = Describe("Edit command", func() {
 		helper = reflectionHelper.Lookup("cluster")
 		Expect(helper).ToNot(BeNil())
 	})
+
+	DescribeTable("isWatchable",
+		func(objectType string, packages map[string]int, expected bool) {
+			builder := reflection.NewHelper().
+				SetLogger(logger).
+				SetConnection(conn)
+			for pkg, order := range packages {
+				builder = builder.AddPackage(pkg, order)
+			}
+			reflectionHelper, err := builder.Build()
+			Expect(err).ToNot(HaveOccurred())
+
+			h := reflectionHelper.Lookup(objectType)
+			Expect(h).ToNot(BeNil(), "failed to look up object type %q", objectType)
+
+			runner := &runnerContext{helper: h}
+			Expect(runner.isWatchable()).To(Equal(expected))
+		},
+		Entry("public cluster is watchable", "cluster", map[string]int{"osac.public.v1": 0}, true),
+		Entry("public compute instance is watchable", "computeinstance", map[string]int{"osac.public.v1": 0}, true),
+		Entry("public identity provider is not watchable", "identityprovider", map[string]int{"osac.public.v1": 0}, false),
+		Entry("private hub is watchable", "hub", map[string]int{"osac.private.v1": 0}, true),
+	)
 
 	Describe("showWatchSuggestion", func() {
 		It("should render watch suggestion with object type and ID", func() {

--- a/internal/cmd/cli/get/get_cmd_watch.go
+++ b/internal/cmd/cli/get/get_cmd_watch.go
@@ -21,10 +21,31 @@ import (
 	"strings"
 	"time"
 
+	"google.golang.org/grpc"
 	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/reflect/protoreflect"
 
+	privatev1 "github.com/osac-project/fulfillment-service/internal/api/osac/private/v1"
 	publicv1 "github.com/osac-project/fulfillment-service/internal/api/osac/public/v1"
 )
+
+type eventStream struct {
+	stream  grpc.ClientStream
+	newResp func() proto.Message
+}
+
+func (s *eventStream) Recv() (proto.Message, error) {
+	resp := s.newResp()
+	if err := s.stream.RecvMsg(resp); err != nil {
+		return nil, err
+	}
+	msg := resp.ProtoReflect()
+	eventField := msg.Descriptor().Fields().ByName("event")
+	if eventField == nil || !msg.Has(eventField) {
+		return nil, nil
+	}
+	return msg.Get(eventField).Message().Interface(), nil
+}
 
 // watch watches for events and displays updated objects.
 func (c *runnerContext) watch(ctx context.Context, keys []string) error {
@@ -34,22 +55,18 @@ func (c *runnerContext) watch(ctx context.Context, keys []string) error {
 		return fmt.Errorf("failed to build event filter: %w", err)
 	}
 
-	// Create events client
-	eventsClient := publicv1.NewEventsClient(c.conn)
-
 	// Start watching
 	c.console.Infof(ctx, "Watching for changes (Ctrl+C to stop)...\n\n")
 
-	stream, err := eventsClient.Watch(ctx, &publicv1.EventsWatchRequest{
-		Filter: &filter,
-	})
+	// Create the appropriate event stream based on the object's API package
+	stream, err := c.createEventStream(ctx, filter)
 	if err != nil {
 		return fmt.Errorf("failed to start watching events: %w", err)
 	}
 
 	// Process events
 	for {
-		response, err := stream.Recv()
+		event, err := stream.Recv()
 		if errors.Is(err, io.EOF) {
 			return nil
 		}
@@ -57,23 +74,12 @@ func (c *runnerContext) watch(ctx context.Context, keys []string) error {
 			return fmt.Errorf("failed to receive event: %w", err)
 		}
 
-		event := response.GetEvent()
 		if event == nil {
 			continue
 		}
 
 		// Extract the object from the event payload
-		object, err := c.extractObjectFromEvent(event)
-		if err != nil {
-			c.logger.WarnContext(
-				ctx,
-				"Failed to extract object from event",
-				"event_id", event.GetId(),
-				"error", err,
-			)
-			continue
-		}
-
+		object := c.extractObjectFromEvent(event)
 		if object == nil {
 			continue
 		}
@@ -81,6 +87,23 @@ func (c *runnerContext) watch(ctx context.Context, keys []string) error {
 		// Display the event
 		c.displayEvent(ctx, event, object)
 	}
+}
+
+func (c *runnerContext) createEventStream(ctx context.Context, filter string) (*eventStream, error) {
+	if c.isPrivateObject() {
+		client := privatev1.NewEventsClient(c.conn)
+		stream, err := client.Watch(ctx, &privatev1.EventsWatchRequest{Filter: &filter})
+		if err != nil {
+			return nil, err
+		}
+		return &eventStream{stream: stream, newResp: func() proto.Message { return &privatev1.EventsWatchResponse{} }}, nil
+	}
+	client := publicv1.NewEventsClient(c.conn)
+	stream, err := client.Watch(ctx, &publicv1.EventsWatchRequest{Filter: &filter})
+	if err != nil {
+		return nil, err
+	}
+	return &eventStream{stream: stream, newResp: func() proto.Message { return &publicv1.EventsWatchResponse{} }}, nil
 }
 
 // buildEventFilter builds a CEL filter expression for watching events.
@@ -113,40 +136,68 @@ func (c *runnerContext) buildEventFilter(keys []string) (string, error) {
 	return strings.Join(parts, " && "), nil
 }
 
-// Map of proto message full names to event payload field names
-var eventPayloadFieldNames = map[string]string{
-	string(proto.MessageName((*publicv1.Cluster)(nil))):         "cluster",
-	string(proto.MessageName((*publicv1.ClusterTemplate)(nil))): "cluster_template",
-}
-
-// getEventPayloadFieldName returns the field name in the Event message for the current object type.
+// getEventPayloadFieldName returns the field name in the Event message for the current object type
+// by introspecting the Event proto descriptor's payload oneof.
 func (c *runnerContext) getEventPayloadFieldName() string {
-	fullName := string(c.objectHelper.Descriptor().FullName())
-	return eventPayloadFieldNames[fullName]
+	eventDesc := c.getEventDescriptor()
+	payloadOneof := eventDesc.Oneofs().ByName("payload")
+	if payloadOneof == nil {
+		return ""
+	}
+
+	objectFullName := c.objectHelper.Descriptor().FullName()
+	for i := 0; i < payloadOneof.Fields().Len(); i++ {
+		field := payloadOneof.Fields().Get(i)
+		if field.Message() != nil && field.Message().FullName() == objectFullName {
+			return string(field.Name())
+		}
+	}
+	return ""
 }
 
-// extractObjectFromEvent extracts the proto message from an event payload.
-func (c *runnerContext) extractObjectFromEvent(event *publicv1.Event) (proto.Message, error) {
-	payload := event.GetPayload()
-	if payload == nil {
-		return nil, fmt.Errorf("event has no payload")
+// getEventDescriptor returns the Event message descriptor matching the object's API package.
+func (c *runnerContext) getEventDescriptor() protoreflect.MessageDescriptor {
+	if c.isPrivateObject() {
+		return (&privatev1.Event{}).ProtoReflect().Descriptor()
 	}
+	return (&publicv1.Event{}).ProtoReflect().Descriptor()
+}
 
-	// Use type switch on the oneof payload
-	switch p := payload.(type) {
-	case *publicv1.Event_Cluster:
-		return p.Cluster, nil
-	case *publicv1.Event_ClusterTemplate:
-		return p.ClusterTemplate, nil
-	default:
-		return nil, fmt.Errorf("unsupported event payload type")
+// isPrivateObject returns true if the current object type belongs to the private API package.
+func (c *runnerContext) isPrivateObject() bool {
+	return strings.HasPrefix(string(c.objectHelper.FullName()), "osac.private.")
+}
+
+// extractObjectFromEvent extracts the proto message from an event's payload oneof using reflection.
+func (c *runnerContext) extractObjectFromEvent(event proto.Message) proto.Message {
+	msg := event.ProtoReflect()
+	payloadOneof := msg.Descriptor().Oneofs().ByName("payload")
+	if payloadOneof == nil {
+		return nil
 	}
+	whichField := msg.WhichOneof(payloadOneof)
+	if whichField == nil {
+		return nil
+	}
+	return msg.Get(whichField).Message().Interface()
+}
+
+// getEventTypeName extracts the event type name from an Event proto message using reflection.
+func getEventTypeName(event proto.Message) string {
+	eventMsg := event.ProtoReflect()
+	typeField := eventMsg.Descriptor().Fields().ByName("type")
+	typeValue := eventMsg.Get(typeField)
+	if enumDesc := typeField.Enum().Values().ByNumber(typeValue.Enum()); enumDesc != nil {
+		return strings.TrimPrefix(string(enumDesc.Name()), "EVENT_TYPE_")
+	}
+	return fmt.Sprintf("UNKNOWN(%d)", typeValue.Enum())
 }
 
 // displayEvent displays an event and the updated object.
-func (c *runnerContext) displayEvent(ctx context.Context, event *publicv1.Event, object proto.Message) {
+func (c *runnerContext) displayEvent(ctx context.Context, event proto.Message, object proto.Message) {
 	timestamp := time.Now().Format(time.TimeOnly)
-	eventType := strings.TrimPrefix(event.GetType().String(), "EVENT_TYPE_")
+
+	eventType := getEventTypeName(event)
 
 	objectId := c.getObjectId(object)
 

--- a/internal/cmd/cli/get/get_cmd_watch_test.go
+++ b/internal/cmd/cli/get/get_cmd_watch_test.go
@@ -18,22 +18,23 @@ import (
 	. "github.com/onsi/ginkgo/v2/dsl/table"
 	. "github.com/onsi/gomega"
 	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/reflect/protoreflect"
 
+	privatev1 "github.com/osac-project/fulfillment-service/internal/api/osac/private/v1"
 	publicv1 "github.com/osac-project/fulfillment-service/internal/api/osac/public/v1"
 )
 
 var _ = Describe("Watch command", func() {
 	DescribeTable("extractObjectFromEvent",
-		func(event *publicv1.Event, expectedType proto.Message, shouldSucceed bool) {
+		func(event proto.Message, expectedType proto.Message, shouldSucceed bool) {
 			runner := &runnerContext{}
-			object, err := runner.extractObjectFromEvent(event)
+			object := runner.extractObjectFromEvent(event)
 
 			if shouldSucceed {
-				Expect(err).ToNot(HaveOccurred())
 				Expect(object).ToNot(BeNil())
 				Expect(proto.MessageName(object)).To(Equal(proto.MessageName(expectedType)))
 			} else {
-				Expect(err).To(HaveOccurred())
+				Expect(object).To(BeNil())
 			}
 		},
 		Entry("cluster event",
@@ -54,10 +55,57 @@ var _ = Describe("Watch command", func() {
 			(*publicv1.ClusterTemplate)(nil),
 			true,
 		),
-		Entry("event with no payload",
+		Entry("compute instance event",
+			&publicv1.Event{
+				Payload: &publicv1.Event_ComputeInstance{
+					ComputeInstance: &publicv1.ComputeInstance{Id: "test-instance"},
+				},
+			},
+			(*publicv1.ComputeInstance)(nil),
+			true,
+		),
+		Entry("private hub event",
+			&privatev1.Event{
+				Payload: &privatev1.Event_Hub{
+					Hub: &privatev1.Hub{Id: "test-hub"},
+				},
+			},
+			(*privatev1.Hub)(nil),
+			true,
+		),
+		Entry("public event with no payload",
 			&publicv1.Event{},
 			nil,
 			false,
+		),
+		Entry("private event with no payload",
+			&privatev1.Event{},
+			nil,
+			false,
+		),
+	)
+
+	DescribeTable("getEventTypeName",
+		func(event proto.Message, expected string) {
+			Expect(getEventTypeName(event)).To(Equal(expected))
+		},
+		Entry("known public event type",
+			&publicv1.Event{Type: publicv1.EventType_EVENT_TYPE_OBJECT_CREATED},
+			"OBJECT_CREATED",
+		),
+		Entry("unspecified event type",
+			&publicv1.Event{},
+			"UNSPECIFIED",
+		),
+		Entry("unknown event type number",
+			func() proto.Message {
+				event := &publicv1.Event{}
+				msg := event.ProtoReflect()
+				typeField := msg.Descriptor().Fields().ByName("type")
+				msg.Set(typeField, protoreflect.ValueOfEnum(9999))
+				return event
+			}(),
+			"UNKNOWN(9999)",
 		),
 	)
 


### PR DESCRIPTION
Replace hardcoded event type maps with protobuf descriptor reflection so --watch works for all Event payload types automatically. Add private API Events client support and only show the watch suggestion in edit for types that have Event payload definitions.

Assisted-by: Claude Code <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The `edit` and `get watch` commands now support more object types and can work with both public and private event streams.
  * Watch suggestions are shown only when the edited object can actually be followed.

* **Bug Fixes**
  * Improved event handling so watched items are extracted and displayed more reliably across supported object types.
  * Fixed support for additional event payloads, including compute instance updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->