### PR TITLE
NO-ISSUE: Exit with code 1 when build commands fail

### DIFF
--- a/dev/build.py
+++ b/dev/build.py
@@ -14,6 +14,7 @@
 #
 
 import logging
+import sys
 
 import click
 
@@ -40,17 +41,28 @@ def binaries() -> None:
     cmd_dir = project_dir / "cmd"
     bin_dir = project_dir / "bin"
     bin_dir.mkdir(parents=True, exist_ok=True)
+    error_count = 0
     for cmd_subdir in sorted(cmd_dir.iterdir()):
         if not cmd_subdir.is_dir():
             continue
         bin_name = cmd_subdir.name
         bin_file = bin_dir / bin_name
+        if bin_file.exists():
+            bin_file.unlink()
         logging.info(f"Building binary '{bin_name}'")
-        commands.run([
+        result = commands.run([
             "go", "build",
             "-o", f"{bin_file.relative_to(project_dir)}",
             f"./{cmd_subdir.relative_to(project_dir)}",
         ])
+        if result.returncode != 0:
+            if bin_file.exists():
+                bin_file.unlink()
+            logging.error(f"Failed to build binary '{bin_name}'")
+            error_count += 1
+    if error_count > 0:
+        logging.error("Found errors while building binaries")
+        sys.exit(1)
 
 
 @build.command()
@@ -59,7 +71,10 @@ def images() -> None:
     Builds the container image using podman.
     """
     logging.info("Building container image")
-    commands.run([
+    result = commands.run([
         "podman", "build",
         ".",
     ])
+    if result.returncode != 0:
+        logging.error("Failed to build container image")
+        sys.exit(1)

--- a/dev/commands.py
+++ b/dev/commands.py
@@ -28,7 +28,7 @@ from . import dirs
 def run(
     args: list[str],
     **kwargs,
-) -> None:
+) -> subprocess.CompletedProcess:
     """
     Runs the given command.
     """
@@ -38,6 +38,7 @@ def run(
     logging.debug(f"Running command '{cmd}'")
     result = subprocess.run(args=args, **kwargs)
     logging.debug(f"Exit code of '{cmd}' is {result.returncode}")
+    return result
 
 
 def eval(


### PR DESCRIPTION
## Summary

- `commands.run` now returns the `subprocess.CompletedProcess` object so callers can inspect the
  exit code.
- The `binaries` command counts build errors across all binaries and exits with code 1 if any
  failed, while still attempting to build the remaining ones.
- The `images` command checks the `podman build` exit code and exits with code 1 on failure.

## Test plan

- Introduce a compilation error in one of the binaries and run `uv run dev.py build binaries` to
  verify it reports the failure and exits with code 1.
- Run `uv run dev.py build images` without podman or with a broken Dockerfile to verify it exits
  with code 1.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Build steps now correctly detect and report failures instead of continuing as if they succeeded.
  * Binary builds remove any partially created outputs for failed build attempts and fail the overall process when any step errors.
  * Image builds now fail fast with a non-zero exit status if the build fails.
  * Command execution now returns the full process result, improving visibility and downstream error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->