### PR TITLE
OSAC-1284: Implement ProjectMembership gRPC servers

### DIFF
--- a/internal/cmd/service/start/grpcserver/start_grpc_server_cmd.go
+++ b/internal/cmd/service/start/grpcserver/start_grpc_server_cmd.go
@@ -980,6 +980,34 @@ func (c *runnerContext) run(cmd *cobra.Command, argv []string) error { //nolint:
 	}
 	privatev1.RegisterRoleBindingsServer(grpcServer, privateRoleBindingsServer)
 
+	// Create the project memberships server:
+	c.logger.InfoContext(ctx, "Creating project memberships server")
+	projectMembershipsServer, err := servers.NewProjectMembershipsServer().
+		SetLogger(c.logger).
+		SetNotifier(notifier).
+		SetAttributionLogic(publicAttributionLogic).
+		SetTenancyLogic(tenancyLogic).
+		SetMetricsRegisterer(metricsRegisterer).
+		Build()
+	if err != nil {
+		return fmt.Errorf("failed to create project memberships server: %w", err)
+	}
+	publicv1.RegisterProjectMembershipsServer(grpcServer, projectMembershipsServer)
+
+	// Create the private project memberships server:
+	c.logger.InfoContext(ctx, "Creating private project memberships server")
+	privateProjectMembershipsServer, err := servers.NewPrivateProjectMembershipsServer().
+		SetLogger(c.logger).
+		SetNotifier(notifier).
+		SetAttributionLogic(privateAttributionLogic).
+		SetTenancyLogic(tenancyLogic).
+		SetMetricsRegisterer(metricsRegisterer).
+		Build()
+	if err != nil {
+		return fmt.Errorf("failed to create private project memberships server: %w", err)
+	}
+	privatev1.RegisterProjectMembershipsServer(grpcServer, privateProjectMembershipsServer)
+
 	// Create the public IPs server:
 	c.logger.InfoContext(ctx, "Creating public IPs server")
 	publicIPsServer, err := servers.NewPublicIPsServer().

--- a/internal/rendering/tables/osac.private.v1.ProjectMembership.yaml
+++ b/internal/rendering/tables/osac.private.v1.ProjectMembership.yaml
@@ -1,0 +1,38 @@
+#
+# Copyright (c) 2026 Red Hat Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+# the License. You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+columns:
+
+- header: ID
+  value: this.id
+
+- header: NAME
+  value: "has(this.metadata.name)? this.metadata.name: '-'"
+
+- header: STATE
+  value: this.status.state
+  type: osac.private.v1.ProjectMembershipState
+
+- header: PROJECT
+  value: this.spec.project
+  type: osac.private.v1.Project
+  lookup: true
+
+- header: USER
+  value: this.spec.user
+  type: osac.private.v1.User
+  lookup: true
+
+- header: ROLE
+  value: this.spec.role
+  type: osac.private.v1.ProjectMembershipRole

--- a/internal/rendering/tables/osac.public.v1.ProjectMembership.yaml
+++ b/internal/rendering/tables/osac.public.v1.ProjectMembership.yaml
@@ -1,0 +1,38 @@
+#
+# Copyright (c) 2026 Red Hat Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+# the License. You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+columns:
+
+- header: ID
+  value: this.id
+
+- header: NAME
+  value: "has(this.metadata.name)? this.metadata.name: '-'"
+
+- header: STATE
+  value: this.status.state
+  type: osac.public.v1.ProjectMembershipState
+
+- header: PROJECT
+  value: this.spec.project
+  type: osac.public.v1.Project
+  lookup: true
+
+- header: USER
+  value: this.spec.user
+  type: osac.public.v1.User
+  lookup: true
+
+- header: ROLE
+  value: this.spec.role
+  type: osac.public.v1.ProjectMembershipRole

--- a/internal/servers/generic_server.go
+++ b/internal/servers/generic_server.go
@@ -889,6 +889,8 @@ func (s *GenericServer[O]) setPayload(event *privatev1.Event, object proto.Messa
 		event.SetRoleBinding(object)
 	case *privatev1.Project:
 		event.SetProject(object)
+	case *privatev1.ProjectMembership:
+		event.SetProjectMembership(object)
 	case *privatev1.ClusterCatalogItem:
 		event.SetClusterCatalogItem(object)
 	case *privatev1.ComputeInstanceCatalogItem:

--- a/internal/servers/private_project_memberships_server.go
+++ b/internal/servers/private_project_memberships_server.go
@@ -1,0 +1,147 @@
+/*
+Copyright (c) 2026 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package servers
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+
+	"github.com/prometheus/client_golang/prometheus"
+
+	privatev1 "github.com/osac-project/fulfillment-service/internal/api/osac/private/v1"
+	"github.com/osac-project/fulfillment-service/internal/auth"
+	"github.com/osac-project/fulfillment-service/internal/events"
+)
+
+// PrivateProjectMembershipsServerBuilder is a builder for creating instances of PrivateProjectMembershipsServer.
+type PrivateProjectMembershipsServerBuilder struct {
+	logger            *slog.Logger
+	notifier          events.Notifier
+	attributionLogic  auth.AttributionLogic
+	tenancyLogic      auth.TenancyLogic
+	metricsRegisterer prometheus.Registerer
+}
+
+var _ privatev1.ProjectMembershipsServer = (*PrivateProjectMembershipsServer)(nil)
+
+// PrivateProjectMembershipsServer implements the private project memberships gRPC service.
+type PrivateProjectMembershipsServer struct {
+	privatev1.UnimplementedProjectMembershipsServer
+
+	logger  *slog.Logger
+	generic *GenericServer[*privatev1.ProjectMembership]
+}
+
+// NewPrivateProjectMembershipsServer creates a new builder for the private project memberships server.
+func NewPrivateProjectMembershipsServer() *PrivateProjectMembershipsServerBuilder {
+	return &PrivateProjectMembershipsServerBuilder{}
+}
+
+// SetLogger sets the logger to use. This is mandatory.
+func (b *PrivateProjectMembershipsServerBuilder) SetLogger(value *slog.Logger) *PrivateProjectMembershipsServerBuilder {
+	b.logger = value
+	return b
+}
+
+// SetNotifier sets the notifier to use. This is optional.
+func (b *PrivateProjectMembershipsServerBuilder) SetNotifier(value events.Notifier) *PrivateProjectMembershipsServerBuilder {
+	b.notifier = value
+	return b
+}
+
+// SetAttributionLogic sets the attribution logic to use. This is optional.
+func (b *PrivateProjectMembershipsServerBuilder) SetAttributionLogic(value auth.AttributionLogic) *PrivateProjectMembershipsServerBuilder {
+	b.attributionLogic = value
+	return b
+}
+
+// SetTenancyLogic sets the tenancy logic to use. This is mandatory.
+func (b *PrivateProjectMembershipsServerBuilder) SetTenancyLogic(value auth.TenancyLogic) *PrivateProjectMembershipsServerBuilder {
+	b.tenancyLogic = value
+	return b
+}
+
+// SetMetricsRegisterer sets the Prometheus registerer used to register the metrics for the underlying database
+// access objects. This is optional. If not set, no metrics will be recorded.
+func (b *PrivateProjectMembershipsServerBuilder) SetMetricsRegisterer(value prometheus.Registerer) *PrivateProjectMembershipsServerBuilder {
+	b.metricsRegisterer = value
+	return b
+}
+
+// Build creates the private project memberships server from the builder configuration.
+func (b *PrivateProjectMembershipsServerBuilder) Build() (result *PrivateProjectMembershipsServer, err error) {
+	if b.logger == nil {
+		err = errors.New("logger is mandatory")
+		return
+	}
+	if b.tenancyLogic == nil {
+		err = errors.New("tenancy logic is mandatory")
+		return
+	}
+
+	generic, err := NewGenericServer[*privatev1.ProjectMembership]().
+		SetLogger(b.logger).
+		SetService(privatev1.ProjectMemberships_ServiceDesc.ServiceName).
+		SetNotifier(b.notifier).
+		SetAttributionLogic(b.attributionLogic).
+		SetTenancyLogic(b.tenancyLogic).
+		SetMetricsRegisterer(b.metricsRegisterer).
+		Build()
+	if err != nil {
+		return
+	}
+
+	result = &PrivateProjectMembershipsServer{
+		logger:  b.logger,
+		generic: generic,
+	}
+	return
+}
+
+func (s *PrivateProjectMembershipsServer) List(ctx context.Context,
+	request *privatev1.ProjectMembershipsListRequest) (response *privatev1.ProjectMembershipsListResponse, err error) {
+	err = s.generic.List(ctx, request, &response)
+	return
+}
+
+func (s *PrivateProjectMembershipsServer) Get(ctx context.Context,
+	request *privatev1.ProjectMembershipsGetRequest) (response *privatev1.ProjectMembershipsGetResponse, err error) {
+	err = s.generic.Get(ctx, request, &response)
+	return
+}
+
+func (s *PrivateProjectMembershipsServer) Create(ctx context.Context,
+	request *privatev1.ProjectMembershipsCreateRequest) (response *privatev1.ProjectMembershipsCreateResponse, err error) {
+	err = s.generic.Create(ctx, request, &response)
+	return
+}
+
+func (s *PrivateProjectMembershipsServer) Update(ctx context.Context,
+	request *privatev1.ProjectMembershipsUpdateRequest) (response *privatev1.ProjectMembershipsUpdateResponse, err error) {
+	err = s.generic.Update(ctx, request, &response)
+	return
+}
+
+func (s *PrivateProjectMembershipsServer) Delete(ctx context.Context,
+	request *privatev1.ProjectMembershipsDeleteRequest) (response *privatev1.ProjectMembershipsDeleteResponse, err error) {
+	err = s.generic.Delete(ctx, request, &response)
+	return
+}
+
+func (s *PrivateProjectMembershipsServer) Signal(ctx context.Context,
+	request *privatev1.ProjectMembershipsSignalRequest) (response *privatev1.ProjectMembershipsSignalResponse, err error) {
+	err = s.generic.Signal(ctx, request, &response)
+	return
+}

--- a/internal/servers/project_memberships_server.go
+++ b/internal/servers/project_memberships_server.go
@@ -1,0 +1,304 @@
+/*
+Copyright (c) 2026 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package servers
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+
+	"github.com/prometheus/client_golang/prometheus"
+	grpccodes "google.golang.org/grpc/codes"
+	grpcstatus "google.golang.org/grpc/status"
+
+	privatev1 "github.com/osac-project/fulfillment-service/internal/api/osac/private/v1"
+	publicv1 "github.com/osac-project/fulfillment-service/internal/api/osac/public/v1"
+	"github.com/osac-project/fulfillment-service/internal/auth"
+	"github.com/osac-project/fulfillment-service/internal/events"
+)
+
+// ProjectMembershipsServerBuilder is a builder for creating instances of ProjectMembershipsServer.
+type ProjectMembershipsServerBuilder struct {
+	logger            *slog.Logger
+	notifier          events.Notifier
+	attributionLogic  auth.AttributionLogic
+	tenancyLogic      auth.TenancyLogic
+	metricsRegisterer prometheus.Registerer
+}
+
+var _ publicv1.ProjectMembershipsServer = (*ProjectMembershipsServer)(nil)
+
+// ProjectMembershipsServer implements the public project memberships gRPC service by delegating to the private server.
+type ProjectMembershipsServer struct {
+	publicv1.UnimplementedProjectMembershipsServer
+
+	logger    *slog.Logger
+	delegate  privatev1.ProjectMembershipsServer
+	inMapper  *GenericMapper[*publicv1.ProjectMembership, *privatev1.ProjectMembership]
+	outMapper *GenericMapper[*privatev1.ProjectMembership, *publicv1.ProjectMembership]
+}
+
+// NewProjectMembershipsServer creates a new builder for the public project memberships server.
+func NewProjectMembershipsServer() *ProjectMembershipsServerBuilder {
+	return &ProjectMembershipsServerBuilder{}
+}
+
+// SetLogger sets the logger to use. This is mandatory.
+func (b *ProjectMembershipsServerBuilder) SetLogger(value *slog.Logger) *ProjectMembershipsServerBuilder {
+	b.logger = value
+	return b
+}
+
+// SetNotifier sets the notifier to use. This is optional.
+func (b *ProjectMembershipsServerBuilder) SetNotifier(value events.Notifier) *ProjectMembershipsServerBuilder {
+	b.notifier = value
+	return b
+}
+
+// SetAttributionLogic sets the attribution logic to use. This is optional.
+func (b *ProjectMembershipsServerBuilder) SetAttributionLogic(value auth.AttributionLogic) *ProjectMembershipsServerBuilder {
+	b.attributionLogic = value
+	return b
+}
+
+// SetTenancyLogic sets the tenancy logic to use. This is mandatory.
+func (b *ProjectMembershipsServerBuilder) SetTenancyLogic(value auth.TenancyLogic) *ProjectMembershipsServerBuilder {
+	b.tenancyLogic = value
+	return b
+}
+
+// SetMetricsRegisterer sets the Prometheus registerer used to register the metrics for the underlying database
+// access objects. This is optional. If not set, no metrics will be recorded.
+func (b *ProjectMembershipsServerBuilder) SetMetricsRegisterer(value prometheus.Registerer) *ProjectMembershipsServerBuilder {
+	b.metricsRegisterer = value
+	return b
+}
+
+// Build creates the public project memberships server from the builder configuration.
+func (b *ProjectMembershipsServerBuilder) Build() (result *ProjectMembershipsServer, err error) {
+	if b.logger == nil {
+		err = errors.New("logger is mandatory")
+		return
+	}
+	if b.tenancyLogic == nil {
+		err = errors.New("tenancy logic is mandatory")
+		return
+	}
+
+	inMapper, err := NewGenericMapper[*publicv1.ProjectMembership, *privatev1.ProjectMembership]().
+		SetLogger(b.logger).
+		SetStrict(true).
+		Build()
+	if err != nil {
+		return
+	}
+	outMapper, err := NewGenericMapper[*privatev1.ProjectMembership, *publicv1.ProjectMembership]().
+		SetLogger(b.logger).
+		SetStrict(false).
+		Build()
+	if err != nil {
+		return
+	}
+
+	delegate, err := NewPrivateProjectMembershipsServer().
+		SetLogger(b.logger).
+		SetNotifier(b.notifier).
+		SetAttributionLogic(b.attributionLogic).
+		SetTenancyLogic(b.tenancyLogic).
+		SetMetricsRegisterer(b.metricsRegisterer).
+		Build()
+	if err != nil {
+		return
+	}
+
+	result = &ProjectMembershipsServer{
+		logger:    b.logger,
+		delegate:  delegate,
+		inMapper:  inMapper,
+		outMapper: outMapper,
+	}
+	return
+}
+
+func (s *ProjectMembershipsServer) List(ctx context.Context,
+	request *publicv1.ProjectMembershipsListRequest) (response *publicv1.ProjectMembershipsListResponse, err error) {
+	privateRequest := &privatev1.ProjectMembershipsListRequest{}
+	privateRequest.SetOffset(request.GetOffset())
+	privateRequest.SetLimit(request.GetLimit())
+	privateRequest.SetFilter(request.GetFilter())
+	privateRequest.SetOrder(request.GetOrder())
+
+	privateResponse, err := s.delegate.List(ctx, privateRequest)
+	if err != nil {
+		return nil, err
+	}
+
+	privateItems := privateResponse.GetItems()
+	publicItems := make([]*publicv1.ProjectMembership, len(privateItems))
+	for i, privateItem := range privateItems {
+		publicItem := &publicv1.ProjectMembership{}
+		err = s.outMapper.Copy(ctx, privateItem, publicItem)
+		if err != nil {
+			s.logger.ErrorContext(
+				ctx,
+				"Failed to map private project membership to public",
+				slog.Any("error", err),
+			)
+			return nil, grpcstatus.Errorf(grpccodes.Internal, "failed to process project memberships")
+		}
+		publicItems[i] = publicItem
+	}
+
+	response = &publicv1.ProjectMembershipsListResponse{}
+	response.SetSize(privateResponse.GetSize())
+	response.SetTotal(privateResponse.GetTotal())
+	response.SetItems(publicItems)
+	return
+}
+
+func (s *ProjectMembershipsServer) Get(ctx context.Context,
+	request *publicv1.ProjectMembershipsGetRequest) (response *publicv1.ProjectMembershipsGetResponse, err error) {
+	privateRequest := &privatev1.ProjectMembershipsGetRequest{}
+	privateRequest.SetId(request.GetId())
+
+	privateResponse, err := s.delegate.Get(ctx, privateRequest)
+	if err != nil {
+		return nil, err
+	}
+
+	privateProjectMembership := privateResponse.GetObject()
+	publicProjectMembership := &publicv1.ProjectMembership{}
+	err = s.outMapper.Copy(ctx, privateProjectMembership, publicProjectMembership)
+	if err != nil {
+		s.logger.ErrorContext(
+			ctx,
+			"Failed to map private project membership to public",
+			slog.Any("error", err),
+		)
+		return nil, grpcstatus.Errorf(grpccodes.Internal, "failed to process project membership")
+	}
+
+	response = &publicv1.ProjectMembershipsGetResponse{}
+	response.SetObject(publicProjectMembership)
+	return
+}
+
+func (s *ProjectMembershipsServer) Create(ctx context.Context,
+	request *publicv1.ProjectMembershipsCreateRequest) (response *publicv1.ProjectMembershipsCreateResponse, err error) {
+	publicProjectMembership := request.GetObject()
+	if publicProjectMembership == nil {
+		err = grpcstatus.Errorf(grpccodes.InvalidArgument, "object is mandatory")
+		return
+	}
+	privateProjectMembership := &privatev1.ProjectMembership{}
+	err = s.inMapper.Copy(ctx, publicProjectMembership, privateProjectMembership)
+	if err != nil {
+		s.logger.ErrorContext(
+			ctx,
+			"Failed to map public project membership to private",
+			slog.Any("error", err),
+		)
+		err = grpcstatus.Errorf(grpccodes.Internal, "failed to process project membership")
+		return
+	}
+
+	privateRequest := &privatev1.ProjectMembershipsCreateRequest{}
+	privateRequest.SetObject(privateProjectMembership)
+	privateResponse, err := s.delegate.Create(ctx, privateRequest)
+	if err != nil {
+		return nil, err
+	}
+
+	createdPrivateProjectMembership := privateResponse.GetObject()
+	createdPublicProjectMembership := &publicv1.ProjectMembership{}
+	err = s.outMapper.Copy(ctx, createdPrivateProjectMembership, createdPublicProjectMembership)
+	if err != nil {
+		s.logger.ErrorContext(
+			ctx,
+			"Failed to map private project membership to public",
+			slog.Any("error", err),
+		)
+		err = grpcstatus.Errorf(grpccodes.Internal, "failed to process project membership")
+		return
+	}
+
+	response = &publicv1.ProjectMembershipsCreateResponse{}
+	response.SetObject(createdPublicProjectMembership)
+	return
+}
+
+func (s *ProjectMembershipsServer) Update(ctx context.Context,
+	request *publicv1.ProjectMembershipsUpdateRequest) (response *publicv1.ProjectMembershipsUpdateResponse, err error) {
+	publicProjectMembership := request.GetObject()
+	if publicProjectMembership == nil {
+		err = grpcstatus.Errorf(grpccodes.InvalidArgument, "object is mandatory")
+		return
+	}
+	if publicProjectMembership.GetId() == "" {
+		err = grpcstatus.Errorf(grpccodes.InvalidArgument, "object identifier is mandatory")
+		return
+	}
+
+	privateProjectMembership := &privatev1.ProjectMembership{}
+	err = s.inMapper.Copy(ctx, publicProjectMembership, privateProjectMembership)
+	if err != nil {
+		s.logger.ErrorContext(
+			ctx,
+			"Failed to map public project membership to private",
+			slog.Any("error", err),
+		)
+		err = grpcstatus.Errorf(grpccodes.Internal, "failed to process project membership")
+		return
+	}
+
+	privateRequest := &privatev1.ProjectMembershipsUpdateRequest{}
+	privateRequest.SetObject(privateProjectMembership)
+	privateRequest.SetUpdateMask(request.GetUpdateMask())
+	privateRequest.SetLock(request.GetLock())
+	privateResponse, err := s.delegate.Update(ctx, privateRequest)
+	if err != nil {
+		return nil, err
+	}
+
+	updatedPrivateProjectMembership := privateResponse.GetObject()
+	updatedPublicProjectMembership := &publicv1.ProjectMembership{}
+	err = s.outMapper.Copy(ctx, updatedPrivateProjectMembership, updatedPublicProjectMembership)
+	if err != nil {
+		s.logger.ErrorContext(
+			ctx,
+			"Failed to map private project membership to public",
+			slog.Any("error", err),
+		)
+		err = grpcstatus.Errorf(grpccodes.Internal, "failed to process project membership")
+		return
+	}
+
+	response = &publicv1.ProjectMembershipsUpdateResponse{}
+	response.SetObject(updatedPublicProjectMembership)
+	return
+}
+
+func (s *ProjectMembershipsServer) Delete(ctx context.Context,
+	request *publicv1.ProjectMembershipsDeleteRequest) (response *publicv1.ProjectMembershipsDeleteResponse, err error) {
+	privateRequest := &privatev1.ProjectMembershipsDeleteRequest{}
+	privateRequest.SetId(request.GetId())
+
+	_, err = s.delegate.Delete(ctx, privateRequest)
+	if err != nil {
+		return nil, err
+	}
+
+	response = &publicv1.ProjectMembershipsDeleteResponse{}
+	return
+}


### PR DESCRIPTION
# Description

Add public and private ProjectMembership servers following the standard server pattern. Public server wraps private server and adds tenant filtering. Both registered in gRPC server startup.

Add rendering table definitions for CLI display.

# Testing

- [x] go unit test passes
- [x] go build passes