### PR TITLE
NO-ISSUE: add bash completion for object types in osac get

### DIFF
--- a/internal/cmd/cli/get/get_cmd.go
+++ b/internal/cmd/cli/get/get_cmd.go
@@ -61,6 +61,7 @@ func Cmd() *cobra.Command {
 		Short:                 shortHelp,
 		Long:                  longHelp,
 		RunE:                  runner.run,
+		ValidArgsFunction:     runner.complete,
 	}
 	result.AddCommand(kubeconfig.Cmd())
 	result.AddCommand(password.Cmd())
@@ -103,6 +104,33 @@ type runnerContext struct {
 	marshalOptions protojson.MarshalOptions
 	globalHelper   reflection.Helper
 	objectHelper   reflection.ObjectHelper
+}
+
+func (c *runnerContext) complete(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	if len(args) > 0 {
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+	ctx := cmd.Context()
+	cfg := config.SettingsFromContext(ctx)
+	if !cfg.Armed() {
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+	conn, err := cfg.Connect(ctx, cmd.Flags())
+	if err != nil {
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+	defer conn.Close()
+	logger := logging.LoggerFromContext(ctx)
+	helper, err := reflection.NewHelper().
+		SetLogger(logger).
+		SetConnection(conn).
+		AddPackages(cfg.Packages()).
+		Build()
+	if err != nil {
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+	names := append(helper.Singulars(), helper.Plurals()...)
+	return names, cobra.ShellCompDirectiveNoFileComp
 }
 
 func (c *runnerContext) run(cmd *cobra.Command, args []string) error {


### PR DESCRIPTION
## Summary

- Add `ValidArgsFunction` to `osac get` so that pressing Tab after `osac get` returns the list of available resource types
- Resource types are discovered via gRPC server reflection (same mechanism the `get` command itself uses), returning both singular and plural forms (e.g. `baremetalinstance`, `baremetalinstances`, `computeinstance`, `computeinstances`, ...)
- Falls back silently to no completions when the user is not logged in or the server is unreachable

## Usage

After sourcing the completion script:

```bash
source <(osac completion bash)   # bash
source <(osac completion zsh)    # zsh
```

```
$ osac get <TAB>
baremetalinstance   baremetalinstances   cluster   clusters   computeinstance   computeinstances   ...
```

## Jira

N/A

## Test plan

- [x] `go build ./cmd/osac/` clean
- [ ] Manual: `source <(osac completion bash)` then `osac get <TAB>` returns resource types

🤖 Generated with [Claude Code](https://claude.com/claude-code)