### PR TITLE
OSAC-1811: Implement deleting IdP connections

### DIFF
--- a/internal/controllers/identityprovider/identity_provider_reconciler_function.go
+++ b/internal/controllers/identityprovider/identity_provider_reconciler_function.go
@@ -18,12 +18,14 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"net/http"
 	"slices"
 
 	"google.golang.org/grpc"
 	"google.golang.org/protobuf/proto"
 
 	privatev1 "github.com/osac-project/fulfillment-service/internal/api/osac/private/v1"
+	"github.com/osac-project/fulfillment-service/internal/apiclient"
 	"github.com/osac-project/fulfillment-service/internal/auth"
 	"github.com/osac-project/fulfillment-service/internal/controllers/finalizers"
 	"github.com/osac-project/fulfillment-service/internal/idp"
@@ -159,18 +161,32 @@ func (t *task) update(ctx context.Context) error {
 
 // syncToIDP synchronizes the identity provider to the IDP backend (Keycloak).
 func (t *task) syncToIDP(ctx context.Context) error {
-	// Build the IDP provider object from the spec
-	// Use tenant-prefixed alias to ensure uniqueness across tenants in Keycloak
-	alias := fmt.Sprintf("%s-%s", t.identityProvider.GetMetadata().GetTenant(), t.identityProvider.GetMetadata().GetName())
-	idpProvider := &idp.IdentityProvider{
-		Alias:       alias,
-		DisplayName: t.identityProvider.GetSpec().GetTitle(),
-		Type:        t.determineProviderType(),
-		Enabled:     t.identityProvider.GetSpec().GetEnabled(),
-		Config:      t.buildConfig(),
+	// Fetch the full identity provider with secrets from the API if available
+	// (events have secrets redacted for security, but tests may provide full objects directly)
+	fullIdp := t.identityProvider
+	if t.r.identityProvidersClient != nil {
+		response, err := t.r.identityProvidersClient.Get(ctx, privatev1.IdentityProvidersGetRequest_builder{
+			Id: t.identityProvider.GetId(),
+		}.Build())
+		if err != nil {
+			return fmt.Errorf("failed to fetch identity provider: %w", err)
+		}
+		fullIdp = response.GetObject()
 	}
 
-	createdIdp, err := t.r.idpClient.CreateIdentityProvider(ctx, idpProvider)
+	// Build the IDP provider object from the spec
+	// Use tenant-prefixed alias to ensure uniqueness across tenants in Keycloak
+	alias := fmt.Sprintf("%s-%s", fullIdp.GetMetadata().GetTenant(), fullIdp.GetMetadata().GetName())
+	idpProvider := &idp.IdentityProvider{
+		Alias:       alias,
+		DisplayName: fullIdp.GetSpec().GetTitle(),
+		Type:        t.determineProviderTypeFromIdp(fullIdp),
+		Enabled:     fullIdp.GetSpec().GetEnabled(),
+		Config:      t.buildConfigFromIdp(fullIdp),
+	}
+
+	organizationName := t.identityProvider.GetMetadata().GetTenant()
+	createdIdp, err := t.r.idpClient.CreateIdentityProvider(ctx, organizationName, idpProvider)
 	if err != nil {
 		t.identityProvider.GetStatus().SetPhase(privatev1.IdentityProviderPhase_IDENTITY_PROVIDER_PHASE_ERROR)
 		t.identityProvider.GetStatus().SetMessage(fmt.Sprintf("Identity provider creation in IDP failed: %v", err))
@@ -188,9 +204,9 @@ func (t *task) syncToIDP(ctx context.Context) error {
 	return nil
 }
 
-// determineProviderType returns the provider type based on which config is set.
-func (t *task) determineProviderType() string {
-	spec := t.identityProvider.GetSpec()
+// determineProviderTypeFromIdp returns the provider type based on which config is set.
+func (t *task) determineProviderTypeFromIdp(idp *privatev1.IdentityProvider) string {
+	spec := idp.GetSpec()
 	if spec.HasLdap() {
 		return "ldap"
 	}
@@ -200,10 +216,10 @@ func (t *task) determineProviderType() string {
 	return ""
 }
 
-// buildConfig builds the provider-specific configuration map.
-func (t *task) buildConfig() map[string]string {
+// buildConfigFromIdp builds the provider-specific configuration map from any identity provider object.
+func (t *task) buildConfigFromIdp(idp *privatev1.IdentityProvider) map[string]string {
 	config := make(map[string]string)
-	spec := t.identityProvider.GetSpec()
+	spec := idp.GetSpec()
 
 	if ldap := spec.GetLdap(); ldap != nil {
 		config["connectionUrl"] = ldap.GetConnectionUrl()
@@ -218,6 +234,8 @@ func (t *task) buildConfig() map[string]string {
 		config["clientId"] = oidc.GetClientId()
 		config["clientSecret"] = oidc.GetClientSecret()
 		config["issuer"] = oidc.GetIssuer()
+		// Keycloak requires clientAuthMethod to be set for OIDC providers
+		config["clientAuthMethod"] = "client_secret_post"
 	}
 
 	return config
@@ -283,11 +301,36 @@ func (t *task) delete(ctx context.Context) error {
 		return nil
 	}
 
-	// TODO: Add DeleteIdentityProvider method to idp.Client interface and implement deletion
-	// For now, we just remove the finalizer to allow the object to be deleted from the database
-	t.r.logger.WarnContext(ctx, "Identity provider deletion from IDP not yet implemented",
-		slog.String("identity_provider_id", t.identityProvider.GetId()),
-	)
+	// Delete the identity provider from Keycloak
+	// Use tenant-prefixed alias (same as in syncToIDP)
+	organizationName := t.identityProvider.GetMetadata().GetTenant()
+	alias := fmt.Sprintf("%s-%s", organizationName, t.identityProvider.GetMetadata().GetName())
+
+	err := t.r.idpClient.DeleteIdentityProvider(ctx, organizationName, alias)
+	if err != nil {
+		// Check if this is a terminal error (not found / already deleted)
+		var apiErr *apiclient.APIError
+		if errors.As(err, &apiErr) && apiErr.StatusCode == http.StatusNotFound {
+			// IdP already deleted - this is expected, proceed with finalizer removal
+			t.r.logger.InfoContext(ctx, "Identity provider not found in IDP (already deleted)",
+				slog.String("identity_provider_id", t.identityProvider.GetId()),
+				slog.String("alias", alias),
+			)
+		} else {
+			// Transient error - keep finalizer and retry
+			t.r.logger.ErrorContext(ctx, "Failed to delete identity provider from IDP",
+				slog.String("identity_provider_id", t.identityProvider.GetId()),
+				slog.String("alias", alias),
+				slog.Any("error", err),
+			)
+			return fmt.Errorf("failed to delete identity provider from IDP: %w", err)
+		}
+	} else {
+		t.r.logger.InfoContext(ctx, "Identity provider deleted from IDP",
+			slog.String("identity_provider_id", t.identityProvider.GetId()),
+			slog.String("alias", alias),
+		)
+	}
 
 	t.removeFinalizer()
 	return nil

--- a/internal/controllers/identityprovider/identity_provider_reconciler_function_test.go
+++ b/internal/controllers/identityprovider/identity_provider_reconciler_function_test.go
@@ -24,9 +24,48 @@ import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	privatev1 "github.com/osac-project/fulfillment-service/internal/api/osac/private/v1"
+	"github.com/osac-project/fulfillment-service/internal/apiclient"
 	"github.com/osac-project/fulfillment-service/internal/controllers/finalizers"
 	"github.com/osac-project/fulfillment-service/internal/idp"
+	"google.golang.org/grpc"
 )
+
+// mockIdentityProvidersClient is a minimal mock for testing the gRPC client path
+type mockIdentityProvidersClient struct {
+	getFunc func(ctx context.Context, req *privatev1.IdentityProvidersGetRequest) (*privatev1.IdentityProvidersGetResponse, error)
+}
+
+func (m *mockIdentityProvidersClient) Get(ctx context.Context, req *privatev1.IdentityProvidersGetRequest, _ ...grpc.CallOption) (*privatev1.IdentityProvidersGetResponse, error) {
+	return m.getFunc(ctx, req)
+}
+
+func (m *mockIdentityProvidersClient) Create(ctx context.Context, req *privatev1.IdentityProvidersCreateRequest, _ ...grpc.CallOption) (*privatev1.IdentityProvidersCreateResponse, error) {
+	return nil, nil
+}
+
+func (m *mockIdentityProvidersClient) List(ctx context.Context, req *privatev1.IdentityProvidersListRequest, _ ...grpc.CallOption) (*privatev1.IdentityProvidersListResponse, error) {
+	return nil, nil
+}
+
+func (m *mockIdentityProvidersClient) Update(ctx context.Context, req *privatev1.IdentityProvidersUpdateRequest, _ ...grpc.CallOption) (*privatev1.IdentityProvidersUpdateResponse, error) {
+	return nil, nil
+}
+
+func (m *mockIdentityProvidersClient) Delete(ctx context.Context, req *privatev1.IdentityProvidersDeleteRequest, _ ...grpc.CallOption) (*privatev1.IdentityProvidersDeleteResponse, error) {
+	return nil, nil
+}
+
+func (m *mockIdentityProvidersClient) Signal(ctx context.Context, req *privatev1.IdentityProvidersSignalRequest, _ ...grpc.CallOption) (*privatev1.IdentityProvidersSignalResponse, error) {
+	return nil, nil
+}
+
+func (m *mockIdentityProvidersClient) Assign(ctx context.Context, req *privatev1.IdentityProvidersAssignRequest, _ ...grpc.CallOption) (*privatev1.IdentityProvidersAssignResponse, error) {
+	return nil, nil
+}
+
+func (m *mockIdentityProvidersClient) Unassign(ctx context.Context, req *privatev1.IdentityProvidersUnassignRequest, _ ...grpc.CallOption) (*privatev1.IdentityProvidersUnassignResponse, error) {
+	return nil, nil
+}
 
 var _ = Describe("Finalizer Management", func() {
 	It("should add finalizer on first call", func() {
@@ -225,7 +264,7 @@ var _ = Describe("Provider Type Detection", func() {
 			identityProvider: identityProvider,
 		}
 
-		providerType := task.determineProviderType()
+		providerType := task.determineProviderTypeFromIdp(identityProvider)
 		Expect(providerType).To(Equal("ldap"))
 	})
 
@@ -242,7 +281,7 @@ var _ = Describe("Provider Type Detection", func() {
 			identityProvider: identityProvider,
 		}
 
-		providerType := task.determineProviderType()
+		providerType := task.determineProviderTypeFromIdp(identityProvider)
 		Expect(providerType).To(Equal("oidc"))
 	})
 
@@ -255,7 +294,7 @@ var _ = Describe("Provider Type Detection", func() {
 			identityProvider: identityProvider,
 		}
 
-		providerType := task.determineProviderType()
+		providerType := task.determineProviderTypeFromIdp(identityProvider)
 		Expect(providerType).To(BeEmpty())
 	})
 
@@ -275,7 +314,7 @@ var _ = Describe("Provider Type Detection", func() {
 			identityProvider: identityProvider,
 		}
 
-		providerType := task.determineProviderType()
+		providerType := task.determineProviderTypeFromIdp(identityProvider)
 		Expect(providerType).To(Equal("ldap"))
 	})
 })
@@ -297,7 +336,7 @@ var _ = Describe("Config Building", func() {
 			identityProvider: identityProvider,
 		}
 
-		config := task.buildConfig()
+		config := task.buildConfigFromIdp(identityProvider)
 		Expect(config).To(HaveKeyWithValue("connectionUrl", "ldap://example.com:389"))
 		Expect(config).To(HaveKeyWithValue("bindDn", "cn=admin,dc=example,dc=com"))
 		Expect(config).To(HaveKeyWithValue("bindCredential", "secret"))
@@ -321,7 +360,7 @@ var _ = Describe("Config Building", func() {
 			identityProvider: identityProvider,
 		}
 
-		config := task.buildConfig()
+		config := task.buildConfigFromIdp(identityProvider)
 		Expect(config).To(HaveKeyWithValue("authorizationUrl", "https://example.com/auth"))
 		Expect(config).To(HaveKeyWithValue("tokenUrl", "https://example.com/token"))
 		Expect(config).To(HaveKeyWithValue("clientId", "client-123"))
@@ -338,7 +377,7 @@ var _ = Describe("Config Building", func() {
 			identityProvider: identityProvider,
 		}
 
-		config := task.buildConfig()
+		config := task.buildConfigFromIdp(identityProvider)
 		Expect(config).To(BeEmpty())
 	})
 })
@@ -385,8 +424,9 @@ var _ = Describe("IDP Sync", func() {
 		}.Build()
 
 		mockClient.EXPECT().
-			CreateIdentityProvider(gomock.Any(), gomock.Any()).
-			DoAndReturn(func(ctx context.Context, idpProvider *idp.IdentityProvider) (*idp.IdentityProvider, error) {
+			CreateIdentityProvider(gomock.Any(), gomock.Any(), gomock.Any()).
+			DoAndReturn(func(ctx context.Context, organizationName string, idpProvider *idp.IdentityProvider) (*idp.IdentityProvider, error) {
+				Expect(organizationName).To(Equal("tenant-1"))
 				Expect(idpProvider.Alias).To(Equal("tenant-1-corporate-ldap"))
 				Expect(idpProvider.DisplayName).To(Equal("Corporate LDAP"))
 				Expect(idpProvider.Type).To(Equal("ldap"))
@@ -432,8 +472,9 @@ var _ = Describe("IDP Sync", func() {
 		}.Build()
 
 		mockClient.EXPECT().
-			CreateIdentityProvider(gomock.Any(), gomock.Any()).
-			DoAndReturn(func(ctx context.Context, idpProvider *idp.IdentityProvider) (*idp.IdentityProvider, error) {
+			CreateIdentityProvider(gomock.Any(), gomock.Any(), gomock.Any()).
+			DoAndReturn(func(ctx context.Context, organizationName string, idpProvider *idp.IdentityProvider) (*idp.IdentityProvider, error) {
+				Expect(organizationName).To(Equal("tenant-2"))
 				Expect(idpProvider.Alias).To(Equal("tenant-2-google-sso"))
 				Expect(idpProvider.DisplayName).To(Equal("Google SSO"))
 				Expect(idpProvider.Type).To(Equal("oidc"))
@@ -454,6 +495,90 @@ var _ = Describe("IDP Sync", func() {
 		Expect(identityProvider.GetStatus().GetPhase()).To(Equal(privatev1.IdentityProviderPhase_IDENTITY_PROVIDER_PHASE_READY))
 	})
 
+	It("should fetch full object with secrets via identityProvidersClient", func() {
+		// This test verifies the full-object fetch path in syncToIDP
+		// when identityProvidersClient is set (real controller scenario)
+
+		// Create event object with redacted secrets (simulating watch event)
+		identityProviderEvent := privatev1.IdentityProvider_builder{
+			Id: "idp-789",
+			Metadata: privatev1.Metadata_builder{
+				Name:       "oidc-provider",
+				Tenant:     "tenant-3",
+				Finalizers: []string{finalizers.Controller},
+			}.Build(),
+			Spec: privatev1.IdentityProviderSpec_builder{
+				Title:   "OIDC Provider",
+				Enabled: true,
+				Oidc: privatev1.OidcConfig_builder{
+					AuthorizationUrl: "https://auth.example.com/authorize",
+					TokenUrl:         "https://auth.example.com/token",
+					ClientId:         "client-xyz",
+					ClientSecret:     "[REDACTED]", // Simulates watch event redaction
+					Issuer:           "https://auth.example.com",
+				}.Build(),
+			}.Build(),
+		}.Build()
+
+		// Create full object with unredacted secrets (simulating Get response)
+		fullIdentityProvider := privatev1.IdentityProvider_builder{
+			Id: "idp-789",
+			Metadata: privatev1.Metadata_builder{
+				Name:       "oidc-provider",
+				Tenant:     "tenant-3",
+				Finalizers: []string{finalizers.Controller},
+			}.Build(),
+			Spec: privatev1.IdentityProviderSpec_builder{
+				Title:   "OIDC Provider",
+				Enabled: true,
+				Oidc: privatev1.OidcConfig_builder{
+					AuthorizationUrl: "https://auth.example.com/authorize",
+					TokenUrl:         "https://auth.example.com/token",
+					ClientId:         "client-xyz",
+					ClientSecret:     "actual-secret-123", // Real secret from Get
+					Issuer:           "https://auth.example.com",
+				}.Build(),
+			}.Build(),
+		}.Build()
+
+		// Mock the gRPC client Get call
+		mockGrpcClient := &mockIdentityProvidersClient{
+			getFunc: func(ctx context.Context, req *privatev1.IdentityProvidersGetRequest) (*privatev1.IdentityProvidersGetResponse, error) {
+				Expect(req.GetId()).To(Equal("idp-789"))
+				return privatev1.IdentityProvidersGetResponse_builder{
+					Object: fullIdentityProvider,
+				}.Build(), nil
+			},
+		}
+
+		reconciler := &function{
+			logger:                  logger,
+			identityProvidersClient: mockGrpcClient,
+			idpClient:               mockClient,
+		}
+
+		mockClient.EXPECT().
+			CreateIdentityProvider(gomock.Any(), gomock.Any(), gomock.Any()).
+			DoAndReturn(func(ctx context.Context, organizationName string, idpProvider *idp.IdentityProvider) (*idp.IdentityProvider, error) {
+				// Verify the full object with unredacted secrets was used
+				Expect(organizationName).To(Equal("tenant-3"))
+				Expect(idpProvider.Config).To(HaveKeyWithValue("clientSecret", "actual-secret-123"))
+				Expect(idpProvider.Config).To(HaveKeyWithValue("clientAuthMethod", "client_secret_post"))
+				Expect(idpProvider.Config).To(HaveKeyWithValue("authorizationUrl", "https://auth.example.com/authorize"))
+				return idpProvider, nil
+			}).
+			Times(1)
+
+		task := &task{
+			r:                reconciler,
+			identityProvider: identityProviderEvent,
+		}
+
+		err := task.update(ctx)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(identityProviderEvent.GetStatus().GetPhase()).To(Equal(privatev1.IdentityProviderPhase_IDENTITY_PROVIDER_PHASE_READY))
+	})
+
 	It("should use tenant-prefixed alias", func() {
 		identityProvider := privatev1.IdentityProvider_builder{
 			Metadata: privatev1.Metadata_builder{
@@ -471,8 +596,9 @@ var _ = Describe("IDP Sync", func() {
 		}.Build()
 
 		mockClient.EXPECT().
-			CreateIdentityProvider(gomock.Any(), gomock.Any()).
-			DoAndReturn(func(ctx context.Context, idpProvider *idp.IdentityProvider) (*idp.IdentityProvider, error) {
+			CreateIdentityProvider(gomock.Any(), gomock.Any(), gomock.Any()).
+			DoAndReturn(func(ctx context.Context, organizationName string, idpProvider *idp.IdentityProvider) (*idp.IdentityProvider, error) {
+				Expect(organizationName).To(Equal("my-tenant"))
 				Expect(idpProvider.Alias).To(Equal("my-tenant-test-idp"))
 				return idpProvider, nil
 			}).
@@ -503,7 +629,7 @@ var _ = Describe("IDP Sync", func() {
 		}.Build()
 
 		mockClient.EXPECT().
-			CreateIdentityProvider(gomock.Any(), gomock.Any()).
+			CreateIdentityProvider(gomock.Any(), gomock.Any(), gomock.Any()).
 			Return(nil, fmt.Errorf("IDP connection timeout")).
 			Times(1)
 
@@ -535,7 +661,7 @@ var _ = Describe("IDP Sync", func() {
 		}.Build()
 
 		mockClient.EXPECT().
-			CreateIdentityProvider(gomock.Any(), gomock.Any()).
+			CreateIdentityProvider(gomock.Any(), gomock.Any(), gomock.Any()).
 			Return(nil, fmt.Errorf("identity provider already exists")).
 			Times(1)
 
@@ -565,8 +691,9 @@ var _ = Describe("IDP Sync", func() {
 		}.Build()
 
 		mockClient.EXPECT().
-			CreateIdentityProvider(gomock.Any(), gomock.Any()).
-			DoAndReturn(func(ctx context.Context, idpProvider *idp.IdentityProvider) (*idp.IdentityProvider, error) {
+			CreateIdentityProvider(gomock.Any(), gomock.Any(), gomock.Any()).
+			DoAndReturn(func(ctx context.Context, organizationName string, idpProvider *idp.IdentityProvider) (*idp.IdentityProvider, error) {
+				Expect(organizationName).To(Equal("tenant-1"))
 				Expect(idpProvider.Enabled).To(BeFalse())
 				return idpProvider, nil
 			}).
@@ -692,12 +819,13 @@ var _ = Describe("Deletion", func() {
 		Expect(identityProvider.GetMetadata().GetFinalizers()).ToNot(ContainElement(finalizers.Controller))
 	})
 
-	It("should log warning when deleting READY identity provider", func() {
+	It("should delete from IDP and remove finalizer when deleting READY identity provider", func() {
 		deletionTimestamp := timestamppb.New(time.Now())
 		identityProvider := privatev1.IdentityProvider_builder{
 			Id: "idp-123",
 			Metadata: privatev1.Metadata_builder{
 				Name:              "test-idp",
+				Tenant:            "tenant-1",
 				Finalizers:        []string{finalizers.Controller},
 				DeletionTimestamp: deletionTimestamp,
 			}.Build(),
@@ -705,6 +833,11 @@ var _ = Describe("Deletion", func() {
 				Phase: privatev1.IdentityProviderPhase_IDENTITY_PROVIDER_PHASE_READY,
 			}.Build(),
 		}.Build()
+
+		mockClient.EXPECT().
+			DeleteIdentityProvider(gomock.Any(), "tenant-1", "tenant-1-test-idp").
+			Return(nil).
+			Times(1)
 
 		task := &task{
 			r:                reconciler,
@@ -714,6 +847,75 @@ var _ = Describe("Deletion", func() {
 		err := task.delete(ctx)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(identityProvider.GetMetadata().GetFinalizers()).ToNot(ContainElement(finalizers.Controller))
+	})
+
+	It("should remove finalizer when IdP deletion returns 404 (already deleted)", func() {
+		deletionTimestamp := timestamppb.New(time.Now())
+		identityProvider := privatev1.IdentityProvider_builder{
+			Id: "idp-404",
+			Metadata: privatev1.Metadata_builder{
+				Name:              "missing-idp",
+				Tenant:            "tenant-1",
+				Finalizers:        []string{finalizers.Controller},
+				DeletionTimestamp: deletionTimestamp,
+			}.Build(),
+			Status: privatev1.IdentityProviderStatus_builder{
+				Phase: privatev1.IdentityProviderPhase_IDENTITY_PROVIDER_PHASE_READY,
+			}.Build(),
+		}.Build()
+
+		// Simulate 404 - IdP was already deleted
+		mockClient.EXPECT().
+			DeleteIdentityProvider(gomock.Any(), "tenant-1", "tenant-1-missing-idp").
+			Return(&apiclient.APIError{
+				StatusCode: 404,
+				Body:       "Identity provider not found",
+			}).
+			Times(1)
+
+		task := &task{
+			r:                reconciler,
+			identityProvider: identityProvider,
+		}
+
+		err := task.delete(ctx)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(identityProvider.GetMetadata().GetFinalizers()).ToNot(ContainElement(finalizers.Controller))
+	})
+
+	It("should keep finalizer and return error on non-404 delete failure", func() {
+		deletionTimestamp := timestamppb.New(time.Now())
+		identityProvider := privatev1.IdentityProvider_builder{
+			Id: "idp-error",
+			Metadata: privatev1.Metadata_builder{
+				Name:              "failing-idp",
+				Tenant:            "tenant-1",
+				Finalizers:        []string{finalizers.Controller},
+				DeletionTimestamp: deletionTimestamp,
+			}.Build(),
+			Status: privatev1.IdentityProviderStatus_builder{
+				Phase: privatev1.IdentityProviderPhase_IDENTITY_PROVIDER_PHASE_READY,
+			}.Build(),
+		}.Build()
+
+		// Simulate transient error (500)
+		mockClient.EXPECT().
+			DeleteIdentityProvider(gomock.Any(), "tenant-1", "tenant-1-failing-idp").
+			Return(&apiclient.APIError{
+				StatusCode: 500,
+				Body:       "Internal server error",
+			}).
+			Times(1)
+
+		task := &task{
+			r:                reconciler,
+			identityProvider: identityProvider,
+		}
+
+		err := task.delete(ctx)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("failed to delete identity provider from IDP"))
+		Expect(identityProvider.GetMetadata().GetFinalizers()).To(ContainElement(finalizers.Controller))
 	})
 
 	It("should remove finalizer when called", func() {

--- a/internal/idp/client.go
+++ b/internal/idp/client.go
@@ -95,24 +95,16 @@ type Client interface {
 	RemoveUserFromGroup(ctx context.Context, organizationName, username, groupID string) error
 
 	// Identity Provider operations
-	// CreateIdentityProvider creates a new external identity provider at the realm level.
-	// The IdP is created but not yet assigned to any organization.
-	CreateIdentityProvider(ctx context.Context, idp *IdentityProvider) (*IdentityProvider, error)
+	// CreateIdentityProvider creates a new external identity provider for a specific organization.
+	CreateIdentityProvider(ctx context.Context, organizationName string, idp *IdentityProvider) (*IdentityProvider, error)
 
-	// GetIdentityProvider retrieves an external identity provider configuration by alias at the realm level.
-	// This returns the IdP without verifying organization assignment.
-	GetIdentityProvider(ctx context.Context, alias string) (*IdentityProvider, error)
+	// GetIdentityProvider retrieves an identity provider by alias for a specific organization.
+	GetIdentityProvider(ctx context.Context, organizationName, alias string) (*IdentityProvider, error)
 
-	// ListAllIdentityProviders lists all external identity providers configured at the realm level.
-	// These are the IdPs available for assignment to organizations.
-	// Returns an empty slice if no IdPs are configured in the realm.
-	ListAllIdentityProviders(ctx context.Context) ([]*IdentityProvider, error)
-
-	// GetOrganizationIdentityProvider retrieves an IdP by alias and verifies it's assigned to the organization.
-	// Returns an error if the IdP is not assigned to the organization.
-	GetOrganizationIdentityProvider(ctx context.Context, organizationName, alias string) (*IdentityProvider, error)
-
-	// ListIdentityProviders lists all external identity providers assigned to a specific organization.
-	// Returns an empty slice if no IdPs are assigned to the organization.
+	// ListIdentityProviders lists all identity providers for a specific organization.
+	// Returns an empty slice if no IdPs are configured for the organization.
 	ListIdentityProviders(ctx context.Context, organizationName string) ([]*IdentityProvider, error)
+
+	// DeleteIdentityProvider deletes an identity provider for a specific organization.
+	DeleteIdentityProvider(ctx context.Context, organizationName, alias string) error
 }

--- a/internal/idp/client_mock.go
+++ b/internal/idp/client_mock.go
@@ -141,18 +141,18 @@ func (mr *MockClientMockRecorder) CreateAuthorizationResource(ctx, resource any)
 }
 
 // CreateIdentityProvider mocks base method.
-func (m *MockClient) CreateIdentityProvider(ctx context.Context, idp *IdentityProvider) (*IdentityProvider, error) {
+func (m *MockClient) CreateIdentityProvider(ctx context.Context, organizationName string, idp *IdentityProvider) (*IdentityProvider, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateIdentityProvider", ctx, idp)
+	ret := m.ctrl.Call(m, "CreateIdentityProvider", ctx, organizationName, idp)
 	ret0, _ := ret[0].(*IdentityProvider)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // CreateIdentityProvider indicates an expected call of CreateIdentityProvider.
-func (mr *MockClientMockRecorder) CreateIdentityProvider(ctx, idp any) *gomock.Call {
+func (mr *MockClientMockRecorder) CreateIdentityProvider(ctx, organizationName, idp any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateIdentityProvider", reflect.TypeOf((*MockClient)(nil).CreateIdentityProvider), ctx, idp)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateIdentityProvider", reflect.TypeOf((*MockClient)(nil).CreateIdentityProvider), ctx, organizationName, idp)
 }
 
 // CreateOrganization mocks base method.
@@ -211,6 +211,20 @@ func (m *MockClient) DeleteAuthorizationResource(ctx context.Context, resourceID
 func (mr *MockClientMockRecorder) DeleteAuthorizationResource(ctx, resourceID any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteAuthorizationResource", reflect.TypeOf((*MockClient)(nil).DeleteAuthorizationResource), ctx, resourceID)
+}
+
+// DeleteIdentityProvider mocks base method.
+func (m *MockClient) DeleteIdentityProvider(ctx context.Context, organizationName, alias string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteIdentityProvider", ctx, organizationName, alias)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteIdentityProvider indicates an expected call of DeleteIdentityProvider.
+func (mr *MockClientMockRecorder) DeleteIdentityProvider(ctx, organizationName, alias any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteIdentityProvider", reflect.TypeOf((*MockClient)(nil).DeleteIdentityProvider), ctx, organizationName, alias)
 }
 
 // DeleteOrganization mocks base method.
@@ -272,18 +286,18 @@ func (mr *MockClientMockRecorder) GetGroupIDByPath(ctx, organizationName, groupP
 }
 
 // GetIdentityProvider mocks base method.
-func (m *MockClient) GetIdentityProvider(ctx context.Context, alias string) (*IdentityProvider, error) {
+func (m *MockClient) GetIdentityProvider(ctx context.Context, organizationName, alias string) (*IdentityProvider, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetIdentityProvider", ctx, alias)
+	ret := m.ctrl.Call(m, "GetIdentityProvider", ctx, organizationName, alias)
 	ret0, _ := ret[0].(*IdentityProvider)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetIdentityProvider indicates an expected call of GetIdentityProvider.
-func (mr *MockClientMockRecorder) GetIdentityProvider(ctx, alias any) *gomock.Call {
+func (mr *MockClientMockRecorder) GetIdentityProvider(ctx, organizationName, alias any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetIdentityProvider", reflect.TypeOf((*MockClient)(nil).GetIdentityProvider), ctx, alias)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetIdentityProvider", reflect.TypeOf((*MockClient)(nil).GetIdentityProvider), ctx, organizationName, alias)
 }
 
 // GetOrganization mocks base method.
@@ -299,21 +313,6 @@ func (m *MockClient) GetOrganization(ctx context.Context, name string) (*Organiz
 func (mr *MockClientMockRecorder) GetOrganization(ctx, name any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetOrganization", reflect.TypeOf((*MockClient)(nil).GetOrganization), ctx, name)
-}
-
-// GetOrganizationIdentityProvider mocks base method.
-func (m *MockClient) GetOrganizationIdentityProvider(ctx context.Context, organizationName, alias string) (*IdentityProvider, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetOrganizationIdentityProvider", ctx, organizationName, alias)
-	ret0, _ := ret[0].(*IdentityProvider)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetOrganizationIdentityProvider indicates an expected call of GetOrganizationIdentityProvider.
-func (mr *MockClientMockRecorder) GetOrganizationIdentityProvider(ctx, organizationName, alias any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetOrganizationIdentityProvider", reflect.TypeOf((*MockClient)(nil).GetOrganizationIdentityProvider), ctx, organizationName, alias)
 }
 
 // GetUser mocks base method.
@@ -359,21 +358,6 @@ func (m *MockClient) GetUserOrganizationRoles(ctx context.Context, organizationN
 func (mr *MockClientMockRecorder) GetUserOrganizationRoles(ctx, organizationName, userID any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUserOrganizationRoles", reflect.TypeOf((*MockClient)(nil).GetUserOrganizationRoles), ctx, organizationName, userID)
-}
-
-// ListAllIdentityProviders mocks base method.
-func (m *MockClient) ListAllIdentityProviders(ctx context.Context) ([]*IdentityProvider, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListAllIdentityProviders", ctx)
-	ret0, _ := ret[0].([]*IdentityProvider)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ListAllIdentityProviders indicates an expected call of ListAllIdentityProviders.
-func (mr *MockClientMockRecorder) ListAllIdentityProviders(ctx any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListAllIdentityProviders", reflect.TypeOf((*MockClient)(nil).ListAllIdentityProviders), ctx)
 }
 
 // ListClientRoles mocks base method.

--- a/internal/idp/keycloak/client.go
+++ b/internal/idp/keycloak/client.go
@@ -756,19 +756,21 @@ func (c *Client) DeleteAuthorizationResource(ctx context.Context, resourceID str
 	return nil
 }
 
-// CreateIdentityProvider creates a new identity provider at the realm level.
-func (c *Client) CreateIdentityProvider(ctx context.Context, idpProvider *idp.IdentityProvider) (*idp.IdentityProvider, error) {
+// CreateIdentityProvider creates an identity provider for a specific organization.
+// In Keycloak, this creates the IdP at realm level and links it to the organization.
+func (c *Client) CreateIdentityProvider(ctx context.Context, organizationName string, idpProvider *idp.IdentityProvider) (*idp.IdentityProvider, error) {
 	if idpProvider == nil {
 		return nil, fmt.Errorf("identity provider is nil")
 	}
 	c.logger.InfoContext(ctx, "Creating identity provider",
 		slog.String("realm", c.realmName),
+		slog.String("organization", organizationName),
 		slog.String("alias", idpProvider.Alias),
 		slog.String("type", idpProvider.Type),
 	)
 
+	// Step 1: Create at realm level
 	path := fmt.Sprintf("/admin/realms/%s/identity-provider/instances", url.PathEscape(c.realmName))
-
 	kcIdp := toKeycloakIdentityProvider(idpProvider)
 
 	response, err := c.httpClient.DoRequest(ctx, http.MethodPost, path, kcIdp)
@@ -777,24 +779,55 @@ func (c *Client) CreateIdentityProvider(ctx context.Context, idpProvider *idp.Id
 	}
 	defer response.Body.Close()
 
-	// Keycloak returns 201 Created with the created object in the response body
-	var createdKcIdp keycloakIdentityProvider
-	if err := json.NewDecoder(response.Body).Decode(&createdKcIdp); err != nil {
-		return nil, fmt.Errorf("failed to decode created identity provider response: %w", err)
+	// Step 2: Link to organization
+	err = c.linkIdentityProviderToOrganization(ctx, organizationName, idpProvider.Alias)
+	if err != nil {
+		// Try to clean up the realm-level IdP if linking fails
+		if cleanupErr := c.deleteIdentityProviderFromRealm(ctx, idpProvider.Alias); cleanupErr != nil {
+			return nil, fmt.Errorf("failed to link identity provider to organization: %w (cleanup also failed: %w)", err, cleanupErr)
+		}
+		return nil, fmt.Errorf("failed to link identity provider to organization: %w", err)
 	}
 
-	return fromKeycloakIdentityProvider(&createdKcIdp), nil
+	// Step 3: Fetch and return (Keycloak returns empty body on creation)
+	result, err := c.GetIdentityProvider(ctx, organizationName, idpProvider.Alias)
+	if err != nil {
+		// IdP was successfully created and linked - treat read failure as non-fatal
+		c.logger.WarnContext(ctx, "Created identity provider but failed to fetch it back",
+			slog.String("organization", organizationName),
+			slog.String("alias", idpProvider.Alias),
+			slog.String("error", err.Error()),
+		)
+		// Return a sanitized copy without sensitive Config data
+		return &idp.IdentityProvider{
+			Alias:       idpProvider.Alias,
+			DisplayName: idpProvider.DisplayName,
+			Type:        idpProvider.Type,
+			Enabled:     idpProvider.Enabled,
+			Config:      nil, // Secrets are automatically filtered in GET responses
+		}, nil
+	}
+	return result, nil
 }
 
-// GetIdentityProvider retrieves an identity provider configuration by alias at the realm level.
-func (c *Client) GetIdentityProvider(ctx context.Context, alias string) (*idp.IdentityProvider, error) {
+// GetIdentityProvider retrieves an identity provider for a specific organization.
+func (c *Client) GetIdentityProvider(ctx context.Context, organizationName, alias string) (*idp.IdentityProvider, error) {
 	c.logger.InfoContext(ctx, "Getting identity provider",
 		slog.String("realm", c.realmName),
+		slog.String("organization", organizationName),
 		slog.String("alias", alias),
 	)
 
-	path := fmt.Sprintf("/admin/realms/%s/identity-provider/instances/%s",
+	// Get the organization to obtain its ID
+	org, err := c.GetOrganization(ctx, organizationName)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get organization: %w", err)
+	}
+
+	// Get the IdP from the organization endpoint
+	path := fmt.Sprintf("/admin/realms/%s/organizations/%s/identity-providers/%s",
 		url.PathEscape(c.realmName),
+		url.PathEscape(org.ID),
 		url.PathEscape(alias),
 	)
 
@@ -812,37 +845,38 @@ func (c *Client) GetIdentityProvider(ctx context.Context, alias string) (*idp.Id
 	return fromKeycloakIdentityProvider(&kcIdp), nil
 }
 
-// ListAllIdentityProviders lists all identity providers configured at the realm level.
-// These are all IdPs.
-func (c *Client) ListAllIdentityProviders(ctx context.Context) ([]*idp.IdentityProvider, error) {
-	c.logger.InfoContext(ctx, "Listing all identity providers",
+// DeleteIdentityProvider deletes an identity provider for a specific organization.
+// In Keycloak, this deletes the IdP at realm level (which auto-removes from all organizations).
+func (c *Client) DeleteIdentityProvider(ctx context.Context, organizationName, alias string) error {
+	c.logger.InfoContext(ctx, "Deleting identity provider",
 		slog.String("realm", c.realmName),
+		slog.String("organization", organizationName),
+		slog.String("alias", alias),
 	)
 
-	path := fmt.Sprintf("/admin/realms/%s/identity-provider/instances", url.PathEscape(c.realmName))
+	// Delete at realm level - this automatically removes from all organizations
+	return c.deleteIdentityProviderFromRealm(ctx, alias)
+}
 
-	response, err := c.httpClient.DoRequest(ctx, http.MethodGet, path, nil)
+// deleteIdentityProviderFromRealm is an internal helper that deletes at realm level.
+func (c *Client) deleteIdentityProviderFromRealm(ctx context.Context, alias string) error {
+	path := fmt.Sprintf("/admin/realms/%s/identity-provider/instances/%s",
+		url.PathEscape(c.realmName),
+		url.PathEscape(alias),
+	)
+
+	response, err := c.httpClient.DoRequest(ctx, http.MethodDelete, path, nil)
 	if err != nil {
-		return nil, fmt.Errorf("failed to list identity providers: %w", err)
+		return fmt.Errorf("failed to delete identity provider: %w", err)
 	}
 	defer response.Body.Close()
 
-	var kcIdps []keycloakIdentityProvider
-	if err := json.NewDecoder(response.Body).Decode(&kcIdps); err != nil {
-		return nil, fmt.Errorf("failed to decode identity providers response: %w", err)
-	}
-
-	idps := make([]*idp.IdentityProvider, 0, len(kcIdps))
-	for i := range kcIdps {
-		idps = append(idps, fromKeycloakIdentityProvider(&kcIdps[i]))
-	}
-
-	return idps, nil
+	return nil
 }
 
-// GetOrganizationIdentityProvider retrieves an IdP by alias and verifies it's assigned to the organization.
-func (c *Client) GetOrganizationIdentityProvider(ctx context.Context, organizationName, alias string) (*idp.IdentityProvider, error) {
-	c.logger.InfoContext(ctx, "Getting organization identity provider",
+// linkIdentityProviderToOrganization is an internal helper that links an IdP to an organization.
+func (c *Client) linkIdentityProviderToOrganization(ctx context.Context, organizationName, alias string) error {
+	c.logger.InfoContext(ctx, "Linking identity provider to organization",
 		slog.String("organization", organizationName),
 		slog.String("alias", alias),
 	)
@@ -850,31 +884,26 @@ func (c *Client) GetOrganizationIdentityProvider(ctx context.Context, organizati
 	// Get the organization to obtain its ID
 	org, err := c.GetOrganization(ctx, organizationName)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get organization: %w", err)
+		return fmt.Errorf("failed to get organization: %w", err)
 	}
 
-	// Get the IdP directly from the organization endpoint
-	path := fmt.Sprintf("/admin/realms/%s/organizations/%s/identity-providers/%s",
+	// Link the IdP to the organization
+	path := fmt.Sprintf("/admin/realms/%s/organizations/%s/identity-providers",
 		url.PathEscape(c.realmName),
 		url.PathEscape(org.ID),
-		url.PathEscape(alias),
 	)
 
-	response, err := c.httpClient.DoRequest(ctx, http.MethodGet, path, nil)
+	// The body is just the alias as a JSON string (Keycloak expects "alias" not {"alias": "value"})
+	response, err := c.httpClient.DoRequest(ctx, http.MethodPost, path, alias)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get organization identity provider: %w", err)
+		return fmt.Errorf("failed to link identity provider to organization: %w", err)
 	}
 	defer response.Body.Close()
 
-	var kcIdp keycloakIdentityProvider
-	if err := json.NewDecoder(response.Body).Decode(&kcIdp); err != nil {
-		return nil, fmt.Errorf("failed to decode identity provider response: %w", err)
-	}
-
-	return fromKeycloakIdentityProvider(&kcIdp), nil
+	return nil
 }
 
-// ListIdentityProviders lists all identity providers assigned to an organization.
+// ListIdentityProviders lists all identity providers for a specific organization.
 func (c *Client) ListIdentityProviders(ctx context.Context, organizationName string) ([]*idp.IdentityProvider, error) {
 	c.logger.InfoContext(ctx, "Listing organization identity providers",
 		slog.String("organization", organizationName),

--- a/internal/idp/keycloak/client_test.go
+++ b/internal/idp/keycloak/client_test.go
@@ -1409,7 +1409,26 @@ var _ = Describe("Keycloak Client", func() {
 		Describe("CreateIdentityProvider", func() {
 			It("creates an identity provider in Keycloak", func() {
 				var receivedIdp *keycloakIdentityProvider
+				var createdResponse keycloakIdentityProvider
 				server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					if r.Method == http.MethodGet && r.URL.Path == "/admin/realms/osac/organizations" {
+						// Organization lookup
+						orgs := []keycloakOrganization{{
+							ID:   "org-123",
+							Name: "test-org",
+						}}
+						w.Header().Set("Content-Type", "application/json")
+						if err := json.NewEncoder(w).Encode(orgs); err != nil {
+							http.Error(w, err.Error(), http.StatusInternalServerError)
+							return
+						}
+						return
+					}
+					if r.Method == http.MethodPost && r.URL.Path == "/admin/realms/osac/organizations/org-123/identity-providers" {
+						// Link IdP to organization
+						w.WriteHeader(http.StatusNoContent)
+						return
+					}
 					if r.Method == http.MethodPost && r.URL.Path == "/admin/realms/osac/identity-provider/instances" {
 						// Create request
 						receivedIdp = &keycloakIdentityProvider{}
@@ -1419,8 +1438,8 @@ var _ = Describe("Keycloak Client", func() {
 							return
 						}
 
-						// Return the created IdP
-						response := keycloakIdentityProvider{
+						// Store the created IdP for subsequent GET
+						createdResponse = keycloakIdentityProvider{
 							Alias:       receivedIdp.Alias,
 							DisplayName: receivedIdp.DisplayName,
 							InternalID:  "idp-uuid-123",
@@ -1428,9 +1447,13 @@ var _ = Describe("Keycloak Client", func() {
 							Enabled:     receivedIdp.Enabled,
 							Config:      receivedIdp.Config,
 						}
-						w.Header().Set("Content-Type", "application/json")
 						w.WriteHeader(http.StatusCreated)
-						if err := json.NewEncoder(w).Encode(response); err != nil {
+						return
+					}
+					if r.Method == http.MethodGet && r.URL.Path == "/admin/realms/osac/organizations/org-123/identity-providers/corporate-ldap" {
+						// Get request after creation (via organization)
+						w.Header().Set("Content-Type", "application/json")
+						if err := json.NewEncoder(w).Encode(createdResponse); err != nil {
 							http.Error(w, err.Error(), http.StatusInternalServerError)
 							return
 						}
@@ -1451,7 +1474,7 @@ var _ = Describe("Keycloak Client", func() {
 						"bindDn":        "cn=admin,dc=example,dc=com",
 					},
 				}
-				createdIdp, err := client.CreateIdentityProvider(ctx, idpProvider)
+				createdIdp, err := client.CreateIdentityProvider(ctx, "test-org", idpProvider)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(receivedIdp).ToNot(BeNil(), "server handler should have set receivedIdp")
 				Expect(receivedIdp.Alias).To(Equal("corporate-ldap"))
@@ -1465,12 +1488,31 @@ var _ = Describe("Keycloak Client", func() {
 			})
 
 			It("creates an OIDC identity provider", func() {
+				var createdResponse keycloakIdentityProvider
 				server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					if r.Method == http.MethodGet && r.URL.Path == "/admin/realms/osac/organizations" {
+						// Organization lookup
+						orgs := []keycloakOrganization{{
+							ID:   "org-123",
+							Name: "test-org",
+						}}
+						w.Header().Set("Content-Type", "application/json")
+						if err := json.NewEncoder(w).Encode(orgs); err != nil {
+							http.Error(w, err.Error(), http.StatusInternalServerError)
+							return
+						}
+						return
+					}
+					if r.Method == http.MethodPost && r.URL.Path == "/admin/realms/osac/organizations/org-123/identity-providers" {
+						// Link IdP to organization
+						w.WriteHeader(http.StatusNoContent)
+						return
+					}
 					if r.Method == http.MethodPost && r.URL.Path == "/admin/realms/osac/identity-provider/instances" {
 						var receivedIdp keycloakIdentityProvider
 						json.NewDecoder(r.Body).Decode(&receivedIdp)
 
-						response := keycloakIdentityProvider{
+						createdResponse = keycloakIdentityProvider{
 							Alias:       receivedIdp.Alias,
 							DisplayName: receivedIdp.DisplayName,
 							InternalID:  "idp-uuid-456",
@@ -1478,9 +1520,13 @@ var _ = Describe("Keycloak Client", func() {
 							Enabled:     receivedIdp.Enabled,
 							Config:      receivedIdp.Config,
 						}
-						w.Header().Set("Content-Type", "application/json")
 						w.WriteHeader(http.StatusCreated)
-						if err := json.NewEncoder(w).Encode(response); err != nil {
+						return
+					}
+					if r.Method == http.MethodGet && r.URL.Path == "/admin/realms/osac/organizations/org-123/identity-providers/google-sso" {
+						// Get request after creation (via organization)
+						w.Header().Set("Content-Type", "application/json")
+						if err := json.NewEncoder(w).Encode(createdResponse); err != nil {
 							http.Error(w, err.Error(), http.StatusInternalServerError)
 							return
 						}
@@ -1503,7 +1549,7 @@ var _ = Describe("Keycloak Client", func() {
 						"clientSecret":     "my-client-secret",
 					},
 				}
-				createdIdp, err := client.CreateIdentityProvider(ctx, idpProvider)
+				createdIdp, err := client.CreateIdentityProvider(ctx, "test-org", idpProvider)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(createdIdp).ToNot(BeNil())
 				Expect(createdIdp.Alias).To(Equal("google-sso"))
@@ -1524,7 +1570,7 @@ var _ = Describe("Keycloak Client", func() {
 					Type:    "ldap",
 					Enabled: true,
 				}
-				_, err := client.CreateIdentityProvider(ctx, idpProvider)
+				_, err := client.CreateIdentityProvider(ctx, "test-org", idpProvider)
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("failed to create identity provider"))
 			})
@@ -1533,7 +1579,20 @@ var _ = Describe("Keycloak Client", func() {
 		Describe("GetIdentityProvider", func() {
 			It("retrieves an identity provider by alias", func() {
 				server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-					if r.Method == http.MethodGet && r.URL.Path == "/admin/realms/osac/identity-provider/instances/corporate-ldap" {
+					if r.Method == http.MethodGet && r.URL.Path == "/admin/realms/osac/organizations" {
+						// Organization lookup
+						orgs := []keycloakOrganization{{
+							ID:   "org-123",
+							Name: "org-1",
+						}}
+						w.Header().Set("Content-Type", "application/json")
+						if err := json.NewEncoder(w).Encode(orgs); err != nil {
+							http.Error(w, err.Error(), http.StatusInternalServerError)
+							return
+						}
+						return
+					}
+					if r.Method == http.MethodGet && r.URL.Path == "/admin/realms/osac/organizations/org-123/identity-providers/corporate-ldap" {
 						response := keycloakIdentityProvider{
 							Alias:       "corporate-ldap",
 							DisplayName: "Corporate LDAP",
@@ -1558,7 +1617,7 @@ var _ = Describe("Keycloak Client", func() {
 
 				client = createTestClient(server.URL)
 
-				idpProvider, err := client.GetIdentityProvider(ctx, "corporate-ldap")
+				idpProvider, err := client.GetIdentityProvider(ctx, "org-1", "corporate-ldap")
 				Expect(err).ToNot(HaveOccurred())
 				Expect(idpProvider).ToNot(BeNil())
 				Expect(idpProvider.Alias).To(Equal("corporate-ldap"))
@@ -1570,84 +1629,27 @@ var _ = Describe("Keycloak Client", func() {
 
 			It("returns an error when IdP not found", func() {
 				server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					if r.Method == http.MethodGet && r.URL.Path == "/admin/realms/osac/organizations" {
+						// Organization lookup succeeds
+						orgs := []keycloakOrganization{{
+							ID:   "org-123",
+							Name: "org-1",
+						}}
+						w.Header().Set("Content-Type", "application/json")
+						if err := json.NewEncoder(w).Encode(orgs); err != nil {
+							http.Error(w, err.Error(), http.StatusInternalServerError)
+							return
+						}
+						return
+					}
+					// IdP lookup fails (all other paths)
 					w.WriteHeader(http.StatusNotFound)
 				}))
 
 				client = createTestClient(server.URL)
 
-				_, err := client.GetIdentityProvider(ctx, "nonexistent")
+				_, err := client.GetIdentityProvider(ctx, "org-1", "nonexistent")
 				Expect(err).To(HaveOccurred())
-			})
-		})
-
-		Describe("ListAllIdentityProviders", func() {
-			It("lists all identity providers in the realm", func() {
-				server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-					if r.Method == http.MethodGet && r.URL.Path == "/admin/realms/osac/identity-provider/instances" {
-						response := []keycloakIdentityProvider{
-							{
-								Alias:       "corporate-ldap",
-								DisplayName: "Corporate LDAP",
-								ProviderID:  "ldap",
-								Enabled:     true,
-							},
-							{
-								Alias:       "okta-sso",
-								DisplayName: "Okta SSO",
-								ProviderID:  "oidc",
-								Enabled:     true,
-							},
-							{
-								Alias:       "disabled-saml",
-								DisplayName: "Disabled SAML",
-								ProviderID:  "saml",
-								Enabled:     false,
-							},
-						}
-						w.Header().Set("Content-Type", "application/json")
-						w.WriteHeader(http.StatusOK)
-						if err := json.NewEncoder(w).Encode(response); err != nil {
-							http.Error(w, err.Error(), http.StatusInternalServerError)
-							return
-						}
-						return
-					}
-					w.WriteHeader(http.StatusNotFound)
-				}))
-
-				client = createTestClient(server.URL)
-
-				idps, err := client.ListAllIdentityProviders(ctx)
-				Expect(err).ToNot(HaveOccurred())
-				Expect(idps).To(HaveLen(3))
-				Expect(idps[0].Alias).To(Equal("corporate-ldap"))
-				Expect(idps[0].Type).To(Equal("ldap"))
-				Expect(idps[1].Alias).To(Equal("okta-sso"))
-				Expect(idps[1].Type).To(Equal("oidc"))
-				Expect(idps[2].Alias).To(Equal("disabled-saml"))
-				Expect(idps[2].Enabled).To(BeFalse())
-			})
-
-			It("returns empty list when no IdPs configured", func() {
-				server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-					if r.Method == http.MethodGet && r.URL.Path == "/admin/realms/osac/identity-provider/instances" {
-						response := []keycloakIdentityProvider{}
-						w.Header().Set("Content-Type", "application/json")
-						w.WriteHeader(http.StatusOK)
-						if err := json.NewEncoder(w).Encode(response); err != nil {
-							http.Error(w, err.Error(), http.StatusInternalServerError)
-							return
-						}
-						return
-					}
-					w.WriteHeader(http.StatusNotFound)
-				}))
-
-				client = createTestClient(server.URL)
-
-				idps, err := client.ListAllIdentityProviders(ctx)
-				Expect(err).ToNot(HaveOccurred())
-				Expect(idps).To(BeEmpty())
 			})
 		})
 
@@ -1694,7 +1696,7 @@ var _ = Describe("Keycloak Client", func() {
 
 				client = createTestClient(server.URL)
 
-				idpProvider, err := client.GetOrganizationIdentityProvider(ctx, "test-org", "corporate-ldap")
+				idpProvider, err := client.GetIdentityProvider(ctx, "test-org", "corporate-ldap")
 				Expect(err).ToNot(HaveOccurred())
 				Expect(idpProvider).ToNot(BeNil())
 				Expect(idpProvider.Alias).To(Equal("corporate-ldap"))
@@ -1730,9 +1732,9 @@ var _ = Describe("Keycloak Client", func() {
 
 				client = createTestClient(server.URL)
 
-				_, err := client.GetOrganizationIdentityProvider(ctx, "test-org", "nonexistent")
+				_, err := client.GetIdentityProvider(ctx, "test-org", "nonexistent")
 				Expect(err).To(HaveOccurred())
-				Expect(err.Error()).To(ContainSubstring("failed to get organization identity provider"))
+				Expect(err.Error()).To(ContainSubstring("failed to get identity provider"))
 			})
 
 			It("returns error when organization not found", func() {
@@ -1753,7 +1755,7 @@ var _ = Describe("Keycloak Client", func() {
 
 				client = createTestClient(server.URL)
 
-				_, err := client.GetOrganizationIdentityProvider(ctx, "nonexistent-org", "corporate-ldap")
+				_, err := client.GetIdentityProvider(ctx, "nonexistent-org", "corporate-ldap")
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("organization"))
 			})

--- a/internal/idp/manager_test.go
+++ b/internal/idp/manager_test.go
@@ -238,24 +238,20 @@ func (m *mockClient) DeleteAuthorizationResource(ctx context.Context, resourceID
 }
 
 // Identity Provider stub methods
-func (m *mockClient) CreateIdentityProvider(ctx context.Context, idp *IdentityProvider) (*IdentityProvider, error) {
+func (m *mockClient) CreateIdentityProvider(ctx context.Context, organizationName string, idp *IdentityProvider) (*IdentityProvider, error) {
 	return idp, nil
 }
 
-func (m *mockClient) GetIdentityProvider(ctx context.Context, alias string) (*IdentityProvider, error) {
-	return nil, nil
-}
-
-func (m *mockClient) ListAllIdentityProviders(ctx context.Context) ([]*IdentityProvider, error) {
-	return nil, nil
-}
-
-func (m *mockClient) GetOrganizationIdentityProvider(ctx context.Context, organizationName, alias string) (*IdentityProvider, error) {
+func (m *mockClient) GetIdentityProvider(ctx context.Context, organizationName, alias string) (*IdentityProvider, error) {
 	return nil, nil
 }
 
 func (m *mockClient) ListIdentityProviders(ctx context.Context, organizationName string) ([]*IdentityProvider, error) {
 	return nil, nil
+}
+
+func (m *mockClient) DeleteIdentityProvider(ctx context.Context, organizationName, alias string) error {
+	return nil
 }
 
 func (m *mockClient) CreateAuthorizationGroup(ctx context.Context, organizationName, groupName, groupPath string) (string, error) {

--- a/internal/servers/generic_server.go
+++ b/internal/servers/generic_server.go
@@ -900,7 +900,7 @@ func (s *GenericServer[O]) setPayload(event *privatev1.Event, object proto.Messa
 		}
 		event.SetStorageBackend(object)
 	case *privatev1.IdentityProvider:
-		// Redact sensitive fields (client secrets and bind credentials) before publishing
+		// Redact sensitive fields before publishing - controller will fetch them separately via API
 		object = proto.Clone(object).(*privatev1.IdentityProvider)
 		spec := object.GetSpec()
 		if spec != nil {


### PR DESCRIPTION
# Description
Additionally includes:
- Creating and linking and IdP to an Organization on create
- Passing the client secret from an IdP connection
    - Enables connection to go through properly

# Testing

- Ran integration test environment locally, created an IDP and logged in as user from IDP successfully

Assisted-by: Claude Code <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Identity provider actions are now organization-scoped, enabling correct behavior in multi-tenant environments.
  * Provider creation and lookup now use an organization-specific context (including tenant-prefixed aliases).

* **Bug Fixes**
  * Sensitive identity provider settings are fetched from the backend when needed to avoid incomplete configurations.
  * OIDC client auth is improved via `client_secret_post`.
  * Deletion now performs backend removal, treats “not found” as already deleted, and updates controller finalization reliably; fetch failures set an ERROR phase.

* **Documentation**
  * Clarified that sensitive payload fields are redacted and retrieved separately.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->