### PR TITLE
OSAC-1679: Add periodic e2e schedule (2x/day)

### DIFF
--- a/.github/workflows/e2e-vmaas-full-install.yml
+++ b/.github/workflows/e2e-vmaas-full-install.yml
@@ -7,6 +7,8 @@ permissions:
 on:
   pull_request:
     branches: [main]
+  schedule:
+    - cron: "0 */12 * * *"
   workflow_dispatch:
     inputs:
       test-suite:


### PR DESCRIPTION
## Summary
- Add schedule trigger to e2e-vmaas-full-install workflow: runs every 12 hours (2x/day) against main

## Test plan
- [ ] Verify scheduled runs trigger at expected times