### PR TITLE
OSAC-761: Rename IDP client parameters from keycloakUserID to idpUserID

### DIFF
--- a/internal/idp/client.go
+++ b/internal/idp/client.go
@@ -35,10 +35,12 @@ type Client interface {
 	DeleteTenant(ctx context.Context, tenantName string) error
 
 	// User operations
+	// All user operations accept idpUserID, which is the identity provider's user UUID stored in User.status.keycloak_user_id.
+	// Controllers should fetch the OSAC User object and extract status.keycloak_user_id before calling these methods.
 	CreateUser(ctx context.Context, tenantName string, user *User) (*User, error)
-	GetUser(ctx context.Context, tenantName, userID string) (*User, error)
+	GetUser(ctx context.Context, tenantName, idpUserID string) (*User, error)
 	ListUsers(ctx context.Context, tenantName string) ([]*User, error)
-	DeleteUser(ctx context.Context, tenantName, userID string) error
+	DeleteUser(ctx context.Context, tenantName, idpUserID string) error
 
 	// Role operations
 	// Roles can be at the tenant level or client level
@@ -46,12 +48,17 @@ type Client interface {
 	ListClientRoles(ctx context.Context, tenantName, clientID string) ([]*Role, error)
 
 	// User role assignments
-	AssignTenantRolesToUser(ctx context.Context, tenantName, userID string, roles []*Role) error
-	AssignClientRolesToUser(ctx context.Context, tenantName, userID, clientID string, roles []*Role) error
-	RemoveTenantRolesFromUser(ctx context.Context, tenantName, userID string, roles []*Role) error
-	RemoveClientRolesFromUser(ctx context.Context, tenantName, userID, clientID string, roles []*Role) error
-	GetUserTenantRoles(ctx context.Context, tenantName, userID string) ([]*Role, error)
-	GetUserClientRoles(ctx context.Context, tenantName, userID, clientID string) ([]*Role, error)
+	// All role assignment methods accept idpUserID (the identity provider's user UUID, not the OSAC user ID).
+	// Controllers must:
+	// 1. Fetch the OSAC User object by the user ID/name from the API request
+	// 2. Extract idpUserID from user.status.keycloak_user_id
+	// 3. Pass idpUserID to these IDP client methods
+	AssignTenantRolesToUser(ctx context.Context, tenantName, idpUserID string, roles []*Role) error
+	AssignClientRolesToUser(ctx context.Context, tenantName, idpUserID, clientID string, roles []*Role) error
+	RemoveTenantRolesFromUser(ctx context.Context, tenantName, idpUserID string, roles []*Role) error
+	RemoveClientRolesFromUser(ctx context.Context, tenantName, idpUserID, clientID string, roles []*Role) error
+	GetUserTenantRoles(ctx context.Context, tenantName, idpUserID string) ([]*Role, error)
+	GetUserClientRoles(ctx context.Context, tenantName, idpUserID, clientID string) ([]*Role, error)
 
 	// Admin permissions
 	// AssignTenantAdminPermissions grants full administrative access to a tenant for the specified user.
@@ -60,7 +67,7 @@ type Client interface {
 	// - Auth0: Assigns organization Admin role
 	// - Okta: Assigns Organizational Administrator role
 	// - Azure AD: Assigns Global Administrator or Organizational Administrator role
-	AssignTenantAdminPermissions(ctx context.Context, tenantName, userID string) error
+	AssignTenantAdminPermissions(ctx context.Context, tenantName, idpUserID string) error
 
 	// AssignIdpManagerPermissions grants limited IdP management permissions to the specified user.
 	// This is used for the break-glass account which can manage user roles and identity providers
@@ -70,7 +77,7 @@ type Client interface {
 	// - Auth0: Assigns organization Member Manager role
 	// - Okta: Assigns User Administrator role
 	// - Azure AD: Assigns User Administrator role
-	AssignIdpManagerPermissions(ctx context.Context, userID string) error
+	AssignIdpManagerPermissions(ctx context.Context, idpUserID string) error
 
 	// Authorization resource operations (Keycloak Authorization Services / UMA 2.0)
 	// These methods manage fine-grained permissions on resources like Projects.

--- a/internal/idp/client_mock.go
+++ b/internal/idp/client_mock.go
@@ -55,59 +55,59 @@ func (mr *MockClientMockRecorder) AddUserToGroup(ctx, tenantName, username, grou
 }
 
 // AssignClientRolesToUser mocks base method.
-func (m *MockClient) AssignClientRolesToUser(ctx context.Context, tenantName, userID, clientID string, roles []*Role) error {
+func (m *MockClient) AssignClientRolesToUser(ctx context.Context, tenantName, idpUserID, clientID string, roles []*Role) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "AssignClientRolesToUser", ctx, tenantName, userID, clientID, roles)
+	ret := m.ctrl.Call(m, "AssignClientRolesToUser", ctx, tenantName, idpUserID, clientID, roles)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // AssignClientRolesToUser indicates an expected call of AssignClientRolesToUser.
-func (mr *MockClientMockRecorder) AssignClientRolesToUser(ctx, tenantName, userID, clientID, roles any) *gomock.Call {
+func (mr *MockClientMockRecorder) AssignClientRolesToUser(ctx, tenantName, idpUserID, clientID, roles any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AssignClientRolesToUser", reflect.TypeOf((*MockClient)(nil).AssignClientRolesToUser), ctx, tenantName, userID, clientID, roles)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AssignClientRolesToUser", reflect.TypeOf((*MockClient)(nil).AssignClientRolesToUser), ctx, tenantName, idpUserID, clientID, roles)
 }
 
 // AssignIdpManagerPermissions mocks base method.
-func (m *MockClient) AssignIdpManagerPermissions(ctx context.Context, userID string) error {
+func (m *MockClient) AssignIdpManagerPermissions(ctx context.Context, idpUserID string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "AssignIdpManagerPermissions", ctx, userID)
+	ret := m.ctrl.Call(m, "AssignIdpManagerPermissions", ctx, idpUserID)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // AssignIdpManagerPermissions indicates an expected call of AssignIdpManagerPermissions.
-func (mr *MockClientMockRecorder) AssignIdpManagerPermissions(ctx, userID any) *gomock.Call {
+func (mr *MockClientMockRecorder) AssignIdpManagerPermissions(ctx, idpUserID any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AssignIdpManagerPermissions", reflect.TypeOf((*MockClient)(nil).AssignIdpManagerPermissions), ctx, userID)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AssignIdpManagerPermissions", reflect.TypeOf((*MockClient)(nil).AssignIdpManagerPermissions), ctx, idpUserID)
 }
 
 // AssignTenantAdminPermissions mocks base method.
-func (m *MockClient) AssignTenantAdminPermissions(ctx context.Context, tenantName, userID string) error {
+func (m *MockClient) AssignTenantAdminPermissions(ctx context.Context, tenantName, idpUserID string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "AssignTenantAdminPermissions", ctx, tenantName, userID)
+	ret := m.ctrl.Call(m, "AssignTenantAdminPermissions", ctx, tenantName, idpUserID)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // AssignTenantAdminPermissions indicates an expected call of AssignTenantAdminPermissions.
-func (mr *MockClientMockRecorder) AssignTenantAdminPermissions(ctx, tenantName, userID any) *gomock.Call {
+func (mr *MockClientMockRecorder) AssignTenantAdminPermissions(ctx, tenantName, idpUserID any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AssignTenantAdminPermissions", reflect.TypeOf((*MockClient)(nil).AssignTenantAdminPermissions), ctx, tenantName, userID)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AssignTenantAdminPermissions", reflect.TypeOf((*MockClient)(nil).AssignTenantAdminPermissions), ctx, tenantName, idpUserID)
 }
 
 // AssignTenantRolesToUser mocks base method.
-func (m *MockClient) AssignTenantRolesToUser(ctx context.Context, tenantName, userID string, roles []*Role) error {
+func (m *MockClient) AssignTenantRolesToUser(ctx context.Context, tenantName, idpUserID string, roles []*Role) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "AssignTenantRolesToUser", ctx, tenantName, userID, roles)
+	ret := m.ctrl.Call(m, "AssignTenantRolesToUser", ctx, tenantName, idpUserID, roles)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // AssignTenantRolesToUser indicates an expected call of AssignTenantRolesToUser.
-func (mr *MockClientMockRecorder) AssignTenantRolesToUser(ctx, tenantName, userID, roles any) *gomock.Call {
+func (mr *MockClientMockRecorder) AssignTenantRolesToUser(ctx, tenantName, idpUserID, roles any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AssignTenantRolesToUser", reflect.TypeOf((*MockClient)(nil).AssignTenantRolesToUser), ctx, tenantName, userID, roles)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AssignTenantRolesToUser", reflect.TypeOf((*MockClient)(nil).AssignTenantRolesToUser), ctx, tenantName, idpUserID, roles)
 }
 
 // CreateAuthorizationGroup mocks base method.
@@ -242,17 +242,17 @@ func (mr *MockClientMockRecorder) DeleteTenant(ctx, tenantName any) *gomock.Call
 }
 
 // DeleteUser mocks base method.
-func (m *MockClient) DeleteUser(ctx context.Context, tenantName, userID string) error {
+func (m *MockClient) DeleteUser(ctx context.Context, tenantName, idpUserID string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteUser", ctx, tenantName, userID)
+	ret := m.ctrl.Call(m, "DeleteUser", ctx, tenantName, idpUserID)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // DeleteUser indicates an expected call of DeleteUser.
-func (mr *MockClientMockRecorder) DeleteUser(ctx, tenantName, userID any) *gomock.Call {
+func (mr *MockClientMockRecorder) DeleteUser(ctx, tenantName, idpUserID any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteUser", reflect.TypeOf((*MockClient)(nil).DeleteUser), ctx, tenantName, userID)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteUser", reflect.TypeOf((*MockClient)(nil).DeleteUser), ctx, tenantName, idpUserID)
 }
 
 // GetAuthorizationResource mocks base method.
@@ -316,48 +316,48 @@ func (mr *MockClientMockRecorder) GetTenant(ctx, name any) *gomock.Call {
 }
 
 // GetUser mocks base method.
-func (m *MockClient) GetUser(ctx context.Context, tenantName, userID string) (*User, error) {
+func (m *MockClient) GetUser(ctx context.Context, tenantName, idpUserID string) (*User, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetUser", ctx, tenantName, userID)
+	ret := m.ctrl.Call(m, "GetUser", ctx, tenantName, idpUserID)
 	ret0, _ := ret[0].(*User)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetUser indicates an expected call of GetUser.
-func (mr *MockClientMockRecorder) GetUser(ctx, tenantName, userID any) *gomock.Call {
+func (mr *MockClientMockRecorder) GetUser(ctx, tenantName, idpUserID any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUser", reflect.TypeOf((*MockClient)(nil).GetUser), ctx, tenantName, userID)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUser", reflect.TypeOf((*MockClient)(nil).GetUser), ctx, tenantName, idpUserID)
 }
 
 // GetUserClientRoles mocks base method.
-func (m *MockClient) GetUserClientRoles(ctx context.Context, tenantName, userID, clientID string) ([]*Role, error) {
+func (m *MockClient) GetUserClientRoles(ctx context.Context, tenantName, idpUserID, clientID string) ([]*Role, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetUserClientRoles", ctx, tenantName, userID, clientID)
+	ret := m.ctrl.Call(m, "GetUserClientRoles", ctx, tenantName, idpUserID, clientID)
 	ret0, _ := ret[0].([]*Role)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetUserClientRoles indicates an expected call of GetUserClientRoles.
-func (mr *MockClientMockRecorder) GetUserClientRoles(ctx, tenantName, userID, clientID any) *gomock.Call {
+func (mr *MockClientMockRecorder) GetUserClientRoles(ctx, tenantName, idpUserID, clientID any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUserClientRoles", reflect.TypeOf((*MockClient)(nil).GetUserClientRoles), ctx, tenantName, userID, clientID)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUserClientRoles", reflect.TypeOf((*MockClient)(nil).GetUserClientRoles), ctx, tenantName, idpUserID, clientID)
 }
 
 // GetUserTenantRoles mocks base method.
-func (m *MockClient) GetUserTenantRoles(ctx context.Context, tenantName, userID string) ([]*Role, error) {
+func (m *MockClient) GetUserTenantRoles(ctx context.Context, tenantName, idpUserID string) ([]*Role, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetUserTenantRoles", ctx, tenantName, userID)
+	ret := m.ctrl.Call(m, "GetUserTenantRoles", ctx, tenantName, idpUserID)
 	ret0, _ := ret[0].([]*Role)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetUserTenantRoles indicates an expected call of GetUserTenantRoles.
-func (mr *MockClientMockRecorder) GetUserTenantRoles(ctx, tenantName, userID any) *gomock.Call {
+func (mr *MockClientMockRecorder) GetUserTenantRoles(ctx, tenantName, idpUserID any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUserTenantRoles", reflect.TypeOf((*MockClient)(nil).GetUserTenantRoles), ctx, tenantName, userID)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUserTenantRoles", reflect.TypeOf((*MockClient)(nil).GetUserTenantRoles), ctx, tenantName, idpUserID)
 }
 
 // ListClientRoles mocks base method.
@@ -421,31 +421,31 @@ func (mr *MockClientMockRecorder) ListUsers(ctx, tenantName any) *gomock.Call {
 }
 
 // RemoveClientRolesFromUser mocks base method.
-func (m *MockClient) RemoveClientRolesFromUser(ctx context.Context, tenantName, userID, clientID string, roles []*Role) error {
+func (m *MockClient) RemoveClientRolesFromUser(ctx context.Context, tenantName, idpUserID, clientID string, roles []*Role) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "RemoveClientRolesFromUser", ctx, tenantName, userID, clientID, roles)
+	ret := m.ctrl.Call(m, "RemoveClientRolesFromUser", ctx, tenantName, idpUserID, clientID, roles)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // RemoveClientRolesFromUser indicates an expected call of RemoveClientRolesFromUser.
-func (mr *MockClientMockRecorder) RemoveClientRolesFromUser(ctx, tenantName, userID, clientID, roles any) *gomock.Call {
+func (mr *MockClientMockRecorder) RemoveClientRolesFromUser(ctx, tenantName, idpUserID, clientID, roles any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveClientRolesFromUser", reflect.TypeOf((*MockClient)(nil).RemoveClientRolesFromUser), ctx, tenantName, userID, clientID, roles)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveClientRolesFromUser", reflect.TypeOf((*MockClient)(nil).RemoveClientRolesFromUser), ctx, tenantName, idpUserID, clientID, roles)
 }
 
 // RemoveTenantRolesFromUser mocks base method.
-func (m *MockClient) RemoveTenantRolesFromUser(ctx context.Context, tenantName, userID string, roles []*Role) error {
+func (m *MockClient) RemoveTenantRolesFromUser(ctx context.Context, tenantName, idpUserID string, roles []*Role) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "RemoveTenantRolesFromUser", ctx, tenantName, userID, roles)
+	ret := m.ctrl.Call(m, "RemoveTenantRolesFromUser", ctx, tenantName, idpUserID, roles)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // RemoveTenantRolesFromUser indicates an expected call of RemoveTenantRolesFromUser.
-func (mr *MockClientMockRecorder) RemoveTenantRolesFromUser(ctx, tenantName, userID, roles any) *gomock.Call {
+func (mr *MockClientMockRecorder) RemoveTenantRolesFromUser(ctx, tenantName, idpUserID, roles any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveTenantRolesFromUser", reflect.TypeOf((*MockClient)(nil).RemoveTenantRolesFromUser), ctx, tenantName, userID, roles)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveTenantRolesFromUser", reflect.TypeOf((*MockClient)(nil).RemoveTenantRolesFromUser), ctx, tenantName, idpUserID, roles)
 }
 
 // RemoveUserFromGroup mocks base method.

--- a/internal/idp/keycloak/authz_groups.go
+++ b/internal/idp/keycloak/authz_groups.go
@@ -322,56 +322,13 @@ func (c *Client) getGroupIDByPath(ctx context.Context, tenantName, groupPath str
 	return c.getGroupIDByPathWithOrgID(ctx, org.ID, groupPath)
 }
 
-// getUserIDByUsername looks up a user's UUID by their username.
-// Returns the user's UUID if found, or an error if not found or multiple matches exist.
-func (c *Client) getUserIDByUsername(ctx context.Context, username string) (string, error) {
-	// Use exact match to find the user by username
-	path := fmt.Sprintf("/admin/realms/%s/users?username=%s&exact=true",
-		url.PathEscape(c.realmName),
-		url.QueryEscape(username),
-	)
-
-	response, err := c.httpClient.DoRequest(ctx, http.MethodGet, path, nil)
-	if err != nil {
-		return "", fmt.Errorf("failed to search for user: %w", err)
-	}
-	defer response.Body.Close()
-
-	var users []struct {
-		ID       string `json:"id"`
-		Username string `json:"username"`
-	}
-	if err := json.NewDecoder(response.Body).Decode(&users); err != nil {
-		return "", fmt.Errorf("failed to decode user search response: %w", err)
-	}
-
-	if len(users) == 0 {
-		return "", fmt.Errorf("user not found: %s", username)
-	}
-	if len(users) > 1 {
-		return "", fmt.Errorf("multiple users found for username: %s", username)
-	}
-
-	return users[0].ID, nil
-}
-
 // AddUserToGroup adds a user to an organization group by group ID.
-func (c *Client) AddUserToGroup(ctx context.Context, tenantName, username, groupID string) error {
+// Accepts idpUserID (the identity provider's user UUID from User.status.keycloak_user_id).
+func (c *Client) AddUserToGroup(ctx context.Context, tenantName, idpUserID, groupID string) error {
 	c.logger.DebugContext(ctx, "Adding user to organization group",
 		slog.String("tenantName", tenantName),
-		slog.String("!username", username),
+		slog.String("!idpUserID", idpUserID),
 		slog.String("groupID", groupID),
-	)
-
-	// Look up the user's UUID by username
-	userUUID, err := c.getUserIDByUsername(ctx, username)
-	if err != nil {
-		return fmt.Errorf("failed to lookup user UUID: %w", err)
-	}
-
-	c.logger.DebugContext(ctx, "Looked up user UUID",
-		slog.String("!username", username),
-		slog.String("!uuid", userUUID),
 	)
 
 	// Get the organization ID
@@ -382,7 +339,7 @@ func (c *Client) AddUserToGroup(ctx context.Context, tenantName, username, group
 
 	// First, ensure the user is a member of the organization
 	// This is required before we can add them to organization groups
-	err = c.ensureOrganizationMember(ctx, org.ID, userUUID)
+	err = c.ensureOrganizationMember(ctx, org.ID, idpUserID)
 	if err != nil {
 		return fmt.Errorf("failed to ensure user is organization member: %w", err)
 	}
@@ -394,7 +351,7 @@ func (c *Client) AddUserToGroup(ctx context.Context, tenantName, username, group
 		url.PathEscape(c.realmName),
 		url.PathEscape(org.ID),
 		url.PathEscape(groupID),
-		url.PathEscape(userUUID),
+		url.PathEscape(idpUserID),
 	)
 
 	response, err := c.httpClient.DoRequest(ctx, http.MethodPut, path, nil)
@@ -405,8 +362,7 @@ func (c *Client) AddUserToGroup(ctx context.Context, tenantName, username, group
 
 	c.logger.InfoContext(ctx, "Added user to organization group",
 		slog.String("tenantName", tenantName),
-		slog.String("!username", username),
-		slog.String("!uuid", userUUID),
+		slog.String("!idpUserID", idpUserID),
 		slog.String("groupID", groupID),
 	)
 
@@ -448,22 +404,11 @@ func (c *Client) ensureOrganizationMember(ctx context.Context, orgID, userUUID s
 }
 
 // RemoveUserFromGroup removes a user from an organization group by group ID.
-func (c *Client) RemoveUserFromGroup(ctx context.Context, tenantName, username, groupID string) error {
+func (c *Client) RemoveUserFromGroup(ctx context.Context, tenantName, idpUserID, groupID string) error {
 	c.logger.DebugContext(ctx, "Removing user from organization group",
 		slog.String("tenantName", tenantName),
-		slog.String("!username", username),
+		slog.String("!idpUserID", idpUserID),
 		slog.String("groupID", groupID),
-	)
-
-	// Look up the user's UUID by username
-	userUUID, err := c.getUserIDByUsername(ctx, username)
-	if err != nil {
-		return fmt.Errorf("failed to lookup user UUID: %w", err)
-	}
-
-	c.logger.DebugContext(ctx, "Looked up user UUID",
-		slog.String("!username", username),
-		slog.String("!uuid", userUUID),
 	)
 
 	// Get the organization ID
@@ -478,7 +423,7 @@ func (c *Client) RemoveUserFromGroup(ctx context.Context, tenantName, username, 
 		url.PathEscape(c.realmName),
 		url.PathEscape(org.ID),
 		url.PathEscape(groupID),
-		url.PathEscape(userUUID),
+		url.PathEscape(idpUserID),
 	)
 
 	response, err := c.httpClient.DoRequest(ctx, http.MethodDelete, path, nil)
@@ -489,8 +434,7 @@ func (c *Client) RemoveUserFromGroup(ctx context.Context, tenantName, username, 
 
 	c.logger.InfoContext(ctx, "Removed user from organization group",
 		slog.String("tenantName", tenantName),
-		slog.String("!username", username),
-		slog.String("!uuid", userUUID),
+		slog.String("!idpUserID", idpUserID),
 		slog.String("groupID", groupID),
 	)
 


### PR DESCRIPTION
# Description
Standardize IDP client interface to use generic idpUserID parameter naming instead of Keycloak-specific keycloakUserID. This makes the interface more provider-agnostic while maintaining the same semantics: the parameter represents the identity provider's user UUID stored in User.status.keycloak_user_id.

Also removed unused getUserIDByUsername function from Keycloak client.

# Testing

- [x] go build passes
- [x] go unit test passes

/cc @jhernand 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Group membership add/remove now uses the identity provider user UUID directly, avoiding issues from username-based lookups.
  * Tenant/client role and permission management now consistently use the same identity provider user identifier across related actions.
* **Documentation**
  * Updated authorization and admin method descriptions to clearly indicate the required identity provider user UUID parameter.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->