### PR TITLE
OSAC-1853: externalize JWKS cache in console proxy JWE opener

### DIFF
--- a/charts/service/templates/console-proxy/deployment.yaml
+++ b/charts/service/templates/console-proxy/deployment.yaml
@@ -91,14 +91,8 @@ spec:
           containerPort: 8002
           protocol: TCP
         livenessProbe:
-          exec:
-            command:
-            - /usr/local/bin/fulfillment-service
-            - probe
-            - grpc-server
-            - --ca-file=/etc/fulfillment-console-proxy/tls/cas
-            - --grpc-server-address=localhost:8000
-            - --grpc-server-timeout=1s
+          tcpSocket:
+            port: 8000
           initialDelaySeconds: 5
           periodSeconds: 10
           timeoutSeconds: 5

--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/jackc/puddle/v2 v2.2.2
 	github.com/json-iterator/go v1.1.12
 	github.com/kelseyhightower/envconfig v1.4.0
+	github.com/lestrrat-go/httprc/v3 v3.0.5
 	github.com/lestrrat-go/jwx/v3 v3.1.1
 	github.com/mattn/go-colorable v0.1.15
 	github.com/mattn/go-isatty v0.0.22
@@ -93,7 +94,6 @@ require (
 	github.com/lestrrat-go/dsig v1.2.1 // indirect
 	github.com/lestrrat-go/dsig-secp256k1 v1.0.0 // indirect
 	github.com/lestrrat-go/httpcc v1.0.1 // indirect
-	github.com/lestrrat-go/httprc/v3 v3.0.5 // indirect
 	github.com/lestrrat-go/option/v2 v2.0.0 // indirect
 	github.com/lucasb-eyer/go-colorful v1.4.0 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect

--- a/internal/auth/jwe/jwe_test.go
+++ b/internal/auth/jwe/jwe_test.go
@@ -17,6 +17,7 @@ import (
 	"context"
 	"crypto/rand"
 	"crypto/rsa"
+	"crypto/tls"
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/base64"
@@ -33,6 +34,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/lestrrat-go/httprc/v3"
 	"github.com/lestrrat-go/jwx/v3/jwa"
 	"github.com/lestrrat-go/jwx/v3/jwe"
 	"github.com/lestrrat-go/jwx/v3/jwk"
@@ -130,7 +132,7 @@ var _ = Describe("Token", func() {
 				SetJWKSURL(jwksServer.URL).
 				SetIssuer(issuer).
 				SetAudience(audience).
-				SetCAPool(jwksCAPool).
+				SetCache(newTestCache(jwksServer.URL, jwksCAPool)).
 				Build()
 			Expect(err).ToNot(HaveOccurred())
 
@@ -160,7 +162,7 @@ var _ = Describe("Token", func() {
 				SetJWKSURL(jwksServer.URL).
 				SetIssuer(issuer).
 				SetAudience(audience).
-				SetCAPool(jwksCAPool).
+				SetCache(newTestCache(jwksServer.URL, jwksCAPool)).
 				Build()
 			Expect(err).ToNot(HaveOccurred())
 
@@ -186,7 +188,7 @@ var _ = Describe("Token", func() {
 				SetJWKSURL(jwksServer.URL).
 				SetIssuer(issuer).
 				SetAudience(audience).
-				SetCAPool(jwksCAPool).
+				SetCache(newTestCache(jwksServer.URL, jwksCAPool)).
 				Build()
 			Expect(err).ToNot(HaveOccurred())
 
@@ -211,7 +213,7 @@ var _ = Describe("Token", func() {
 				SetJWKSURL(jwksServer.URL).
 				SetIssuer(issuer).
 				SetAudience(audience).
-				SetCAPool(jwksCAPool).
+				SetCache(newTestCache(jwksServer.URL, jwksCAPool)).
 				Build()
 			Expect(err).ToNot(HaveOccurred())
 
@@ -244,7 +246,7 @@ var _ = Describe("Token", func() {
 				SetJWKSURL(jwksServer.URL).
 				SetIssuer(issuer).
 				SetAudience(audience).
-				SetCAPool(jwksCAPool).
+				SetCache(newTestCache(jwksServer.URL, jwksCAPool)).
 				Build()
 			Expect(err).ToNot(HaveOccurred())
 
@@ -282,7 +284,7 @@ var _ = Describe("Token", func() {
 				SetJWKSURL(jwksServer.URL).
 				SetIssuer(issuer).
 				SetAudience(audience).
-				SetCAPool(jwksCAPool).
+				SetCache(newTestCache(jwksServer.URL, jwksCAPool)).
 				Build()
 			Expect(err).ToNot(HaveOccurred())
 
@@ -343,7 +345,7 @@ var _ = Describe("Token", func() {
 				SetJWKSURL(jwksServer.URL).
 				SetIssuer(issuer).
 				SetAudience("aud-b").
-				SetCAPool(jwksCAPool).
+				SetCache(newTestCache(jwksServer.URL, jwksCAPool)).
 				Build()
 			Expect(err).ToNot(HaveOccurred())
 
@@ -366,7 +368,7 @@ var _ = Describe("Token", func() {
 				SetJWKSURL(jwksServer.URL).
 				SetIssuer(issuer).
 				SetAudience("my-service").
-				SetCAPool(jwksCAPool).
+				SetCache(newTestCache(jwksServer.URL, jwksCAPool)).
 				Build()
 			Expect(err).ToNot(HaveOccurred())
 
@@ -426,7 +428,7 @@ var _ = Describe("Token", func() {
 				SetJWKSURL(jwksServer.URL).
 				SetIssuer(issuer).
 				SetAudience("aud-b").
-				SetCAPool(jwksCAPool).
+				SetCache(newTestCache(jwksServer.URL, jwksCAPool)).
 				Build()
 			Expect(err).ToNot(HaveOccurred())
 
@@ -568,7 +570,7 @@ var _ = Describe("Token", func() {
 				SetJWKSURL(jwksServer.URL).
 				SetIssuer(issuer).
 				SetAudience(audience).
-				SetCAPool(jwksCAPool).
+				SetCache(newTestCache(jwksServer.URL, jwksCAPool)).
 				Build()
 			Expect(err).ToNot(HaveOccurred())
 
@@ -606,7 +608,7 @@ var _ = Describe("Token", func() {
 				SetJWKSURL(jwksServer.URL).
 				SetIssuer(issuer).
 				SetAudience(audience).
-				SetCAPool(jwksCAPool).
+				SetCache(newTestCache(jwksServer.URL, jwksCAPool)).
 				Build()
 			Expect(err).ToNot(HaveOccurred())
 
@@ -659,6 +661,25 @@ func countDots(s string) int {
 		}
 	}
 	return count
+}
+
+// newTestCache creates a jwk.Cache with the given test server URL registered and ready.
+func newTestCache(serverURL string, caPool *x509.CertPool) *jwk.Cache {
+	cache, err := jwk.NewCache(context.Background(), httprc.NewClient())
+	Expect(err).ToNot(HaveOccurred())
+	opts := []jwk.RegisterOption{}
+	if caPool != nil {
+		opts = append(opts, jwk.WithHTTPClient(
+			jwk.WrapHTTPClientDefaults(&http.Client{
+				Transport: &http.Transport{
+					TLSClientConfig: &tls.Config{RootCAs: caPool},
+				},
+			}),
+		))
+	}
+	err = cache.Register(context.Background(), serverURL, opts...)
+	Expect(err).ToNot(HaveOccurred())
+	return cache
 }
 
 // serveJWKS starts a TLS test server serving the sealer's JWKS and returns

--- a/internal/auth/jwe/opener.go
+++ b/internal/auth/jwe/opener.go
@@ -15,12 +15,9 @@ package jwe
 
 import (
 	"context"
-	"crypto/tls"
-	"crypto/x509"
 	"errors"
 	"fmt"
 	"log/slog"
-	"net/http"
 	"net/url"
 	"sync"
 	"time"
@@ -52,23 +49,22 @@ type OpenerBuilder struct {
 	jwksURL           string
 	issuer            string
 	audience          string
-	caPool            *x509.CertPool
+	cache             *jwk.Cache
 }
 
 // Opener decrypts nested JWTs (JWE, RSA-OAEP-256) and verifies the inner
 // JWS (RS256) against a JWKS fetched on demand when the token's kid is
-// unknown. Enforces single-use via JTI tracking.
+// unknown. Uses jwk.Cache for periodic background refresh and forces an
+// immediate re-fetch when a token's kid is not in the cached set.
+// Enforces single-use via JTI tracking.
 type Opener struct {
 	logger        *slog.Logger
 	decryptionKey *privateKeyReloader
 	jwksURL       string
 	issuer        string
 	audience      string
-	fetchOpts     []jwk.FetchOption  // TLS config reused for every jwk.Fetch call
-	jwks          jwk.Set            // cached JWKS, refreshed on unknown kid
-	jwksMu        sync.Mutex         // protects jwks and lastAttempt
-	lastAttempt   time.Time          // last JWKS refresh attempt, zero after Build
-	refreshGroup  singleflight.Group // coalesces concurrent JWKS refreshes
+	cache         *jwk.Cache         // periodically refreshes JWKS in background
+	refreshGroup  singleflight.Group // coalesces concurrent forced JWKS refreshes
 	mu            sync.Mutex
 	seen          map[string]time.Time // jti -> cleanup expiry
 }
@@ -78,7 +74,7 @@ func NewOpener() *OpenerBuilder {
 	return &OpenerBuilder{}
 }
 
-// SetContext sets the context used for the initial JWKS fetch and the JTI cleanup goroutine. This is mandatory.
+// SetContext sets the context used for loading the decryption key and the JTI cleanup goroutine. This is mandatory.
 func (b *OpenerBuilder) SetContext(value context.Context) *OpenerBuilder {
 	b.ctx = value
 	return b
@@ -114,10 +110,10 @@ func (b *OpenerBuilder) SetAudience(value string) *OpenerBuilder {
 	return b
 }
 
-// SetCAPool sets the CA certificate pool for TLS when fetching JWKS. This is optional; if not set, system roots
-// are used.
-func (b *OpenerBuilder) SetCAPool(value *x509.CertPool) *OpenerBuilder {
-	b.caPool = value
+// SetCache sets the JWKS cache used for key discovery and periodic refresh. The caller must
+// create the cache, register the JWKS URL, and configure TLS before passing it in. This is mandatory.
+func (b *OpenerBuilder) SetCache(value *jwk.Cache) *OpenerBuilder {
+	b.cache = value
 	return b
 }
 
@@ -136,11 +132,22 @@ func (b *OpenerBuilder) Build() (*Opener, error) {
 	if b.jwksURL == "" {
 		return nil, errors.New("JWKS URL is mandatory")
 	}
+	// OIDC Discovery (RFC 8414) requires jwks_uri to use HTTPS.
+	parsed, err := url.Parse(b.jwksURL)
+	if err != nil {
+		return nil, fmt.Errorf("parse JWKS URL %q: %w", b.jwksURL, err)
+	}
+	if parsed.Scheme != "https" {
+		return nil, fmt.Errorf("JWKS URL %q must use HTTPS scheme", b.jwksURL)
+	}
 	if b.issuer == "" {
 		return nil, errors.New("issuer is mandatory")
 	}
 	if b.audience == "" {
 		return nil, errors.New("audience is mandatory")
+	}
+	if b.cache == nil {
+		return nil, errors.New("cache is mandatory")
 	}
 
 	// Load the decryption key:
@@ -152,36 +159,6 @@ func (b *OpenerBuilder) Build() (*Opener, error) {
 		return nil, fmt.Errorf("initial load of decryption key: %w", err)
 	}
 
-	// OIDC Discovery (RFC 8414) requires jwks_uri to use HTTPS.
-	parsed, err := url.Parse(b.jwksURL)
-	if err != nil {
-		return nil, fmt.Errorf("parse JWKS URL %q: %w", b.jwksURL, err)
-	}
-	if parsed.Scheme != "https" {
-		return nil, fmt.Errorf("JWKS URL %q must use HTTPS scheme", b.jwksURL)
-	}
-
-	// Build fetch options for the JWKS endpoint.
-	var fetchOpts []jwk.FetchOption
-	if b.caPool != nil {
-		fetchOpts = append(fetchOpts, jwk.WithHTTPClient(
-			jwk.WrapHTTPClientDefaults(&http.Client{
-				Transport: &http.Transport{
-					TLSClientConfig: &tls.Config{
-						RootCAs:    b.caPool,
-						MinVersion: tls.VersionTLS13,
-					},
-				},
-			}),
-		))
-	}
-
-	// Seed the cache; validates that the endpoint is reachable.
-	jwks, err := jwk.Fetch(b.ctx, b.jwksURL, fetchOpts...)
-	if err != nil {
-		return nil, fmt.Errorf("initial JWKS fetch from %q: %w", b.jwksURL, err)
-	}
-
 	// Create and populate the object:
 	o := &Opener{
 		logger:        b.logger,
@@ -189,11 +166,8 @@ func (b *OpenerBuilder) Build() (*Opener, error) {
 		jwksURL:       b.jwksURL,
 		issuer:        b.issuer,
 		audience:      b.audience,
-		fetchOpts:     fetchOpts,
-		jwks:          jwks,
-		// lastAttempt intentionally zero: the bootstrap fetch does not count
-		// toward the rate limit, so the first unknown-kid refresh is immediate.
-		seen: make(map[string]time.Time),
+		cache:         b.cache,
+		seen:          make(map[string]time.Time),
 	}
 	go o.cleanupLoop(b.ctx)
 	return o, nil
@@ -265,9 +239,10 @@ func (o *Opener) resolveKeySet(ctx context.Context, jwsPayload []byte) (jwk.Set,
 		return nil, fmt.Errorf("parse JWS: %w", err)
 	}
 
-	o.jwksMu.Lock()
-	set := o.jwks
-	o.jwksMu.Unlock()
+	set, err := o.cache.Lookup(ctx, o.jwksURL)
+	if err != nil {
+		return o.refreshJWKS(ctx)
+	}
 
 	sigs := jwsMsg.Signatures()
 	if len(sigs) == 0 {
@@ -280,50 +255,36 @@ func (o *Opener) resolveKeySet(ctx context.Context, jwsPayload []byte) (jwk.Set,
 	if _, found := set.LookupKeyID(kid); found {
 		return set, nil
 	}
-	return o.refreshJWKS(ctx), nil
+	return o.refreshJWKS(ctx)
 }
 
-// minRefreshInterval is the minimum time between JWKS refresh attempts.
-// Prevents amplification attacks where forged kid values trigger unbounded
-// outbound HTTP requests to the JWKS endpoint.
-const minRefreshInterval = 60 * time.Second
-
-// refreshJWKS coalesces concurrent JWKS refreshes via singleflight.
-// Rate-limited to one fetch per minRefreshInterval.
-func (o *Opener) refreshJWKS(ctx context.Context) jwk.Set {
+// refreshJWKS forces an immediate JWKS re-fetch via the cache, coalescing
+// concurrent callers via singleflight.
+func (o *Opener) refreshJWKS(ctx context.Context) (jwk.Set, error) {
 	// Detach from the caller's context so one cancelled request does
 	// not abort the shared fetch. Also strips deadline intentionally —
 	// the HTTP transport timeout bounds the fetch.
 	ctx = context.WithoutCancel(ctx)
 
-	v, _, _ := o.refreshGroup.Do("jwks", func() (any, error) {
-		o.jwksMu.Lock()
-		if time.Since(o.lastAttempt) < minRefreshInterval {
-			set := o.jwks
-			o.jwksMu.Unlock()
-			return set, nil
-		}
-		o.lastAttempt = time.Now()
-		o.jwksMu.Unlock()
-
-		set, err := jwk.Fetch(ctx, o.jwksURL, o.fetchOpts...)
+	v, err, _ := o.refreshGroup.Do("jwks", func() (any, error) {
+		set, err := o.cache.Refresh(ctx, o.jwksURL)
 		if err != nil {
 			o.logger.WarnContext(ctx, "JWKS refresh failed, using cached keyset",
 				slog.String("jwks_url", o.jwksURL),
 				slog.Any("error", err),
 			)
-			o.jwksMu.Lock()
-			cached := o.jwks
-			o.jwksMu.Unlock()
+			cached, lookupErr := o.cache.Lookup(ctx, o.jwksURL)
+			if lookupErr != nil {
+				return nil, fmt.Errorf("JWKS refresh failed and no cached keyset available: %w", err)
+			}
 			return cached, nil
 		}
-
-		o.jwksMu.Lock()
-		o.jwks = set
-		o.jwksMu.Unlock()
 		return set, nil
 	})
-	return v.(jwk.Set)
+	if err != nil {
+		return nil, err
+	}
+	return v.(jwk.Set), nil
 }
 
 // extractClaims reads standard and custom claims from a verified JWT token.

--- a/internal/cmd/service/start/consoleproxy/start_console_proxy_cmd.go
+++ b/internal/cmd/service/start/consoleproxy/start_console_proxy_cmd.go
@@ -15,6 +15,8 @@ package consoleproxy
 
 import (
 	"context"
+	"crypto/tls"
+	"crypto/x509"
 	"fmt"
 	"log/slog"
 	"net/http"
@@ -23,6 +25,9 @@ import (
 
 	"errors"
 
+	"github.com/lestrrat-go/httprc/v3"
+	"github.com/lestrrat-go/httprc/v3/errsink"
+	"github.com/lestrrat-go/jwx/v3/jwk"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/spf13/cobra"
@@ -141,11 +146,16 @@ func (c *runnerContext) run(cmd *cobra.Command, argv []string) error {
 		return fmt.Errorf("flag '--token-decryption-key' is required")
 	}
 
-	// Create the token opener (decrypt JWE + verify JWS infrastructure):
+	// Create the JWKS cache for background key refresh:
 	jwksURL := c.args.tokenIssuer + "/.well-known/jwks.json"
+	jwksCache, err := c.createJWKSCache(ctx, jwksURL, caPool)
+	if err != nil {
+		return err
+	}
+
+	// Create the token opener (decrypt JWE + verify JWS):
 	c.logger.InfoContext(ctx, "Creating token opener",
 		slog.String("issuer", c.args.tokenIssuer),
-		slog.String("jwks_url", jwksURL),
 		slog.String("decryption_key", c.args.tokenDecryptionKey),
 	)
 	tokenOpener, err := jwe.NewOpener().
@@ -155,7 +165,7 @@ func (c *runnerContext) run(cmd *cobra.Command, argv []string) error {
 		SetJWKSURL(jwksURL).
 		SetIssuer(c.args.tokenIssuer).
 		SetAudience(console.TicketAudience).
-		SetCAPool(caPool).
+		SetCache(jwksCache).
 		Build()
 	if err != nil {
 		return fmt.Errorf("failed to create token opener: %w", err)
@@ -266,10 +276,12 @@ func (c *runnerContext) run(cmd *cobra.Command, argv []string) error {
 	)
 	shutdown.AddGrpcServer(network.GrpcListenerName, 0, grpcServer)
 
-	// Register the reflection and health servers:
+	// Register the reflection and health servers. Start as NOT_SERVING so
+	// that the readiness probe fails until the JWKS cache is warm.
 	c.logger.InfoContext(ctx, "Registering gRPC reflection server")
 	reflection.RegisterV1(grpcServer)
 	healthServer := health.NewServer()
+	healthServer.SetServingStatus("", healthv1.HealthCheckResponse_NOT_SERVING)
 	healthv1.RegisterHealthServer(grpcServer, healthServer)
 
 	// Register the ConsoleProxy gRPC server:
@@ -386,6 +398,9 @@ func (c *runnerContext) run(cmd *cobra.Command, argv []string) error {
 		}
 	}()
 
+	// Wait for JWKS keys in the background, then mark the service as ready:
+	go c.waitForJWKSReady(ctx, jwksCache, jwksURL, healthServer)
+
 	// Keep running till the shutdown sequence finishes or a server fails:
 	c.logger.InfoContext(ctx, "Waiting for shutdown sequence to complete")
 	shutdownDone := make(chan struct{})
@@ -404,6 +419,59 @@ func (c *runnerContext) run(cmd *cobra.Command, argv []string) error {
 		return err
 	case <-shutdownDone:
 		return nil
+	}
+}
+
+// createJWKSCache creates a JWKS cache and registers the given URL without
+// blocking on the first fetch. The cache starts fetching in the background;
+// callers should poll cache.Lookup to detect when keys are available.
+func (c *runnerContext) createJWKSCache(ctx context.Context, jwksURL string, caPool *x509.CertPool) (*jwk.Cache, error) {
+	c.logger.InfoContext(ctx, "Creating JWKS cache",
+		slog.String("jwks_url", jwksURL),
+	)
+	cache, err := jwk.NewCache(ctx, httprc.NewClient(
+		httprc.WithErrorSink(errsink.NewSlog(c.logger)),
+	))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create JWKS cache: %w", err)
+	}
+
+	registerOpts := []jwk.RegisterOption{
+		jwk.WithWaitReady(false),
+		jwk.WithHttprcResourceOption(httprc.WithMinInterval(time.Minute)),
+	}
+	if caPool != nil {
+		registerOpts = append(registerOpts, jwk.WithHTTPClient(
+			jwk.WrapHTTPClientDefaults(&http.Client{
+				Transport: &http.Transport{
+					TLSClientConfig: &tls.Config{
+						RootCAs:    caPool,
+						MinVersion: tls.VersionTLS13,
+					},
+				},
+			}),
+		))
+	}
+	if err := cache.Register(ctx, jwksURL, registerOpts...); err != nil {
+		return nil, fmt.Errorf("failed to register JWKS URL: %w", err)
+	}
+	return cache, nil
+}
+
+// waitForJWKSReady polls the JWKS cache until keys are available, then sets
+// the health server to SERVING. Exits if ctx is cancelled.
+func (c *runnerContext) waitForJWKSReady(ctx context.Context, cache *jwk.Cache, jwksURL string, healthServer *health.Server) {
+	for {
+		if _, err := cache.Lookup(ctx, jwksURL); err == nil {
+			c.logger.InfoContext(ctx, "JWKS keys available, setting health to SERVING")
+			healthServer.SetServingStatus("", healthv1.HealthCheckResponse_SERVING)
+			return
+		}
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(time.Second):
+		}
 	}
 }
 

--- a/internal/console/ticket_test.go
+++ b/internal/console/ticket_test.go
@@ -17,6 +17,7 @@ import (
 	"context"
 	"crypto/rand"
 	"crypto/rsa"
+	"crypto/tls"
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/json"
@@ -28,6 +29,8 @@ import (
 	"path/filepath"
 	"time"
 
+	"github.com/lestrrat-go/httprc/v3"
+	"github.com/lestrrat-go/jwx/v3/jwk"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
@@ -104,7 +107,7 @@ var _ = Describe("Ticket", func() {
 				SetJWKSURL(jwksServer.URL).
 				SetIssuer(issuer).
 				SetAudience(TicketAudience).
-				SetCAPool(jwksCAPool).
+				SetCache(newTicketTestCache(jwksServer.URL, jwksCAPool)).
 				Build()
 			Expect(err).ToNot(HaveOccurred())
 			opener := NewTicketOpener(tokenOpener)
@@ -139,7 +142,7 @@ var _ = Describe("Ticket", func() {
 				SetJWKSURL(jwksServer.URL).
 				SetIssuer(issuer).
 				SetAudience(TicketAudience).
-				SetCAPool(jwksCAPool).
+				SetCache(newTicketTestCache(jwksServer.URL, jwksCAPool)).
 				Build()
 			Expect(err).ToNot(HaveOccurred())
 			opener := NewTicketOpener(tokenOpener)
@@ -205,6 +208,26 @@ func generateTicketTestCA() *testTicketCAInfo {
 	pool := x509.NewCertPool()
 	pool.AddCert(caCert)
 	return &testTicketCAInfo{key: caKey, cert: caCert, pool: pool}
+}
+
+// newTicketTestCache creates a jwk.Cache registered to the given JWKS server URL,
+// optionally configured with a custom CA pool for TLS.
+func newTicketTestCache(serverURL string, caPool *x509.CertPool) *jwk.Cache {
+	cache, err := jwk.NewCache(context.Background(), httprc.NewClient())
+	Expect(err).ToNot(HaveOccurred())
+	opts := []jwk.RegisterOption{}
+	if caPool != nil {
+		opts = append(opts, jwk.WithHTTPClient(
+			jwk.WrapHTTPClientDefaults(&http.Client{
+				Transport: &http.Transport{
+					TLSClientConfig: &tls.Config{RootCAs: caPool},
+				},
+			}),
+		))
+	}
+	err = cache.Register(context.Background(), serverURL, opts...)
+	Expect(err).ToNot(HaveOccurred())
+	return cache
 }
 
 // generateTicketLeafCert generates a leaf certificate signed by the given CA and writes


### PR DESCRIPTION
## Summary

- **Externalize JWKS cache**: Replace the Opener's internal `jwk.Fetch` + mutex-guarded keyset with an externally managed `jwk.Cache` that handles background polling and HTTP-level caching via `httprc/v3`. The `SetCAPool` builder method is replaced with `SetCache`.
- **Fix liveness probe failure during startup**: The console proxy previously blocked on the initial JWKS fetch before starting the gRPC server, causing both liveness and readiness probes to fail. Now `cache.Register` is non-blocking (`WithWaitReady(false)`), the gRPC server starts immediately with `NOT_SERVING` health, and a background goroutine transitions to `SERVING` once keys are available.
- **Separate liveness from readiness**: Liveness probe changed from `exec probe grpc-server` (which checks SERVING status) to `tcpSocket` on port 8000 (checks TCP connectivity only). Readiness probe unchanged.

## Changes

| File | What changed |
|------|-------------|
| `internal/auth/jwe/opener.go` | `SetCAPool` -> `SetCache(*jwk.Cache)`, removed internal JWKS state (`jwks`, `jwksMu`, `lastAttempt`, `fetchOpts`, `minRefreshInterval`), `refreshJWKS` now delegates to `cache.Refresh` with `cache.Lookup` fallback |
| `internal/cmd/service/start/consoleproxy/start_console_proxy_cmd.go` | New `createJWKSCache` and `waitForJWKSReady` methods, health server starts as `NOT_SERVING` |
| `charts/service/templates/console-proxy/deployment.yaml` | Liveness probe: `exec` -> `tcpSocket` |
| `internal/auth/jwe/jwe_test.go` | Updated 11 call sites from `SetCAPool` to `SetCache`, added `newTestCache` helper |
| `internal/console/ticket_test.go` | Updated 2 call sites, added `newTicketTestCache` helper |
| `go.mod` | Promoted `httprc/v3` from indirect to direct dependency |

## Test plan

- [x] `ginkgo run -r internal` -- all 70 test suites pass
- [x] `go build ./cmd/fulfillment-service` -- compiles
- [x] `uv run dev.py lint` -- 0 issues
- [x] Deploy to dev cluster and verify:
  - Pod starts, liveness passes immediately (tcpSocket on 8000)
  - Readiness fails initially (health returns NOT_SERVING)
  - After JWKS fetch succeeds, readiness passes (health returns SERVING)
  - Console proxy handles tokens correctly after readiness

Assisted-by: Claude <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved startup behavior for the console proxy so it only reports healthy once signing keys are available.
  * Token verification now uses a shared key cache for faster, more reliable key lookups.

* **Bug Fixes**
  * Updated health checks to better reflect actual service readiness.
  * Improved certificate-aware key fetching, helping secure environments connect to key endpoints more consistently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->