### PR TITLE
OSAC-1708: Update RoleBinding controller to extract IDP user ID from User status

### DIFF
--- a/internal/controllers/rolebinding/role_binding_reconciler_function.go
+++ b/internal/controllers/rolebinding/role_binding_reconciler_function.go
@@ -251,11 +251,34 @@ func (t *task) handleUserListChange(ctx context.Context) error {
 	// Remove roles from users that were removed from the binding
 	var removalErrors []string
 	for _, userID := range usersToRemove {
-		var err error
+		// Fetch the user to get their Keycloak ID
+		userResp, err := t.r.usersClient.Get(ctx, privatev1.UsersGetRequest_builder{
+			Id: userID,
+		}.Build())
+		if err != nil {
+			removalErrors = append(removalErrors, fmt.Sprintf("user %s: failed to fetch user: %v", userID, err))
+			t.r.logger.ErrorContext(ctx, "Failed to fetch user for role removal",
+				slog.String("role_binding_id", t.binding.GetId()),
+				slog.String("user_id", userID),
+				slog.Any("error", err),
+			)
+			continue
+		}
+
+		idpUserID := userResp.GetObject().GetStatus().GetKeycloakUserId()
+		if idpUserID == "" {
+			removalErrors = append(removalErrors, fmt.Sprintf("user %s: no IDP user ID", userID))
+			t.r.logger.ErrorContext(ctx, "User has no IDP user ID",
+				slog.String("role_binding_id", t.binding.GetId()),
+				slog.String("user_id", userID),
+			)
+			continue
+		}
+
 		if clientID != "" {
-			err = t.r.idpClient.RemoveClientRolesFromUser(ctx, tenantName, userID, clientID, keycloakRoles)
+			err = t.r.idpClient.RemoveClientRolesFromUser(ctx, tenantName, idpUserID, clientID, keycloakRoles)
 		} else {
-			err = t.r.idpClient.RemoveTenantRolesFromUser(ctx, tenantName, userID, keycloakRoles)
+			err = t.r.idpClient.RemoveTenantRolesFromUser(ctx, tenantName, idpUserID, keycloakRoles)
 		}
 
 		if err != nil {
@@ -263,6 +286,7 @@ func (t *task) handleUserListChange(ctx context.Context) error {
 			t.r.logger.ErrorContext(ctx, "Failed to remove role from user",
 				slog.String("role_binding_id", t.binding.GetId()),
 				slog.String("user_id", userID),
+				slog.String("idp_user_id", idpUserID),
 				slog.String("role", roleName),
 				slog.Any("error", err),
 			)
@@ -270,6 +294,7 @@ func (t *task) handleUserListChange(ctx context.Context) error {
 			t.r.logger.InfoContext(ctx, "Role removed from user during update",
 				slog.String("role_binding_id", t.binding.GetId()),
 				slog.String("user_id", userID),
+				slog.String("idp_user_id", idpUserID),
 				slog.String("role", roleName),
 			)
 		}
@@ -278,11 +303,34 @@ func (t *task) handleUserListChange(ctx context.Context) error {
 	// Assign roles to users that were added to the binding
 	var assignmentErrors []string
 	for _, userID := range usersToAdd {
-		var err error
+		// Fetch the user to get their Keycloak ID
+		userResp, err := t.r.usersClient.Get(ctx, privatev1.UsersGetRequest_builder{
+			Id: userID,
+		}.Build())
+		if err != nil {
+			assignmentErrors = append(assignmentErrors, fmt.Sprintf("user %s: failed to fetch user: %v", userID, err))
+			t.r.logger.ErrorContext(ctx, "Failed to fetch user for role assignment",
+				slog.String("role_binding_id", t.binding.GetId()),
+				slog.String("user_id", userID),
+				slog.Any("error", err),
+			)
+			continue
+		}
+
+		idpUserID := userResp.GetObject().GetStatus().GetKeycloakUserId()
+		if idpUserID == "" {
+			assignmentErrors = append(assignmentErrors, fmt.Sprintf("user %s: no IDP user ID", userID))
+			t.r.logger.ErrorContext(ctx, "User has no IDP user ID",
+				slog.String("role_binding_id", t.binding.GetId()),
+				slog.String("user_id", userID),
+			)
+			continue
+		}
+
 		if clientID != "" {
-			err = t.r.idpClient.AssignClientRolesToUser(ctx, tenantName, userID, clientID, keycloakRoles)
+			err = t.r.idpClient.AssignClientRolesToUser(ctx, tenantName, idpUserID, clientID, keycloakRoles)
 		} else {
-			err = t.r.idpClient.AssignTenantRolesToUser(ctx, tenantName, userID, keycloakRoles)
+			err = t.r.idpClient.AssignTenantRolesToUser(ctx, tenantName, idpUserID, keycloakRoles)
 		}
 
 		if err != nil {
@@ -290,6 +338,7 @@ func (t *task) handleUserListChange(ctx context.Context) error {
 			t.r.logger.ErrorContext(ctx, "Failed to assign role to user",
 				slog.String("role_binding_id", t.binding.GetId()),
 				slog.String("user_id", userID),
+				slog.String("idp_user_id", idpUserID),
 				slog.String("role", roleName),
 				slog.Any("error", err),
 			)
@@ -349,13 +398,36 @@ func (t *task) syncRoleAssignments(ctx context.Context) error {
 	// Assign the roles to each user in the binding
 	var assignmentErrors []string
 	for _, userID := range t.binding.GetSpec().GetUsers() {
-		var err error
+		// Fetch the user to get their Keycloak ID
+		userResp, err := t.r.usersClient.Get(ctx, privatev1.UsersGetRequest_builder{
+			Id: userID,
+		}.Build())
+		if err != nil {
+			assignmentErrors = append(assignmentErrors, fmt.Sprintf("user %s: failed to fetch user: %v", userID, err))
+			t.r.logger.ErrorContext(ctx, "Failed to fetch user for role assignment",
+				slog.String("role_binding_id", t.binding.GetId()),
+				slog.String("user_id", userID),
+				slog.Any("error", err),
+			)
+			continue
+		}
+
+		idpUserID := userResp.GetObject().GetStatus().GetKeycloakUserId()
+		if idpUserID == "" {
+			assignmentErrors = append(assignmentErrors, fmt.Sprintf("user %s: no IDP user ID", userID))
+			t.r.logger.ErrorContext(ctx, "User has no IDP user ID",
+				slog.String("role_binding_id", t.binding.GetId()),
+				slog.String("user_id", userID),
+			)
+			continue
+		}
+
 		if clientID != "" {
 			// Client-level role (e.g., realm-management)
-			err = t.r.idpClient.AssignClientRolesToUser(ctx, tenantName, userID, clientID, keycloakRoles)
+			err = t.r.idpClient.AssignClientRolesToUser(ctx, tenantName, idpUserID, clientID, keycloakRoles)
 		} else {
 			// Tenant-level role
-			err = t.r.idpClient.AssignTenantRolesToUser(ctx, tenantName, userID, keycloakRoles)
+			err = t.r.idpClient.AssignTenantRolesToUser(ctx, tenantName, idpUserID, keycloakRoles)
 		}
 
 		if err != nil {
@@ -363,6 +435,7 @@ func (t *task) syncRoleAssignments(ctx context.Context) error {
 			t.r.logger.ErrorContext(ctx, "Failed to assign role to user",
 				slog.String("role_binding_id", t.binding.GetId()),
 				slog.String("user_id", userID),
+				slog.String("idp_user_id", idpUserID),
 				slog.String("role", roleName),
 				slog.Any("error", err),
 			)
@@ -434,19 +507,41 @@ func (t *task) delete(ctx context.Context) error {
 
 	// Remove the roles from each user in the binding
 	for _, userID := range t.binding.GetSpec().GetUsers() {
-		var err error
+		// Fetch the user to get their Keycloak ID
+		userResp, err := t.r.usersClient.Get(ctx, privatev1.UsersGetRequest_builder{
+			Id: userID,
+		}.Build())
+		if err != nil {
+			t.r.logger.ErrorContext(ctx, "Failed to fetch user for role removal during delete",
+				slog.String("role_binding_id", t.binding.GetId()),
+				slog.String("user_id", userID),
+				slog.Any("error", err),
+			)
+			continue
+		}
+
+		idpUserID := userResp.GetObject().GetStatus().GetKeycloakUserId()
+		if idpUserID == "" {
+			t.r.logger.WarnContext(ctx, "User has no IDP user ID during delete",
+				slog.String("role_binding_id", t.binding.GetId()),
+				slog.String("user_id", userID),
+			)
+			continue
+		}
+
 		if clientID != "" {
 			// Client-level role (e.g., realm-management)
-			err = t.r.idpClient.RemoveClientRolesFromUser(ctx, tenantName, userID, clientID, keycloakRoles)
+			err = t.r.idpClient.RemoveClientRolesFromUser(ctx, tenantName, idpUserID, clientID, keycloakRoles)
 		} else {
 			// Tenant-level role
-			err = t.r.idpClient.RemoveTenantRolesFromUser(ctx, tenantName, userID, keycloakRoles)
+			err = t.r.idpClient.RemoveTenantRolesFromUser(ctx, tenantName, idpUserID, keycloakRoles)
 		}
 
 		if err != nil {
 			t.r.logger.ErrorContext(ctx, "Failed to remove role from user",
 				slog.String("role_binding_id", t.binding.GetId()),
 				slog.String("user_id", userID),
+				slog.String("idp_user_id", idpUserID),
 				slog.String("role", roleName),
 				slog.Any("error", err),
 			)
@@ -455,6 +550,7 @@ func (t *task) delete(ctx context.Context) error {
 			t.r.logger.InfoContext(ctx, "Role removed from user",
 				slog.String("role_binding_id", t.binding.GetId()),
 				slog.String("user_id", userID),
+				slog.String("idp_user_id", idpUserID),
 				slog.String("role", roleName),
 			)
 		}

--- a/internal/controllers/rolebinding/role_binding_reconciler_function_test.go
+++ b/internal/controllers/rolebinding/role_binding_reconciler_function_test.go
@@ -79,9 +79,52 @@ func (m *mockRolesClient) List(
 	return m.listResponse, m.listErr
 }
 
+// mockUsersClient implements the minimal UsersClient interface for testing.
+type mockUsersClient struct {
+	privatev1.UsersClient
+	getResponse *privatev1.UsersGetResponse
+	getErr      error
+	users       map[string]*privatev1.User
+}
+
+func (m *mockUsersClient) Get(
+	_ context.Context,
+	req *privatev1.UsersGetRequest,
+	_ ...grpc.CallOption,
+) (*privatev1.UsersGetResponse, error) {
+	if m.getErr != nil {
+		return nil, m.getErr
+	}
+	if m.getResponse != nil {
+		return m.getResponse, nil
+	}
+	if m.users != nil {
+		if user, ok := m.users[req.GetId()]; ok {
+			return &privatev1.UsersGetResponse{Object: user}, nil
+		}
+	}
+	return nil, fmt.Errorf("user %q not found", req.GetId())
+}
+
 // hasFinalizer checks if the controller finalizer is present.
 func hasFinalizer(binding *privatev1.RoleBinding) bool {
 	return slices.Contains(binding.GetMetadata().GetFinalizers(), finalizers.Controller)
+}
+
+// newMockUsersClient creates a mock users client that returns users with Keycloak IDs.
+// userIDs should be a list of user IDs (e.g., "user-1", "user-2").
+// The Keycloak ID for each user will be "keycloak-<userID>".
+func newMockUsersClient(userIDs ...string) *mockUsersClient {
+	users := make(map[string]*privatev1.User)
+	for _, userID := range userIDs {
+		users[userID] = privatev1.User_builder{
+			Id: userID,
+			Status: privatev1.UserStatus_builder{
+				KeycloakUserId: "keycloak-" + userID,
+			}.Build(),
+		}.Build()
+	}
+	return &mockUsersClient{users: users}
 }
 
 var _ = Describe("RoleBinding Reconciler", func() {
@@ -154,11 +197,13 @@ var _ = Describe("RoleBinding Reconciler", func() {
 				getResponse: &privatev1.RolesGetResponse{Object: role},
 			}
 
+			usersClient := newMockUsersClient("user-1")
+
 			bindingsClient := &mockRoleBindingsClient{}
 			idpClient := idp.NewMockClient(ctrl)
 			// When binding already has finalizer, update will call syncRoleAssignments
 			idpClient.EXPECT().
-				AssignTenantRolesToUser(ctx, "test-org", "user-1", gomock.Any()).
+				AssignTenantRolesToUser(ctx, "test-org", "keycloak-user-1", gomock.Any()).
 				Return(nil).
 				Times(1)
 
@@ -166,6 +211,7 @@ var _ = Describe("RoleBinding Reconciler", func() {
 				logger:             logger,
 				roleBindingsClient: bindingsClient,
 				rolesClient:        rolesClient,
+				usersClient:        usersClient,
 				idpClient:          idpClient,
 				maskCalculator:     masks.NewCalculator().Build(),
 			}
@@ -201,16 +247,19 @@ var _ = Describe("RoleBinding Reconciler", func() {
 				getResponse: &privatev1.RolesGetResponse{Object: role},
 			}
 
+			usersClient := newMockUsersClient("user-1")
+
 			bindingsClient := &mockRoleBindingsClient{}
 			idpClient := idp.NewMockClient(ctrl)
 			idpClient.EXPECT().
-				RemoveTenantRolesFromUser(ctx, "test-org", "user-1", gomock.Any()).
+				RemoveTenantRolesFromUser(ctx, "test-org", "keycloak-user-1", gomock.Any()).
 				Return(nil)
 
 			f := &function{
 				logger:             logger,
 				roleBindingsClient: bindingsClient,
 				rolesClient:        rolesClient,
+				usersClient:        usersClient,
 				idpClient:          idpClient,
 				maskCalculator:     masks.NewCalculator().Build(),
 			}
@@ -484,12 +533,14 @@ var _ = Describe("RoleBinding Reconciler", func() {
 				getResponse: &privatev1.RolesGetResponse{Object: role},
 			}
 
+			usersClient := newMockUsersClient("user-1", "user-2")
+
 			idpClient := idp.NewMockClient(ctrl)
 			idpClient.EXPECT().
-				AssignTenantRolesToUser(ctx, "test-org", "user-1", gomock.Any()).
+				AssignTenantRolesToUser(ctx, "test-org", "keycloak-user-1", gomock.Any()).
 				Return(nil)
 			idpClient.EXPECT().
-				AssignTenantRolesToUser(ctx, "test-org", "user-2", gomock.Any()).
+				AssignTenantRolesToUser(ctx, "test-org", "keycloak-user-2", gomock.Any()).
 				Return(nil)
 
 			binding := privatev1.RoleBinding_builder{
@@ -509,6 +560,7 @@ var _ = Describe("RoleBinding Reconciler", func() {
 			f := &function{
 				logger:      logger,
 				rolesClient: rolesClient,
+				usersClient: usersClient,
 				idpClient:   idpClient,
 			}
 			t := &task{r: f, binding: binding}
@@ -531,9 +583,11 @@ var _ = Describe("RoleBinding Reconciler", func() {
 				getResponse: &privatev1.RolesGetResponse{Object: role},
 			}
 
+			usersClient := newMockUsersClient("user-1")
+
 			idpClient := idp.NewMockClient(ctrl)
 			idpClient.EXPECT().
-				AssignTenantRolesToUser(ctx, "test-org", "user-1", gomock.Any()).
+				AssignTenantRolesToUser(ctx, "test-org", "keycloak-user-1", gomock.Any()).
 				Return(nil)
 
 			binding := privatev1.RoleBinding_builder{
@@ -553,6 +607,7 @@ var _ = Describe("RoleBinding Reconciler", func() {
 			f := &function{
 				logger:      logger,
 				rolesClient: rolesClient,
+				usersClient: usersClient,
 				idpClient:   idpClient,
 			}
 			t := &task{r: f, binding: binding}
@@ -574,9 +629,11 @@ var _ = Describe("RoleBinding Reconciler", func() {
 				getResponse: &privatev1.RolesGetResponse{Object: role},
 			}
 
+			usersClient := newMockUsersClient("user-1")
+
 			idpClient := idp.NewMockClient(ctrl)
 			idpClient.EXPECT().
-				AssignTenantRolesToUser(ctx, "test-org", "user-1", gomock.Any()).
+				AssignTenantRolesToUser(ctx, "test-org", "keycloak-user-1", gomock.Any()).
 				Return(fmt.Errorf("IDP error"))
 
 			binding := privatev1.RoleBinding_builder{
@@ -596,6 +653,7 @@ var _ = Describe("RoleBinding Reconciler", func() {
 			f := &function{
 				logger:      logger,
 				rolesClient: rolesClient,
+				usersClient: usersClient,
 				idpClient:   idpClient,
 			}
 			t := &task{r: f, binding: binding}
@@ -650,9 +708,11 @@ var _ = Describe("RoleBinding Reconciler", func() {
 				getResponse: &privatev1.RolesGetResponse{Object: role},
 			}
 
+			usersClient := newMockUsersClient("user-1", "user-2", "user-3")
+
 			idpClient := idp.NewMockClient(ctrl)
 			idpClient.EXPECT().
-				AssignTenantRolesToUser(ctx, "test-org", "user-3", gomock.Any()).
+				AssignTenantRolesToUser(ctx, "test-org", "keycloak-user-3", gomock.Any()).
 				Return(nil)
 
 			binding := privatev1.RoleBinding_builder{
@@ -673,6 +733,7 @@ var _ = Describe("RoleBinding Reconciler", func() {
 			f := &function{
 				logger:      logger,
 				rolesClient: rolesClient,
+				usersClient: usersClient,
 				idpClient:   idpClient,
 			}
 			t := &task{r: f, binding: binding}
@@ -695,9 +756,11 @@ var _ = Describe("RoleBinding Reconciler", func() {
 				getResponse: &privatev1.RolesGetResponse{Object: role},
 			}
 
+			usersClient := newMockUsersClient("user-1", "user-2", "user-3")
+
 			idpClient := idp.NewMockClient(ctrl)
 			idpClient.EXPECT().
-				RemoveTenantRolesFromUser(ctx, "test-org", "user-3", gomock.Any()).
+				RemoveTenantRolesFromUser(ctx, "test-org", "keycloak-user-3", gomock.Any()).
 				Return(nil)
 
 			binding := privatev1.RoleBinding_builder{
@@ -718,6 +781,7 @@ var _ = Describe("RoleBinding Reconciler", func() {
 			f := &function{
 				logger:      logger,
 				rolesClient: rolesClient,
+				usersClient: usersClient,
 				idpClient:   idpClient,
 			}
 			t := &task{r: f, binding: binding}
@@ -740,12 +804,14 @@ var _ = Describe("RoleBinding Reconciler", func() {
 				getResponse: &privatev1.RolesGetResponse{Object: role},
 			}
 
+			usersClient := newMockUsersClient("user-1", "user-2", "user-3")
+
 			idpClient := idp.NewMockClient(ctrl)
 			idpClient.EXPECT().
-				RemoveTenantRolesFromUser(ctx, "test-org", "user-2", gomock.Any()).
+				RemoveTenantRolesFromUser(ctx, "test-org", "keycloak-user-2", gomock.Any()).
 				Return(nil)
 			idpClient.EXPECT().
-				AssignTenantRolesToUser(ctx, "test-org", "user-3", gomock.Any()).
+				AssignTenantRolesToUser(ctx, "test-org", "keycloak-user-3", gomock.Any()).
 				Return(nil)
 
 			binding := privatev1.RoleBinding_builder{
@@ -766,6 +832,7 @@ var _ = Describe("RoleBinding Reconciler", func() {
 			f := &function{
 				logger:      logger,
 				rolesClient: rolesClient,
+				usersClient: usersClient,
 				idpClient:   idpClient,
 			}
 			t := &task{r: f, binding: binding}
@@ -840,9 +907,11 @@ var _ = Describe("RoleBinding Reconciler", func() {
 				getResponse: &privatev1.RolesGetResponse{Object: role},
 			}
 
+			usersClient := newMockUsersClient("user-1", "user-2")
+
 			idpClient := idp.NewMockClient(ctrl)
 			idpClient.EXPECT().
-				AssignTenantRolesToUser(ctx, "test-org", "user-2", gomock.Any()).
+				AssignTenantRolesToUser(ctx, "test-org", "keycloak-user-2", gomock.Any()).
 				Return(fmt.Errorf("IDP error"))
 
 			binding := privatev1.RoleBinding_builder{
@@ -863,6 +932,7 @@ var _ = Describe("RoleBinding Reconciler", func() {
 			f := &function{
 				logger:      logger,
 				rolesClient: rolesClient,
+				usersClient: usersClient,
 				idpClient:   idpClient,
 			}
 			t := &task{r: f, binding: binding}
@@ -884,9 +954,11 @@ var _ = Describe("RoleBinding Reconciler", func() {
 				getResponse: &privatev1.RolesGetResponse{Object: role},
 			}
 
+			usersClient := newMockUsersClient("user-1", "user-2")
+
 			idpClient := idp.NewMockClient(ctrl)
 			idpClient.EXPECT().
-				RemoveTenantRolesFromUser(ctx, "test-org", "user-2", gomock.Any()).
+				RemoveTenantRolesFromUser(ctx, "test-org", "keycloak-user-2", gomock.Any()).
 				Return(fmt.Errorf("IDP error"))
 
 			binding := privatev1.RoleBinding_builder{
@@ -907,6 +979,7 @@ var _ = Describe("RoleBinding Reconciler", func() {
 			f := &function{
 				logger:      logger,
 				rolesClient: rolesClient,
+				usersClient: usersClient,
 				idpClient:   idpClient,
 			}
 			t := &task{r: f, binding: binding}
@@ -930,12 +1003,14 @@ var _ = Describe("RoleBinding Reconciler", func() {
 				getResponse: &privatev1.RolesGetResponse{Object: role},
 			}
 
+			usersClient := newMockUsersClient("user-1", "user-2")
+
 			idpClient := idp.NewMockClient(ctrl)
 			idpClient.EXPECT().
-				RemoveTenantRolesFromUser(ctx, "test-org", "user-1", gomock.Any()).
+				RemoveTenantRolesFromUser(ctx, "test-org", "keycloak-user-1", gomock.Any()).
 				Return(nil)
 			idpClient.EXPECT().
-				RemoveTenantRolesFromUser(ctx, "test-org", "user-2", gomock.Any()).
+				RemoveTenantRolesFromUser(ctx, "test-org", "keycloak-user-2", gomock.Any()).
 				Return(nil)
 
 			binding := privatev1.RoleBinding_builder{
@@ -956,6 +1031,7 @@ var _ = Describe("RoleBinding Reconciler", func() {
 			f := &function{
 				logger:      logger,
 				rolesClient: rolesClient,
+				usersClient: usersClient,
 				idpClient:   idpClient,
 			}
 			t := &task{r: f, binding: binding}
@@ -1029,12 +1105,14 @@ var _ = Describe("RoleBinding Reconciler", func() {
 				getResponse: &privatev1.RolesGetResponse{Object: role},
 			}
 
+			usersClient := newMockUsersClient("user-1", "user-2")
+
 			idpClient := idp.NewMockClient(ctrl)
 			idpClient.EXPECT().
-				RemoveTenantRolesFromUser(ctx, "test-org", "user-1", gomock.Any()).
+				RemoveTenantRolesFromUser(ctx, "test-org", "keycloak-user-1", gomock.Any()).
 				Return(fmt.Errorf("IDP error"))
 			idpClient.EXPECT().
-				RemoveTenantRolesFromUser(ctx, "test-org", "user-2", gomock.Any()).
+				RemoveTenantRolesFromUser(ctx, "test-org", "keycloak-user-2", gomock.Any()).
 				Return(nil)
 
 			binding := privatev1.RoleBinding_builder{
@@ -1055,6 +1133,7 @@ var _ = Describe("RoleBinding Reconciler", func() {
 			f := &function{
 				logger:      logger,
 				rolesClient: rolesClient,
+				usersClient: usersClient,
 				idpClient:   idpClient,
 			}
 			t := &task{r: f, binding: binding}

--- a/it/it_role_binding_reconciler_test.go
+++ b/it/it_role_binding_reconciler_test.go
@@ -31,17 +31,20 @@ import (
 
 var _ = Describe("Role binding reconciler", func() {
 	var (
-		ctx          context.Context
-		client       privatev1.RoleBindingsClient
-		rolesClient  privatev1.RolesClient
-		testRoleName string
-		testUserID   string
+		ctx            context.Context
+		client         privatev1.RoleBindingsClient
+		rolesClient    privatev1.RolesClient
+		usersClient    privatev1.UsersClient
+		testRoleName   string
+		testUserID     string
+		testKeycloakID string
 	)
 
 	BeforeEach(func() {
 		ctx = context.Background()
 		client = privatev1.NewRoleBindingsClient(tool.InternalView().AdminConn())
 		rolesClient = privatev1.NewRolesClient(tool.InternalView().AdminConn())
+		usersClient = privatev1.NewUsersClient(tool.InternalView().AdminConn())
 		testRoleName = fmt.Sprintf("test-role-%s", uuid.New())
 
 		// Create a role in OSAC that will also be created in Keycloak
@@ -93,13 +96,34 @@ var _ = Describe("Role binding reconciler", func() {
 		Expect(err).ToNot(HaveOccurred())
 		Expect(users).To(HaveLen(1))
 		var ok bool
-		testUserID, ok = users[0]["id"].(string)
+		testKeycloakID, ok = users[0]["id"].(string)
 		Expect(ok).To(BeTrue())
-		Expect(testUserID).ToNot(BeEmpty())
+		Expect(testKeycloakID).ToNot(BeEmpty())
 
 		// Clean up the Keycloak user after the test
 		DeferCleanup(func() {
-			_, _, _ = tool.KeycloakAdminRequest(ctx, "DELETE", fmt.Sprintf("/users/%s", testUserID), nil)
+			_, _, _ = tool.KeycloakAdminRequest(ctx, "DELETE", fmt.Sprintf("/users/%s", testKeycloakID), nil)
+		})
+
+		// Create a User object in OSAC with the Keycloak ID in status
+		userResponse, err := usersClient.Create(ctx, privatev1.UsersCreateRequest_builder{
+			Object: privatev1.User_builder{
+				Metadata: privatev1.Metadata_builder{
+					Name: "my-user",
+				}.Build(),
+				Status: privatev1.UserStatus_builder{
+					KeycloakUserId: testKeycloakID,
+				}.Build(),
+			}.Build(),
+		}.Build())
+		Expect(err).ToNot(HaveOccurred())
+		testUserID = userResponse.GetObject().GetId()
+
+		// Clean up the OSAC user after the test
+		DeferCleanup(func() {
+			_, _ = usersClient.Delete(ctx, privatev1.UsersDeleteRequest_builder{
+				Id: testUserID,
+			}.Build())
 		})
 	})
 


### PR DESCRIPTION
# Description

Change RoleBinding controller to fetch the OSAC User object and extract the IDP user ID from status.keycloak_user_id before calling IDP client methods. 

# Testing

- [x] go unit-test passes
- [x] go build passes

/cc @jhernand 

Requires https://github.com/osac-project/fulfillment-service/pull/791