### PR TITLE
Add lightweight API mock server for UI development

### DIFF
--- a/mock/.gitignore
+++ b/mock/.gitignore
@@ -1,0 +1,4 @@
+.venv/
+__pycache__/
+*.pyc
+*.egg-info/

--- a/mock/Containerfile
+++ b/mock/Containerfile
@@ -2,17 +2,22 @@ FROM python:3.12-slim AS base
 
 WORKDIR /app
 
-COPY pyproject.toml .
-RUN pip install --no-cache-dir .
+COPY mock/pyproject.toml .
+RUN pip install --no-cache-dir . && \
+    groupadd -r mockuser && useradd -r -g mockuser mockuser
 
-COPY *.py .
-COPY scenarios/ scenarios/
+COPY mock/*.py .
+COPY mock/scenarios/ scenarios/
 
 # Copy the OpenAPI spec from the parent build context
 # Build with: podman build -f mock/Containerfile -t fulfillment-mock .
 COPY pages/openapi/v3/public.yaml /app/spec/public.yaml
 
+USER mockuser
 EXPOSE 8000
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=5s --retries=3 \
+    CMD python -c "import urllib.request; urllib.request.urlopen('http://localhost:8000/api/fulfillment/v1/capabilities')" || exit 1
 
 ENTRYPOINT ["python", "mock_server.py", "--spec", "/app/spec/public.yaml"]
 CMD ["--scenario", "scenarios/default.yaml"]

--- a/mock/Containerfile
+++ b/mock/Containerfile
@@ -1,0 +1,18 @@
+FROM python:3.12-slim AS base
+
+WORKDIR /app
+
+COPY pyproject.toml .
+RUN pip install --no-cache-dir .
+
+COPY *.py .
+COPY scenarios/ scenarios/
+
+# Copy the OpenAPI spec from the parent build context
+# Build with: podman build -f mock/Containerfile -t fulfillment-mock .
+COPY pages/openapi/v3/public.yaml /app/spec/public.yaml
+
+EXPOSE 8000
+
+ENTRYPOINT ["python", "mock_server.py", "--spec", "/app/spec/public.yaml"]
+CMD ["--scenario", "scenarios/default.yaml"]

--- a/mock/README.md
+++ b/mock/README.md
@@ -161,7 +161,7 @@ See `scenarios/default.yaml` for the format.
 
 ## CLI options
 
-```
+```text
 --port PORT        Port to listen on (default: 8000)
 --spec PATH        Path to OpenAPI v3 spec (default: ../pages/openapi/v3/public.yaml)
 --scenario PATH    Scenario YAML file to preload (repeatable)

--- a/mock/README.md
+++ b/mock/README.md
@@ -1,0 +1,189 @@
+# Fulfillment Service Mock
+
+A lightweight mock server for the OSAC fulfillment-service REST API. It reads the
+OpenAPI v3 spec at startup, auto-discovers all resource types, and serves them with
+in-memory state, JWT authentication, state machine progression, and SSE events.
+
+## Quick start
+
+```bash
+cd fulfillment-service/mock
+
+# Create a virtual environment and install dependencies
+python3 -m venv .venv
+.venv/bin/pip install -e .
+
+# Run with default scenario (pre-populated resources)
+.venv/bin/python mock_server.py --scenario scenarios/default.yaml
+
+# Run without auth (all requests treated as admin)
+.venv/bin/python mock_server.py --no-auth --scenario scenarios/default.yaml
+```
+
+The server starts on `http://localhost:8000`.
+
+## Authentication
+
+The mock includes a complete OIDC-compatible auth flow.
+
+### Get a token
+
+```bash
+curl -X POST http://localhost:8000/auth/token \
+  -H "Content-Type: application/json" \
+  -d '{"username": "adam", "password": "adam"}'
+```
+
+### Use the token
+
+```bash
+export TOKEN="<access_token from above>"
+curl -H "Authorization: Bearer $TOKEN" \
+  http://localhost:8000/api/fulfillment/v1/virtual_networks
+```
+
+### Pre-configured users
+
+| Username  | Password  | Tenants              | Role                 |
+|-----------|-----------|----------------------|----------------------|
+| `admin`   | `admin`   | all                  | cloud-provider-admin |
+| `adam`     | `adam`    | engineering          | tenant-admin         |
+| `ben`     | `ben`     | engineering, sales   | tenant-user          |
+| `charles` | `charles` | sales                | tenant-user          |
+
+### OIDC discovery
+
+- `GET /.well-known/openid-configuration` — OIDC discovery document
+- `GET /.well-known/jwks.json` — JSON Web Key Set
+- `GET /api/fulfillment/v1/capabilities` — Auth configuration (no auth required)
+
+## API usage
+
+All resource types from the fulfillment-service are available with standard CRUD:
+
+```bash
+# List
+curl $AUTH http://localhost:8000/api/fulfillment/v1/virtual_networks
+
+# Get
+curl $AUTH http://localhost:8000/api/fulfillment/v1/virtual_networks/{id}
+
+# Create
+curl -X POST $AUTH -H "Content-Type: application/json" \
+  http://localhost:8000/api/fulfillment/v1/virtual_networks \
+  -d '{"metadata":{"name":"my-net"},"spec":{"network_class":"nc-udn-001","ipv4_cidr":"10.0.0.0/16"}}'
+
+# Update
+curl -X PATCH $AUTH -H "Content-Type: application/json" \
+  http://localhost:8000/api/fulfillment/v1/virtual_networks/{id} \
+  -d '{"metadata":{"name":"renamed-net"}}'
+
+# Delete
+curl -X DELETE $AUTH http://localhost:8000/api/fulfillment/v1/virtual_networks/{id}
+```
+
+Where `$AUTH` is `-H "Authorization: Bearer $TOKEN"`.
+
+## State progression
+
+Stateful resources automatically progress through their lifecycle after creation:
+
+| Resource           | Transition                     | Delay |
+|--------------------|--------------------------------|-------|
+| VirtualNetwork     | PENDING → READY                | 1s    |
+| Subnet             | PENDING → READY                | 1s    |
+| SecurityGroup      | PENDING → READY                | 0.5s  |
+| Cluster            | PROGRESSING → READY            | 2s    |
+| ComputeInstance     | STARTING → RUNNING             | 1.5s  |
+| BareMetalInstance   | PROVISIONING → RUNNING         | 3s    |
+| PublicIP           | PENDING → ALLOCATED            | 1s    |
+| PublicIPAttachment  | PENDING → READY                | 0.5s  |
+
+## Failure injection
+
+Use labels with the `mock.osac.dev/` prefix to control mock behavior:
+
+| Label                              | Effect                                      |
+|------------------------------------|---------------------------------------------|
+| `mock.osac.dev/fail-provision`     | Resource transitions to FAILED              |
+| `mock.osac.dev/provision-delay`    | Custom delay (e.g., `"5s"`, `"500ms"`)      |
+| `mock.osac.dev/fail-after`         | Reach READY, then fail after delay           |
+| `mock.osac.dev/fail-create`        | Create request returns 400                   |
+| `mock.osac.dev/fail-delete`        | Delete request returns 500                   |
+| `mock.osac.dev/error-message`      | Custom message in status.message             |
+
+Example — create a VM that fails to provision:
+
+```bash
+curl -X POST $AUTH -H "Content-Type: application/json" \
+  http://localhost:8000/api/fulfillment/v1/compute_instances \
+  -d '{
+    "metadata": {
+      "name": "doomed-vm",
+      "labels": {
+        "mock.osac.dev/fail-provision": "true",
+        "mock.osac.dev/error-message": "Insufficient host capacity"
+      }
+    },
+    "spec": {"instance_type": "it-large-001"}
+  }'
+```
+
+## SSE events
+
+Connect to the event stream to receive real-time notifications:
+
+```bash
+curl -N $AUTH http://localhost:8000/api/events/v1/events
+```
+
+Events are emitted when resources are created, updated (including state transitions),
+or deleted. Each event includes the full resource object.
+
+## Scenarios
+
+Scenario files (YAML) pre-populate the mock with resources in various states.
+The default scenario includes networking, compute, clusters, and identity resources
+across the `engineering` and `sales` tenants.
+
+```bash
+# Load a specific scenario
+.venv/bin/python mock_server.py --scenario scenarios/default.yaml
+
+# Load multiple scenarios
+.venv/bin/python mock_server.py --scenario scenarios/default.yaml --scenario scenarios/extra.yaml
+
+# Start empty
+.venv/bin/python mock_server.py
+```
+
+See `scenarios/default.yaml` for the format.
+
+## CLI options
+
+```
+--port PORT        Port to listen on (default: 8000)
+--spec PATH        Path to OpenAPI v3 spec (default: ../pages/openapi/v3/public.yaml)
+--scenario PATH    Scenario YAML file to preload (repeatable)
+--no-auth          Disable JWT authentication
+```
+
+## Container image
+
+Build from the `fulfillment-service/` root:
+
+```bash
+podman build -f mock/Containerfile -t fulfillment-mock .
+podman run -p 8000:8000 fulfillment-mock
+```
+
+## Updating for API changes
+
+The mock auto-discovers routes from the OpenAPI spec. When proto definitions change:
+
+1. Run `buf generate` in `fulfillment-service/` to regenerate the OpenAPI spec
+2. Restart the mock server — new resource types appear automatically
+
+Manual updates are only needed when adding a new **stateful** resource type
+(one that needs state machine transitions). Add an entry to `STATE_MACHINES`
+in `state_machines.py`.

--- a/mock/auth.py
+++ b/mock/auth.py
@@ -7,7 +7,6 @@ import time
 from dataclasses import dataclass
 
 import jwt
-from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import rsa
 from fastapi import Request
 from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoint

--- a/mock/auth.py
+++ b/mock/auth.py
@@ -79,6 +79,10 @@ class AuthProvider:
 
         if organization is None:
             organization = user.tenants[0] if user.tenants[0] != "*" else ""
+        elif "*" not in user.tenants and organization not in user.tenants:
+            raise ValueError(
+                f"User {username} is not authorized for organization {organization}"
+            )
 
         now = int(time.time())
         payload = {

--- a/mock/auth.py
+++ b/mock/auth.py
@@ -1,0 +1,205 @@
+"""Authentication simulation: RSA key generation, JWT create/validate, OIDC endpoints."""
+
+from __future__ import annotations
+
+import base64
+import time
+from dataclasses import dataclass
+
+import jwt
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+from fastapi import Request
+from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoint
+from starlette.responses import JSONResponse, Response
+
+ALGORITHM = "RS256"
+TOKEN_LIFETIME = 3600
+
+
+@dataclass
+class UserConfig:
+    password: str
+    tenants: list[str]
+    roles: list[str]
+    groups: list[str]
+
+
+USERS: dict[str, UserConfig] = {
+    "admin": UserConfig(
+        password="admin",
+        tenants=["*"],
+        roles=["cloud-provider-admin"],
+        groups=["admins"],
+    ),
+    "adam": UserConfig(
+        password="adam",
+        tenants=["engineering"],
+        roles=["tenant-admin"],
+        groups=["engineering"],
+    ),
+    "ben": UserConfig(
+        password="ben",
+        tenants=["engineering", "sales"],
+        roles=["tenant-user"],
+        groups=["engineering", "sales"],
+    ),
+    "charles": UserConfig(
+        password="charles",
+        tenants=["sales"],
+        roles=["tenant-user"],
+        groups=["sales"],
+    ),
+}
+
+_NO_AUTH_PATHS = {
+    "/.well-known/openid-configuration",
+    "/.well-known/jwks.json",
+    "/auth/token",
+    "/api/fulfillment/v1/capabilities",
+}
+
+
+class AuthProvider:
+    def __init__(self, issuer: str) -> None:
+        self.issuer = issuer
+        self._private_key = rsa.generate_private_key(
+            public_exponent=65537, key_size=2048
+        )
+        self._public_key = self._private_key.public_key()
+        self._kid = "mock-key-1"
+
+    def create_token(
+        self,
+        username: str,
+        organization: str | None = None,
+    ) -> str:
+        user = USERS.get(username)
+        if not user:
+            raise ValueError(f"Unknown user: {username}")
+
+        if organization is None:
+            organization = user.tenants[0] if user.tenants[0] != "*" else ""
+
+        now = int(time.time())
+        payload = {
+            "iss": self.issuer,
+            "sub": username,
+            "iat": now,
+            "exp": now + TOKEN_LIFETIME,
+            "typ": "Bearer",
+            "organization": organization,
+            "groups": user.groups,
+            "realm_access": {"roles": user.roles},
+            "preferred_username": username,
+        }
+        return jwt.encode(
+            payload,
+            self._private_key,
+            algorithm=ALGORITHM,
+            headers={"kid": self._kid},
+        )
+
+    def validate_token(self, token: str) -> dict:
+        return jwt.decode(
+            token,
+            self._public_key,
+            algorithms=[ALGORITHM],
+            options={"verify_aud": False},
+        )
+
+    def jwks(self) -> dict:
+        pub_numbers = self._public_key.public_numbers()
+        n_bytes = pub_numbers.n.to_bytes(
+            (pub_numbers.n.bit_length() + 7) // 8, byteorder="big"
+        )
+        e_bytes = pub_numbers.e.to_bytes(
+            (pub_numbers.e.bit_length() + 7) // 8, byteorder="big"
+        )
+        return {
+            "keys": [
+                {
+                    "kty": "RSA",
+                    "use": "sig",
+                    "kid": self._kid,
+                    "alg": ALGORITHM,
+                    "n": base64.urlsafe_b64encode(n_bytes)
+                    .rstrip(b"=")
+                    .decode(),
+                    "e": base64.urlsafe_b64encode(e_bytes)
+                    .rstrip(b"=")
+                    .decode(),
+                }
+            ]
+        }
+
+    def openid_configuration(self) -> dict:
+        return {
+            "issuer": self.issuer,
+            "authorization_endpoint": f"{self.issuer}/auth/authorize",
+            "token_endpoint": f"{self.issuer}/auth/token",
+            "jwks_uri": f"{self.issuer}/.well-known/jwks.json",
+            "response_types_supported": ["code", "token"],
+            "subject_types_supported": ["public"],
+            "id_token_signing_alg_values_supported": [ALGORITHM],
+            "grant_types_supported": ["password", "client_credentials"],
+        }
+
+    def capabilities(self) -> dict:
+        return {
+            "authn": {
+                "trusted_token_issuers": [self.issuer],
+            }
+        }
+
+
+class AuthMiddleware(BaseHTTPMiddleware):
+    def __init__(self, app, auth_provider: AuthProvider, no_auth: bool = False) -> None:
+        super().__init__(app)
+        self.auth_provider = auth_provider
+        self.no_auth = no_auth
+
+    async def dispatch(
+        self, request: Request, call_next: RequestResponseEndpoint
+    ) -> Response:
+        if request.url.path in _NO_AUTH_PATHS:
+            request.state.tenant = ""
+            request.state.user = "anonymous"
+            request.state.roles = []
+            return await call_next(request)
+
+        if self.no_auth:
+            request.state.tenant = "engineering"
+            request.state.user = "admin"
+            request.state.roles = ["cloud-provider-admin"]
+            return await call_next(request)
+
+        auth_header = request.headers.get("authorization", "")
+        if not auth_header.lower().startswith("bearer "):
+            return JSONResponse(
+                {"code": 16, "message": "Missing or invalid authorization header", "details": []},
+                status_code=401,
+            )
+
+        token = auth_header[7:]
+        try:
+            claims = self.auth_provider.validate_token(token)
+        except jwt.ExpiredSignatureError:
+            return JSONResponse(
+                {"code": 16, "message": "Token expired", "details": []},
+                status_code=401,
+            )
+        except jwt.InvalidTokenError as e:
+            return JSONResponse(
+                {"code": 16, "message": f"Invalid token: {e}", "details": []},
+                status_code=401,
+            )
+
+        request.state.user = claims.get("sub", "")
+        request.state.tenant = claims.get("organization", "")
+        request.state.roles = claims.get("realm_access", {}).get("roles", [])
+
+        if "*" in USERS.get(request.state.user, UserConfig("", [], [], [])).tenants:
+            request.state.tenant = "*"
+
+        return await call_next(request)

--- a/mock/events.py
+++ b/mock/events.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import asyncio
 import json
 from datetime import datetime, timezone
-from typing import Any
 
 from sse_starlette.sse import EventSourceResponse
 from starlette.requests import Request

--- a/mock/events.py
+++ b/mock/events.py
@@ -90,6 +90,8 @@ def _build_event(
 
 
 async def events_endpoint(request: Request, event_bus: EventBus) -> EventSourceResponse:
+    tenant = getattr(request.state, "tenant", "") or ""
+    is_admin = "cloud-provider-admin" in (getattr(request.state, "roles", None) or [])
     queue = await event_bus.subscribe()
 
     async def event_generator():
@@ -99,6 +101,16 @@ async def events_endpoint(request: Request, event_bus: EventBus) -> EventSourceR
                     break
                 try:
                     event = await asyncio.wait_for(queue.get(), timeout=30.0)
+                    if not is_admin and tenant:
+                        obj_tenant = ""
+                        for key in event:
+                            if isinstance(event[key], dict):
+                                obj_tenant = (
+                                    event[key].get("metadata", {}).get("tenant", "")
+                                )
+                                break
+                        if obj_tenant and obj_tenant != tenant:
+                            continue
                     yield {"data": json.dumps(event)}
                 except asyncio.TimeoutError:
                     yield {"comment": "keepalive"}

--- a/mock/events.py
+++ b/mock/events.py
@@ -1,0 +1,109 @@
+"""SSE event stream — emits events when resources change state."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from datetime import datetime, timezone
+from typing import Any
+
+from sse_starlette.sse import EventSourceResponse
+from starlette.requests import Request
+
+
+class EventBus:
+    """Fan-out event bus for SSE clients."""
+
+    def __init__(self) -> None:
+        self._subscribers: list[asyncio.Queue[dict]] = []
+        self._lock = asyncio.Lock()
+
+    async def subscribe(self) -> asyncio.Queue[dict]:
+        queue: asyncio.Queue[dict] = asyncio.Queue(maxsize=256)
+        async with self._lock:
+            self._subscribers.append(queue)
+        return queue
+
+    async def unsubscribe(self, queue: asyncio.Queue[dict]) -> None:
+        async with self._lock:
+            try:
+                self._subscribers.remove(queue)
+            except ValueError:
+                pass
+
+    def publish(
+        self,
+        event_type: str,
+        resource_type: str,
+        resource_id: str,
+        obj: dict,
+    ) -> None:
+        event = _build_event(event_type, resource_type, resource_id, obj)
+        for queue in list(self._subscribers):
+            try:
+                queue.put_nowait(event)
+            except asyncio.QueueFull:
+                pass
+
+
+_EVENT_TYPE_MAP = {
+    "OBJECT_CREATED": "EVENT_TYPE_OBJECT_CREATED",
+    "OBJECT_UPDATED": "EVENT_TYPE_OBJECT_UPDATED",
+    "OBJECT_DELETED": "EVENT_TYPE_OBJECT_DELETED",
+}
+
+_RESOURCE_TYPE_MAP: dict[str, str] = {}
+
+
+def _resource_type_to_field(resource_type: str) -> str:
+    """Convert 'virtual_networks' to 'virtual_network' (singular form for event field)."""
+    if resource_type in _RESOURCE_TYPE_MAP:
+        return _RESOURCE_TYPE_MAP[resource_type]
+    singular = resource_type.rstrip("s")
+    if resource_type.endswith("ies"):
+        singular = resource_type[:-3] + "y"
+    elif resource_type.endswith("sses"):
+        singular = resource_type[:-2]
+    elif resource_type.endswith("ses"):
+        singular = resource_type[:-2]
+    _RESOURCE_TYPE_MAP[resource_type] = singular
+    return singular
+
+
+def _strip_internal(obj: dict) -> dict:
+    return {k: v for k, v in obj.items() if not k.startswith("_mock_")}
+
+
+def _build_event(
+    event_type: str,
+    resource_type: str,
+    resource_id: str,
+    obj: dict,
+) -> dict:
+    field_name = _resource_type_to_field(resource_type)
+    return {
+        "type": _EVENT_TYPE_MAP.get(event_type, event_type),
+        "object_type": resource_type,
+        "object_id": resource_id,
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+        field_name: _strip_internal(obj),
+    }
+
+
+async def events_endpoint(request: Request, event_bus: EventBus) -> EventSourceResponse:
+    queue = await event_bus.subscribe()
+
+    async def event_generator():
+        try:
+            while True:
+                if await request.is_disconnected():
+                    break
+                try:
+                    event = await asyncio.wait_for(queue.get(), timeout=30.0)
+                    yield {"data": json.dumps(event)}
+                except asyncio.TimeoutError:
+                    yield {"comment": "keepalive"}
+        finally:
+            await event_bus.unsubscribe(queue)
+
+    return EventSourceResponse(event_generator())

--- a/mock/filter_parser.py
+++ b/mock/filter_parser.py
@@ -1,0 +1,172 @@
+"""Minimal CEL-subset filter evaluator for List operations.
+
+Supports:
+  this.field.path == "value"
+  this.field.path != "value"
+  this.field.path.startsWith("prefix")
+  this.field.path.endsWith("suffix")
+  this.field.path.contains("substr")
+  has(this.field.path)
+  expr && expr
+  expr || expr
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any, Callable
+
+
+def parse_filter(expr: str) -> Callable[[dict], bool] | None:
+    """Parse a CEL-like filter expression into a predicate function.
+
+    Returns None if the expression is empty or unparseable (matches all).
+    """
+    expr = expr.strip()
+    if not expr:
+        return None
+    try:
+        return _parse_or(expr)
+    except _ParseError:
+        return None
+
+
+class _ParseError(Exception):
+    pass
+
+
+def _parse_or(expr: str) -> Callable[[dict], bool]:
+    parts = _split_top_level(expr, "||")
+    if len(parts) == 1:
+        return _parse_and(parts[0])
+    fns = [_parse_and(p) for p in parts]
+    return lambda obj: any(fn(obj) for fn in fns)
+
+
+def _parse_and(expr: str) -> Callable[[dict], bool]:
+    parts = _split_top_level(expr, "&&")
+    if len(parts) == 1:
+        return _parse_atom(parts[0])
+    fns = [_parse_atom(p) for p in parts]
+    return lambda obj: all(fn(obj) for fn in fns)
+
+
+def _split_top_level(expr: str, op: str) -> list[str]:
+    """Split on operator, respecting parentheses and string literals."""
+    parts: list[str] = []
+    depth = 0
+    in_string = False
+    string_char = ""
+    current: list[str] = []
+    i = 0
+    while i < len(expr):
+        c = expr[i]
+        if in_string:
+            current.append(c)
+            if c == string_char:
+                in_string = False
+        elif c in ('"', "'"):
+            in_string = True
+            string_char = c
+            current.append(c)
+        elif c == "(":
+            depth += 1
+            current.append(c)
+        elif c == ")":
+            depth -= 1
+            current.append(c)
+        elif depth == 0 and expr[i : i + len(op)] == op:
+            parts.append("".join(current).strip())
+            current = []
+            i += len(op)
+            continue
+        else:
+            current.append(c)
+        i += 1
+    remainder = "".join(current).strip()
+    if remainder:
+        parts.append(remainder)
+    return parts
+
+
+_HAS_RE = re.compile(r'^has\(this\.(.+)\)$')
+_COMPARE_RE = re.compile(r'^this\.(.+?)\s*(==|!=)\s*"(.*)"$')
+_METHOD_RE = re.compile(r'^this\.(.+?)\.(startsWith|endsWith|contains)\("(.*)"\)$')
+_NEGATION_RE = re.compile(r'^!\s*(.+)$')
+
+
+def _parse_atom(expr: str) -> Callable[[dict], bool]:
+    expr = expr.strip()
+
+    if expr.startswith("(") and expr.endswith(")"):
+        return _parse_or(expr[1:-1])
+
+    m = _NEGATION_RE.match(expr)
+    if m:
+        inner = _parse_atom(m.group(1))
+        return lambda obj, _f=inner: not _f(obj)
+
+    m = _HAS_RE.match(expr)
+    if m:
+        path = m.group(1)
+        return lambda obj, _p=path: _get_path(obj, _p) is not None
+
+    m = _METHOD_RE.match(expr)
+    if m:
+        path, method, arg = m.group(1), m.group(2), m.group(3)
+        return lambda obj, _p=path, _m=method, _a=arg: _string_method(
+            _get_path(obj, _p), _m, _a
+        )
+
+    m = _COMPARE_RE.match(expr)
+    if m:
+        path, op, value = m.group(1), m.group(2), m.group(3)
+        if op == "==":
+            return lambda obj, _p=path, _v=value: str(_get_path(obj, _p) or "") == _v
+        else:
+            return lambda obj, _p=path, _v=value: str(_get_path(obj, _p) or "") != _v
+
+    raise _ParseError(f"Unsupported expression: {expr}")
+
+
+def _get_path(obj: dict, path: str) -> Any:
+    """Navigate dotted path, handling map access like labels["key"]."""
+    node: Any = obj
+    for part in _split_path(path):
+        if node is None:
+            return None
+        if isinstance(part, tuple):
+            field, key = part
+            node = node.get(field, {}) if isinstance(node, dict) else None
+            node = node.get(key) if isinstance(node, dict) else None
+        else:
+            node = node.get(part) if isinstance(node, dict) else None
+    return node
+
+
+_MAP_ACCESS_RE = re.compile(r'^(.+)\["(.+)"\]$')
+
+
+def _split_path(path: str) -> list[str | tuple[str, str]]:
+    """Split 'metadata.labels["env"]' into [metadata, (labels, env)]."""
+    parts: list[str | tuple[str, str]] = []
+    for segment in path.split("."):
+        m = _MAP_ACCESS_RE.match(segment)
+        if m:
+            parts.append((m.group(1), m.group(2)))
+        else:
+            parts.append(segment)
+    return parts
+
+
+def _string_method(value: Any, method: str, arg: str) -> bool:
+    if value is None:
+        return False
+    s = str(value)
+    if method == "startsWith":
+        return s.startswith(arg)
+    elif method == "endsWith":
+        return s.endswith(arg)
+    elif method == "contains":
+        return arg in s
+    return False

--- a/mock/filter_parser.py
+++ b/mock/filter_parser.py
@@ -122,11 +122,19 @@ def _parse_atom(expr: str) -> Callable[[dict], bool]:
     if m:
         path, op, value = m.group(1), m.group(2), m.group(3)
         if op == "==":
-            return lambda obj, _p=path, _v=value: str(_get_path(obj, _p) or "") == _v
+            return lambda obj, _p=path, _v=value: _stringify(_get_path(obj, _p)) == _v
         else:
-            return lambda obj, _p=path, _v=value: str(_get_path(obj, _p) or "") != _v
+            return lambda obj, _p=path, _v=value: _stringify(_get_path(obj, _p)) != _v
 
     raise _ParseError(f"Unsupported expression: {expr}")
+
+
+def _stringify(v: Any) -> str:
+    if v is None:
+        return ""
+    if isinstance(v, bool):
+        return "true" if v else "false"
+    return str(v)
 
 
 def _get_path(obj: dict, path: str) -> Any:

--- a/mock/handlers.py
+++ b/mock/handlers.py
@@ -1,0 +1,162 @@
+"""Generic CRUD request handlers for all resource types."""
+
+from __future__ import annotations
+
+from fastapi import Request, Response
+from fastapi.responses import JSONResponse
+
+from filter_parser import parse_filter
+from store import BadRequestError, ConflictError, NotFoundError, ResourceStore
+
+MOCK_LABEL_PREFIX = "mock.osac.dev/"
+
+
+def get_tenant(request: Request) -> str:
+    return getattr(request.state, "tenant", "") or ""
+
+
+def get_user(request: Request) -> str:
+    return getattr(request.state, "user", "") or "anonymous"
+
+
+def get_roles(request: Request) -> list[str]:
+    return getattr(request.state, "roles", [])
+
+
+def is_admin(request: Request) -> bool:
+    return "cloud-provider-admin" in get_roles(request)
+
+
+async def handle_list(
+    resource_type: str,
+    store: ResourceStore,
+    request: Request,
+    initial_state: str | None = None,
+) -> JSONResponse:
+    tenant = None if is_admin(request) else get_tenant(request)
+    offset = int(request.query_params.get("offset", 0))
+    limit_str = request.query_params.get("limit")
+    limit = int(limit_str) if limit_str else None
+    filter_expr = request.query_params.get("filter", "")
+    filter_fn = parse_filter(filter_expr)
+
+    items, total = await store.list(
+        resource_type, tenant=tenant, filter_fn=filter_fn, offset=offset, limit=limit
+    )
+    return JSONResponse(
+        {"items": items, "size": len(items), "total": total}
+    )
+
+
+async def handle_get(
+    resource_type: str,
+    resource_id: str,
+    store: ResourceStore,
+    request: Request,
+) -> JSONResponse:
+    tenant = None if is_admin(request) else get_tenant(request)
+    try:
+        obj = await store.get(resource_type, resource_id, tenant=tenant)
+    except NotFoundError:
+        return JSONResponse(
+            {"code": 5, "message": "Not found", "details": []}, status_code=404
+        )
+    return JSONResponse({"object": obj})
+
+
+async def handle_create(
+    resource_type: str,
+    store: ResourceStore,
+    request: Request,
+    initial_state: str | None = None,
+    state_field: str = "status.state",
+) -> JSONResponse:
+    body = await request.json()
+    obj = body.get("object", body)
+
+    labels = obj.get("metadata", {}).get("labels", {})
+    if labels.get(f"{MOCK_LABEL_PREFIX}fail-create") == "true":
+        msg = labels.get(f"{MOCK_LABEL_PREFIX}error-message", "Simulated create failure")
+        return JSONResponse(
+            {"code": 3, "message": msg, "details": []}, status_code=400
+        )
+
+    tenant = get_tenant(request)
+    creator = get_user(request)
+
+    try:
+        created = await store.create(
+            resource_type,
+            obj,
+            tenant=tenant,
+            creator=creator,
+            initial_state=initial_state,
+            state_field=state_field,
+        )
+    except ConflictError:
+        return JSONResponse(
+            {"code": 6, "message": "Already exists", "details": []}, status_code=409
+        )
+    except BadRequestError as e:
+        return JSONResponse(
+            {"code": 3, "message": e.message, "details": []}, status_code=400
+        )
+    return JSONResponse({"object": created})
+
+
+async def handle_update(
+    resource_type: str,
+    resource_id: str,
+    store: ResourceStore,
+    request: Request,
+) -> JSONResponse:
+    body = await request.json()
+    lock = request.query_params.get("lock", "").lower() == "true"
+
+    updates = body.get("object", body)
+
+    tenant = None if is_admin(request) else get_tenant(request)
+    try:
+        updated = await store.update(
+            resource_type, resource_id, updates, lock=lock, tenant=tenant
+        )
+    except NotFoundError:
+        return JSONResponse(
+            {"code": 5, "message": "Not found", "details": []}, status_code=404
+        )
+    except ConflictError:
+        return JSONResponse(
+            {"code": 9, "message": "Version conflict", "details": []}, status_code=409
+        )
+    return JSONResponse({"object": updated})
+
+
+async def handle_delete(
+    resource_type: str,
+    resource_id: str,
+    store: ResourceStore,
+    request: Request,
+) -> Response:
+    tenant = None if is_admin(request) else get_tenant(request)
+
+    try:
+        obj = await store.get(resource_type, resource_id, tenant=tenant)
+    except NotFoundError:
+        return JSONResponse(
+            {"code": 5, "message": "Not found", "details": []}, status_code=404
+        )
+
+    labels = obj.get("metadata", {}).get("labels", {})
+    if labels.get(f"{MOCK_LABEL_PREFIX}fail-delete") == "true":
+        msg = labels.get(f"{MOCK_LABEL_PREFIX}error-message", "Simulated delete failure")
+        return JSONResponse(
+            {"code": 13, "message": msg, "details": []}, status_code=500
+        )
+
+    try:
+        await store.delete(resource_type, resource_id, tenant=tenant)
+    except NotFoundError:
+        return JSONResponse(
+            {"code": 5, "message": "Not found", "details": []}, status_code=404
+        )
+    return JSONResponse({})

--- a/mock/handlers.py
+++ b/mock/handlers.py
@@ -34,9 +34,15 @@ async def handle_list(
     initial_state: str | None = None,
 ) -> JSONResponse:
     tenant = None if is_admin(request) else get_tenant(request)
-    offset = int(request.query_params.get("offset", 0))
-    limit_str = request.query_params.get("limit")
-    limit = int(limit_str) if limit_str else None
+
+    def _to_int(value: str | None) -> int | None:
+        try:
+            return max(0, int(value)) if value is not None else None
+        except ValueError:
+            return None
+
+    offset = _to_int(request.query_params.get("offset")) or 0
+    limit = _to_int(request.query_params.get("limit"))
     filter_expr = request.query_params.get("filter", "")
     filter_fn = parse_filter(filter_expr)
 
@@ -71,10 +77,16 @@ async def handle_create(
     initial_state: str | None = None,
     state_field: str = "status.state",
 ) -> JSONResponse:
-    body = await request.json()
+    try:
+        body = await request.json()
+    except Exception:
+        return JSONResponse(
+            {"code": 3, "message": "Invalid request body", "details": []},
+            status_code=400,
+        )
     obj = body.get("object", body)
 
-    labels = obj.get("metadata", {}).get("labels", {})
+    labels = (obj.get("metadata") or {}).get("labels") or {}
     if labels.get(f"{MOCK_LABEL_PREFIX}fail-create") == "true":
         msg = labels.get(f"{MOCK_LABEL_PREFIX}error-message", "Simulated create failure")
         return JSONResponse(
@@ -146,7 +158,7 @@ async def handle_delete(
             {"code": 5, "message": "Not found", "details": []}, status_code=404
         )
 
-    labels = obj.get("metadata", {}).get("labels", {})
+    labels = (obj.get("metadata") or {}).get("labels") or {}
     if labels.get(f"{MOCK_LABEL_PREFIX}fail-delete") == "true":
         msg = labels.get(f"{MOCK_LABEL_PREFIX}error-message", "Simulated delete failure")
         return JSONResponse(

--- a/mock/mock_server.py
+++ b/mock/mock_server.py
@@ -1,0 +1,340 @@
+"""Fulfillment-service mock server.
+
+Reads the OpenAPI v3 spec, discovers all resource types, and serves them
+with in-memory state, JWT auth, state machine progression, and SSE events.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import sys
+from contextlib import asynccontextmanager
+from pathlib import Path
+
+import uvicorn
+import yaml
+from fastapi import FastAPI, Request, Response
+from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import JSONResponse
+
+from auth import AuthMiddleware, AuthProvider, USERS
+from events import EventBus, events_endpoint
+from handlers import (
+    handle_create,
+    handle_delete,
+    handle_get,
+    handle_list,
+    handle_update,
+)
+from openapi_loader import ResourceConfig, discover_resources, load_spec
+from state_machines import STATE_MACHINES, run_ticker
+from store import ResourceStore
+
+DEFAULT_SPEC = Path(__file__).parent.parent / "pages" / "openapi" / "v3" / "public.yaml"
+
+
+async def load_scenario(store: ResourceStore, scenario_path: Path) -> int:
+    """Load a YAML scenario file into the store. Returns count of loaded resources."""
+    with open(scenario_path) as f:
+        data = yaml.safe_load(f)
+
+    resources = data.get("resources", [])
+    count = 0
+
+    for res in resources:
+        resource_type = res.pop("type", None)
+        if not resource_type:
+            continue
+
+        res.setdefault("metadata", {})
+        res["metadata"].setdefault("labels", {})
+        res["metadata"].setdefault("annotations", {})
+        res["metadata"].setdefault("version", 1)
+
+        state = (res.get("status") or {}).get("state")
+        sm = STATE_MACHINES.get(resource_type)
+        if state and sm:
+            terminal_states = set()
+            for t in sm.transitions.values():
+                terminal_states.add(t.next_state)
+                if t.fail_state:
+                    terminal_states.add(t.fail_state)
+            if state not in terminal_states:
+                from datetime import datetime, timezone
+                res["_mock_entered_state_at"] = datetime.now(timezone.utc).isoformat()
+
+        await store.insert_raw(resource_type, res)
+        count += 1
+
+    return count
+
+
+def create_app(
+    spec_path: Path = DEFAULT_SPEC,
+    scenario_paths: list[Path] | None = None,
+    no_auth: bool = False,
+    port: int = 8000,
+) -> FastAPI:
+    store = ResourceStore()
+    event_bus = EventBus()
+
+    store.set_event_callback(
+        lambda et, rt, rid, obj: event_bus.publish(et, rt, rid, obj)
+    )
+
+    spec = load_spec(spec_path)
+    resource_configs = discover_resources(spec)
+
+    ticker_task: asyncio.Task | None = None
+
+    @asynccontextmanager
+    async def lifespan(app: FastAPI):
+        nonlocal ticker_task
+        if scenario_paths:
+            for sp in scenario_paths:
+                count = await load_scenario(store, sp)
+                print(f"Loaded {count} resources from {sp}")
+        ticker_task = asyncio.create_task(run_ticker(store))
+        print(f"State machine ticker started")
+        yield
+        if ticker_task:
+            ticker_task.cancel()
+            try:
+                await ticker_task
+            except asyncio.CancelledError:
+                pass
+
+    host = f"http://localhost:{port}"
+    auth_provider = AuthProvider(issuer=host)
+
+    app = FastAPI(
+        title="Fulfillment Service Mock",
+        version="0.1.0",
+        lifespan=lifespan,
+    )
+
+    app.add_middleware(
+        CORSMiddleware,
+        allow_origins=["*"],
+        allow_credentials=True,
+        allow_methods=["*"],
+        allow_headers=["*"],
+    )
+    app.add_middleware(AuthMiddleware, auth_provider=auth_provider, no_auth=no_auth)
+
+    # --- Auth endpoints ---
+
+    @app.get("/.well-known/openid-configuration")
+    async def openid_config():
+        return auth_provider.openid_configuration()
+
+    @app.get("/.well-known/jwks.json")
+    async def jwks():
+        return auth_provider.jwks()
+
+    @app.post("/auth/token")
+    async def token(request: Request):
+        content_type = request.headers.get("content-type", "")
+        if "application/json" in content_type:
+            body = await request.json()
+        else:
+            body = dict(await request.form())
+
+        username = body.get("username", "")
+        password = body.get("password", "")
+        organization = body.get("organization")
+
+        user = USERS.get(username)
+        if not user or user.password != password:
+            return JSONResponse(
+                {"error": "invalid_grant", "error_description": "Invalid credentials"},
+                status_code=401,
+            )
+
+        token = auth_provider.create_token(username, organization)
+        return {
+            "access_token": token,
+            "token_type": "bearer",
+            "expires_in": 3600,
+        }
+
+    @app.get("/api/fulfillment/v1/capabilities")
+    async def capabilities():
+        return auth_provider.capabilities()
+
+    # --- Events endpoint ---
+
+    @app.get("/api/events/v1/events")
+    async def events(request: Request):
+        return await events_endpoint(request, event_bus)
+
+    # --- Special cluster endpoints ---
+
+    @app.get("/api/fulfillment/v1/clusters/{cluster_id}/kubeconfig")
+    async def cluster_kubeconfig(cluster_id: str, request: Request):
+        try:
+            obj = await store.get("clusters", cluster_id)
+        except Exception:
+            return JSONResponse({"code": 5, "message": "Not found"}, status_code=404)
+        name = obj.get("metadata", {}).get("name", "cluster")
+        kubeconfig = f"""\
+apiVersion: v1
+kind: Config
+clusters:
+- cluster:
+    server: https://api.{name}.mock.osac.dev:6443
+    certificate-authority-data: bW9jay1jYS1kYXRh
+  name: {name}
+contexts:
+- context:
+    cluster: {name}
+    user: admin
+  name: {name}
+current-context: {name}
+users:
+- name: admin
+  user:
+    token: mock-admin-token
+"""
+        return Response(content=kubeconfig, media_type="application/yaml")
+
+    @app.get("/api/fulfillment/v1/clusters/{cluster_id}/password")
+    async def cluster_password(cluster_id: str, request: Request):
+        try:
+            await store.get("clusters", cluster_id)
+        except Exception:
+            return JSONResponse({"code": 5, "message": "Not found"}, status_code=404)
+        return Response(content="mock-admin-password", media_type="text/plain")
+
+    # --- Dynamic CRUD routes ---
+
+    _register_crud_routes(app, resource_configs, store)
+
+    print(f"Registered {len(resource_configs)} resource types:")
+    for rc in resource_configs:
+        sm = " [stateful]" if rc.name in STATE_MACHINES else ""
+        print(f"  {rc.collection_path}{sm}")
+
+    return app
+
+
+def _register_crud_routes(
+    app: FastAPI,
+    resource_configs: list[ResourceConfig],
+    store: ResourceStore,
+) -> None:
+    for rc in resource_configs:
+        resource_type = rc.name
+        sm = STATE_MACHINES.get(resource_type)
+
+        initial_state = sm.initial_state if sm else None
+        state_field = sm.state_field if sm else "status.state"
+
+        _rt = resource_type
+        _is = initial_state
+        _sf = state_field
+
+        app.get(rc.collection_path)(
+            _make_list_handler(_rt, store)
+        )
+
+        if rc.has_create:
+            app.post(rc.collection_path)(
+                _make_create_handler(_rt, store, _is, _sf)
+            )
+
+        if rc.item_path:
+            item_path = rc.item_path.replace("{id}", "{resource_id}")
+            app.get(item_path)(
+                _make_get_handler(_rt, store)
+            )
+
+            if rc.has_delete:
+                app.delete(item_path)(
+                    _make_delete_handler(_rt, store)
+                )
+
+        if rc.update_path and rc.has_update:
+            update_path = rc.update_path.replace("{object.id}", "{resource_id}")
+            app.patch(update_path)(
+                _make_update_handler(_rt, store)
+            )
+
+
+def _make_list_handler(resource_type: str, store: ResourceStore):
+    async def handler(request: Request):
+        return await handle_list(resource_type, store, request)
+    handler.__name__ = f"list_{resource_type}"
+    return handler
+
+
+def _make_get_handler(resource_type: str, store: ResourceStore):
+    async def handler(resource_id: str, request: Request):
+        return await handle_get(resource_type, resource_id, store, request)
+    handler.__name__ = f"get_{resource_type}"
+    return handler
+
+
+def _make_create_handler(
+    resource_type: str,
+    store: ResourceStore,
+    initial_state: str | None,
+    state_field: str,
+):
+    async def handler(request: Request):
+        return await handle_create(resource_type, store, request, initial_state, state_field)
+    handler.__name__ = f"create_{resource_type}"
+    return handler
+
+
+def _make_update_handler(resource_type: str, store: ResourceStore):
+    async def handler(resource_id: str, request: Request):
+        return await handle_update(resource_type, resource_id, store, request)
+    handler.__name__ = f"update_{resource_type}"
+    return handler
+
+
+def _make_delete_handler(resource_type: str, store: ResourceStore):
+    async def handler(resource_id: str, request: Request):
+        return await handle_delete(resource_type, resource_id, store, request)
+    handler.__name__ = f"delete_{resource_type}"
+    return handler
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Fulfillment Service Mock Server")
+    parser.add_argument(
+        "--port", type=int, default=8000, help="Port to listen on (default: 8000)"
+    )
+    parser.add_argument(
+        "--spec",
+        type=Path,
+        default=DEFAULT_SPEC,
+        help="Path to OpenAPI v3 spec (default: ../pages/openapi/v3/public.yaml)",
+    )
+    parser.add_argument(
+        "--scenario",
+        type=Path,
+        action="append",
+        dest="scenarios",
+        help="Path to scenario YAML file(s) to preload (can specify multiple)",
+    )
+    parser.add_argument(
+        "--no-auth",
+        action="store_true",
+        help="Disable JWT authentication (all requests treated as admin)",
+    )
+    args = parser.parse_args()
+
+    app = create_app(
+        spec_path=args.spec,
+        scenario_paths=args.scenarios,
+        no_auth=args.no_auth,
+        port=args.port,
+    )
+    uvicorn.run(app, host="0.0.0.0", port=args.port)
+
+
+if __name__ == "__main__":
+    main()

--- a/mock/mock_server.py
+++ b/mock/mock_server.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 
 import argparse
 import asyncio
-import sys
 from contextlib import asynccontextmanager
 from pathlib import Path
 
@@ -96,7 +95,7 @@ def create_app(
                 count = await load_scenario(store, sp)
                 print(f"Loaded {count} resources from {sp}")
         ticker_task = asyncio.create_task(run_ticker(store))
-        print(f"State machine ticker started")
+        print("State machine ticker started")
         yield
         if ticker_task:
             ticker_task.cancel()

--- a/mock/mock_server.py
+++ b/mock/mock_server.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import argparse
 import asyncio
+import secrets
 from contextlib import asynccontextmanager
 from pathlib import Path
 
@@ -20,15 +21,17 @@ from fastapi.responses import JSONResponse
 from auth import AuthMiddleware, AuthProvider, USERS
 from events import EventBus, events_endpoint
 from handlers import (
+    get_tenant,
     handle_create,
     handle_delete,
     handle_get,
     handle_list,
     handle_update,
+    is_admin,
 )
 from openapi_loader import ResourceConfig, discover_resources, load_spec
 from state_machines import STATE_MACHINES, run_ticker
-from store import ResourceStore
+from store import NotFoundError, ResourceStore
 
 DEFAULT_SPEC = Path(__file__).parent.parent / "pages" / "openapi" / "v3" / "public.yaml"
 
@@ -115,7 +118,14 @@ def create_app(
 
     app.add_middleware(
         CORSMiddleware,
-        allow_origins=["*"],
+        allow_origins=[
+            "http://localhost:3000",
+            "http://localhost:5173",
+            "http://localhost:8080",
+            "http://127.0.0.1:3000",
+            "http://127.0.0.1:5173",
+            "http://127.0.0.1:8080",
+        ],
         allow_credentials=True,
         allow_methods=["*"],
         allow_headers=["*"],
@@ -151,7 +161,13 @@ def create_app(
                 status_code=401,
             )
 
-        token = auth_provider.create_token(username, organization)
+        try:
+            token = auth_provider.create_token(username, organization)
+        except ValueError as e:
+            return JSONResponse(
+                {"error": "invalid_grant", "error_description": str(e)},
+                status_code=403,
+            )
         return {
             "access_token": token,
             "token_type": "bearer",
@@ -170,11 +186,15 @@ def create_app(
 
     # --- Special cluster endpoints ---
 
+    mock_cluster_token = secrets.token_urlsafe(32)
+    mock_cluster_password = secrets.token_urlsafe(24)
+
     @app.get("/api/fulfillment/v1/clusters/{cluster_id}/kubeconfig")
     async def cluster_kubeconfig(cluster_id: str, request: Request):
+        tenant = None if is_admin(request) else get_tenant(request)
         try:
-            obj = await store.get("clusters", cluster_id)
-        except Exception:
+            obj = await store.get("clusters", cluster_id, tenant=tenant)
+        except NotFoundError:
             return JSONResponse({"code": 5, "message": "Not found"}, status_code=404)
         name = obj.get("metadata", {}).get("name", "cluster")
         kubeconfig = f"""\
@@ -194,17 +214,18 @@ current-context: {name}
 users:
 - name: admin
   user:
-    token: mock-admin-token
+    token: {mock_cluster_token}
 """
         return Response(content=kubeconfig, media_type="application/yaml")
 
     @app.get("/api/fulfillment/v1/clusters/{cluster_id}/password")
     async def cluster_password(cluster_id: str, request: Request):
+        tenant = None if is_admin(request) else get_tenant(request)
         try:
-            await store.get("clusters", cluster_id)
-        except Exception:
+            await store.get("clusters", cluster_id, tenant=tenant)
+        except NotFoundError:
             return JSONResponse({"code": 5, "message": "Not found"}, status_code=404)
-        return Response(content="mock-admin-password", media_type="text/plain")
+        return Response(content=mock_cluster_password, media_type="text/plain")
 
     # --- Dynamic CRUD routes ---
 

--- a/mock/openapi_loader.py
+++ b/mock/openapi_loader.py
@@ -1,0 +1,161 @@
+"""Parse the fulfillment-service OpenAPI v3 spec and discover resource types."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import yaml
+
+
+@dataclass
+class ResourceConfig:
+    name: str  # e.g. "virtual_networks"
+    collection_path: str  # e.g. "/api/fulfillment/v1/virtual_networks"
+    item_path: str | None  # e.g. "/api/fulfillment/v1/virtual_networks/{id}"
+    update_path: str | None  # e.g. "/api/fulfillment/v1/virtual_networks/{object.id}"
+    schema_ref: str | None  # e.g. "v1VirtualNetwork"
+    state_enum_values: list[str] = field(default_factory=list)
+    has_create: bool = False
+    has_update: bool = False
+    has_delete: bool = False
+    extra_paths: dict[str, list[str]] = field(default_factory=dict)
+
+
+_COLLECTION_RE = re.compile(r"^/api/fulfillment/v1/([a-z_]+)$")
+_ITEM_RE = re.compile(r"^/api/fulfillment/v1/([a-z_]+)/\{id\}$")
+_UPDATE_RE = re.compile(r"^/api/fulfillment/v1/([a-z_]+)/\{object\.id\}$")
+_EXTRA_RE = re.compile(r"^/api/fulfillment/v1/([a-z_]+)/\{id\}/(.+)$")
+
+
+def _resolve_ref(spec: dict, ref: str) -> dict | None:
+    if not ref.startswith("#/"):
+        return None
+    parts = ref.lstrip("#/").split("/")
+    node = spec
+    for p in parts:
+        node = node.get(p, {})
+    return node if node else None
+
+
+def _find_state_enum(spec: dict, schema_ref: str) -> list[str]:
+    """Given a resource schema ref name, find state enum values from status.state."""
+    schema = spec.get("components", {}).get("schemas", {}).get(schema_ref, {})
+    status_prop = schema.get("properties", {}).get("status", {})
+
+    status_ref = status_prop.get("$ref", "")
+    if status_ref:
+        status_schema = _resolve_ref(spec, status_ref)
+    else:
+        status_schema = status_prop
+
+    if not status_schema:
+        return []
+
+    state_prop = status_schema.get("properties", {}).get("state", {})
+    state_ref = state_prop.get("$ref", "")
+    if state_ref:
+        state_schema = _resolve_ref(spec, state_ref)
+    else:
+        state_schema = state_prop
+
+    if not state_schema:
+        return []
+
+    return state_schema.get("enum", [])
+
+
+def _extract_schema_ref(spec: dict, path_info: dict) -> str | None:
+    """Extract the resource schema ref from a List or Create response."""
+    for method in ("get", "post"):
+        method_info = path_info.get(method, {})
+        resp_200 = method_info.get("responses", {}).get("200", {})
+        content = resp_200.get("content", {}).get("application/json", {})
+        schema = content.get("schema", {})
+        ref = schema.get("$ref", "")
+        if not ref:
+            continue
+        resp_schema = _resolve_ref(spec, ref)
+        if not resp_schema:
+            continue
+        # List responses have items array, Create/Get responses have object
+        for prop_name in ("items", "object"):
+            prop = resp_schema.get("properties", {}).get(prop_name, {})
+            if "$ref" in prop:
+                return prop["$ref"].rsplit("/", 1)[-1]
+            if prop.get("items", {}).get("$ref"):
+                return prop["items"]["$ref"].rsplit("/", 1)[-1]
+    return None
+
+
+def discover_resources(spec: dict) -> list[ResourceConfig]:
+    """Discover all CRUD resource types from the OpenAPI spec."""
+    resources: dict[str, ResourceConfig] = {}
+    paths = spec.get("paths", {})
+
+    for path, path_info in paths.items():
+        m = _COLLECTION_RE.match(path)
+        if m:
+            name = m.group(1)
+            if name not in resources:
+                resources[name] = ResourceConfig(
+                    name=name,
+                    collection_path=path,
+                    item_path=None,
+                    update_path=None,
+                    schema_ref=None,
+                )
+            resources[name].collection_path = path
+            resources[name].has_create = "post" in path_info
+            resources[name].schema_ref = _extract_schema_ref(spec, path_info)
+            continue
+
+        m = _ITEM_RE.match(path)
+        if m:
+            name = m.group(1)
+            if name not in resources:
+                resources[name] = ResourceConfig(
+                    name=name,
+                    collection_path=f"/api/fulfillment/v1/{name}",
+                    item_path=None,
+                    update_path=None,
+                    schema_ref=None,
+                )
+            resources[name].item_path = path
+            resources[name].has_delete = "delete" in path_info
+            continue
+
+        m = _UPDATE_RE.match(path)
+        if m:
+            name = m.group(1)
+            if name not in resources:
+                resources[name] = ResourceConfig(
+                    name=name,
+                    collection_path=f"/api/fulfillment/v1/{name}",
+                    item_path=None,
+                    update_path=None,
+                    schema_ref=None,
+                )
+            resources[name].update_path = path
+            resources[name].has_update = "patch" in path_info
+            continue
+
+        m = _EXTRA_RE.match(path)
+        if m:
+            name = m.group(1)
+            sub = m.group(2)
+            if name in resources:
+                methods = list(path_info.keys())
+                resources[name].extra_paths[sub] = methods
+
+    for rc in resources.values():
+        if rc.schema_ref:
+            rc.state_enum_values = _find_state_enum(spec, rc.schema_ref)
+
+    return sorted(resources.values(), key=lambda r: r.name)
+
+
+def load_spec(spec_path: str | Path) -> dict:
+    with open(spec_path) as f:
+        return yaml.safe_load(f)

--- a/mock/pyproject.toml
+++ b/mock/pyproject.toml
@@ -1,0 +1,17 @@
+[project]
+name = "fulfillment-mock"
+version = "0.1.0"
+description = "Lightweight mock server for the OSAC fulfillment-service REST API"
+requires-python = ">=3.12"
+dependencies = [
+    "fastapi>=0.115",
+    "uvicorn[standard]>=0.34",
+    "pyyaml>=6.0",
+    "pyjwt[crypto]>=2.9",
+    "cryptography>=44.0",
+    "sse-starlette>=2.2",
+    "python-multipart>=0.0.18",
+]
+
+[project.scripts]
+fulfillment-mock = "mock_server:main"

--- a/mock/scenarios/default.yaml
+++ b/mock/scenarios/default.yaml
@@ -1,0 +1,509 @@
+name: "Default UI Development Scenario"
+description: >
+  Pre-populated resources for a realistic UI development environment.
+  Includes resources across multiple tenants in various states.
+
+resources:
+  # --- Platform resources (no tenant, admin-only creation) ---
+
+  - type: network_classes
+    id: "nc-udn-001"
+    metadata:
+      name: "udn-net"
+    spec:
+      implementation_strategy: "cudn_net"
+      capabilities:
+        supports_ipv4: true
+        supports_ipv6: true
+        supports_dual_stack: true
+    status:
+      state: "NETWORK_CLASS_STATE_READY"
+
+  - type: network_classes
+    id: "nc-phys-001"
+    metadata:
+      name: "phys-net"
+    spec:
+      implementation_strategy: "phys_net"
+      capabilities:
+        supports_ipv4: true
+        supports_ipv6: false
+        supports_dual_stack: false
+    status:
+      state: "NETWORK_CLASS_STATE_READY"
+
+  - type: instance_types
+    id: "it-small-001"
+    metadata:
+      name: "small"
+    title: "Small"
+    spec:
+      cpus: 2
+      memory_gib: 4
+
+  - type: instance_types
+    id: "it-medium-001"
+    metadata:
+      name: "medium"
+    title: "Medium"
+    spec:
+      cpus: 4
+      memory_gib: 8
+
+  - type: instance_types
+    id: "it-large-001"
+    metadata:
+      name: "large"
+    title: "Large"
+    spec:
+      cpus: 8
+      memory_gib: 16
+
+  - type: host_types
+    id: "ht-standard-001"
+    metadata:
+      name: "standard"
+    title: "Standard Host"
+    spec:
+      cpus: 64
+      memory_gib: 256
+
+  - type: cluster_templates
+    id: "tpl-ocp-417-small"
+    metadata:
+      name: "ocp-4-17-small"
+    title: "OpenShift 4.17 Small"
+    description: "Single control plane, 2 worker nodes"
+
+  - type: cluster_templates
+    id: "tpl-ocp-417-medium"
+    metadata:
+      name: "ocp-4-17-medium"
+    title: "OpenShift 4.17 Medium"
+    description: "3 control plane nodes, 4 worker nodes"
+
+  - type: compute_instance_templates
+    id: "tpl-ci-rhel9"
+    metadata:
+      name: "rhel9-base"
+    title: "RHEL 9 Base"
+    description: "Red Hat Enterprise Linux 9 base image"
+
+  - type: public_ip_pools
+    id: "pool-public-001"
+    metadata:
+      name: "public-ipv4"
+    spec:
+      cidr: "203.0.113.0/24"
+    status:
+      state: "PUBLIC_IP_POOL_STATE_READY"
+
+  # --- Tenants ---
+
+  - type: tenants
+    id: "tenant-engineering"
+    metadata:
+      name: "engineering"
+    spec: {}
+    status: {}
+
+  - type: tenants
+    id: "tenant-sales"
+    metadata:
+      name: "sales"
+    spec: {}
+    status: {}
+
+  # --- Engineering tenant: networking ---
+
+  - type: virtual_networks
+    id: "vn-eng-prod"
+    metadata:
+      name: "prod-network"
+      tenant: "engineering"
+    spec:
+      network_class: "nc-udn-001"
+      ipv4_cidr: "10.0.0.0/16"
+      capabilities:
+        enable_ipv4: true
+    status:
+      state: "VIRTUAL_NETWORK_STATE_READY"
+      message: ""
+
+  - type: virtual_networks
+    id: "vn-eng-staging"
+    metadata:
+      name: "staging-network"
+      tenant: "engineering"
+    spec:
+      network_class: "nc-udn-001"
+      ipv4_cidr: "10.1.0.0/16"
+      capabilities:
+        enable_ipv4: true
+    status:
+      state: "VIRTUAL_NETWORK_STATE_PENDING"
+
+  - type: virtual_networks
+    id: "vn-eng-failed"
+    metadata:
+      name: "bad-network"
+      tenant: "engineering"
+    spec:
+      network_class: "nc-phys-001"
+      ipv4_cidr: "invalid-cidr"
+      ipv6_cidr: "2001:db8::/48"
+      capabilities:
+        enable_dual_stack: true
+    status:
+      state: "VIRTUAL_NETWORK_STATE_FAILED"
+      message: "NetworkClass 'phys-net' does not support dual-stack"
+
+  - type: subnets
+    id: "sn-eng-prod-a"
+    metadata:
+      name: "prod-subnet-a"
+      tenant: "engineering"
+      annotations:
+        "osac.openshift.io/owner-reference": "vn-eng-prod"
+    spec:
+      virtual_network: "vn-eng-prod"
+      ipv4_cidr: "10.0.1.0/24"
+    status:
+      state: "SUBNET_STATE_READY"
+
+  - type: subnets
+    id: "sn-eng-prod-b"
+    metadata:
+      name: "prod-subnet-b"
+      tenant: "engineering"
+      annotations:
+        "osac.openshift.io/owner-reference": "vn-eng-prod"
+    spec:
+      virtual_network: "vn-eng-prod"
+      ipv4_cidr: "10.0.2.0/24"
+    status:
+      state: "SUBNET_STATE_READY"
+
+  - type: security_groups
+    id: "sg-eng-web"
+    metadata:
+      name: "web-traffic"
+      tenant: "engineering"
+      annotations:
+        "osac.openshift.io/owner-reference": "vn-eng-prod"
+    spec:
+      virtual_network: "vn-eng-prod"
+      ingress:
+        - protocol: "TCP"
+          port_range_min: 80
+          port_range_max: 80
+          ipv4_cidr: "0.0.0.0/0"
+        - protocol: "TCP"
+          port_range_min: 443
+          port_range_max: 443
+          ipv4_cidr: "0.0.0.0/0"
+      egress:
+        - protocol: "TCP"
+          port_range_min: 0
+          port_range_max: 65535
+          ipv4_cidr: "0.0.0.0/0"
+    status:
+      state: "SECURITY_GROUP_STATE_READY"
+
+  - type: security_groups
+    id: "sg-eng-ssh"
+    metadata:
+      name: "ssh-access"
+      tenant: "engineering"
+      annotations:
+        "osac.openshift.io/owner-reference": "vn-eng-prod"
+    spec:
+      virtual_network: "vn-eng-prod"
+      ingress:
+        - protocol: "TCP"
+          port_range_min: 22
+          port_range_max: 22
+          ipv4_cidr: "10.0.0.0/8"
+    status:
+      state: "SECURITY_GROUP_STATE_READY"
+
+  # --- Engineering tenant: compute instances ---
+
+  - type: compute_instances
+    id: "ci-eng-web-1"
+    metadata:
+      name: "web-server-1"
+      tenant: "engineering"
+      labels:
+        role: "web"
+        env: "production"
+    spec:
+      instance_type: "it-medium-001"
+      image:
+        source_type: "IMAGE_SOURCE_TYPE_URL"
+        source_ref: "https://images.example.com/rhel9.qcow2"
+      network_attachments:
+        - subnet: "sn-eng-prod-a"
+          security_groups: ["sg-eng-web", "sg-eng-ssh"]
+    status:
+      state: "COMPUTE_INSTANCE_STATE_RUNNING"
+      internal_ip_address: "10.0.1.10"
+
+  - type: compute_instances
+    id: "ci-eng-web-2"
+    metadata:
+      name: "web-server-2"
+      tenant: "engineering"
+      labels:
+        role: "web"
+        env: "production"
+    spec:
+      instance_type: "it-medium-001"
+      image:
+        source_type: "IMAGE_SOURCE_TYPE_URL"
+        source_ref: "https://images.example.com/rhel9.qcow2"
+      network_attachments:
+        - subnet: "sn-eng-prod-a"
+          security_groups: ["sg-eng-web"]
+    status:
+      state: "COMPUTE_INSTANCE_STATE_RUNNING"
+      internal_ip_address: "10.0.1.11"
+
+  - type: compute_instances
+    id: "ci-eng-db-1"
+    metadata:
+      name: "database-1"
+      tenant: "engineering"
+      labels:
+        role: "database"
+        env: "production"
+    spec:
+      instance_type: "it-large-001"
+      image:
+        source_type: "IMAGE_SOURCE_TYPE_URL"
+        source_ref: "https://images.example.com/rhel9.qcow2"
+      network_attachments:
+        - subnet: "sn-eng-prod-b"
+          security_groups: ["sg-eng-ssh"]
+    status:
+      state: "COMPUTE_INSTANCE_STATE_RUNNING"
+      internal_ip_address: "10.0.2.10"
+
+  - type: compute_instances
+    id: "ci-eng-new"
+    metadata:
+      name: "staging-app"
+      tenant: "engineering"
+      labels:
+        role: "app"
+        env: "staging"
+    spec:
+      instance_type: "it-small-001"
+      image:
+        source_type: "IMAGE_SOURCE_TYPE_URL"
+        source_ref: "https://images.example.com/rhel9.qcow2"
+      network_attachments:
+        - subnet: "sn-eng-prod-a"
+    status:
+      state: "COMPUTE_INSTANCE_STATE_STARTING"
+
+  - type: compute_instances
+    id: "ci-eng-stopped"
+    metadata:
+      name: "dev-box"
+      tenant: "engineering"
+      labels:
+        role: "dev"
+        env: "development"
+    spec:
+      instance_type: "it-small-001"
+      run_strategy: "Halted"
+    status:
+      state: "COMPUTE_INSTANCE_STATE_STOPPED"
+
+  # --- Engineering tenant: clusters ---
+
+  - type: clusters
+    id: "cl-eng-prod"
+    metadata:
+      name: "prod-cluster"
+      tenant: "engineering"
+      labels:
+        env: "production"
+    spec:
+      template: "tpl-ocp-417-medium"
+    status:
+      state: "CLUSTER_STATE_READY"
+      api_url: "https://api.prod-cluster.mock.osac.dev:6443"
+      console_url: "https://console.prod-cluster.mock.osac.dev"
+
+  - type: clusters
+    id: "cl-eng-staging"
+    metadata:
+      name: "staging-cluster"
+      tenant: "engineering"
+      labels:
+        env: "staging"
+    spec:
+      template: "tpl-ocp-417-small"
+    status:
+      state: "CLUSTER_STATE_PROGRESSING"
+
+  - type: clusters
+    id: "cl-eng-failed"
+    metadata:
+      name: "broken-cluster"
+      tenant: "engineering"
+      labels:
+        env: "test"
+    spec:
+      template: "tpl-ocp-417-small"
+    status:
+      state: "CLUSTER_STATE_FAILED"
+      message: "Insufficient host capacity in region"
+
+  # --- Engineering tenant: public IPs ---
+
+  - type: public_ips
+    id: "pip-eng-web"
+    metadata:
+      name: "web-public-ip"
+      tenant: "engineering"
+    spec:
+      pool: "pool-public-001"
+    status:
+      state: "PUBLIC_IP_STATE_ALLOCATED"
+      address: "203.0.113.10"
+      pool: "pool-public-001"
+
+  - type: public_ip_attachments
+    id: "pipa-eng-web"
+    metadata:
+      name: "web-ip-attachment"
+      tenant: "engineering"
+    spec:
+      public_ip: "pip-eng-web"
+      target: "ci-eng-web-1"
+    status:
+      state: "PUBLIC_IP_ATTACHMENT_STATE_READY"
+
+  # --- Sales tenant: networking ---
+
+  - type: virtual_networks
+    id: "vn-sales-prod"
+    metadata:
+      name: "sales-network"
+      tenant: "sales"
+    spec:
+      network_class: "nc-udn-001"
+      ipv4_cidr: "10.10.0.0/16"
+      capabilities:
+        enable_ipv4: true
+    status:
+      state: "VIRTUAL_NETWORK_STATE_READY"
+
+  - type: subnets
+    id: "sn-sales-prod"
+    metadata:
+      name: "sales-subnet"
+      tenant: "sales"
+      annotations:
+        "osac.openshift.io/owner-reference": "vn-sales-prod"
+    spec:
+      virtual_network: "vn-sales-prod"
+      ipv4_cidr: "10.10.1.0/24"
+    status:
+      state: "SUBNET_STATE_READY"
+
+  # --- Sales tenant: compute ---
+
+  - type: compute_instances
+    id: "ci-sales-crm"
+    metadata:
+      name: "crm-server"
+      tenant: "sales"
+      labels:
+        role: "crm"
+    spec:
+      instance_type: "it-medium-001"
+    status:
+      state: "COMPUTE_INSTANCE_STATE_RUNNING"
+      internal_ip_address: "10.10.1.10"
+
+  # --- Users and roles ---
+
+  - type: users
+    id: "user-adam"
+    metadata:
+      name: "adam"
+      tenant: "engineering"
+    spec:
+      email: "adam@example.com"
+
+  - type: users
+    id: "user-ben"
+    metadata:
+      name: "ben"
+      tenant: "engineering"
+    spec:
+      email: "ben@example.com"
+
+  - type: users
+    id: "user-charles"
+    metadata:
+      name: "charles"
+      tenant: "sales"
+    spec:
+      email: "charles@example.com"
+
+  - type: roles
+    id: "role-tenant-admin"
+    metadata:
+      name: "tenant-admin"
+    spec:
+      permissions:
+        - "clusters:*"
+        - "compute_instances:*"
+        - "virtual_networks:*"
+        - "subnets:*"
+        - "security_groups:*"
+        - "users:*"
+
+  - type: roles
+    id: "role-tenant-user"
+    metadata:
+      name: "tenant-user"
+    spec:
+      permissions:
+        - "clusters:read"
+        - "compute_instances:*"
+        - "virtual_networks:read"
+        - "subnets:read"
+        - "security_groups:read"
+
+  - type: role_bindings
+    id: "rb-adam-admin"
+    metadata:
+      name: "adam-engineering-admin"
+      tenant: "engineering"
+    spec:
+      role: "role-tenant-admin"
+      user: "user-adam"
+
+  - type: role_bindings
+    id: "rb-ben-user"
+    metadata:
+      name: "ben-engineering-user"
+      tenant: "engineering"
+    spec:
+      role: "role-tenant-user"
+      user: "user-ben"
+
+  - type: role_bindings
+    id: "rb-charles-user"
+    metadata:
+      name: "charles-sales-user"
+      tenant: "sales"
+    spec:
+      role: "role-tenant-user"
+      user: "user-charles"

--- a/mock/state_machines.py
+++ b/mock/state_machines.py
@@ -17,7 +17,6 @@ def _random_ip(base: str = "10.0.1") -> str:
 
 
 def _populate_cluster_ready(obj: dict) -> dict:
-    resource_id = obj.get("id", "unknown")
     name = obj.get("metadata", {}).get("name", "cluster")
     return {
         "status": {

--- a/mock/state_machines.py
+++ b/mock/state_machines.py
@@ -263,8 +263,9 @@ async def run_ticker(store: ResourceStore, interval: float = 0.5) -> None:
                     }
                     _set_nested(updates, config.state_field, transition.fail_state)
                     _set_nested(updates, "status.message", error_msg)
-                    await store.update_internal(resource_type, resource_id, updates)
-                    store._emit("OBJECT_UPDATED", resource_type, obj)
+                    result = await store.update_internal(resource_type, resource_id, updates)
+                    if result:
+                        store._emit("OBJECT_UPDATED", resource_type, result)
                 else:
                     updates = {
                         "_mock_entered_state_at": now.isoformat(),
@@ -328,8 +329,9 @@ async def _check_fail_after(
             new_labels = dict(labels)
             del new_labels[f"{MOCK_LABEL_PREFIX}fail-after"]
             updates.setdefault("metadata", {})["labels"] = new_labels
-            await store.update_internal(resource_type, resource_id, updates)
-            store._emit("OBJECT_UPDATED", resource_type, obj)
+            result = await store.update_internal(resource_type, resource_id, updates)
+            if result:
+                store._emit("OBJECT_UPDATED", resource_type, result)
             return
 
 

--- a/mock/state_machines.py
+++ b/mock/state_machines.py
@@ -1,0 +1,346 @@
+"""Per-resource state machine definitions and background ticker."""
+
+from __future__ import annotations
+
+import asyncio
+import random
+from datetime import datetime, timezone
+from typing import Any
+
+from store import ResourceStore
+
+MOCK_LABEL_PREFIX = "mock.osac.dev/"
+
+
+def _random_ip(base: str = "10.0.1") -> str:
+    return f"{base}.{random.randint(2, 254)}"
+
+
+def _populate_cluster_ready(obj: dict) -> dict:
+    resource_id = obj.get("id", "unknown")
+    name = obj.get("metadata", {}).get("name", "cluster")
+    return {
+        "status": {
+            "api_url": f"https://api.{name}.mock.osac.dev:6443",
+            "console_url": f"https://console.{name}.mock.osac.dev",
+        }
+    }
+
+
+def _populate_compute_instance_running(obj: dict) -> dict:
+    return {
+        "status": {
+            "internal_ip_address": _random_ip(),
+        }
+    }
+
+
+def _populate_public_ip_allocated(obj: dict) -> dict:
+    pool = obj.get("spec", {}).get("pool", "")
+    return {
+        "status": {
+            "address": f"203.0.113.{random.randint(1, 254)}",
+            "pool": pool,
+        }
+    }
+
+
+def _populate_external_ip_allocated(obj: dict) -> dict:
+    pool = obj.get("spec", {}).get("pool", "")
+    return {
+        "status": {
+            "address": f"198.51.100.{random.randint(1, 254)}",
+            "pool": pool,
+        }
+    }
+
+
+class Transition:
+    def __init__(
+        self,
+        next_state: str,
+        delay: float = 1.0,
+        fail_state: str | None = None,
+        on_ready: Any = None,
+    ):
+        self.next_state = next_state
+        self.delay = delay
+        self.fail_state = fail_state
+        self.on_ready = on_ready
+
+
+class StateMachineConfig:
+    def __init__(
+        self,
+        state_field: str = "status.state",
+        initial_state: str = "",
+        transitions: dict[str, Transition] | None = None,
+    ):
+        self.state_field = state_field
+        self.initial_state = initial_state
+        self.transitions = transitions or {}
+
+
+STATE_MACHINES: dict[str, StateMachineConfig] = {
+    "virtual_networks": StateMachineConfig(
+        initial_state="VIRTUAL_NETWORK_STATE_PENDING",
+        transitions={
+            "VIRTUAL_NETWORK_STATE_PENDING": Transition(
+                next_state="VIRTUAL_NETWORK_STATE_READY",
+                delay=1.0,
+                fail_state="VIRTUAL_NETWORK_STATE_FAILED",
+            ),
+        },
+    ),
+    "subnets": StateMachineConfig(
+        initial_state="SUBNET_STATE_PENDING",
+        transitions={
+            "SUBNET_STATE_PENDING": Transition(
+                next_state="SUBNET_STATE_READY",
+                delay=1.0,
+                fail_state="SUBNET_STATE_FAILED",
+            ),
+        },
+    ),
+    "security_groups": StateMachineConfig(
+        initial_state="SECURITY_GROUP_STATE_PENDING",
+        transitions={
+            "SECURITY_GROUP_STATE_PENDING": Transition(
+                next_state="SECURITY_GROUP_STATE_READY",
+                delay=0.5,
+                fail_state="SECURITY_GROUP_STATE_FAILED",
+            ),
+        },
+    ),
+    "clusters": StateMachineConfig(
+        initial_state="CLUSTER_STATE_PROGRESSING",
+        transitions={
+            "CLUSTER_STATE_PROGRESSING": Transition(
+                next_state="CLUSTER_STATE_READY",
+                delay=2.0,
+                fail_state="CLUSTER_STATE_FAILED",
+                on_ready=_populate_cluster_ready,
+            ),
+        },
+    ),
+    "compute_instances": StateMachineConfig(
+        initial_state="COMPUTE_INSTANCE_STATE_STARTING",
+        transitions={
+            "COMPUTE_INSTANCE_STATE_STARTING": Transition(
+                next_state="COMPUTE_INSTANCE_STATE_RUNNING",
+                delay=1.5,
+                fail_state="COMPUTE_INSTANCE_STATE_FAILED",
+                on_ready=_populate_compute_instance_running,
+            ),
+        },
+    ),
+    "baremetal_instances": StateMachineConfig(
+        initial_state="BARE_METAL_INSTANCE_STATE_PROVISIONING",
+        transitions={
+            "BARE_METAL_INSTANCE_STATE_PROVISIONING": Transition(
+                next_state="BARE_METAL_INSTANCE_STATE_RUNNING",
+                delay=3.0,
+                fail_state="BARE_METAL_INSTANCE_STATE_FAILED",
+            ),
+        },
+    ),
+    "public_ips": StateMachineConfig(
+        initial_state="PUBLIC_IP_STATE_PENDING",
+        transitions={
+            "PUBLIC_IP_STATE_PENDING": Transition(
+                next_state="PUBLIC_IP_STATE_ALLOCATED",
+                delay=1.0,
+                fail_state="PUBLIC_IP_STATE_FAILED",
+                on_ready=_populate_public_ip_allocated,
+            ),
+        },
+    ),
+    "public_ip_attachments": StateMachineConfig(
+        initial_state="PUBLIC_IP_ATTACHMENT_STATE_PENDING",
+        transitions={
+            "PUBLIC_IP_ATTACHMENT_STATE_PENDING": Transition(
+                next_state="PUBLIC_IP_ATTACHMENT_STATE_READY",
+                delay=0.5,
+                fail_state="PUBLIC_IP_ATTACHMENT_STATE_FAILED",
+            ),
+        },
+    ),
+    "external_ips": StateMachineConfig(
+        initial_state="EXTERNAL_IP_STATE_PENDING",
+        transitions={
+            "EXTERNAL_IP_STATE_PENDING": Transition(
+                next_state="EXTERNAL_IP_STATE_ALLOCATED",
+                delay=1.0,
+                fail_state="EXTERNAL_IP_STATE_FAILED",
+                on_ready=_populate_external_ip_allocated,
+            ),
+        },
+    ),
+    "external_ip_attachments": StateMachineConfig(
+        initial_state="EXTERNAL_IP_ATTACHMENT_STATE_PENDING",
+        transitions={
+            "EXTERNAL_IP_ATTACHMENT_STATE_PENDING": Transition(
+                next_state="EXTERNAL_IP_ATTACHMENT_STATE_READY",
+                delay=0.5,
+                fail_state="EXTERNAL_IP_ATTACHMENT_STATE_FAILED",
+            ),
+        },
+    ),
+}
+
+
+def _get_nested(obj: dict, path: str) -> Any:
+    parts = path.split(".")
+    node = obj
+    for part in parts:
+        if not isinstance(node, dict):
+            return None
+        node = node.get(part)
+    return node
+
+
+def _set_nested(obj: dict, path: str, value: Any) -> None:
+    parts = path.split(".")
+    node = obj
+    for part in parts[:-1]:
+        node = node.setdefault(part, {})
+    node[parts[-1]] = value
+
+
+def _deep_merge(base: dict, override: dict) -> None:
+    for key, value in override.items():
+        if isinstance(value, dict) and isinstance(base.get(key), dict):
+            _deep_merge(base[key], value)
+        else:
+            base[key] = value
+
+
+async def run_ticker(store: ResourceStore, interval: float = 0.5) -> None:
+    """Background task that advances resource state machines."""
+    while True:
+        await asyncio.sleep(interval)
+        now = datetime.now(timezone.utc)
+
+        for resource_type, config in STATE_MACHINES.items():
+            resources = await store.all_resources(resource_type)
+            for resource_id, obj in resources:
+                current_state = _get_nested(obj, config.state_field)
+                if current_state is None:
+                    continue
+
+                transition = config.transitions.get(current_state)
+                if transition is None:
+                    # Check for fail-after on terminal states
+                    await _check_fail_after(store, resource_type, resource_id, obj, config, now)
+                    continue
+
+                entered_at_str = obj.get("_mock_entered_state_at")
+                if not entered_at_str:
+                    continue
+
+                entered_at = datetime.fromisoformat(entered_at_str)
+                elapsed = (now - entered_at).total_seconds()
+
+                labels = obj.get("metadata", {}).get("labels", {})
+                delay = transition.delay
+                custom_delay = labels.get(f"{MOCK_LABEL_PREFIX}provision-delay")
+                if custom_delay:
+                    try:
+                        delay = _parse_duration(custom_delay)
+                    except ValueError:
+                        pass
+
+                if elapsed < delay:
+                    continue
+
+                should_fail = labels.get(f"{MOCK_LABEL_PREFIX}fail-provision") == "true"
+                if should_fail and transition.fail_state:
+                    error_msg = labels.get(
+                        f"{MOCK_LABEL_PREFIX}error-message",
+                        "Simulated provisioning failure",
+                    )
+                    updates: dict[str, Any] = {
+                        "_mock_entered_state_at": now.isoformat(),
+                    }
+                    _set_nested(updates, config.state_field, transition.fail_state)
+                    _set_nested(updates, "status.message", error_msg)
+                    await store.update_internal(resource_type, resource_id, updates)
+                    store._emit("OBJECT_UPDATED", resource_type, obj)
+                else:
+                    updates = {
+                        "_mock_entered_state_at": now.isoformat(),
+                    }
+                    _set_nested(updates, config.state_field, transition.next_state)
+                    _set_nested(updates, "status.message", "")
+
+                    if transition.on_ready:
+                        extra = transition.on_ready(obj)
+                        if extra:
+                            _deep_merge(updates, extra)
+
+                    result = await store.update_internal(
+                        resource_type, resource_id, updates
+                    )
+                    if result:
+                        store._emit("OBJECT_UPDATED", resource_type, result)
+
+
+async def _check_fail_after(
+    store: ResourceStore,
+    resource_type: str,
+    resource_id: str,
+    obj: dict,
+    config: StateMachineConfig,
+    now: datetime,
+) -> None:
+    """Handle fail-after label: transition to FAILED after reaching a ready state."""
+    labels = obj.get("metadata", {}).get("labels", {})
+    fail_after_str = labels.get(f"{MOCK_LABEL_PREFIX}fail-after")
+    if not fail_after_str:
+        return
+
+    entered_at_str = obj.get("_mock_entered_state_at")
+    if not entered_at_str:
+        return
+
+    entered_at = datetime.fromisoformat(entered_at_str)
+    elapsed = (now - entered_at).total_seconds()
+
+    try:
+        fail_after = _parse_duration(fail_after_str)
+    except ValueError:
+        return
+
+    if elapsed < fail_after:
+        return
+
+    current_state = _get_nested(obj, config.state_field) or ""
+    for transition in config.transitions.values():
+        if transition.fail_state and current_state == transition.next_state:
+            error_msg = labels.get(
+                f"{MOCK_LABEL_PREFIX}error-message",
+                "Simulated delayed failure",
+            )
+            updates: dict[str, Any] = {
+                "_mock_entered_state_at": now.isoformat(),
+            }
+            _set_nested(updates, config.state_field, transition.fail_state)
+            _set_nested(updates, "status.message", error_msg)
+            new_labels = dict(labels)
+            del new_labels[f"{MOCK_LABEL_PREFIX}fail-after"]
+            updates.setdefault("metadata", {})["labels"] = new_labels
+            await store.update_internal(resource_type, resource_id, updates)
+            store._emit("OBJECT_UPDATED", resource_type, obj)
+            return
+
+
+def _parse_duration(s: str) -> float:
+    """Parse a duration string like '3s', '1.5s', '500ms'."""
+    s = s.strip()
+    if s.endswith("ms"):
+        return float(s[:-2]) / 1000
+    if s.endswith("s"):
+        return float(s[:-1])
+    if s.endswith("m"):
+        return float(s[:-1]) * 60
+    return float(s)

--- a/mock/store.py
+++ b/mock/store.py
@@ -142,17 +142,23 @@ class ResourceStore:
                 if obj_tenant and obj_tenant != tenant:
                     raise NotFoundError()
 
+            current_version = obj.get("metadata", {}).get("version", 0)
             if lock:
-                incoming_version = (
-                    updates.get("metadata", {}).get("version")
-                    or updates.get("object", {}).get("metadata", {}).get("version")
-                )
-                current_version = obj.get("metadata", {}).get("version", 0)
-                if incoming_version is not None and incoming_version != current_version:
+                incoming_version = updates.get("metadata", {}).get("version")
+                if incoming_version is None or incoming_version != current_version:
                     raise ConflictError()
 
+            updates = copy.deepcopy(updates)
+            update_meta = updates.get("metadata", {})
+            for protected in ("version", "tenant", "creator", "creation_timestamp"):
+                update_meta.pop(protected, None)
+            if update_meta:
+                updates["metadata"] = update_meta
+            elif "metadata" in updates:
+                del updates["metadata"]
+
             _deep_merge(obj, updates)
-            obj["metadata"]["version"] = obj["metadata"].get("version", 0) + 1
+            obj["metadata"]["version"] = current_version + 1
             bucket[resource_id] = obj
             result = copy.deepcopy(obj)
 

--- a/mock/store.py
+++ b/mock/store.py
@@ -1,0 +1,259 @@
+"""In-memory resource store with CRUD operations and tenant scoping."""
+
+from __future__ import annotations
+
+import asyncio
+import copy
+import uuid
+from datetime import datetime, timezone
+from typing import Any, Callable
+
+
+class ConflictError(Exception):
+    pass
+
+
+class NotFoundError(Exception):
+    pass
+
+
+class BadRequestError(Exception):
+    def __init__(self, message: str = "Bad request"):
+        self.message = message
+        super().__init__(message)
+
+
+class ResourceStore:
+    def __init__(self) -> None:
+        self._data: dict[str, dict[str, dict]] = {}
+        self._lock = asyncio.Lock()
+        self._event_callback: Callable[[str, str, str, dict], None] | None = None
+
+    def set_event_callback(
+        self, cb: Callable[[str, str, str, dict], None]
+    ) -> None:
+        """Set callback(event_type, resource_type, resource_id, obj) for state changes."""
+        self._event_callback = cb
+
+    def _emit(self, event_type: str, resource_type: str, obj: dict) -> None:
+        if self._event_callback:
+            self._event_callback(event_type, resource_type, obj.get("id", ""), obj)
+
+    async def list(
+        self,
+        resource_type: str,
+        tenant: str | None = None,
+        filter_fn: Callable[[dict], bool] | None = None,
+        offset: int = 0,
+        limit: int | None = None,
+    ) -> tuple[list[dict], int]:
+        async with self._lock:
+            bucket = self._data.get(resource_type, {})
+            items = list(bucket.values())
+
+        if tenant and tenant != "*":
+            items = [
+                i
+                for i in items
+                if i.get("metadata", {}).get("tenant", "") in (tenant, "", None)
+            ]
+
+        if filter_fn:
+            items = [i for i in items if filter_fn(i)]
+
+        total = len(items)
+        if offset:
+            items = items[offset:]
+        if limit is not None and limit > 0:
+            items = items[:limit]
+
+        return [_strip_internal(i) for i in items], total
+
+    async def get(
+        self, resource_type: str, resource_id: str, tenant: str | None = None
+    ) -> dict:
+        async with self._lock:
+            bucket = self._data.get(resource_type, {})
+            obj = bucket.get(resource_id)
+
+        if obj is None:
+            raise NotFoundError()
+
+        if tenant and tenant != "*":
+            obj_tenant = obj.get("metadata", {}).get("tenant", "")
+            if obj_tenant and obj_tenant != tenant:
+                raise NotFoundError()
+
+        return _strip_internal(obj)
+
+    async def create(
+        self,
+        resource_type: str,
+        obj: dict,
+        tenant: str = "",
+        creator: str = "",
+        initial_state: str | None = None,
+        state_field: str = "status.state",
+    ) -> dict:
+        resource_id = obj.get("id") or str(uuid.uuid4())
+        now = datetime.now(timezone.utc).isoformat()
+
+        metadata = obj.get("metadata", {})
+        metadata.setdefault("creation_timestamp", now)
+        metadata.setdefault("version", 1)
+        metadata.setdefault("labels", {})
+        metadata.setdefault("annotations", {})
+        if tenant:
+            metadata["tenant"] = tenant
+        if creator:
+            metadata["creator"] = creator
+        obj["metadata"] = metadata
+        obj["id"] = resource_id
+
+        if initial_state:
+            _set_nested(obj, state_field, initial_state)
+            obj["_mock_entered_state_at"] = now
+
+        async with self._lock:
+            bucket = self._data.setdefault(resource_type, {})
+            if resource_id in bucket:
+                raise ConflictError()
+            bucket[resource_id] = copy.deepcopy(obj)
+
+        self._emit("OBJECT_CREATED", resource_type, obj)
+        return _strip_internal(obj)
+
+    async def update(
+        self,
+        resource_type: str,
+        resource_id: str,
+        updates: dict,
+        lock: bool = False,
+        tenant: str | None = None,
+    ) -> dict:
+        async with self._lock:
+            bucket = self._data.get(resource_type, {})
+            obj = bucket.get(resource_id)
+            if obj is None:
+                raise NotFoundError()
+
+            if tenant and tenant != "*":
+                obj_tenant = obj.get("metadata", {}).get("tenant", "")
+                if obj_tenant and obj_tenant != tenant:
+                    raise NotFoundError()
+
+            if lock:
+                incoming_version = (
+                    updates.get("metadata", {}).get("version")
+                    or updates.get("object", {}).get("metadata", {}).get("version")
+                )
+                current_version = obj.get("metadata", {}).get("version", 0)
+                if incoming_version is not None and incoming_version != current_version:
+                    raise ConflictError()
+
+            _deep_merge(obj, updates)
+            obj["metadata"]["version"] = obj["metadata"].get("version", 0) + 1
+            bucket[resource_id] = obj
+            result = copy.deepcopy(obj)
+
+        self._emit("OBJECT_UPDATED", resource_type, result)
+        return _strip_internal(result)
+
+    async def delete(
+        self,
+        resource_type: str,
+        resource_id: str,
+        tenant: str | None = None,
+    ) -> bool:
+        async with self._lock:
+            bucket = self._data.get(resource_type, {})
+            obj = bucket.get(resource_id)
+            if obj is None:
+                raise NotFoundError()
+
+            if tenant and tenant != "*":
+                obj_tenant = obj.get("metadata", {}).get("tenant", "")
+                if obj_tenant and obj_tenant != tenant:
+                    raise NotFoundError()
+
+            deleted = bucket.pop(resource_id, None)
+
+        if deleted:
+            self._emit("OBJECT_DELETED", resource_type, deleted)
+        return deleted is not None
+
+    async def update_internal(
+        self, resource_type: str, resource_id: str, updates: dict
+    ) -> dict | None:
+        """Update without version bump or tenant check — used by state machine."""
+        async with self._lock:
+            bucket = self._data.get(resource_type, {})
+            obj = bucket.get(resource_id)
+            if obj is None:
+                return None
+            _deep_merge(obj, updates)
+            return copy.deepcopy(obj)
+
+    async def get_internal(self, resource_type: str, resource_id: str) -> dict | None:
+        """Get raw object including internal fields."""
+        async with self._lock:
+            bucket = self._data.get(resource_type, {})
+            obj = bucket.get(resource_id)
+            return copy.deepcopy(obj) if obj else None
+
+    async def all_resources(
+        self, resource_type: str
+    ) -> list[tuple[str, dict]]:
+        """Return all (id, obj) pairs for a resource type, including internal fields."""
+        async with self._lock:
+            bucket = self._data.get(resource_type, {})
+            return [(k, copy.deepcopy(v)) for k, v in bucket.items()]
+
+    async def insert_raw(self, resource_type: str, obj: dict) -> None:
+        """Insert a pre-built object directly — used by scenario loader."""
+        resource_id = obj.get("id") or str(uuid.uuid4())
+        obj["id"] = resource_id
+        async with self._lock:
+            bucket = self._data.setdefault(resource_type, {})
+            bucket[resource_id] = copy.deepcopy(obj)
+
+
+def _strip_internal(obj: dict) -> dict:
+    result = copy.deepcopy(obj)
+    for key in list(result.keys()):
+        if key.startswith("_mock_"):
+            del result[key]
+    return result
+
+
+def _deep_merge(base: dict, override: dict) -> None:
+    for key, value in override.items():
+        if key == "id":
+            continue
+        if (
+            isinstance(value, dict)
+            and isinstance(base.get(key), dict)
+            and key != "labels"
+            and key != "annotations"
+        ):
+            _deep_merge(base[key], value)
+        else:
+            base[key] = copy.deepcopy(value)
+
+
+def _set_nested(obj: dict, path: str, value: Any) -> None:
+    parts = path.split(".")
+    node = obj
+    for part in parts[:-1]:
+        node = node.setdefault(part, {})
+    node[parts[-1]] = value
+
+
+def _get_nested(obj: dict, path: str) -> Any:
+    parts = path.split(".")
+    node = obj
+    for part in parts:
+        if not isinstance(node, dict):
+            return None
+        node = node.get(part)
+    return node


### PR DESCRIPTION
## Summary

- Adds `mock/` directory with a self-contained Python (FastAPI) mock server that reads the OpenAPI v3 spec at startup and auto-discovers all 26+ resource types
- Provides JWT auth with pre-configured users and tenant isolation, state machine progression (resources transition through lifecycle states ~1s after creation), SSE event stream, failure injection via `mock.osac.dev/*` labels, and YAML-based scenario preloading
- Includes a default scenario with 40 resources across engineering/sales tenants in various states (READY, PENDING, FAILED, RUNNING, STOPPED)
- No code changes needed when APIs evolve — just regenerate the OpenAPI spec and restart

## How to run

```bash
cd fulfillment-service/mock
python3 -m venv .venv
.venv/bin/pip install -e .
.venv/bin/python mock_server.py --scenario scenarios/default.yaml
```

Or with auth disabled: `--no-auth`

## Key files

| File | Purpose |
|------|---------|
| `mock_server.py` | FastAPI app, CLI, route wiring |
| `openapi_loader.py` | Parses OpenAPI spec, discovers resource types |
| `store.py` | In-memory CRUD store with tenant scoping |
| `auth.py` | JWT/OIDC simulation with 4 pre-configured users |
| `state_machines.py` | Background ticker advancing resource states |
| `events.py` | SSE event stream on state changes |
| `filter_parser.py` | Minimal CEL-subset for List filtering |
| `scenarios/default.yaml` | 40 pre-loaded resources |
| `Containerfile` | Container image for UI devs |

## Test plan

- [x] Server starts and discovers 26 resource types from OpenAPI spec
- [x] CRUD operations work (List/Get/Create/Update/Delete)
- [x] JWT auth: token endpoint returns valid JWT, JWKS/OIDC discovery works
- [x] Unauthenticated requests return 401
- [x] Tenant isolation: users only see resources in their tenant
- [x] State machines: resources transition PENDING → READY after ~1s
- [x] Failure injection: `mock.osac.dev/fail-provision` label → FAILED state
- [x] SSE events emitted on create and state transitions
- [x] Scenario loading: 40 resources from default.yaml

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a standalone mock fulfillment service with container and CLI support.
  * Introduced built-in sign-in, token, and access-control behavior for testing.
  * Added event streaming, filtering, and scenario-based preloaded data for more realistic demos.
  * Dynamic API routes now support create, read, update, delete, pagination, and tenant-aware data handling.

* **Documentation**
  * Added setup and usage guidance for running the mock service locally or in a container.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->