### PR TITLE
OSAC-1812: Auto create IdP user

### DIFF
--- a/internal/auth/grpc_authz_interceptor.go
+++ b/internal/auth/grpc_authz_interceptor.go
@@ -362,12 +362,14 @@ func (i *GrpcAuthzInterceptor) authorizeWithToken(ctx context.Context, method st
 		return
 	}
 
+	// Store subject in context
+	result = ContextWithSubject(ctx, subject)
+
 	logger.DebugContext(
-		ctx,
+		result,
 		"Permission granted by authorization policy",
 		slog.String("user", subject.User),
 	)
-	result = ContextWithSubject(ctx, subject)
 	return
 }
 

--- a/internal/auth/grpc_jit_provisioning_interceptor.go
+++ b/internal/auth/grpc_jit_provisioning_interceptor.go
@@ -1,0 +1,159 @@
+/*
+Copyright (c) 2026 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package auth
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	"github.com/golang-jwt/jwt/v5"
+	"google.golang.org/grpc"
+
+	"github.com/osac-project/fulfillment-service/internal/reflection"
+)
+
+//go:generate mockgen -source=$GOFILE -destination=grpc_jit_provisioning_interceptor_mock.go -package=$GOPACKAGE UserProvisioner
+
+// UserProvisioner provisions user records in the database.
+type UserProvisioner interface {
+	Provision(ctx context.Context, username, tenant string, claims jwt.MapClaims) error
+}
+
+// GrpcJitProvisioningInterceptorBuilder builds a GrpcJitProvisioningInterceptor.
+type GrpcJitProvisioningInterceptorBuilder struct {
+	logger      *slog.Logger
+	provisioner UserProvisioner
+}
+
+// GrpcJitProvisioningInterceptor performs just-in-time user provisioning for authenticated requests.
+// It runs after authentication and authorization, provisioning users who have been granted access.
+type GrpcJitProvisioningInterceptor struct {
+	logger      *slog.Logger
+	provisioner UserProvisioner
+}
+
+// NewGrpcJitProvisioningInterceptor creates a new builder.
+func NewGrpcJitProvisioningInterceptor() *GrpcJitProvisioningInterceptorBuilder {
+	return &GrpcJitProvisioningInterceptorBuilder{}
+}
+
+// SetLogger sets the logger.
+func (b *GrpcJitProvisioningInterceptorBuilder) SetLogger(value *slog.Logger) *GrpcJitProvisioningInterceptorBuilder {
+	b.logger = value
+	return b
+}
+
+// SetProvisioner sets the user provisioner.
+func (b *GrpcJitProvisioningInterceptorBuilder) SetProvisioner(value UserProvisioner) *GrpcJitProvisioningInterceptorBuilder {
+	b.provisioner = reflection.NormalizeNil(value)
+	return b
+}
+
+// Build creates the interceptor.
+func (b *GrpcJitProvisioningInterceptorBuilder) Build() (result *GrpcJitProvisioningInterceptor, err error) {
+	if b.logger == nil {
+		return nil, fmt.Errorf("logger is mandatory")
+	}
+	result = &GrpcJitProvisioningInterceptor{
+		logger:      b.logger,
+		provisioner: b.provisioner,
+	}
+	return result, nil
+}
+
+// UnaryServer is the unary server interceptor function.
+func (i *GrpcJitProvisioningInterceptor) UnaryServer(ctx context.Context, req any,
+	info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {
+	err := i.provisionIfNeeded(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return handler(ctx, req)
+}
+
+// StreamServer is the stream server interceptor function.
+func (i *GrpcJitProvisioningInterceptor) StreamServer(srv any, stream grpc.ServerStream,
+	info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
+	err := i.provisionIfNeeded(stream.Context())
+	if err != nil {
+		return err
+	}
+	return handler(srv, stream)
+}
+
+// provisionIfNeeded checks if user provisioning is needed and performs it.
+// Returns nil if provisioning is not needed or succeeds, error if provisioning fails.
+func (i *GrpcJitProvisioningInterceptor) provisionIfNeeded(ctx context.Context) error {
+	// Skip if no provisioner configured
+	if i.provisioner == nil {
+		return nil
+	}
+
+	// Get subject from context (set by authz interceptor)
+	subject := SubjectFromContext(ctx)
+	if subject == nil {
+		// No subject means anonymous or unauthenticated request - skip provisioning
+		return nil
+	}
+
+	// Only provision for users with exactly one tenant
+	// Users with zero tenants (unauthenticated), multiple tenants (cloud provider admins),
+	// or special tenants (system/shared) should not have user records
+	if !subject.Tenants.Finite() {
+		return nil
+	}
+
+	tenants := subject.Tenants.Inclusions()
+	if len(tenants) != 1 {
+		// Zero or multiple tenants - not a regular user
+		return nil
+	}
+
+	tenant := tenants[0]
+	if tenant == SystemTenant || tenant == SharedTenant {
+		// System and shared tenants don't have user records
+		return nil
+	}
+
+	// Get username from subject
+	username := subject.User
+
+	// Get JWT token from context for additional claims
+	token := TokenFromContext(ctx)
+	if token == nil {
+		// No token in context - skip provisioning
+		return nil
+	}
+
+	// Extract JWT claims for email, name, etc.
+	claims, ok := token.Claims.(jwt.MapClaims)
+	if !ok {
+		i.logger.ErrorContext(ctx, "Failed to extract claims from JWT token for user provisioning")
+		return nil
+	}
+
+	// Provision the user
+	err := i.provisioner.Provision(ctx, username, tenant, claims)
+	if err != nil {
+		i.logger.ErrorContext(ctx, "Failed to provision user",
+			slog.String("!username", username),
+			slog.String("!tenant", tenant),
+			slog.Any("error", err),
+		)
+		return fmt.Errorf("user provisioning failed: %w", err)
+	}
+
+	return nil
+}

--- a/internal/auth/grpc_jit_provisioning_interceptor.go
+++ b/internal/auth/grpc_jit_provisioning_interceptor.go
@@ -21,7 +21,7 @@ import (
 	"github.com/golang-jwt/jwt/v5"
 	"google.golang.org/grpc"
 
-	"github.com/osac-project/fulfillment-service/internal/reflection"
+	"github.com/osac-project/fulfillment-service/internal/util"
 )
 
 //go:generate mockgen -source=$GOFILE -destination=grpc_jit_provisioning_interceptor_mock.go -package=$GOPACKAGE UserProvisioner
@@ -57,7 +57,7 @@ func (b *GrpcJitProvisioningInterceptorBuilder) SetLogger(value *slog.Logger) *G
 
 // SetProvisioner sets the user provisioner.
 func (b *GrpcJitProvisioningInterceptorBuilder) SetProvisioner(value UserProvisioner) *GrpcJitProvisioningInterceptorBuilder {
-	b.provisioner = reflection.NormalizeNil(value)
+	b.provisioner = util.NormalizeNil(value)
 	return b
 }
 

--- a/internal/auth/grpc_jit_provisioning_interceptor_test.go
+++ b/internal/auth/grpc_jit_provisioning_interceptor_test.go
@@ -1,0 +1,558 @@
+/*
+Copyright (c) 2026 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package auth
+
+import (
+	"context"
+	"errors"
+	"maps"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+	. "github.com/onsi/ginkgo/v2/dsl/core"
+	. "github.com/onsi/gomega"
+	"google.golang.org/grpc"
+
+	"github.com/osac-project/fulfillment-service/internal/collections"
+	"github.com/osac-project/fulfillment-service/internal/testing"
+	"github.com/osac-project/fulfillment-service/internal/uuid"
+)
+
+// mockUserProvisioner is a simple test double for UserProvisioner.
+type mockUserProvisioner struct {
+	provisionFunc func(ctx context.Context, username, tenant string, claims jwt.MapClaims) error
+	callCount     int
+	lastUsername  string
+	lastTenant    string
+	lastClaims    jwt.MapClaims
+}
+
+func newMockUserProvisioner() *mockUserProvisioner {
+	return &mockUserProvisioner{
+		provisionFunc: func(ctx context.Context, username, tenant string, claims jwt.MapClaims) error {
+			return nil
+		},
+	}
+}
+
+func (m *mockUserProvisioner) Provision(ctx context.Context, username, tenant string, claims jwt.MapClaims) error {
+	m.callCount++
+	m.lastUsername = username
+	m.lastTenant = tenant
+	m.lastClaims = claims
+	return m.provisionFunc(ctx, username, tenant, claims)
+}
+
+var _ UserProvisioner = (*mockUserProvisioner)(nil)
+
+// mockServerStream is a simple test double for grpc.ServerStream.
+type mockServerStream struct {
+	grpc.ServerStream
+	ctx context.Context
+}
+
+func (m *mockServerStream) Context() context.Context {
+	return m.ctx
+}
+
+var _ = Describe("JIT Provisioning Interceptor", func() {
+	var (
+		ctx             context.Context
+		interceptor     *GrpcJitProvisioningInterceptor
+		mockProvisioner *mockUserProvisioner
+		handler         grpc.UnaryHandler
+		handlerCalled   bool
+	)
+
+	// createKeycloakUserToken creates a token resembling the ones issued by Keycloak for regular users.
+	createKeycloakUserToken := func(tenant, name string, overrides jwt.MapClaims) *jwt.Token {
+		now := time.Now()
+		claims := jwt.MapClaims{
+			"auth_time": now.Unix(),
+			"azp":       "osac-cli",
+			"exp":       now.Add(time.Hour).Unix(),
+			"organization": []any{
+				tenant,
+			},
+			"iat":      now.Unix(),
+			"iss":      "https://keycloak.keycloak.svc.cluster.local:8000/realms/osac",
+			"jti":      uuid.New(),
+			"scope":    "openid organization",
+			"sid":      uuid.New(),
+			"sub":      uuid.New(),
+			"typ":      "Bearer",
+			"username": name,
+		}
+		maps.Copy(claims, overrides)
+		return testing.MakeTokenObject(nil, claims)
+	}
+
+	BeforeEach(func() {
+		var err error
+
+		// Create a context:
+		ctx = context.Background()
+
+		// Reset handler tracking:
+		handlerCalled = false
+
+		// Create a mock user provisioner:
+		mockProvisioner = newMockUserProvisioner()
+
+		// Create a mock handler:
+		handler = func(ctx context.Context, req any) (any, error) {
+			handlerCalled = true
+			return nil, nil
+		}
+
+		// Create the interceptor with JIT provisioning enabled:
+		interceptor, err = NewGrpcJitProvisioningInterceptor().
+			SetLogger(logger).
+			SetProvisioner(mockProvisioner).
+			Build()
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	Describe("Builder validation", func() {
+		It("Requires a logger", func() {
+			_, err := NewGrpcJitProvisioningInterceptor().
+				SetProvisioner(mockProvisioner).
+				Build()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("logger is mandatory"))
+		})
+
+		It("Allows nil provisioner", func() {
+			interceptor, err := NewGrpcJitProvisioningInterceptor().
+				SetLogger(logger).
+				SetProvisioner(nil).
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(interceptor).ToNot(BeNil())
+		})
+	})
+
+	Describe("User provisioning", func() {
+		It("Provisions a new user on first authentication", func() {
+			token := createKeycloakUserToken("tenant1", "alice", jwt.MapClaims{
+				"email":          "alice@example.com",
+				"email_verified": true,
+				"name":           "Alice Smith",
+			})
+			ctx = ContextWithToken(ctx, token)
+
+			// Create subject with single tenant (provisioning should happen)
+			subject := &Subject{
+				User:    "alice",
+				Tenants: collections.NewSet("tenant1"),
+			}
+			ctx = ContextWithSubject(ctx, subject)
+
+			_, err := interceptor.UnaryServer(
+				ctx,
+				nil,
+				&grpc.UnaryServerInfo{
+					FullMethod: "/osac.public.v1.Clusters/List",
+				},
+				handler,
+			)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(handlerCalled).To(BeTrue())
+
+			// Verify provisioner was called:
+			Expect(mockProvisioner.callCount).To(Equal(1))
+			Expect(mockProvisioner.lastUsername).To(Equal("alice"))
+			Expect(mockProvisioner.lastTenant).To(Equal("tenant1"))
+			Expect(mockProvisioner.lastClaims["email"]).To(Equal("alice@example.com"))
+			Expect(mockProvisioner.lastClaims["name"]).To(Equal("Alice Smith"))
+		})
+
+		It("Does not provision when no provisioner is configured", func() {
+			var err error
+			interceptor, err = NewGrpcJitProvisioningInterceptor().
+				SetLogger(logger).
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+
+			token := createKeycloakUserToken("tenant1", "bob", nil)
+			ctx = ContextWithToken(ctx, token)
+			subject := &Subject{
+				User:    "bob",
+				Tenants: collections.NewSet("tenant1"),
+			}
+			ctx = ContextWithSubject(ctx, subject)
+
+			_, err = interceptor.UnaryServer(
+				ctx,
+				nil,
+				&grpc.UnaryServerInfo{
+					FullMethod: "/osac.public.v1.Clusters/List",
+				},
+				handler,
+			)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(handlerCalled).To(BeTrue())
+		})
+
+		It("Does not provision when subject has no tenants", func() {
+			token := createKeycloakUserToken("tenant1", "david", nil)
+			ctx = ContextWithToken(ctx, token)
+			subject := &Subject{
+				User:    "david",
+				Tenants: collections.NewSet[string](), // Empty tenant set
+			}
+			ctx = ContextWithSubject(ctx, subject)
+
+			_, err := interceptor.UnaryServer(
+				ctx,
+				nil,
+				&grpc.UnaryServerInfo{
+					FullMethod: "/osac.public.v1.Clusters/List",
+				},
+				handler,
+			)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(handlerCalled).To(BeTrue())
+			Expect(mockProvisioner.callCount).To(Equal(0))
+		})
+
+		It("Does not provision when subject has multiple tenants", func() {
+			token := createKeycloakUserToken("tenant1", "eve", jwt.MapClaims{
+				"organizations": []any{"tenant2", "tenant3"},
+			})
+			ctx = ContextWithToken(ctx, token)
+			subject := &Subject{
+				User:    "eve",
+				Tenants: collections.NewSet("tenant1", "tenant2", "tenant3"),
+			}
+			ctx = ContextWithSubject(ctx, subject)
+
+			_, err := interceptor.UnaryServer(
+				ctx,
+				nil,
+				&grpc.UnaryServerInfo{
+					FullMethod: "/osac.public.v1.Clusters/List",
+				},
+				handler,
+			)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(handlerCalled).To(BeTrue())
+			Expect(mockProvisioner.callCount).To(Equal(0))
+		})
+
+		It("Does not provision when subject has infinite tenants", func() {
+			token := createKeycloakUserToken("tenant1", "frank", nil)
+			ctx = ContextWithToken(ctx, token)
+			subject := &Subject{
+				User:    "frank",
+				Tenants: AllTenants, // Infinite tenant set
+			}
+			ctx = ContextWithSubject(ctx, subject)
+
+			_, err := interceptor.UnaryServer(
+				ctx,
+				nil,
+				&grpc.UnaryServerInfo{
+					FullMethod: "/osac.public.v1.Clusters/List",
+				},
+				handler,
+			)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(handlerCalled).To(BeTrue())
+			Expect(mockProvisioner.callCount).To(Equal(0))
+		})
+
+		It("Does not provision users with system tenant", func() {
+			token := createKeycloakUserToken(SystemTenant, "admin", nil)
+			ctx = ContextWithToken(ctx, token)
+			subject := &Subject{
+				User:    "admin",
+				Tenants: collections.NewSet(SystemTenant),
+			}
+			ctx = ContextWithSubject(ctx, subject)
+
+			_, err := interceptor.UnaryServer(
+				ctx,
+				nil,
+				&grpc.UnaryServerInfo{
+					FullMethod: "/osac.public.v1.Clusters/List",
+				},
+				handler,
+			)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(handlerCalled).To(BeTrue())
+			Expect(mockProvisioner.callCount).To(Equal(0))
+		})
+
+		It("Does not provision users with shared tenant", func() {
+			token := createKeycloakUserToken(SharedTenant, "shared-user", nil)
+			ctx = ContextWithToken(ctx, token)
+			subject := &Subject{
+				User:    "shared-user",
+				Tenants: collections.NewSet(SharedTenant),
+			}
+			ctx = ContextWithSubject(ctx, subject)
+
+			_, err := interceptor.UnaryServer(
+				ctx,
+				nil,
+				&grpc.UnaryServerInfo{
+					FullMethod: "/osac.public.v1.Clusters/List",
+				},
+				handler,
+			)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(handlerCalled).To(BeTrue())
+			Expect(mockProvisioner.callCount).To(Equal(0))
+		})
+
+		It("Does not provision when token is not in context", func() {
+			// No token in context
+			subject := &Subject{
+				User:    "george",
+				Tenants: collections.NewSet("tenant1"),
+			}
+			ctx = ContextWithSubject(ctx, subject)
+
+			_, err := interceptor.UnaryServer(
+				ctx,
+				nil,
+				&grpc.UnaryServerInfo{
+					FullMethod: "/osac.public.v1.Clusters/List",
+				},
+				handler,
+			)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(handlerCalled).To(BeTrue())
+			Expect(mockProvisioner.callCount).To(Equal(0))
+		})
+
+		It("Does not provision when token has non-MapClaims", func() {
+			// Create a token with non-MapClaims type
+			token := &jwt.Token{
+				Claims: jwt.RegisteredClaims{
+					Subject: "harry",
+				},
+			}
+			ctx = ContextWithToken(ctx, token)
+			subject := &Subject{
+				User:    "harry",
+				Tenants: collections.NewSet("tenant1"),
+			}
+			ctx = ContextWithSubject(ctx, subject)
+
+			_, err := interceptor.UnaryServer(
+				ctx,
+				nil,
+				&grpc.UnaryServerInfo{
+					FullMethod: "/osac.public.v1.Clusters/List",
+				},
+				handler,
+			)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(handlerCalled).To(BeTrue())
+			Expect(mockProvisioner.callCount).To(Equal(0))
+		})
+
+		It("Fails request when provisioner fails", func() {
+			token := createKeycloakUserToken("tenant1", "iris", nil)
+			ctx = ContextWithToken(ctx, token)
+			subject := &Subject{
+				User:    "iris",
+				Tenants: collections.NewSet("tenant1"),
+			}
+			ctx = ContextWithSubject(ctx, subject)
+
+			// Configure provisioner to return error:
+			mockProvisioner.provisionFunc = func(ctx context.Context, username, tenant string, claims jwt.MapClaims) error {
+				return errors.New("database connection failed")
+			}
+
+			_, err := interceptor.UnaryServer(
+				ctx,
+				nil,
+				&grpc.UnaryServerInfo{
+					FullMethod: "/osac.public.v1.Clusters/List",
+				},
+				handler,
+			)
+			// Provisioning failure should block the request
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("user provisioning failed"))
+			Expect(err.Error()).To(ContainSubstring("database connection failed"))
+			Expect(handlerCalled).To(BeFalse())
+			// Verify provisioner was called
+			Expect(mockProvisioner.callCount).To(Equal(1))
+		})
+
+		It("Passes correct claims to provisioner", func() {
+			token := createKeycloakUserToken("tenant1", "judy", jwt.MapClaims{
+				"email":          "judy@example.com",
+				"email_verified": true,
+				"name":           "Judy Lee",
+				"custom_field":   "custom_value",
+			})
+			ctx = ContextWithToken(ctx, token)
+			subject := &Subject{
+				User:    "judy",
+				Tenants: collections.NewSet("tenant1"),
+			}
+			ctx = ContextWithSubject(ctx, subject)
+
+			_, err := interceptor.UnaryServer(
+				ctx,
+				nil,
+				&grpc.UnaryServerInfo{
+					FullMethod: "/osac.public.v1.Clusters/List",
+				},
+				handler,
+			)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(handlerCalled).To(BeTrue())
+
+			// Verify all claims were passed:
+			Expect(mockProvisioner.callCount).To(Equal(1))
+			Expect(mockProvisioner.lastUsername).To(Equal("judy"))
+			Expect(mockProvisioner.lastTenant).To(Equal("tenant1"))
+			Expect(mockProvisioner.lastClaims["email"]).To(Equal("judy@example.com"))
+			Expect(mockProvisioner.lastClaims["email_verified"]).To(BeTrue())
+			Expect(mockProvisioner.lastClaims["name"]).To(Equal("Judy Lee"))
+			Expect(mockProvisioner.lastClaims["custom_field"]).To(Equal("custom_value"))
+			Expect(mockProvisioner.lastClaims["username"]).To(Equal("judy"))
+		})
+
+		It("Invokes handler even when provisioning is skipped", func() {
+			token := createKeycloakUserToken("tenant1", "karl", nil)
+			ctx = ContextWithToken(ctx, token)
+			subject := &Subject{
+				User:    "karl",
+				Tenants: collections.NewSet("tenant1", "tenant2"), // Multiple tenants
+			}
+			ctx = ContextWithSubject(ctx, subject)
+
+			_, err := interceptor.UnaryServer(
+				ctx,
+				nil,
+				&grpc.UnaryServerInfo{
+					FullMethod: "/osac.public.v1.Clusters/List",
+				},
+				handler,
+			)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(handlerCalled).To(BeTrue())
+			Expect(mockProvisioner.callCount).To(Equal(0))
+		})
+
+		Describe("Stream provisioning", func() {
+			var (
+				streamHandler       grpc.StreamHandler
+				streamHandlerCalled bool
+			)
+
+			BeforeEach(func() {
+				streamHandlerCalled = false
+				streamHandler = func(srv any, stream grpc.ServerStream) error {
+					streamHandlerCalled = true
+					return nil
+				}
+			})
+
+			It("Provisions a new user on first stream authentication", func() {
+				token := createKeycloakUserToken("tenant1", "alice-stream", jwt.MapClaims{
+					"email":          "alice-stream@example.com",
+					"email_verified": true,
+					"name":           "Alice Stream",
+				})
+				ctx = ContextWithToken(ctx, token)
+
+				subject := &Subject{
+					User:    "alice-stream",
+					Tenants: collections.NewSet("tenant1"),
+				}
+				ctx = ContextWithSubject(ctx, subject)
+
+				stream := &mockServerStream{ctx: ctx}
+				err := interceptor.StreamServer(
+					nil,
+					stream,
+					&grpc.StreamServerInfo{
+						FullMethod: "/osac.public.v1.Clusters/Watch",
+					},
+					streamHandler,
+				)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(streamHandlerCalled).To(BeTrue())
+
+				// Verify provisioner was called:
+				Expect(mockProvisioner.callCount).To(Equal(1))
+				Expect(mockProvisioner.lastUsername).To(Equal("alice-stream"))
+				Expect(mockProvisioner.lastTenant).To(Equal("tenant1"))
+			})
+
+			It("Fails stream request when provisioner fails", func() {
+				token := createKeycloakUserToken("tenant1", "bob-stream", nil)
+				ctx = ContextWithToken(ctx, token)
+				subject := &Subject{
+					User:    "bob-stream",
+					Tenants: collections.NewSet("tenant1"),
+				}
+				ctx = ContextWithSubject(ctx, subject)
+
+				// Configure provisioner to return error:
+				mockProvisioner.provisionFunc = func(ctx context.Context, username, tenant string, claims jwt.MapClaims) error {
+					return errors.New("database unavailable")
+				}
+
+				stream := &mockServerStream{ctx: ctx}
+				err := interceptor.StreamServer(
+					nil,
+					stream,
+					&grpc.StreamServerInfo{
+						FullMethod: "/osac.public.v1.Clusters/Watch",
+					},
+					streamHandler,
+				)
+				// Provisioning failure should block the stream
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("user provisioning failed"))
+				Expect(err.Error()).To(ContainSubstring("database unavailable"))
+				Expect(streamHandlerCalled).To(BeFalse())
+				Expect(mockProvisioner.callCount).To(Equal(1))
+			})
+
+			It("Does not provision when subject has multiple tenants", func() {
+				token := createKeycloakUserToken("tenant1", "charlie-stream", nil)
+				ctx = ContextWithToken(ctx, token)
+				subject := &Subject{
+					User:    "charlie-stream",
+					Tenants: collections.NewSet("tenant1", "tenant2"),
+				}
+				ctx = ContextWithSubject(ctx, subject)
+
+				stream := &mockServerStream{ctx: ctx}
+				err := interceptor.StreamServer(
+					nil,
+					stream,
+					&grpc.StreamServerInfo{
+						FullMethod: "/osac.public.v1.Clusters/Watch",
+					},
+					streamHandler,
+				)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(streamHandlerCalled).To(BeTrue())
+				Expect(mockProvisioner.callCount).To(Equal(0))
+			})
+		})
+	})
+})

--- a/internal/cmd/service/start/grpcserver/start_grpc_server_cmd.go
+++ b/internal/cmd/service/start/grpcserver/start_grpc_server_cmd.go
@@ -48,6 +48,7 @@ import (
 	"github.com/osac-project/fulfillment-service/internal/logging"
 	"github.com/osac-project/fulfillment-service/internal/metrics"
 	"github.com/osac-project/fulfillment-service/internal/network"
+	"github.com/osac-project/fulfillment-service/internal/provisioners"
 	"github.com/osac-project/fulfillment-service/internal/recovery"
 	"github.com/osac-project/fulfillment-service/internal/servers"
 	shtdwn "github.com/osac-project/fulfillment-service/internal/shutdown"
@@ -308,6 +309,20 @@ func (c *runnerContext) run(cmd *cobra.Command, argv []string) error { //nolint:
 		return fmt.Errorf("failed to create authentication interceptor: %w", err)
 	}
 
+	// Create the tenancy logic (needed by both authz interceptor and DAO):
+	c.logger.InfoContext(
+		ctx,
+		"Creating tenancy logic",
+		slog.String("type", c.args.tenancyLogic),
+	)
+	var tenancyLogic auth.TenancyLogic
+	tenancyLogic, err = auth.NewDefaultTenancyLogic().
+		SetLogger(c.logger).
+		Build()
+	if err != nil {
+		return fmt.Errorf("failed to create default tenancy logic: %w", err)
+	}
+
 	// Prepare the authorization interceptor:
 	c.logger.InfoContext(ctx, "Creating Rego authorization interceptor")
 	authzInterceptor, err := auth.NewGrpcAuthzInterceptor().
@@ -320,18 +335,31 @@ func (c *runnerContext) run(cmd *cobra.Command, argv []string) error { //nolint:
 		return fmt.Errorf("failed to create Rego authorization interceptor: %w", err)
 	}
 
-	// Create the tenancy logic:
-	c.logger.InfoContext(
-		ctx,
-		"Creating tenancy logic",
-		slog.String("type", c.args.tenancyLogic),
-	)
-	var tenancyLogic auth.TenancyLogic
-	tenancyLogic, err = auth.NewDefaultTenancyLogic().
+	// Create the users DAO and user provisioner for just-in-time user provisioning:
+	c.logger.InfoContext(ctx, "Creating users DAO for JIT provisioning")
+	usersDAO, err := dao.NewGenericDAO[*privatev1.User]().
 		SetLogger(c.logger).
+		SetTenancyLogic(tenancyLogic).
 		Build()
 	if err != nil {
-		return fmt.Errorf("failed to create default tenancy logic: %w", err)
+		return fmt.Errorf("failed to create users DAO: %w", err)
+	}
+
+	c.logger.InfoContext(ctx, "Creating user provisioner for JIT provisioning")
+	userProvisioner, err := provisioners.NewUserProvisioner().
+		SetUsersDAO(usersDAO).
+		Build()
+	if err != nil {
+		return fmt.Errorf("failed to create user provisioner: %w", err)
+	}
+
+	c.logger.InfoContext(ctx, "Creating JIT provisioning interceptor")
+	jitProvisioningInterceptor, err := auth.NewGrpcJitProvisioningInterceptor().
+		SetLogger(c.logger).
+		SetProvisioner(userProvisioner).
+		Build()
+	if err != nil {
+		return fmt.Errorf("failed to create JIT provisioning interceptor: %w", err)
 	}
 
 	// Prepare the transactions manager:
@@ -397,6 +425,7 @@ func (c *runnerContext) run(cmd *cobra.Command, argv []string) error { //nolint:
 			txInterceptor.UnaryServer,
 			authnInterceptor.UnaryServer,
 			authzInterceptor.UnaryServer,
+			jitProvisioningInterceptor.UnaryServer,
 		),
 		grpc.ChainStreamInterceptor(
 			panicInterceptor.StreamServer,
@@ -404,6 +433,7 @@ func (c *runnerContext) run(cmd *cobra.Command, argv []string) error { //nolint:
 			loggingInterceptor.StreamServer,
 			authnInterceptor.StreamServer,
 			authzInterceptor.StreamServer,
+			jitProvisioningInterceptor.StreamServer,
 		),
 	)
 	shutdown.AddGrpcServer(network.GrpcListenerName, 0, grpcServer)

--- a/internal/database/database_listener.go
+++ b/internal/database/database_listener.go
@@ -29,7 +29,7 @@ import (
 	"google.golang.org/protobuf/types/known/anypb"
 
 	"github.com/osac-project/fulfillment-service/internal/events"
-	"github.com/osac-project/fulfillment-service/internal/reflection"
+	"github.com/osac-project/fulfillment-service/internal/util"
 )
 
 // ListenerBuilder contains the data and logic needed to build a listener.
@@ -144,7 +144,7 @@ func (l *Listener) Ready() bool {
 // process it. This is a blocking operation that returns only when the context is canceled.
 func (l *Listener) Listen(ctx context.Context, callback events.Callback) error {
 	// Check that the callback is not nil:
-	callback = reflection.NormalizeNil(callback)
+	callback = util.NormalizeNil(callback)
 	if callback == nil {
 		return errors.New("callback is mandatory")
 	}

--- a/internal/idp/keycloak/client_test.go
+++ b/internal/idp/keycloak/client_test.go
@@ -2468,7 +2468,7 @@ var _ = Describe("Keycloak Client", func() {
 					}
 					// Create parent group: /web-app
 					if r.Method == http.MethodPost && r.URL.Path == "/admin/realms/osac/organizations/org-123/groups" {
-						var payload map[string]interface{}
+						var payload map[string]any
 						if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
 							http.Error(w, err.Error(), http.StatusBadRequest)
 							return
@@ -2482,7 +2482,7 @@ var _ = Describe("Keycloak Client", func() {
 					}
 					// Create child group: system:viewers under /web-app
 					if r.Method == http.MethodPost && strings.Contains(r.URL.Path, "/children") {
-						var payload map[string]interface{}
+						var payload map[string]any
 						if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
 							http.Error(w, err.Error(), http.StatusBadRequest)
 							return
@@ -2571,7 +2571,7 @@ var _ = Describe("Keycloak Client", func() {
 					}
 					// Create child group under existing parent
 					if r.Method == http.MethodPost && strings.Contains(r.URL.Path, "/children") {
-						var payload map[string]interface{}
+						var payload map[string]any
 						if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
 							http.Error(w, err.Error(), http.StatusBadRequest)
 							return

--- a/internal/provisioners/user_provisioner.go
+++ b/internal/provisioners/user_provisioner.go
@@ -1,0 +1,102 @@
+/*
+Copyright (c) 2026 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package provisioners
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/golang-jwt/jwt/v5"
+
+	privatev1 "github.com/osac-project/fulfillment-service/internal/api/osac/private/v1"
+	"github.com/osac-project/fulfillment-service/internal/auth"
+	"github.com/osac-project/fulfillment-service/internal/database/dao"
+)
+
+// UserProvisionerBuilder builds a UserProvisioner.
+type UserProvisionerBuilder struct {
+	usersDAO *dao.GenericDAO[*privatev1.User]
+}
+
+// UserProvisioner implements auth.UserProvisioner using a GenericDAO.
+type UserProvisioner struct {
+	usersDAO *dao.GenericDAO[*privatev1.User]
+}
+
+// NewUserProvisioner creates a new builder.
+func NewUserProvisioner() *UserProvisionerBuilder {
+	return &UserProvisionerBuilder{}
+}
+
+// SetUsersDAO sets the users DAO.
+func (b *UserProvisionerBuilder) SetUsersDAO(value *dao.GenericDAO[*privatev1.User]) *UserProvisionerBuilder {
+	b.usersDAO = value
+	return b
+}
+
+// Build creates the provisioner.
+func (b *UserProvisionerBuilder) Build() (result *UserProvisioner, err error) {
+	if b.usersDAO == nil {
+		return nil, fmt.Errorf("users DAO is mandatory")
+	}
+	result = &UserProvisioner{
+		usersDAO: b.usersDAO,
+	}
+	return result, nil
+}
+
+// Provision creates a user record if it doesn't exist.
+func (p *UserProvisioner) Provision(ctx context.Context, username, tenant string, claims jwt.MapClaims) error {
+	// Check if user exists
+	filter := fmt.Sprintf("this.spec.username==%q", username)
+	listResponse, err := p.usersDAO.List().
+		SetFilter(filter).
+		SetLimit(1).
+		Do(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to check if user exists: %w", err)
+	}
+
+	// User already exists
+	if listResponse.GetSize() > 0 {
+		return nil
+	}
+
+	// Extract claims
+	email, _ := claims["email"].(string)
+
+	// Create user
+	user := privatev1.User_builder{
+		Metadata: privatev1.Metadata_builder{
+			Name:   username,
+			Tenant: tenant,
+		}.Build(),
+		Spec: privatev1.UserSpec_builder{
+			Username: username,
+			Email:    email,
+			Enabled:  true,
+		}.Build(),
+	}.Build()
+
+	_, err = p.usersDAO.Create().
+		SetObject(user).
+		Do(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to create user: %w", err)
+	}
+
+	return nil
+}
+
+var _ auth.UserProvisioner = (*UserProvisioner)(nil)

--- a/internal/provisioners/user_provisioner_test.go
+++ b/internal/provisioners/user_provisioner_test.go
@@ -1,0 +1,251 @@
+/*
+Copyright (c) 2026 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package provisioners
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"go.uber.org/mock/gomock"
+
+	privatev1 "github.com/osac-project/fulfillment-service/internal/api/osac/private/v1"
+	"github.com/osac-project/fulfillment-service/internal/auth"
+	"github.com/osac-project/fulfillment-service/internal/database"
+	"github.com/osac-project/fulfillment-service/internal/database/dao"
+	"github.com/osac-project/fulfillment-service/internal/logging"
+)
+
+func TestUserProvisioner(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "User Provisioner Suite")
+}
+
+var (
+	ctx      context.Context
+	ctrl     *gomock.Controller
+	logger   *slog.Logger
+	server   *database.Container
+	usersDAO *dao.GenericDAO[*privatev1.User]
+	tenancy  *auth.MockTenancyLogic
+	prov     *UserProvisioner
+)
+
+var _ = BeforeSuite(func() {
+	var err error
+
+	// Create the mock controller:
+	ctrl = gomock.NewController(GinkgoT())
+	DeferCleanup(ctrl.Finish)
+
+	// Create logger:
+	logger, err = logging.NewLogger().
+		SetLevel(slog.LevelDebug.String()).
+		SetWriter(GinkgoWriter).
+		Build()
+	Expect(err).ToNot(HaveOccurred())
+
+	// Create the tenancy logic:
+	tenancy = auth.NewMockTenancyLogic(ctrl)
+	tenancy.EXPECT().DetermineAssignableTenants(gomock.Any()).
+		Return(auth.AllTenants, nil).
+		AnyTimes()
+	tenancy.EXPECT().DetermineDefaultTenant(gomock.Any()).
+		Return(auth.SystemTenant, nil).
+		AnyTimes()
+	tenancy.EXPECT().DetermineVisibleTenants(gomock.Any()).
+		Return(auth.AllTenants, nil).
+		AnyTimes()
+
+	// Create the database server:
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	DeferCleanup(cancel)
+	server, err = database.NewContainer().
+		SetLogger(logger).
+		Build()
+	Expect(err).ToNot(HaveOccurred())
+	err = server.Start(ctx)
+	Expect(err).ToNot(HaveOccurred())
+	DeferCleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+		defer cancel()
+		err = server.Stop(ctx)
+		Expect(err).ToNot(HaveOccurred())
+	})
+})
+
+var _ = BeforeEach(func() {
+	var err error
+
+	// Create a context:
+	ctx = context.Background()
+
+	// Prepare the database pool:
+	db, err := server.NewInstance().Build()
+	Expect(err).ToNot(HaveOccurred())
+	DeferCleanup(db.Close)
+	pool, err := db.Pool(ctx)
+	Expect(err).ToNot(HaveOccurred())
+	DeferCleanup(pool.Close)
+
+	// Create the transaction manager:
+	tm, err := database.NewTxManager().
+		SetLogger(logger).
+		SetPool(pool).
+		Build()
+	Expect(err).ToNot(HaveOccurred())
+
+	// Start a transaction and add it to the context:
+	tx, err := tm.Begin(ctx)
+	Expect(err).ToNot(HaveOccurred())
+	DeferCleanup(func() {
+		err := tx.End(ctx)
+		Expect(err).ToNot(HaveOccurred())
+	})
+	ctx = database.TxIntoContext(ctx, tx)
+
+	// Create users DAO:
+	usersDAO, err = dao.NewGenericDAO[*privatev1.User]().
+		SetLogger(logger).
+		SetTenancyLogic(tenancy).
+		Build()
+	Expect(err).ToNot(HaveOccurred())
+
+	// Create provisioner:
+	prov, err = NewUserProvisioner().
+		SetUsersDAO(usersDAO).
+		Build()
+	Expect(err).ToNot(HaveOccurred())
+})
+
+var _ = Describe("UserProvisioner", func() {
+
+	Describe("Builder validation", func() {
+		It("Requires users DAO", func() {
+			_, err := NewUserProvisioner().
+				Build()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("users DAO is mandatory"))
+		})
+
+		It("Builds successfully with all required parameters", func() {
+			p, err := NewUserProvisioner().
+				SetUsersDAO(usersDAO).
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(p).ToNot(BeNil())
+		})
+	})
+
+	Describe("Provision", func() {
+		It("Creates a new user with all fields populated", func() {
+			claims := jwt.MapClaims{
+				"email": "alice@example.com",
+			}
+
+			err := prov.Provision(ctx, "alice", auth.SystemTenant, claims)
+			Expect(err).ToNot(HaveOccurred())
+
+			// Verify user was created:
+			listResp, err := usersDAO.List().
+				SetFilter("this.spec.username=='alice'").
+				Do(ctx)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(listResp.GetSize()).To(Equal(int32(1)))
+
+			user := listResp.GetItems()[0]
+			Expect(user.GetMetadata().GetName()).To(Equal("alice"))
+			Expect(user.GetMetadata().GetTenant()).To(Equal(auth.SystemTenant))
+			Expect(user.GetSpec().GetUsername()).To(Equal("alice"))
+			Expect(user.GetSpec().GetEmail()).To(Equal("alice@example.com"))
+			Expect(user.GetSpec().GetEnabled()).To(BeTrue())
+		})
+
+		It("Creates a user with minimal claims", func() {
+			claims := jwt.MapClaims{}
+
+			err := prov.Provision(ctx, "bob", auth.SystemTenant, claims)
+			Expect(err).ToNot(HaveOccurred())
+
+			// Verify user was created:
+			listResp, err := usersDAO.List().
+				SetFilter("this.spec.username=='bob'").
+				Do(ctx)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(listResp.GetSize()).To(Equal(int32(1)))
+
+			user := listResp.GetItems()[0]
+			Expect(user.GetMetadata().GetName()).To(Equal("bob"))
+			Expect(user.GetMetadata().GetTenant()).To(Equal(auth.SystemTenant))
+			Expect(user.GetSpec().GetUsername()).To(Equal("bob"))
+			Expect(user.GetSpec().GetEmail()).To(Equal(""))
+			Expect(user.GetSpec().GetEnabled()).To(BeTrue())
+		})
+
+		It("Does not create duplicate user if user already exists", func() {
+			claims := jwt.MapClaims{
+				"email": "eve@example.com",
+			}
+
+			// Create user first time:
+			err := prov.Provision(ctx, "eve", auth.SystemTenant, claims)
+			Expect(err).ToNot(HaveOccurred())
+
+			// Try to create same user again:
+			err = prov.Provision(ctx, "eve", auth.SystemTenant, claims)
+			Expect(err).ToNot(HaveOccurred())
+
+			// Verify only one user exists:
+			listResp, err := usersDAO.List().
+				SetFilter("this.spec.username=='eve'").
+				Do(ctx)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(listResp.GetSize()).To(Equal(int32(1)))
+		})
+
+		It("Handles email claim as non-string gracefully", func() {
+			claims := jwt.MapClaims{
+				"email": 12345, // Number instead of string
+			}
+
+			err := prov.Provision(ctx, "harry", auth.SystemTenant, claims)
+			Expect(err).ToNot(HaveOccurred())
+
+			listResp, err := usersDAO.List().
+				SetFilter("this.spec.username=='harry'").
+				Do(ctx)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(listResp.GetSize()).To(Equal(int32(1)))
+
+			user := listResp.GetItems()[0]
+			Expect(user.GetSpec().GetEmail()).To(Equal("")) // Defaults to empty string for non-string
+		})
+
+		It("Returns error when tenant doesn't exist", func() {
+			claims := jwt.MapClaims{
+				"email": "orphan@example.com",
+			}
+
+			// Try to provision a user in a non-existent tenant:
+			err := prov.Provision(ctx, "orphan", "nonexistent_tenant", claims)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("tenant 'nonexistent_tenant' doesn't exist"))
+		})
+
+	})
+})

--- a/internal/rendering/table_renderer.go
+++ b/internal/rendering/table_renderer.go
@@ -38,6 +38,7 @@ import (
 
 	"github.com/osac-project/fulfillment-service/internal/config"
 	"github.com/osac-project/fulfillment-service/internal/reflection"
+	"github.com/osac-project/fulfillment-service/internal/util"
 )
 
 //go:embed tables
@@ -107,7 +108,7 @@ func (b *TableRendererBuilder) SetLogger(value *slog.Logger) *TableRendererBuild
 
 // SetHelper sets the reflection helper that will be used to introspect objects. This is mandatory.
 func (b *TableRendererBuilder) SetHelper(value reflection.Helper) *TableRendererBuilder {
-	b.helper = reflection.NormalizeNil(value)
+	b.helper = util.NormalizeNil(value)
 	return b
 }
 

--- a/internal/rendering/table_renderer.go
+++ b/internal/rendering/table_renderer.go
@@ -177,12 +177,18 @@ func (r *TableRenderer) Render(ctx context.Context, objects any) error {
 		return fmt.Errorf("failed to find object helper for type %q", descriptor.FullName())
 	}
 
-	// Try to load the table definition for this object type:
+	// Try to load the table definition for this object type.
+	// If loading fails for any reason (file not found, parse error, etc.),
+	// fall back to the default table so the CLI remains functional.
 	table, err := r.loadTable(helper)
 	if err != nil {
-		return err
-	}
-	if table == nil {
+		r.logger.Warn(
+			"Failed to load table definition, using default",
+			slog.String("type", string(helper.FullName())),
+			slog.Any("error", err),
+		)
+		table = r.defaultTable()
+	} else if table == nil {
 		table = r.defaultTable()
 	}
 
@@ -266,7 +272,13 @@ func (r *TableRenderer) loadTable(helper reflection.ObjectHelper) (result *table
 	data, err := fs.ReadFile(tablesFS, path.Join("tables", file))
 	if err != nil {
 		// If the file doesn't exist, that's okay - we'll use the default table.
-		return
+		// This handles both fs.ErrNotExist and any path-related errors.
+		r.logger.Debug(
+			"Table definition not found, will use default",
+			slog.String("type", string(helper.FullName())),
+			slog.String("file", file),
+		)
+		return nil, nil
 	}
 
 	// Unmarshal the table definition:

--- a/internal/servers/events_server.go
+++ b/internal/servers/events_server.go
@@ -36,7 +36,7 @@ import (
 	"github.com/osac-project/fulfillment-service/internal/collections"
 	"github.com/osac-project/fulfillment-service/internal/events"
 	"github.com/osac-project/fulfillment-service/internal/packages"
-	"github.com/osac-project/fulfillment-service/internal/reflection"
+	"github.com/osac-project/fulfillment-service/internal/util"
 	"github.com/osac-project/fulfillment-service/internal/uuid"
 )
 
@@ -80,12 +80,12 @@ func (b *EventsServerBuilder) SetLogger(value *slog.Logger) *EventsServerBuilder
 
 // SetListener sets the listener that will be used to receive event notifications. This is mandatory.
 func (b *EventsServerBuilder) SetListener(value events.Listener) *EventsServerBuilder {
-	b.listener = reflection.NormalizeNil(value)
+	b.listener = util.NormalizeNil(value)
 	return b
 }
 
 func (b *EventsServerBuilder) SetTenancyLogic(value auth.TenancyLogic) *EventsServerBuilder {
-	b.tenancyLogic = reflection.NormalizeNil(value)
+	b.tenancyLogic = util.NormalizeNil(value)
 	return b
 }
 

--- a/internal/servers/generic_server.go
+++ b/internal/servers/generic_server.go
@@ -35,7 +35,7 @@ import (
 	"github.com/osac-project/fulfillment-service/internal/database/dao"
 	"github.com/osac-project/fulfillment-service/internal/events"
 	"github.com/osac-project/fulfillment-service/internal/masks"
-	"github.com/osac-project/fulfillment-service/internal/reflection"
+	"github.com/osac-project/fulfillment-service/internal/util"
 	"github.com/osac-project/fulfillment-service/internal/uuid"
 )
 
@@ -137,7 +137,7 @@ func (b *GenericServerBuilder[O]) AddIgnoredFields(values ...any) *GenericServer
 
 // SetNotifier sets the notifier that the server will use to send change notifications. This is optional.
 func (b *GenericServerBuilder[O]) SetNotifier(value events.Notifier) *GenericServerBuilder[O] {
-	b.notifier = reflection.NormalizeNil(value)
+	b.notifier = util.NormalizeNil(value)
 	return b
 }
 

--- a/internal/util/nil.go
+++ b/internal/util/nil.go
@@ -11,14 +11,24 @@ Unless required by applicable law or agreed to in writing, software distributed 
 language governing permissions and limitations under the License.
 */
 
-package reflection
+package util
 
-import "github.com/osac-project/fulfillment-service/internal/util"
+import "reflect"
 
 // NormalizeNil returns a true nil when the interface holds a nil pointer, preventing typed-nil values from bypassing
 // nil checks and causing panics on method calls.
-//
-// Deprecated: Use util.NormalizeNil instead. This wrapper is provided for backward compatibility.
 func NormalizeNil[T any](value T) T {
-	return util.NormalizeNil(value)
+	v := reflect.ValueOf(&value).Elem()
+	if v.Kind() == reflect.Interface {
+		elem := v.Elem()
+		if !elem.IsValid() {
+			var zero T
+			return zero
+		}
+		if elem.Kind() == reflect.Pointer && elem.IsNil() {
+			var zero T
+			return zero
+		}
+	}
+	return value
 }

--- a/internal/util/nil_test.go
+++ b/internal/util/nil_test.go
@@ -1,0 +1,41 @@
+/*
+Copyright (c) 2026 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package util
+
+import (
+	. "github.com/onsi/ginkgo/v2/dsl/core"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Normalize nil", func() {
+	type fake struct{}
+
+	It("Returns nil for a nil interface", func() {
+		var n any
+		Expect(NormalizeNil(n)).To(BeNil())
+	})
+
+	It("Returns nil for a typed-nil pointer", func() {
+		var f *fake                                                  //nolint:staticcheck // SA4023: intentional typed-nil test
+		var n any = f                                                //nolint:staticcheck // SA4023: intentional typed-nil test
+		Expect(n != nil).To(BeTrue(), "interface itself is not nil") //nolint:ginkgolinter,staticcheck // intentional typed-nil test
+		Expect(NormalizeNil(n)).To(BeNil())
+	})
+
+	It("Returns the value when it holds a valid pointer", func() {
+		f := &fake{}
+		var n any = f
+		Expect(NormalizeNil(n)).To(Equal(f))
+	})
+})

--- a/internal/util/util_suite_test.go
+++ b/internal/util/util_suite_test.go
@@ -11,14 +11,16 @@ Unless required by applicable law or agreed to in writing, software distributed 
 language governing permissions and limitations under the License.
 */
 
-package reflection
+package util
 
-import "github.com/osac-project/fulfillment-service/internal/util"
+import (
+	"testing"
 
-// NormalizeNil returns a true nil when the interface holds a nil pointer, preventing typed-nil values from bypassing
-// nil checks and causing panics on method calls.
-//
-// Deprecated: Use util.NormalizeNil instead. This wrapper is provided for backward compatibility.
-func NormalizeNil[T any](value T) T {
-	return util.NormalizeNil(value)
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestUtil(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Util Suite")
 }


### PR DESCRIPTION
# Description
When an IdP user first logs in, we should create the user in our database for persistent records. This creates a new
interceptor to handle this case.

# Testing

- Created Org, IdP connection, logged in as IdP user

Assisted-by: Claude Code <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added just-in-time user provisioning for gRPC requests, automatically creating users when an authenticated request identifies a single eligible tenant.
* **Bug Fixes**
  * Updated authorization to store the subject in request context before emitting access-grant logging.
  * Improved gRPC startup reliability by initializing tenancy logic earlier and wiring the JIT provisioning interceptor into unary and streaming request chains.
  * Enhanced table rendering fallback: missing or unloadable table definitions now safely use the default layout.
* **Tests**
  * Added comprehensive coverage for JIT provisioning and user provisioning behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->