### PR TITLE
Align compute update warnings and IDP assign/unassign IDs

### DIFF
--- a/internal/servers/compute_instances_server.go
+++ b/internal/servers/compute_instances_server.go
@@ -321,6 +321,7 @@ func (s *ComputeInstancesServer) Update(ctx context.Context,
 	// Create the public response:
 	response = &publicv1.ComputeInstancesUpdateResponse{}
 	response.SetObject(updatedPublicComputeInstance)
+	response.SetWarnings(privateResponse.GetWarnings())
 	return
 }
 

--- a/internal/servers/private_compute_instances_server.go
+++ b/internal/servers/private_compute_instances_server.go
@@ -295,7 +295,22 @@ func (s *PrivateComputeInstancesServer) Update(ctx context.Context,
 		return
 	}
 
+	var warnings []string
+	if request.GetObject() != nil && hasMaskPrefix(mask, "spec") {
+		warnings, err = s.validateInstanceType(ctx, request.GetObject())
+		if err != nil {
+			return
+		}
+	}
+
 	err = s.generic.Update(ctx, request, &response)
+	if err != nil {
+		return
+	}
+
+	if len(warnings) > 0 && response != nil {
+		response.SetWarnings(warnings)
+	}
 	return
 }
 

--- a/internal/servers/private_identity_providers_server_test.go
+++ b/internal/servers/private_identity_providers_server_test.go
@@ -468,7 +468,7 @@ var _ = Describe("Private identity providers server", func() {
 	Describe("Assign and Unassign", func() {
 		It("Returns not implemented for Assign", func() {
 			_, err := privateServer.Assign(ctx, &privatev1.IdentityProvidersAssignRequest{
-				Name:       "test-ldap",
+				Id:         "test-ldap-id",
 				TenantName: "my-tenant",
 			})
 			Expect(err).To(HaveOccurred())
@@ -479,7 +479,7 @@ var _ = Describe("Private identity providers server", func() {
 
 		It("Returns not implemented for Unassign", func() {
 			_, err := privateServer.Unassign(ctx, &privatev1.IdentityProvidersUnassignRequest{
-				Name:       "test-ldap",
+				Id:         "test-ldap-id",
 				TenantName: "my-tenant",
 			})
 			Expect(err).To(HaveOccurred())

--- a/proto/private/osac/private/v1/compute_instances_service.proto
+++ b/proto/private/osac/private/v1/compute_instances_service.proto
@@ -69,6 +69,10 @@ message ComputeInstancesUpdateRequest {
 
 message ComputeInstancesUpdateResponse {
   ComputeInstance object = 1;
+
+  // Deprecation notices returned when the compute instance references a DEPRECATED instance type
+  // or uses the legacy cores/memory_gib fields directly.
+  repeated string warnings = 2;
 }
 
 message ComputeInstancesSignalRequest {

--- a/proto/private/osac/private/v1/identity_providers_service.proto
+++ b/proto/private/osac/private/v1/identity_providers_service.proto
@@ -98,8 +98,8 @@ message IdentityProvidersDeleteResponse {}
 
 // Request to assign an identity provider to a tenant.
 message IdentityProvidersAssignRequest {
-  // Name of the identity provider to assign.
-  string name = 1;
+  // ID of the identity provider to assign.
+  string id = 1;
 
   // Name of the tenant to assign the identity provider to.
   string tenant_name = 2;
@@ -110,8 +110,8 @@ message IdentityProvidersAssignResponse {}
 
 // Request to unassign an identity provider from a tenant.
 message IdentityProvidersUnassignRequest {
-  // Name of the identity provider to unassign.
-  string name = 1;
+  // ID of the identity provider to unassign.
+  string id = 1;
 
   // Name of the tenant to unassign the identity provider from.
   string tenant_name = 2;
@@ -172,7 +172,7 @@ service IdentityProviders {
   // Assigns an identity provider to a tenant.
   rpc Assign(IdentityProvidersAssignRequest) returns (IdentityProvidersAssignResponse) {
     option (google.api.http) = {
-      post: "/api/private/v1/identity_providers/{name}:assign"
+      post: "/api/private/v1/identity_providers/{id}:assign"
       body: "*"
     };
   }
@@ -180,7 +180,7 @@ service IdentityProviders {
   // Unassigns an identity provider from a tenant.
   rpc Unassign(IdentityProvidersUnassignRequest) returns (IdentityProvidersUnassignResponse) {
     option (google.api.http) = {
-      post: "/api/private/v1/identity_providers/{name}:unassign"
+      post: "/api/private/v1/identity_providers/{id}:unassign"
       body: "*"
     };
   }

--- a/proto/public/osac/public/v1/compute_instances_service.proto
+++ b/proto/public/osac/public/v1/compute_instances_service.proto
@@ -100,6 +100,10 @@ message ComputeInstancesUpdateRequest {
 
 message ComputeInstancesUpdateResponse {
   ComputeInstance object = 1;
+
+  // Deprecation notices returned when the compute instance references a DEPRECATED instance type
+  // or uses the legacy cores/memory_gib fields directly.
+  repeated string warnings = 2;
 }
 
 message ComputeInstancesDeleteRequest {

--- a/proto/public/osac/public/v1/identity_providers_service.proto
+++ b/proto/public/osac/public/v1/identity_providers_service.proto
@@ -124,8 +124,8 @@ message IdentityProvidersDeleteResponse {}
 // Request to assign an identity provider to a tenant.
 // The tenant is inferred from the authenticated user's context.
 message IdentityProvidersAssignRequest {
-  // Name of the identity provider to assign.
-  string name = 1;
+  // ID of the identity provider to assign.
+  string id = 1;
 }
 
 // Response for assign operation.
@@ -134,8 +134,8 @@ message IdentityProvidersAssignResponse {}
 // Request to unassign an identity provider from a tenant.
 // The tenant is inferred from the authenticated user's context.
 message IdentityProvidersUnassignRequest {
-  // Name of the identity provider to unassign.
-  string name = 1;
+  // ID of the identity provider to unassign.
+  string id = 1;
 }
 
 // Response for unassign operation.
@@ -196,7 +196,7 @@ service IdentityProviders {
   // The tenant is specified in metadata.tenant.
   rpc Assign(IdentityProvidersAssignRequest) returns (IdentityProvidersAssignResponse) {
     option (google.api.http) = {
-      post: "/api/fulfillment/v1/identity_providers/{name}:assign"
+      post: "/api/fulfillment/v1/identity_providers/{id}:assign"
       body: "*"
     };
   }
@@ -205,7 +205,7 @@ service IdentityProviders {
   // The tenant is specified in metadata.tenant.
   rpc Unassign(IdentityProvidersUnassignRequest) returns (IdentityProvidersUnassignResponse) {
     option (google.api.http) = {
-      post: "/api/fulfillment/v1/identity_providers/{name}:unassign"
+      post: "/api/fulfillment/v1/identity_providers/{id}:unassign"
       body: "*"
     };
   }


### PR DESCRIPTION
## Summary
- Add `warnings` to `ComputeInstancesUpdateResponse` (public and private protos) so update responses match create and sibling compute services.
- Propagate deprecation warnings through public and private compute instance update handlers.
- Finish the IdentityProvider ID migration for `Assign`/`Unassign` request fields and HTTP paths (`{id}` instead of `{name}`).

## Context
Addresses CodeRabbit review feedback on osac-project/osac-ui#47 — the regenerated TypeScript bindings exposed proto gaps that should be fixed at the source.

## Test plan
- [ ] `buf generate` / Go codegen succeeds
- [ ] Unit tests for compute instances and identity providers pass

Made with [Cursor](https://cursor.com)