### PR TITLE
OSAC-1679: Add E2E full install presubmit job

### DIFF
--- a/.github/workflows/e2e-vmaas-full-install.yml
+++ b/.github/workflows/e2e-vmaas-full-install.yml
@@ -1,0 +1,41 @@
+---
+name: E2E VMaaS Full Install
+
+permissions:
+  contents: read
+
+on:
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+    inputs:
+      test-suite:
+        description: "Test suite (vmaas, caas, or empty for all)"
+        required: false
+        default: "vmaas"
+      test-filter:
+        description: "pytest -k filter"
+        required: false
+        default: ""
+      test-infra-ref:
+        description: "Branch/ref of osac-test-infra"
+        required: false
+        default: "main"
+
+concurrency:
+  group: e2e-vmaas-full-install-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  e2e-full-install:
+    uses: osac-project/osac-test-infra/.github/workflows/e2e-vmaas-full-install.yml@main
+    with:
+      test-suite: ${{ inputs.test-suite || 'vmaas' }}
+      test-filter: ${{ inputs.test-filter || '' }}
+      # Build the component image from the PR's fork/branch
+      component-repo: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
+      component-ref: ${{ github.event.pull_request.head.ref || github.ref_name }}
+      component-image-key: service.images.service
+      # Checkout osac-test-infra for tests/Containerfile (not the caller repo)
+      test-infra-repository: osac-project/osac-test-infra
+      test-infra-ref: ${{ inputs.test-infra-ref || 'main' }}


### PR DESCRIPTION
## Summary
- Add `e2e-vmaas-full-install.yml` workflow that triggers on PRs to `main` and `workflow_dispatch`
- Calls the reusable workflow in `osac-test-infra` to run a full OSAC install + E2E tests
- Builds the fulfillment-service image from the PR branch and loads it onto the test cluster
- Uses `component-image-key: service.images.service` for Helm override

## Test plan
- [ ] Verify workflow triggers on PR to main
- [ ] Verify `workflow_dispatch` works with optional inputs (test-suite, test-filter, test-infra-ref)
- [ ] Confirm the reusable workflow builds the PR's code (not main branch)

Jira: https://redhat.atlassian.net/browse/OSAC-1679

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an automated end-to-end full-install test workflow for pull requests targeting the main branch.
  * Supports manual runs with options to select a test suite, apply a `pytest -k` filter, and choose a test reference.
  * Prevents overlapping runs for the same pull request by canceling older in-progress executions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->