### PR TITLE
NO-ISSUE: Validate migration files before updating the hash

### DIFF
--- a/dev/update.py
+++ b/dev/update.py
@@ -15,8 +15,10 @@
 
 import hashlib
 import logging
+import sys
 
 import click
+import humanize
 
 from . import dirs
 
@@ -33,10 +35,48 @@ def hashes() -> None:
     """
     Updates the database migrations hash.
     """
-    # Compute the hash of the migration files:
+    # Collect and sort migration files:
     migrations_dir = dirs.project() / "internal" / "database" / "migrations"
     migration_files = migrations_dir.glob("*.up.sql")
     migration_files_sorted = sorted(migration_files)
+
+    # We will report errors as we find them, and keep a count, so we can raise an error at the end if there are any:
+    error_count = 0
+
+    # Check that all migration files have a numeric prefix, while building an index of migration numbers to file names:
+    migration_index: dict[int, list[str]] = {}
+    for migration_file in migration_files_sorted:
+        migration_parts = migration_file.name.split("_", 1)
+        if len(migration_parts) < 2:
+            logging.error(f"Migration file '{migration_file.name}' has an invalid prefix")
+            error_count += 1
+            continue
+        migration_prefix = migration_parts[0]
+        if not migration_prefix.isdigit():
+            logging.error(f"Migration file '{migration_file.name}' has an invalid prefix")
+            error_count += 1
+            continue
+        migration_number = int(migration_prefix)
+        migration_index.setdefault(migration_number, []).append(migration_file.name)
+
+    # Check that there are no duplicate migration numbers:
+    for migration_number, migration_files in migration_index.items():
+        if len(migration_files) <= 1:
+            continue
+        migration_names = [f"'{migration_file}'" for migration_file in migration_files]
+        migration_names.sort()
+        migration_list = humanize.natural_list(migration_names)
+        logging.error(
+            f"Migrations {migration_list} have the same number",
+        )
+        error_count += 1
+
+    # Raise an error if there were any errors:
+    if error_count > 0:
+        logging.error("Found errors in migration files, fix them and run the command again")
+        sys.exit(1)
+
+    # Compute the hash of the migration files:
     computed_hash_source = "".join(migration_file.name + "\n" for migration_file in migration_files_sorted)
     computed_hash_source_bytes = computed_hash_source.encode()
     computed_hash_bytes = hashlib.sha256(computed_hash_source_bytes).digest()

--- a/internal/database/database_migrations_test.go
+++ b/internal/database/database_migrations_test.go
@@ -125,9 +125,9 @@ var _ = Describe("Migrations", func() {
 		// Compare the computed hash with the stored hash:
 		if computedHashText != storedHashText {
 			Fail(fmt.Sprintf(
-				"Database migrations hash in '%s' is outdated, should be '%s' but is '%s', update "+
-					"it manually or run 'uv run dev.py update hashes' to update it automatically",
-				storedHashFile, computedHashText, storedHashText,
+				"Database migrations hash in '%s' is outdated, run 'uv run dev.py update hashes' "+
+					"to update it",
+				storedHashFile,
 			))
 		}
 	})

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,7 @@ version = "0.0.0"
 requires-python = ">=3.14"
 dependencies = [
     "click>=8.4.1",
+    "humanize==4.15.0",
     "requests>=2.34.2",
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -79,13 +79,24 @@ version = "0.0.0"
 source = { virtual = "." }
 dependencies = [
     { name = "click" },
+    { name = "humanize" },
     { name = "requests" },
 ]
 
 [package.metadata]
 requires-dist = [
     { name = "click", specifier = ">=8.4.1" },
+    { name = "humanize", specifier = "==4.15.0" },
     { name = "requests", specifier = ">=2.34.2" },
+]
+
+[[package]]
+name = "humanize"
+version = "4.15.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ba/66/a3921783d54be8a6870ac4ccffcd15c4dc0dd7fcce51c6d63b8c63935276/humanize-4.15.0.tar.gz", hash = "sha256:1dd098483eb1c7ee8e32eb2e99ad1910baefa4b75c3aff3a82f4d78688993b10", size = 83599, upload-time = "2025-12-20T20:16:13.19Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c5/7b/bca5613a0c3b542420cf92bd5e5fb8ebd5435ce1011a091f66bb7693285e/humanize-4.15.0-py3-none-any.whl", hash = "sha256:b1186eb9f5a9749cd9cb8565aee77919dd7c8d076161cf44d70e59e3301e1769", size = 132203, upload-time = "2025-12-20T20:16:11.67Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- The `update hashes` command now validates migration file prefixes and checks for duplicate
  migration numbers before computing the hash, preventing developers from unknowingly working
  with an incorrect hash when their migrations have problems.
- The unit test failure message no longer reveals the expected hash value, directing developers
  to use `uv run dev.py update hashes` instead of manual updates.

## Test plan

- Run `uv run dev.py update hashes` with valid migrations and verify the hash is updated.
- Introduce a duplicate migration number and verify the command reports the error and exits
  without updating the hash.
- Run `ginkgo run internal/database` and verify the hash test passes with a correct hash and
  fails with a helpful message when the hash is outdated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved migration hash update validation by verifying migration filename formats and detecting duplicate numeric prefixes.
  * Updated error handling so validation failures are reported more clearly and the command exits with a non-zero status when issues are found.
* **Tests**
  * Simplified the “out-of-date migrations hash” test failure message to direct running the hashes update command.
* **Chores**
  * Added the `humanize` library to support clearer, human-readable error output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->