### PR TITLE
OSAC-1476: Implement ExternalIPPool and ExternalIP public and private servers

### DIFF
--- a/internal/cmd/service/start/grpcserver/start_grpc_server_cmd.go
+++ b/internal/cmd/service/start/grpcserver/start_grpc_server_cmd.go
@@ -1092,6 +1092,62 @@ func (c *runnerContext) run(cmd *cobra.Command, argv []string) error { //nolint:
 	}
 	publicv1.RegisterPublicIPAttachmentsServer(grpcServer, publicIPAttachmentsServer)
 
+	// Create the external IP pools server (read-only: List + Get):
+	c.logger.InfoContext(ctx, "Creating external IP pools server")
+	externalIPPoolsServer, err := servers.NewExternalIPPoolsServer().
+		SetLogger(c.logger).
+		SetNotifier(notifier).
+		SetAttributionLogic(publicAttributionLogic).
+		SetTenancyLogic(tenancyLogic).
+		SetMetricsRegisterer(metricsRegisterer).
+		Build()
+	if err != nil {
+		return fmt.Errorf("failed to create external IP pools server: %w", err)
+	}
+	publicv1.RegisterExternalIPPoolsServer(grpcServer, externalIPPoolsServer)
+
+	// Create the private external IP pools server:
+	c.logger.InfoContext(ctx, "Creating private external IP pools server")
+	privateExternalIPPoolsServer, err := servers.NewPrivateExternalIPPoolsServer().
+		SetLogger(c.logger).
+		SetNotifier(notifier).
+		SetAttributionLogic(privateAttributionLogic).
+		SetTenancyLogic(tenancyLogic).
+		SetMetricsRegisterer(metricsRegisterer).
+		Build()
+	if err != nil {
+		return fmt.Errorf("failed to create private external IP pools server: %w", err)
+	}
+	privatev1.RegisterExternalIPPoolsServer(grpcServer, privateExternalIPPoolsServer)
+
+	// Create the external IPs server:
+	c.logger.InfoContext(ctx, "Creating external IPs server")
+	externalIPsServer, err := servers.NewExternalIPsServer().
+		SetLogger(c.logger).
+		SetNotifier(notifier).
+		SetAttributionLogic(publicAttributionLogic).
+		SetTenancyLogic(tenancyLogic).
+		SetMetricsRegisterer(metricsRegisterer).
+		Build()
+	if err != nil {
+		return fmt.Errorf("failed to create external IPs server: %w", err)
+	}
+	publicv1.RegisterExternalIPsServer(grpcServer, externalIPsServer)
+
+	// Create the private external IPs server:
+	c.logger.InfoContext(ctx, "Creating private external IPs server")
+	privateExternalIPsServer, err := servers.NewPrivateExternalIPsServer().
+		SetLogger(c.logger).
+		SetNotifier(notifier).
+		SetAttributionLogic(privateAttributionLogic).
+		SetTenancyLogic(tenancyLogic).
+		SetMetricsRegisterer(metricsRegisterer).
+		Build()
+	if err != nil {
+		return fmt.Errorf("failed to create private external IPs server: %w", err)
+	}
+	privatev1.RegisterExternalIPsServer(grpcServer, privateExternalIPsServer)
+
 	// Create the public tenants server:
 	c.logger.InfoContext(ctx, "Creating public tenants server")
 	publicTenantsServer, err := servers.NewTenantsServer().

--- a/internal/servers/external_ip_pools_server.go
+++ b/internal/servers/external_ip_pools_server.go
@@ -1,0 +1,201 @@
+/*
+Copyright (c) 2026 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package servers
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+
+	"github.com/prometheus/client_golang/prometheus"
+	grpccodes "google.golang.org/grpc/codes"
+	grpcstatus "google.golang.org/grpc/status"
+
+	privatev1 "github.com/osac-project/fulfillment-service/internal/api/osac/private/v1"
+	publicv1 "github.com/osac-project/fulfillment-service/internal/api/osac/public/v1"
+	"github.com/osac-project/fulfillment-service/internal/auth"
+	"github.com/osac-project/fulfillment-service/internal/database"
+)
+
+type ExternalIPPoolsServerBuilder struct {
+	logger            *slog.Logger
+	notifier          *database.Notifier
+	attributionLogic  auth.AttributionLogic
+	tenancyLogic      auth.TenancyLogic
+	metricsRegisterer prometheus.Registerer
+}
+
+var _ publicv1.ExternalIPPoolsServer = (*ExternalIPPoolsServer)(nil)
+
+type ExternalIPPoolsServer struct {
+	publicv1.UnimplementedExternalIPPoolsServer
+
+	logger    *slog.Logger
+	delegate  privatev1.ExternalIPPoolsServer
+	outMapper *GenericMapper[*privatev1.ExternalIPPool, *publicv1.ExternalIPPool]
+}
+
+func NewExternalIPPoolsServer() *ExternalIPPoolsServerBuilder {
+	return &ExternalIPPoolsServerBuilder{}
+}
+
+func (b *ExternalIPPoolsServerBuilder) SetLogger(value *slog.Logger) *ExternalIPPoolsServerBuilder {
+	b.logger = value
+	return b
+}
+
+func (b *ExternalIPPoolsServerBuilder) SetNotifier(value *database.Notifier) *ExternalIPPoolsServerBuilder {
+	b.notifier = value
+	return b
+}
+
+func (b *ExternalIPPoolsServerBuilder) SetAttributionLogic(value auth.AttributionLogic) *ExternalIPPoolsServerBuilder {
+	b.attributionLogic = value
+	return b
+}
+
+func (b *ExternalIPPoolsServerBuilder) SetTenancyLogic(value auth.TenancyLogic) *ExternalIPPoolsServerBuilder {
+	b.tenancyLogic = value
+	return b
+}
+
+func (b *ExternalIPPoolsServerBuilder) SetMetricsRegisterer(value prometheus.Registerer) *ExternalIPPoolsServerBuilder {
+	b.metricsRegisterer = value
+	return b
+}
+
+func (b *ExternalIPPoolsServerBuilder) Build() (result *ExternalIPPoolsServer, err error) {
+	if b.logger == nil {
+		err = errors.New("logger is mandatory")
+		return
+	}
+	if b.attributionLogic == nil {
+		err = errors.New("attribution logic is mandatory")
+		return
+	}
+	if b.tenancyLogic == nil {
+		err = errors.New("tenancy logic is mandatory")
+		return
+	}
+
+	outMapper, err := NewGenericMapper[*privatev1.ExternalIPPool, *publicv1.ExternalIPPool]().
+		SetLogger(b.logger).
+		SetStrict(false).
+		Build()
+	if err != nil {
+		return
+	}
+
+	delegate, err := NewPrivateExternalIPPoolsServer().
+		SetLogger(b.logger).
+		SetNotifier(b.notifier).
+		SetAttributionLogic(b.attributionLogic).
+		SetTenancyLogic(b.tenancyLogic).
+		SetMetricsRegisterer(b.metricsRegisterer).
+		Build()
+	if err != nil {
+		return
+	}
+
+	result = &ExternalIPPoolsServer{
+		logger:    b.logger,
+		delegate:  delegate,
+		outMapper: outMapper,
+	}
+	return
+}
+
+func isExternalIPPoolPubliclyVisible(p *privatev1.ExternalIPPool) bool {
+	return p.GetStatus().GetState() == privatev1.ExternalIPPoolState_EXTERNAL_IP_POOL_STATE_READY &&
+		p.GetStatus().GetAvailable() > 0
+}
+
+func (s *ExternalIPPoolsServer) List(ctx context.Context,
+	request *publicv1.ExternalIPPoolsListRequest) (response *publicv1.ExternalIPPoolsListResponse, err error) {
+	privateRequest := &privatev1.ExternalIPPoolsListRequest{}
+	privateRequest.SetFilter(request.GetFilter())
+
+	privateResponse, err := s.delegate.List(ctx, privateRequest)
+	if err != nil {
+		return nil, err
+	}
+
+	var eligible []*privatev1.ExternalIPPool
+	for _, p := range privateResponse.GetItems() {
+		if isExternalIPPoolPubliclyVisible(p) {
+			eligible = append(eligible, p)
+		}
+	}
+
+	total := int32(len(eligible)) // #nosec G115 -- bounded by pool size
+	offset := request.GetOffset()
+	limit := request.GetLimit()
+	if offset < 0 || limit < 0 {
+		return nil, grpcstatus.Errorf(grpccodes.InvalidArgument, "offset and limit must be non-negative")
+	}
+	if offset > total {
+		offset = total
+	}
+	paged := eligible[offset:]
+	if limit > 0 && int32(len(paged)) > limit { // #nosec G115 -- bounded by pool size
+		paged = paged[:limit]
+	}
+
+	publicItems := make([]*publicv1.ExternalIPPool, len(paged))
+	for i, privateItem := range paged {
+		publicItem := &publicv1.ExternalIPPool{}
+		err = s.outMapper.Copy(ctx, privateItem, publicItem)
+		if err != nil {
+			s.logger.ErrorContext(ctx, "Failed to map private external IP pool to public", slog.Any("error", err))
+			return nil, grpcstatus.Errorf(grpccodes.Internal, "failed to process external IP pools")
+		}
+		publicItems[i] = publicItem
+	}
+
+	response = &publicv1.ExternalIPPoolsListResponse{}
+	response.SetSize(int32(len(publicItems))) // #nosec G115 -- bounded by pool size
+	response.SetTotal(total)
+	response.SetItems(publicItems)
+	return
+}
+
+func (s *ExternalIPPoolsServer) Get(ctx context.Context,
+	request *publicv1.ExternalIPPoolsGetRequest) (response *publicv1.ExternalIPPoolsGetResponse, err error) {
+	privateRequest := &privatev1.ExternalIPPoolsGetRequest{}
+	privateRequest.SetId(request.GetId())
+
+	privateResponse, err := s.delegate.Get(ctx, privateRequest)
+	if err != nil {
+		return nil, err
+	}
+
+	pool := privateResponse.GetObject()
+	if !isExternalIPPoolPubliclyVisible(pool) {
+		s.logger.DebugContext(ctx, "Pool not eligible for public API",
+			slog.String("id", request.GetId()),
+		)
+		return nil, grpcstatus.Errorf(grpccodes.NotFound, "external IP pool not found")
+	}
+
+	publicPool := &publicv1.ExternalIPPool{}
+	err = s.outMapper.Copy(ctx, pool, publicPool)
+	if err != nil {
+		s.logger.ErrorContext(ctx, "Failed to map private external IP pool to public", slog.Any("error", err))
+		return nil, grpcstatus.Errorf(grpccodes.Internal, "failed to process external IP pool")
+	}
+
+	response = &publicv1.ExternalIPPoolsGetResponse{}
+	response.SetObject(publicPool)
+	return
+}

--- a/internal/servers/external_ip_pools_server_test.go
+++ b/internal/servers/external_ip_pools_server_test.go
@@ -1,0 +1,245 @@
+/*
+Copyright (c) 2026 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package servers
+
+import (
+	"fmt"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	grpccodes "google.golang.org/grpc/codes"
+	grpcstatus "google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/fieldmaskpb"
+
+	privatev1 "github.com/osac-project/fulfillment-service/internal/api/osac/private/v1"
+	publicv1 "github.com/osac-project/fulfillment-service/internal/api/osac/public/v1"
+)
+
+var _ = Describe("Public external IP pools server", func() {
+	var privatePool *PrivateExternalIPPoolsServer
+
+	BeforeEach(func() {
+		var err error
+
+		privatePool, err = NewPrivateExternalIPPoolsServer().
+			SetLogger(logger).
+			SetAttributionLogic(attribution).
+			SetTenancyLogic(tenancy).
+			Build()
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	Describe("Builder", func() {
+		It("Builds successfully with required parameters", func() {
+			s, err := NewExternalIPPoolsServer().
+				SetLogger(logger).
+				SetAttributionLogic(attribution).
+				SetTenancyLogic(tenancy).
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(s).ToNot(BeNil())
+		})
+
+		It("Fails if logger is not set", func() {
+			s, err := NewExternalIPPoolsServer().
+				SetAttributionLogic(attribution).
+				SetTenancyLogic(tenancy).
+				Build()
+			Expect(err).To(MatchError("logger is mandatory"))
+			Expect(s).To(BeNil())
+		})
+
+		It("Fails if attribution logic is not set", func() {
+			s, err := NewExternalIPPoolsServer().
+				SetLogger(logger).
+				SetTenancyLogic(tenancy).
+				Build()
+			Expect(err).To(MatchError("attribution logic is mandatory"))
+			Expect(s).To(BeNil())
+		})
+
+		It("Fails if tenancy logic is not set", func() {
+			s, err := NewExternalIPPoolsServer().
+				SetLogger(logger).
+				SetAttributionLogic(attribution).
+				Build()
+			Expect(err).To(MatchError("tenancy logic is mandatory"))
+			Expect(s).To(BeNil())
+		})
+	})
+
+	Describe("List", func() {
+		It("Returns only READY pools with available capacity", func() {
+			for i := range 3 {
+				_, err := privatePool.Create(ctx, privatev1.ExternalIPPoolsCreateRequest_builder{
+					Object: privatev1.ExternalIPPool_builder{
+						Metadata: privatev1.Metadata_builder{
+							Name: fmt.Sprintf("pool-%d", i),
+						}.Build(),
+						Spec: privatev1.ExternalIPPoolSpec_builder{
+							Cidrs:    []string{fmt.Sprintf("10.%d.0.0/24", i)},
+							IpFamily: privatev1.IPFamily_IP_FAMILY_IPV4,
+						}.Build(),
+					}.Build(),
+				}.Build())
+				Expect(err).ToNot(HaveOccurred())
+			}
+
+			// Set pool-1 to READY with capacity:
+			listResp, err := privatePool.List(ctx, privatev1.ExternalIPPoolsListRequest_builder{}.Build())
+			Expect(err).ToNot(HaveOccurred())
+			for _, p := range listResp.GetItems() {
+				if p.GetMetadata().GetName() == "pool-1" {
+					_, err = privatePool.Update(ctx, privatev1.ExternalIPPoolsUpdateRequest_builder{
+						Object: privatev1.ExternalIPPool_builder{
+							Id: p.GetId(),
+							Status: privatev1.ExternalIPPoolStatus_builder{
+								State:     privatev1.ExternalIPPoolState_EXTERNAL_IP_POOL_STATE_READY,
+								Total:     10,
+								Available: 5,
+								Allocated: 5,
+							}.Build(),
+						}.Build(),
+						UpdateMask: &fieldmaskpb.FieldMask{
+							Paths: []string{"status"},
+						},
+					}.Build())
+					Expect(err).ToNot(HaveOccurred())
+				}
+			}
+
+			publicServer, err := NewExternalIPPoolsServer().
+				SetLogger(logger).
+				SetAttributionLogic(attribution).
+				SetTenancyLogic(tenancy).
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+
+			publicResp, err := publicServer.List(ctx, publicv1.ExternalIPPoolsListRequest_builder{}.Build())
+			Expect(err).ToNot(HaveOccurred())
+			Expect(publicResp.GetItems()).To(HaveLen(1))
+			Expect(publicResp.GetTotal()).To(BeNumerically("==", 1))
+		})
+
+		It("Excludes READY pools with zero available capacity", func() {
+			createResp, err := privatePool.Create(ctx, privatev1.ExternalIPPoolsCreateRequest_builder{
+				Object: privatev1.ExternalIPPool_builder{
+					Spec: privatev1.ExternalIPPoolSpec_builder{
+						Cidrs:    []string{"10.0.0.0/24"},
+						IpFamily: privatev1.IPFamily_IP_FAMILY_IPV4,
+					}.Build(),
+				}.Build(),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+
+			_, err = privatePool.Update(ctx, privatev1.ExternalIPPoolsUpdateRequest_builder{
+				Object: privatev1.ExternalIPPool_builder{
+					Id: createResp.GetObject().GetId(),
+					Status: privatev1.ExternalIPPoolStatus_builder{
+						State:     privatev1.ExternalIPPoolState_EXTERNAL_IP_POOL_STATE_READY,
+						Total:     10,
+						Available: 0,
+						Allocated: 10,
+					}.Build(),
+				}.Build(),
+				UpdateMask: &fieldmaskpb.FieldMask{
+					Paths: []string{"status"},
+				},
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+
+			publicServer, err := NewExternalIPPoolsServer().
+				SetLogger(logger).
+				SetAttributionLogic(attribution).
+				SetTenancyLogic(tenancy).
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+
+			publicResp, err := publicServer.List(ctx, publicv1.ExternalIPPoolsListRequest_builder{}.Build())
+			Expect(err).ToNot(HaveOccurred())
+			Expect(publicResp.GetItems()).To(BeEmpty())
+		})
+	})
+
+	Describe("Get", func() {
+		It("Returns pool when READY with available capacity", func() {
+			createResp, err := privatePool.Create(ctx, privatev1.ExternalIPPoolsCreateRequest_builder{
+				Object: privatev1.ExternalIPPool_builder{
+					Spec: privatev1.ExternalIPPoolSpec_builder{
+						Cidrs:    []string{"10.0.0.0/24"},
+						IpFamily: privatev1.IPFamily_IP_FAMILY_IPV4,
+					}.Build(),
+				}.Build(),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+			poolID := createResp.GetObject().GetId()
+
+			_, err = privatePool.Update(ctx, privatev1.ExternalIPPoolsUpdateRequest_builder{
+				Object: privatev1.ExternalIPPool_builder{
+					Id: poolID,
+					Status: privatev1.ExternalIPPoolStatus_builder{
+						State:     privatev1.ExternalIPPoolState_EXTERNAL_IP_POOL_STATE_READY,
+						Total:     10,
+						Available: 5,
+						Allocated: 5,
+					}.Build(),
+				}.Build(),
+				UpdateMask: &fieldmaskpb.FieldMask{
+					Paths: []string{"status"},
+				},
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+
+			publicServer, err := NewExternalIPPoolsServer().
+				SetLogger(logger).
+				SetAttributionLogic(attribution).
+				SetTenancyLogic(tenancy).
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+
+			getResp, err := publicServer.Get(ctx, publicv1.ExternalIPPoolsGetRequest_builder{
+				Id: poolID,
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+			Expect(getResp.GetObject()).ToNot(BeNil())
+		})
+
+		It("Returns NotFound when pool is not READY", func() {
+			createResp, err := privatePool.Create(ctx, privatev1.ExternalIPPoolsCreateRequest_builder{
+				Object: privatev1.ExternalIPPool_builder{
+					Spec: privatev1.ExternalIPPoolSpec_builder{
+						Cidrs:    []string{"10.0.0.0/24"},
+						IpFamily: privatev1.IPFamily_IP_FAMILY_IPV4,
+					}.Build(),
+				}.Build(),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+
+			publicServer, err := NewExternalIPPoolsServer().
+				SetLogger(logger).
+				SetAttributionLogic(attribution).
+				SetTenancyLogic(tenancy).
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+
+			_, err = publicServer.Get(ctx, publicv1.ExternalIPPoolsGetRequest_builder{
+				Id: createResp.GetObject().GetId(),
+			}.Build())
+			Expect(err).To(HaveOccurred())
+			status, ok := grpcstatus.FromError(err)
+			Expect(ok).To(BeTrue())
+			Expect(status.Code()).To(Equal(grpccodes.NotFound))
+		})
+	})
+})

--- a/internal/servers/external_ips_server.go
+++ b/internal/servers/external_ips_server.go
@@ -1,0 +1,293 @@
+/*
+Copyright (c) 2026 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package servers
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+
+	"github.com/prometheus/client_golang/prometheus"
+	grpccodes "google.golang.org/grpc/codes"
+	grpcstatus "google.golang.org/grpc/status"
+
+	privatev1 "github.com/osac-project/fulfillment-service/internal/api/osac/private/v1"
+	publicv1 "github.com/osac-project/fulfillment-service/internal/api/osac/public/v1"
+	"github.com/osac-project/fulfillment-service/internal/auth"
+	"github.com/osac-project/fulfillment-service/internal/events"
+)
+
+type ExternalIPsServerBuilder struct {
+	logger            *slog.Logger
+	notifier          events.Notifier
+	attributionLogic  auth.AttributionLogic
+	tenancyLogic      auth.TenancyLogic
+	metricsRegisterer prometheus.Registerer
+}
+
+var _ publicv1.ExternalIPsServer = (*ExternalIPsServer)(nil)
+
+type ExternalIPsServer struct {
+	publicv1.UnimplementedExternalIPsServer
+
+	logger    *slog.Logger
+	delegate  privatev1.ExternalIPsServer
+	inMapper  *GenericMapper[*publicv1.ExternalIP, *privatev1.ExternalIP]
+	outMapper *GenericMapper[*privatev1.ExternalIP, *publicv1.ExternalIP]
+}
+
+func NewExternalIPsServer() *ExternalIPsServerBuilder {
+	return &ExternalIPsServerBuilder{}
+}
+
+func (b *ExternalIPsServerBuilder) SetLogger(value *slog.Logger) *ExternalIPsServerBuilder {
+	b.logger = value
+	return b
+}
+
+func (b *ExternalIPsServerBuilder) SetNotifier(value events.Notifier) *ExternalIPsServerBuilder {
+	b.notifier = value
+	return b
+}
+
+func (b *ExternalIPsServerBuilder) SetAttributionLogic(value auth.AttributionLogic) *ExternalIPsServerBuilder {
+	b.attributionLogic = value
+	return b
+}
+
+func (b *ExternalIPsServerBuilder) SetTenancyLogic(value auth.TenancyLogic) *ExternalIPsServerBuilder {
+	b.tenancyLogic = value
+	return b
+}
+
+func (b *ExternalIPsServerBuilder) SetMetricsRegisterer(value prometheus.Registerer) *ExternalIPsServerBuilder {
+	b.metricsRegisterer = value
+	return b
+}
+
+func (b *ExternalIPsServerBuilder) Build() (result *ExternalIPsServer, err error) {
+	if b.logger == nil {
+		err = errors.New("logger is mandatory")
+		return
+	}
+	if b.tenancyLogic == nil {
+		err = errors.New("tenancy logic is mandatory")
+		return
+	}
+	if b.attributionLogic == nil {
+		err = errors.New("attribution logic is mandatory")
+		return
+	}
+
+	inMapper, err := NewGenericMapper[*publicv1.ExternalIP, *privatev1.ExternalIP]().
+		SetLogger(b.logger).
+		SetStrict(true).
+		Build()
+	if err != nil {
+		return
+	}
+	outMapper, err := NewGenericMapper[*privatev1.ExternalIP, *publicv1.ExternalIP]().
+		SetLogger(b.logger).
+		SetStrict(false).
+		Build()
+	if err != nil {
+		return
+	}
+
+	delegate, err := NewPrivateExternalIPsServer().
+		SetLogger(b.logger).
+		SetNotifier(b.notifier).
+		SetAttributionLogic(b.attributionLogic).
+		SetTenancyLogic(b.tenancyLogic).
+		SetMetricsRegisterer(b.metricsRegisterer).
+		Build()
+	if err != nil {
+		return
+	}
+
+	result = &ExternalIPsServer{
+		logger:    b.logger,
+		delegate:  delegate,
+		inMapper:  inMapper,
+		outMapper: outMapper,
+	}
+	return
+}
+
+func (s *ExternalIPsServer) List(ctx context.Context,
+	request *publicv1.ExternalIPsListRequest) (response *publicv1.ExternalIPsListResponse, err error) {
+	privateRequest := &privatev1.ExternalIPsListRequest{}
+	privateRequest.SetOffset(request.GetOffset())
+	privateRequest.SetLimit(request.GetLimit())
+	privateRequest.SetFilter(request.GetFilter())
+	privateRequest.SetOrder(request.GetOrder())
+
+	privateResponse, err := s.delegate.List(ctx, privateRequest)
+	if err != nil {
+		return nil, err
+	}
+
+	privateItems := privateResponse.GetItems()
+	publicItems := make([]*publicv1.ExternalIP, len(privateItems))
+	for i, privateItem := range privateItems {
+		publicItem := &publicv1.ExternalIP{}
+		err = s.outMapper.Copy(ctx, privateItem, publicItem)
+		if err != nil {
+			s.logger.ErrorContext(
+				ctx,
+				"Failed to map private external IP to public",
+				slog.Any("error", err),
+			)
+			return nil, grpcstatus.Errorf(grpccodes.Internal, "failed to process external IPs")
+		}
+		publicItems[i] = publicItem
+	}
+
+	response = &publicv1.ExternalIPsListResponse{}
+	response.SetSize(privateResponse.GetSize())
+	response.SetTotal(privateResponse.GetTotal())
+	response.SetItems(publicItems)
+	return
+}
+
+func (s *ExternalIPsServer) Get(ctx context.Context,
+	request *publicv1.ExternalIPsGetRequest) (response *publicv1.ExternalIPsGetResponse, err error) {
+	privateRequest := &privatev1.ExternalIPsGetRequest{}
+	privateRequest.SetId(request.GetId())
+
+	privateResponse, err := s.delegate.Get(ctx, privateRequest)
+	if err != nil {
+		return nil, err
+	}
+
+	privateExternalIP := privateResponse.GetObject()
+	publicExternalIP := &publicv1.ExternalIP{}
+	err = s.outMapper.Copy(ctx, privateExternalIP, publicExternalIP)
+	if err != nil {
+		s.logger.ErrorContext(
+			ctx,
+			"Failed to map private external IP to public",
+			slog.Any("error", err),
+		)
+		return nil, grpcstatus.Errorf(grpccodes.Internal, "failed to process external IP")
+	}
+
+	response = &publicv1.ExternalIPsGetResponse{}
+	response.SetObject(publicExternalIP)
+	return
+}
+
+func (s *ExternalIPsServer) Create(ctx context.Context,
+	request *publicv1.ExternalIPsCreateRequest) (response *publicv1.ExternalIPsCreateResponse, err error) {
+	publicExternalIP := request.GetObject()
+	if publicExternalIP == nil {
+		err = grpcstatus.Errorf(grpccodes.InvalidArgument, "object is mandatory")
+		return
+	}
+	privateExternalIP := &privatev1.ExternalIP{}
+	err = s.inMapper.Copy(ctx, publicExternalIP, privateExternalIP)
+	if err != nil {
+		s.logger.ErrorContext(
+			ctx,
+			"Failed to map public external IP to private",
+			slog.Any("error", err),
+		)
+		err = grpcstatus.Errorf(grpccodes.Internal, "failed to process external IP")
+		return
+	}
+
+	privateRequest := &privatev1.ExternalIPsCreateRequest{}
+	privateRequest.SetObject(privateExternalIP)
+	privateResponse, err := s.delegate.Create(ctx, privateRequest)
+	if err != nil {
+		return nil, err
+	}
+
+	createdPrivateExternalIP := privateResponse.GetObject()
+	createdPublicExternalIP := &publicv1.ExternalIP{}
+	err = s.outMapper.Copy(ctx, createdPrivateExternalIP, createdPublicExternalIP)
+	if err != nil {
+		s.logger.ErrorContext(
+			ctx,
+			"Failed to map private external IP to public",
+			slog.Any("error", err),
+		)
+		err = grpcstatus.Errorf(grpccodes.Internal, "failed to process external IP")
+		return
+	}
+
+	response = &publicv1.ExternalIPsCreateResponse{}
+	response.SetObject(createdPublicExternalIP)
+	return
+}
+
+func (s *ExternalIPsServer) Update(ctx context.Context,
+	request *publicv1.ExternalIPsUpdateRequest) (response *publicv1.ExternalIPsUpdateResponse, err error) {
+	publicExternalIP := request.GetObject()
+	if publicExternalIP == nil {
+		err = grpcstatus.Errorf(grpccodes.InvalidArgument, "object is mandatory")
+		return
+	}
+	privateExternalIP := &privatev1.ExternalIP{}
+	err = s.inMapper.Copy(ctx, publicExternalIP, privateExternalIP)
+	if err != nil {
+		s.logger.ErrorContext(
+			ctx,
+			"Failed to map public external IP to private",
+			slog.Any("error", err),
+		)
+		err = grpcstatus.Errorf(grpccodes.Internal, "failed to process external IP")
+		return
+	}
+
+	privateRequest := &privatev1.ExternalIPsUpdateRequest{}
+	privateRequest.SetObject(privateExternalIP)
+	privateRequest.SetUpdateMask(request.GetUpdateMask())
+	privateRequest.SetLock(request.GetLock())
+	privateResponse, err := s.delegate.Update(ctx, privateRequest)
+	if err != nil {
+		return nil, err
+	}
+
+	updatedPrivateExternalIP := privateResponse.GetObject()
+	updatedPublicExternalIP := &publicv1.ExternalIP{}
+	err = s.outMapper.Copy(ctx, updatedPrivateExternalIP, updatedPublicExternalIP)
+	if err != nil {
+		s.logger.ErrorContext(
+			ctx,
+			"Failed to map private external IP to public",
+			slog.Any("error", err),
+		)
+		err = grpcstatus.Errorf(grpccodes.Internal, "failed to process external IP")
+		return
+	}
+
+	response = &publicv1.ExternalIPsUpdateResponse{}
+	response.SetObject(updatedPublicExternalIP)
+	return
+}
+
+func (s *ExternalIPsServer) Delete(ctx context.Context,
+	request *publicv1.ExternalIPsDeleteRequest) (response *publicv1.ExternalIPsDeleteResponse, err error) {
+	privateRequest := &privatev1.ExternalIPsDeleteRequest{}
+	privateRequest.SetId(request.GetId())
+
+	_, err = s.delegate.Delete(ctx, privateRequest)
+	if err != nil {
+		return nil, err
+	}
+
+	response = &publicv1.ExternalIPsDeleteResponse{}
+	return
+}

--- a/internal/servers/external_ips_server_test.go
+++ b/internal/servers/external_ips_server_test.go
@@ -1,0 +1,191 @@
+/*
+Copyright (c) 2026 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package servers
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	privatev1 "github.com/osac-project/fulfillment-service/internal/api/osac/private/v1"
+	publicv1 "github.com/osac-project/fulfillment-service/internal/api/osac/public/v1"
+	"github.com/osac-project/fulfillment-service/internal/auth"
+	"github.com/osac-project/fulfillment-service/internal/database/dao"
+)
+
+var _ = Describe("Public external IPs server", func() {
+	Describe("Builder", func() {
+		It("Builds successfully with required parameters", func() {
+			s, err := NewExternalIPsServer().
+				SetLogger(logger).
+				SetAttributionLogic(attribution).
+				SetTenancyLogic(tenancy).
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(s).ToNot(BeNil())
+		})
+
+		It("Fails if logger is not set", func() {
+			s, err := NewExternalIPsServer().
+				SetAttributionLogic(attribution).
+				SetTenancyLogic(tenancy).
+				Build()
+			Expect(err).To(MatchError("logger is mandatory"))
+			Expect(s).To(BeNil())
+		})
+
+		It("Fails if tenancy logic is not set", func() {
+			s, err := NewExternalIPsServer().
+				SetLogger(logger).
+				SetAttributionLogic(attribution).
+				Build()
+			Expect(err).To(MatchError("tenancy logic is mandatory"))
+			Expect(s).To(BeNil())
+		})
+
+		It("Fails if attribution logic is not set", func() {
+			s, err := NewExternalIPsServer().
+				SetLogger(logger).
+				SetTenancyLogic(tenancy).
+				Build()
+			Expect(err).To(MatchError("attribution logic is mandatory"))
+			Expect(s).To(BeNil())
+		})
+	})
+
+	Describe("CRUD operations", func() {
+		var (
+			publicServer      *ExternalIPsServer
+			externalIPPoolDao *dao.GenericDAO[*privatev1.ExternalIPPool]
+		)
+
+		BeforeEach(func() {
+			var err error
+
+			publicServer, err = NewExternalIPsServer().
+				SetLogger(logger).
+				SetAttributionLogic(attribution).
+				SetTenancyLogic(tenancy).
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+
+			externalIPPoolDao, err = dao.NewGenericDAO[*privatev1.ExternalIPPool]().
+				SetLogger(logger).
+				SetTenancyLogic(tenancy).
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+
+			// Create a READY pool for CRUD tests:
+			_, err = externalIPPoolDao.Create().SetObject(
+				privatev1.ExternalIPPool_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name:   "test-pool",
+						Tenant: auth.SharedTenant,
+					}.Build(),
+					Spec: privatev1.ExternalIPPoolSpec_builder{
+						Cidrs: []string{"10.0.0.0/24"},
+					}.Build(),
+					Status: privatev1.ExternalIPPoolStatus_builder{
+						State:     privatev1.ExternalIPPoolState_EXTERNAL_IP_POOL_STATE_READY,
+						Total:     100,
+						Allocated: 0,
+						Available: 100,
+					}.Build(),
+				}.Build(),
+			).Do(ctx)
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		// getPoolID returns the ID of the test pool created in BeforeEach.
+		getPoolID := func() string {
+			externalIPPoolDao, err := dao.NewGenericDAO[*privatev1.ExternalIPPool]().
+				SetLogger(logger).
+				SetTenancyLogic(tenancy).
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+			resp, err := externalIPPoolDao.List().Do(ctx)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(resp.GetItems()).ToNot(BeEmpty())
+			return resp.GetItems()[0].GetId()
+		}
+
+		It("creates and retrieves an ExternalIP", func() {
+			poolID := getPoolID()
+			createResp, err := publicServer.Create(ctx, publicv1.ExternalIPsCreateRequest_builder{
+				Object: publicv1.ExternalIP_builder{
+					Metadata: publicv1.Metadata_builder{Tenant: auth.SharedTenant}.Build(),
+					Spec:     publicv1.ExternalIPSpec_builder{Pool: poolID}.Build(),
+				}.Build(),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+			Expect(createResp.GetObject().GetId()).ToNot(BeEmpty())
+
+			getResp, err := publicServer.Get(ctx, publicv1.ExternalIPsGetRequest_builder{
+				Id: createResp.GetObject().GetId(),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+			Expect(getResp.GetObject().GetId()).To(Equal(createResp.GetObject().GetId()))
+		})
+
+		It("lists ExternalIPs", func() {
+			poolID := getPoolID()
+			for range 3 {
+				_, err := publicServer.Create(ctx, publicv1.ExternalIPsCreateRequest_builder{
+					Object: publicv1.ExternalIP_builder{
+						Metadata: publicv1.Metadata_builder{Tenant: auth.SharedTenant}.Build(),
+						Spec:     publicv1.ExternalIPSpec_builder{Pool: poolID}.Build(),
+					}.Build(),
+				}.Build())
+				Expect(err).ToNot(HaveOccurred())
+			}
+
+			listResp, err := publicServer.List(ctx, publicv1.ExternalIPsListRequest_builder{}.Build())
+			Expect(err).ToNot(HaveOccurred())
+			Expect(listResp.GetItems()).To(HaveLen(3))
+		})
+
+		It("deletes an ExternalIP", func() {
+			poolID := getPoolID()
+			createResp, err := publicServer.Create(ctx, publicv1.ExternalIPsCreateRequest_builder{
+				Object: publicv1.ExternalIP_builder{
+					Metadata: publicv1.Metadata_builder{Tenant: auth.SharedTenant}.Build(),
+					Spec:     publicv1.ExternalIPSpec_builder{Pool: poolID}.Build(),
+				}.Build(),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+
+			// Transition to ALLOCATED via private server (public API doesn't expose state changes):
+			privateServer, err := NewPrivateExternalIPsServer().
+				SetLogger(logger).
+				SetAttributionLogic(attribution).
+				SetTenancyLogic(tenancy).
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+			getResp, err := privateServer.Get(ctx, privatev1.ExternalIPsGetRequest_builder{
+				Id: createResp.GetObject().GetId(),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+			object := getResp.GetObject()
+			object.GetStatus().SetState(privatev1.ExternalIPState_EXTERNAL_IP_STATE_ALLOCATED)
+			_, err = privateServer.Update(ctx, privatev1.ExternalIPsUpdateRequest_builder{
+				Object: object,
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+
+			_, err = publicServer.Delete(ctx, publicv1.ExternalIPsDeleteRequest_builder{
+				Id: createResp.GetObject().GetId(),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+		})
+	})
+})

--- a/internal/servers/generic_server.go
+++ b/internal/servers/generic_server.go
@@ -897,6 +897,12 @@ func (s *GenericServer[O]) setPayload(event *privatev1.Event, object proto.Messa
 		event.SetPublicIp(object)
 	case *privatev1.PublicIPAttachment:
 		event.SetPublicIpAttachment(object)
+	case *privatev1.ExternalIPPool:
+		// Event proto does not yet have ExternalIPPool payload fields; skip notification payload.
+	case *privatev1.ExternalIP:
+		// Event proto does not yet have ExternalIP payload fields; skip notification payload.
+	case *privatev1.ExternalIPAttachment:
+		// Event proto does not yet have ExternalIPAttachment payload fields; skip notification payload.
 	case *privatev1.Tenant:
 		event.SetTenant(object)
 	case *privatev1.User:

--- a/internal/servers/private_external_ip_pools_server.go
+++ b/internal/servers/private_external_ip_pools_server.go
@@ -1,0 +1,290 @@
+/*
+Copyright (c) 2026 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package servers
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+
+	"github.com/prometheus/client_golang/prometheus"
+	grpccodes "google.golang.org/grpc/codes"
+	grpcstatus "google.golang.org/grpc/status"
+
+	privatev1 "github.com/osac-project/fulfillment-service/internal/api/osac/private/v1"
+	"github.com/osac-project/fulfillment-service/internal/auth"
+	"github.com/osac-project/fulfillment-service/internal/events"
+)
+
+type PrivateExternalIPPoolsServerBuilder struct {
+	logger            *slog.Logger
+	notifier          events.Notifier
+	attributionLogic  auth.AttributionLogic
+	tenancyLogic      auth.TenancyLogic
+	metricsRegisterer prometheus.Registerer
+}
+
+var _ privatev1.ExternalIPPoolsServer = (*PrivateExternalIPPoolsServer)(nil)
+
+type PrivateExternalIPPoolsServer struct {
+	privatev1.UnimplementedExternalIPPoolsServer
+
+	logger  *slog.Logger
+	generic *GenericServer[*privatev1.ExternalIPPool]
+}
+
+func NewPrivateExternalIPPoolsServer() *PrivateExternalIPPoolsServerBuilder {
+	return &PrivateExternalIPPoolsServerBuilder{}
+}
+
+func (b *PrivateExternalIPPoolsServerBuilder) SetLogger(value *slog.Logger) *PrivateExternalIPPoolsServerBuilder {
+	b.logger = value
+	return b
+}
+
+func (b *PrivateExternalIPPoolsServerBuilder) SetNotifier(value events.Notifier) *PrivateExternalIPPoolsServerBuilder {
+	b.notifier = value
+	return b
+}
+
+func (b *PrivateExternalIPPoolsServerBuilder) SetAttributionLogic(value auth.AttributionLogic) *PrivateExternalIPPoolsServerBuilder {
+	b.attributionLogic = value
+	return b
+}
+
+func (b *PrivateExternalIPPoolsServerBuilder) SetTenancyLogic(value auth.TenancyLogic) *PrivateExternalIPPoolsServerBuilder {
+	b.tenancyLogic = value
+	return b
+}
+
+func (b *PrivateExternalIPPoolsServerBuilder) SetMetricsRegisterer(value prometheus.Registerer) *PrivateExternalIPPoolsServerBuilder {
+	b.metricsRegisterer = value
+	return b
+}
+
+func (b *PrivateExternalIPPoolsServerBuilder) Build() (result *PrivateExternalIPPoolsServer, err error) {
+	if b.logger == nil {
+		err = errors.New("logger is mandatory")
+		return
+	}
+	if b.tenancyLogic == nil {
+		err = errors.New("tenancy logic is mandatory")
+		return
+	}
+
+	generic, err := NewGenericServer[*privatev1.ExternalIPPool]().
+		SetLogger(b.logger).
+		SetService(privatev1.ExternalIPPools_ServiceDesc.ServiceName).
+		SetNotifier(b.notifier).
+		SetAttributionLogic(b.attributionLogic).
+		SetTenancyLogic(b.tenancyLogic).
+		SetMetricsRegisterer(b.metricsRegisterer).
+		Build()
+	if err != nil {
+		return
+	}
+
+	result = &PrivateExternalIPPoolsServer{
+		logger:  b.logger,
+		generic: generic,
+	}
+	return
+}
+
+func (s *PrivateExternalIPPoolsServer) List(ctx context.Context,
+	request *privatev1.ExternalIPPoolsListRequest) (response *privatev1.ExternalIPPoolsListResponse, err error) {
+	err = s.generic.List(ctx, request, &response)
+	return
+}
+
+func (s *PrivateExternalIPPoolsServer) Get(ctx context.Context,
+	request *privatev1.ExternalIPPoolsGetRequest) (response *privatev1.ExternalIPPoolsGetResponse, err error) {
+	err = s.generic.Get(ctx, request, &response)
+	return
+}
+
+func (s *PrivateExternalIPPoolsServer) Create(ctx context.Context,
+	request *privatev1.ExternalIPPoolsCreateRequest) (response *privatev1.ExternalIPPoolsCreateResponse, err error) {
+	pool := request.GetObject()
+
+	err = s.validateCreate(ctx, pool)
+	if err != nil {
+		return
+	}
+
+	total := calculatePoolCapacity(pool.GetSpec().GetCidrs(), pool.GetSpec().GetIpFamily())
+	pool.SetStatus(privatev1.ExternalIPPoolStatus_builder{
+		Total:     total,
+		Available: total,
+	}.Build())
+
+	err = s.generic.Create(ctx, request, &response)
+	return
+}
+
+func (s *PrivateExternalIPPoolsServer) Update(ctx context.Context,
+	request *privatev1.ExternalIPPoolsUpdateRequest) (response *privatev1.ExternalIPPoolsUpdateResponse, err error) {
+	id := request.GetObject().GetId()
+	if id == "" {
+		err = grpcstatus.Errorf(grpccodes.InvalidArgument, "object identifier is mandatory")
+		return
+	}
+
+	getRequest := &privatev1.ExternalIPPoolsGetRequest{}
+	getRequest.SetId(id)
+	var getResponse *privatev1.ExternalIPPoolsGetResponse
+	err = s.generic.Get(ctx, getRequest, &getResponse)
+	if err != nil {
+		return
+	}
+
+	err = validateExternalIPPoolUpdate(request.GetObject(), getResponse.GetObject())
+	if err != nil {
+		return
+	}
+
+	err = s.generic.Update(ctx, request, &response)
+	return
+}
+
+func (s *PrivateExternalIPPoolsServer) validateCreate(ctx context.Context,
+	pool *privatev1.ExternalIPPool) error {
+
+	if pool == nil {
+		return grpcstatus.Errorf(grpccodes.InvalidArgument, "external IP pool is mandatory")
+	}
+
+	spec := pool.GetSpec()
+	if spec == nil {
+		return grpcstatus.Errorf(grpccodes.InvalidArgument, "external IP pool spec is mandatory")
+	}
+
+	if spec.GetIpFamily() == privatev1.IPFamily_IP_FAMILY_UNSPECIFIED {
+		return grpcstatus.Errorf(grpccodes.InvalidArgument, "field 'spec.ip_family' is required")
+	}
+
+	cidrs := spec.GetCidrs()
+	if len(cidrs) == 0 {
+		return grpcstatus.Errorf(grpccodes.InvalidArgument, "field 'spec.cidrs' is required")
+	}
+
+	canonicalCIDRs := make([]string, len(cidrs))
+	for i, cidr := range cidrs {
+		canonical, err := validatePoolCIDRFormat(cidr, spec.GetIpFamily(), i)
+		if err != nil {
+			return err
+		}
+		canonicalCIDRs[i] = canonical
+	}
+	spec.SetCidrs(canonicalCIDRs)
+
+	if err := validateNoCIDRSelfOverlap(canonicalCIDRs); err != nil {
+		return err
+	}
+
+	return s.validateNoExternalIPPoolCIDROverlap(ctx, pool)
+}
+
+func validateExternalIPPoolUpdate(newPool *privatev1.ExternalIPPool, existing *privatev1.ExternalIPPool) error {
+	if newPool == nil {
+		return grpcstatus.Errorf(grpccodes.InvalidArgument, "external IP pool is mandatory")
+	}
+
+	spec := newPool.GetSpec()
+	if spec == nil {
+		return nil
+	}
+
+	if spec.GetIpFamily() != privatev1.IPFamily_IP_FAMILY_UNSPECIFIED &&
+		spec.GetIpFamily() != existing.GetSpec().GetIpFamily() {
+		return grpcstatus.Errorf(grpccodes.InvalidArgument,
+			"field 'spec.ip_family' is immutable and cannot be changed from '%s' to '%s'",
+			existing.GetSpec().GetIpFamily().String(), spec.GetIpFamily().String())
+	}
+
+	if newCIDRs := spec.GetCidrs(); len(newCIDRs) > 0 && !cidrSlicesEqual(newCIDRs, existing.GetSpec().GetCidrs()) {
+		return grpcstatus.Errorf(grpccodes.InvalidArgument,
+			"field 'spec.cidrs' is immutable and cannot be changed after creation")
+	}
+
+	return nil
+}
+
+func (s *PrivateExternalIPPoolsServer) validateNoExternalIPPoolCIDROverlap(ctx context.Context,
+	pool *privatev1.ExternalIPPool) error {
+
+	newCIDRs := pool.GetSpec().GetCidrs()
+
+	var offset int32
+	for {
+		listRequest := &privatev1.ExternalIPPoolsListRequest{}
+		listRequest.SetOffset(offset)
+		var listResponse *privatev1.ExternalIPPoolsListResponse
+		if err := s.generic.List(ctx, listRequest, &listResponse); err != nil {
+			s.logger.ErrorContext(ctx, "Failed to list pools for overlap check", slog.Any("error", err))
+			return grpcstatus.Errorf(grpccodes.Internal, "failed to validate CIDR overlap")
+		}
+
+		for _, existing := range listResponse.GetItems() {
+			for _, existingCIDR := range existing.GetSpec().GetCidrs() {
+				for _, newCIDR := range newCIDRs {
+					overlap, err := cidrsOverlap(newCIDR, existingCIDR)
+					if err != nil {
+						s.logger.ErrorContext(ctx, "Failed to check CIDR overlap", slog.Any("error", err))
+						return grpcstatus.Errorf(grpccodes.Internal, "failed to validate CIDR overlap")
+					}
+					if overlap {
+						return grpcstatus.Errorf(grpccodes.AlreadyExists,
+							"CIDR '%s' overlaps with CIDR '%s' from existing pool '%s'",
+							newCIDR, existingCIDR, existing.GetMetadata().GetName())
+					}
+				}
+			}
+		}
+
+		if offset+listResponse.GetSize() >= listResponse.GetTotal() {
+			break
+		}
+		offset += listResponse.GetSize()
+	}
+
+	return nil
+}
+
+func (s *PrivateExternalIPPoolsServer) Delete(ctx context.Context,
+	request *privatev1.ExternalIPPoolsDeleteRequest) (response *privatev1.ExternalIPPoolsDeleteResponse, err error) {
+	var getResponse *privatev1.ExternalIPPoolsGetResponse
+	err = s.generic.Get(ctx, privatev1.ExternalIPPoolsGetRequest_builder{
+		Id: request.GetId(),
+	}.Build(), &getResponse)
+	if err != nil {
+		return
+	}
+	if allocated := getResponse.GetObject().GetStatus().GetAllocated(); allocated > 0 {
+		err = grpcstatus.Errorf(
+			grpccodes.FailedPrecondition,
+			"cannot delete external IP pool '%s': %d external IP(s) are still allocated from it",
+			request.GetId(), allocated,
+		)
+		return
+	}
+	err = s.generic.Delete(ctx, request, &response)
+	return
+}
+
+func (s *PrivateExternalIPPoolsServer) Signal(ctx context.Context,
+	request *privatev1.ExternalIPPoolsSignalRequest) (response *privatev1.ExternalIPPoolsSignalResponse, err error) {
+	err = s.generic.Signal(ctx, request, &response)
+	return
+}

--- a/internal/servers/private_external_ip_pools_server_test.go
+++ b/internal/servers/private_external_ip_pools_server_test.go
@@ -1,0 +1,543 @@
+/*
+Copyright (c) 2026 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package servers
+
+import (
+	"fmt"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	grpccodes "google.golang.org/grpc/codes"
+	grpcstatus "google.golang.org/grpc/status"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/fieldmaskpb"
+
+	privatev1 "github.com/osac-project/fulfillment-service/internal/api/osac/private/v1"
+)
+
+var _ = Describe("Private external IP pools server", func() {
+	Describe("Creation", func() {
+		It("Can be built if all the required parameters are set", func() {
+			server, err := NewPrivateExternalIPPoolsServer().
+				SetLogger(logger).
+				SetAttributionLogic(attribution).
+				SetTenancyLogic(tenancy).
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(server).ToNot(BeNil())
+		})
+
+		It("Fails if logger is not set", func() {
+			server, err := NewPrivateExternalIPPoolsServer().
+				SetAttributionLogic(attribution).
+				SetTenancyLogic(tenancy).
+				Build()
+			Expect(err).To(MatchError("logger is mandatory"))
+			Expect(server).To(BeNil())
+		})
+
+		It("Fails if tenancy logic is not set", func() {
+			server, err := NewPrivateExternalIPPoolsServer().
+				SetLogger(logger).
+				SetAttributionLogic(attribution).
+				Build()
+			Expect(err).To(MatchError("tenancy logic is mandatory"))
+			Expect(server).To(BeNil())
+		})
+	})
+
+	Describe("Behaviour", func() {
+		var (
+			poolsServer *PrivateExternalIPPoolsServer
+			ipsServer   *PrivateExternalIPsServer
+		)
+
+		BeforeEach(func() {
+			var err error
+
+			poolsServer, err = NewPrivateExternalIPPoolsServer().
+				SetLogger(logger).
+				SetAttributionLogic(attribution).
+				SetTenancyLogic(tenancy).
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+
+			ipsServer, err = NewPrivateExternalIPsServer().
+				SetLogger(logger).
+				SetAttributionLogic(attribution).
+				SetTenancyLogic(tenancy).
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("Creates a pool", func() {
+			response, err := poolsServer.Create(ctx, privatev1.ExternalIPPoolsCreateRequest_builder{
+				Object: privatev1.ExternalIPPool_builder{
+					Spec: privatev1.ExternalIPPoolSpec_builder{
+						Cidrs:    []string{"192.168.1.0/24"},
+						IpFamily: privatev1.IPFamily_IP_FAMILY_IPV4,
+					}.Build(),
+				}.Build(),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+			Expect(response).ToNot(BeNil())
+			object := response.GetObject()
+			Expect(object.GetId()).ToNot(BeEmpty())
+			Expect(object.GetSpec().GetCidrs()).To(ConsistOf("192.168.1.0/24"))
+			Expect(object.GetSpec().GetIpFamily()).To(Equal(privatev1.IPFamily_IP_FAMILY_IPV4))
+		})
+
+		It("Lists pools", func() {
+			const count = 5
+			for i := range count {
+				_, err := poolsServer.Create(ctx, privatev1.ExternalIPPoolsCreateRequest_builder{
+					Object: privatev1.ExternalIPPool_builder{
+						Metadata: privatev1.Metadata_builder{
+							Name: fmt.Sprintf("pool-%d", i),
+						}.Build(),
+						Spec: privatev1.ExternalIPPoolSpec_builder{
+							Cidrs:    []string{fmt.Sprintf("10.%d.0.0/24", i)},
+							IpFamily: privatev1.IPFamily_IP_FAMILY_IPV4,
+						}.Build(),
+					}.Build(),
+				}.Build())
+				Expect(err).ToNot(HaveOccurred())
+			}
+
+			response, err := poolsServer.List(ctx, privatev1.ExternalIPPoolsListRequest_builder{}.Build())
+			Expect(err).ToNot(HaveOccurred())
+			Expect(response.GetItems()).To(HaveLen(count))
+		})
+
+		It("Gets a pool", func() {
+			createResponse, err := poolsServer.Create(ctx, privatev1.ExternalIPPoolsCreateRequest_builder{
+				Object: privatev1.ExternalIPPool_builder{
+					Spec: privatev1.ExternalIPPoolSpec_builder{
+						Cidrs:    []string{"192.168.1.0/24"},
+						IpFamily: privatev1.IPFamily_IP_FAMILY_IPV4,
+					}.Build(),
+				}.Build(),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+
+			getResponse, err := poolsServer.Get(ctx, privatev1.ExternalIPPoolsGetRequest_builder{
+				Id: createResponse.GetObject().GetId(),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+			Expect(proto.Equal(createResponse.GetObject(), getResponse.GetObject())).To(BeTrue())
+		})
+
+		It("Updates a pool", func() {
+			createResponse, err := poolsServer.Create(ctx, privatev1.ExternalIPPoolsCreateRequest_builder{
+				Object: privatev1.ExternalIPPool_builder{
+					Spec: privatev1.ExternalIPPoolSpec_builder{
+						Cidrs:    []string{"192.168.1.0/24"},
+						IpFamily: privatev1.IPFamily_IP_FAMILY_IPV4,
+					}.Build(),
+				}.Build(),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+			object := createResponse.GetObject()
+
+			updateResponse, err := poolsServer.Update(ctx, privatev1.ExternalIPPoolsUpdateRequest_builder{
+				Object: privatev1.ExternalIPPool_builder{
+					Id: object.GetId(),
+					Metadata: privatev1.Metadata_builder{
+						Name: "my-pool",
+					}.Build(),
+				}.Build(),
+				UpdateMask: &fieldmaskpb.FieldMask{
+					Paths: []string{"metadata.name"},
+				},
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+			Expect(updateResponse.GetObject().GetMetadata().GetName()).To(Equal("my-pool"))
+		})
+
+		It("Deletes a pool", func() {
+			createResponse, err := poolsServer.Create(ctx, privatev1.ExternalIPPoolsCreateRequest_builder{
+				Object: privatev1.ExternalIPPool_builder{
+					Metadata: privatev1.Metadata_builder{
+						Finalizers: []string{"test"},
+					}.Build(),
+					Spec: privatev1.ExternalIPPoolSpec_builder{
+						Cidrs:    []string{"192.168.1.0/24"},
+						IpFamily: privatev1.IPFamily_IP_FAMILY_IPV4,
+					}.Build(),
+				}.Build(),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+			object := createResponse.GetObject()
+
+			_, err = poolsServer.Delete(ctx, privatev1.ExternalIPPoolsDeleteRequest_builder{
+				Id: object.GetId(),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+
+			getResponse, err := poolsServer.Get(ctx, privatev1.ExternalIPPoolsGetRequest_builder{
+				Id: object.GetId(),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+			Expect(getResponse.GetObject().GetMetadata().GetDeletionTimestamp()).ToNot(BeNil())
+		})
+
+		It("Rejects deletion when allocated ExternalIPs reference the pool", func() {
+			createPoolResponse, err := poolsServer.Create(ctx, privatev1.ExternalIPPoolsCreateRequest_builder{
+				Object: privatev1.ExternalIPPool_builder{
+					Spec: privatev1.ExternalIPPoolSpec_builder{
+						Cidrs:    []string{"10.0.0.0/24"},
+						IpFamily: privatev1.IPFamily_IP_FAMILY_IPV4,
+					}.Build(),
+				}.Build(),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+			poolID := createPoolResponse.GetObject().GetId()
+
+			_, err = poolsServer.Update(ctx, privatev1.ExternalIPPoolsUpdateRequest_builder{
+				Object: privatev1.ExternalIPPool_builder{
+					Id: poolID,
+					Status: privatev1.ExternalIPPoolStatus_builder{
+						State:     privatev1.ExternalIPPoolState_EXTERNAL_IP_POOL_STATE_READY,
+						Total:     10,
+						Allocated: 0,
+						Available: 10,
+					}.Build(),
+				}.Build(),
+				UpdateMask: &fieldmaskpb.FieldMask{
+					Paths: []string{"status"},
+				},
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+
+			_, err = ipsServer.Create(ctx, privatev1.ExternalIPsCreateRequest_builder{
+				Object: privatev1.ExternalIP_builder{
+					Spec: privatev1.ExternalIPSpec_builder{
+						Pool: poolID,
+					}.Build(),
+				}.Build(),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+
+			_, err = poolsServer.Delete(ctx, privatev1.ExternalIPPoolsDeleteRequest_builder{
+				Id: poolID,
+			}.Build())
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("external IP(s) are still allocated"))
+		})
+
+		It("Allows deletion when no ExternalIPs reference the pool", func() {
+			createPoolResponse, err := poolsServer.Create(ctx, privatev1.ExternalIPPoolsCreateRequest_builder{
+				Object: privatev1.ExternalIPPool_builder{
+					Spec: privatev1.ExternalIPPoolSpec_builder{
+						Cidrs:    []string{"10.1.0.0/24"},
+						IpFamily: privatev1.IPFamily_IP_FAMILY_IPV4,
+					}.Build(),
+				}.Build(),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+			poolID := createPoolResponse.GetObject().GetId()
+
+			_, err = poolsServer.Delete(ctx, privatev1.ExternalIPPoolsDeleteRequest_builder{
+				Id: poolID,
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+		})
+	})
+
+	Describe("Validation tests", func() {
+		var poolsServer *PrivateExternalIPPoolsServer
+
+		BeforeEach(func() {
+			var err error
+
+			poolsServer, err = NewPrivateExternalIPPoolsServer().
+				SetLogger(logger).
+				SetAttributionLogic(attribution).
+				SetTenancyLogic(tenancy).
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		Context("ip_family validation", func() {
+			It("rejects pool with unspecified ip_family", func() {
+				pool := privatev1.ExternalIPPool_builder{
+					Spec: privatev1.ExternalIPPoolSpec_builder{
+						Cidrs: []string{"192.168.1.0/24"},
+					}.Build(),
+				}.Build()
+
+				err := poolsServer.validateCreate(ctx, pool)
+				Expect(err).To(HaveOccurred())
+				status, ok := grpcstatus.FromError(err)
+				Expect(ok).To(BeTrue())
+				Expect(status.Code()).To(Equal(grpccodes.InvalidArgument))
+				Expect(err.Error()).To(ContainSubstring("ip_family"))
+			})
+		})
+
+		Context("CIDRs required", func() {
+			It("rejects pool with no CIDRs", func() {
+				pool := privatev1.ExternalIPPool_builder{
+					Spec: privatev1.ExternalIPPoolSpec_builder{
+						IpFamily: privatev1.IPFamily_IP_FAMILY_IPV4,
+					}.Build(),
+				}.Build()
+
+				err := poolsServer.validateCreate(ctx, pool)
+				Expect(err).To(HaveOccurred())
+				status, ok := grpcstatus.FromError(err)
+				Expect(ok).To(BeTrue())
+				Expect(status.Code()).To(Equal(grpccodes.InvalidArgument))
+				Expect(err.Error()).To(ContainSubstring("cidrs"))
+			})
+		})
+
+		Context("CIDR format validation", func() {
+			It("rejects malformed CIDR", func() {
+				pool := privatev1.ExternalIPPool_builder{
+					Spec: privatev1.ExternalIPPoolSpec_builder{
+						Cidrs:    []string{"not-a-cidr"},
+						IpFamily: privatev1.IPFamily_IP_FAMILY_IPV4,
+					}.Build(),
+				}.Build()
+
+				err := poolsServer.validateCreate(ctx, pool)
+				Expect(err).To(HaveOccurred())
+				status, ok := grpcstatus.FromError(err)
+				Expect(ok).To(BeTrue())
+				Expect(status.Code()).To(Equal(grpccodes.InvalidArgument))
+				Expect(err.Error()).To(ContainSubstring("invalid CIDR format"))
+			})
+		})
+
+		Context("IP family consistency", func() {
+			It("rejects IPv6 CIDR in an IPv4 pool", func() {
+				pool := privatev1.ExternalIPPool_builder{
+					Spec: privatev1.ExternalIPPoolSpec_builder{
+						Cidrs:    []string{"2001:db8::/64"},
+						IpFamily: privatev1.IPFamily_IP_FAMILY_IPV4,
+					}.Build(),
+				}.Build()
+
+				err := poolsServer.validateCreate(ctx, pool)
+				Expect(err).To(HaveOccurred())
+				status, ok := grpcstatus.FromError(err)
+				Expect(ok).To(BeTrue())
+				Expect(status.Code()).To(Equal(grpccodes.InvalidArgument))
+				Expect(err.Error()).To(ContainSubstring("IPv6"))
+			})
+
+			It("canonicalizes non-canonical CIDRs on Create", func() {
+				pool := privatev1.ExternalIPPool_builder{
+					Spec: privatev1.ExternalIPPoolSpec_builder{
+						Cidrs:    []string{"10.0.1.5/24"},
+						IpFamily: privatev1.IPFamily_IP_FAMILY_IPV4,
+					}.Build(),
+				}.Build()
+
+				err := poolsServer.validateCreate(ctx, pool)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(pool.GetSpec().GetCidrs()).To(Equal([]string{"10.0.1.0/24"}))
+			})
+		})
+
+		Context("Cross-pool CIDR overlap detection", func() {
+			It("rejects a pool whose CIDR exactly matches an existing pool", func() {
+				_, err := poolsServer.Create(ctx, privatev1.ExternalIPPoolsCreateRequest_builder{
+					Object: privatev1.ExternalIPPool_builder{
+						Metadata: privatev1.Metadata_builder{Name: "pool-a"}.Build(),
+						Spec: privatev1.ExternalIPPoolSpec_builder{
+							Cidrs:    []string{"10.0.0.0/24"},
+							IpFamily: privatev1.IPFamily_IP_FAMILY_IPV4,
+						}.Build(),
+					}.Build(),
+				}.Build())
+				Expect(err).ToNot(HaveOccurred())
+
+				_, err = poolsServer.Create(ctx, privatev1.ExternalIPPoolsCreateRequest_builder{
+					Object: privatev1.ExternalIPPool_builder{
+						Metadata: privatev1.Metadata_builder{Name: "pool-b"}.Build(),
+						Spec: privatev1.ExternalIPPoolSpec_builder{
+							Cidrs:    []string{"10.0.0.0/24"},
+							IpFamily: privatev1.IPFamily_IP_FAMILY_IPV4,
+						}.Build(),
+					}.Build(),
+				}.Build())
+				Expect(err).To(HaveOccurred())
+				status, ok := grpcstatus.FromError(err)
+				Expect(ok).To(BeTrue())
+				Expect(status.Code()).To(Equal(grpccodes.AlreadyExists))
+				Expect(err.Error()).To(ContainSubstring("overlaps"))
+				Expect(err.Error()).To(ContainSubstring("pool-a"))
+			})
+
+			It("accepts a pool with a non-overlapping CIDR", func() {
+				_, err := poolsServer.Create(ctx, privatev1.ExternalIPPoolsCreateRequest_builder{
+					Object: privatev1.ExternalIPPool_builder{
+						Spec: privatev1.ExternalIPPoolSpec_builder{
+							Cidrs:    []string{"10.0.0.0/24"},
+							IpFamily: privatev1.IPFamily_IP_FAMILY_IPV4,
+						}.Build(),
+					}.Build(),
+				}.Build())
+				Expect(err).ToNot(HaveOccurred())
+
+				_, err = poolsServer.Create(ctx, privatev1.ExternalIPPoolsCreateRequest_builder{
+					Object: privatev1.ExternalIPPool_builder{
+						Spec: privatev1.ExternalIPPoolSpec_builder{
+							Cidrs:    []string{"10.0.1.0/24"},
+							IpFamily: privatev1.IPFamily_IP_FAMILY_IPV4,
+						}.Build(),
+					}.Build(),
+				}.Build())
+				Expect(err).ToNot(HaveOccurred())
+			})
+		})
+
+		Context("Intra-pool CIDR overlap detection", func() {
+			It("rejects a pool whose second CIDR is a subset of the first", func() {
+				pool := privatev1.ExternalIPPool_builder{
+					Spec: privatev1.ExternalIPPoolSpec_builder{
+						Cidrs:    []string{"10.0.0.0/24", "10.0.0.0/25"},
+						IpFamily: privatev1.IPFamily_IP_FAMILY_IPV4,
+					}.Build(),
+				}.Build()
+
+				err := poolsServer.validateCreate(ctx, pool)
+				Expect(err).To(HaveOccurred())
+				status, ok := grpcstatus.FromError(err)
+				Expect(ok).To(BeTrue())
+				Expect(status.Code()).To(Equal(grpccodes.InvalidArgument))
+				Expect(err.Error()).To(ContainSubstring("overlaps"))
+			})
+		})
+
+		Context("Capacity calculation on Create", func() {
+			It("sets status.total to 254 for a /24 IPv4 CIDR", func() {
+				response, err := poolsServer.Create(ctx, privatev1.ExternalIPPoolsCreateRequest_builder{
+					Object: privatev1.ExternalIPPool_builder{
+						Spec: privatev1.ExternalIPPoolSpec_builder{
+							Cidrs:    []string{"192.168.1.0/24"},
+							IpFamily: privatev1.IPFamily_IP_FAMILY_IPV4,
+						}.Build(),
+					}.Build(),
+				}.Build())
+				Expect(err).ToNot(HaveOccurred())
+				Expect(response.GetObject().GetStatus().GetTotal()).To(BeNumerically("==", 254))
+			})
+
+			It("sets status.available equal to status.total on a new pool", func() {
+				response, err := poolsServer.Create(ctx, privatev1.ExternalIPPoolsCreateRequest_builder{
+					Object: privatev1.ExternalIPPool_builder{
+						Spec: privatev1.ExternalIPPoolSpec_builder{
+							Cidrs:    []string{"10.0.0.0/24"},
+							IpFamily: privatev1.IPFamily_IP_FAMILY_IPV4,
+						}.Build(),
+					}.Build(),
+				}.Build())
+				Expect(err).ToNot(HaveOccurred())
+				status := response.GetObject().GetStatus()
+				Expect(status.GetAvailable()).To(Equal(status.GetTotal()))
+				Expect(status.GetAllocated()).To(BeNumerically("==", 0))
+			})
+		})
+
+		Context("Immutability on Update", func() {
+			It("prevents changing spec.cidrs after creation", func() {
+				createResponse, err := poolsServer.Create(ctx, privatev1.ExternalIPPoolsCreateRequest_builder{
+					Object: privatev1.ExternalIPPool_builder{
+						Spec: privatev1.ExternalIPPoolSpec_builder{
+							Cidrs:    []string{"10.0.0.0/24"},
+							IpFamily: privatev1.IPFamily_IP_FAMILY_IPV4,
+						}.Build(),
+					}.Build(),
+				}.Build())
+				Expect(err).ToNot(HaveOccurred())
+				id := createResponse.GetObject().GetId()
+
+				_, err = poolsServer.Update(ctx, privatev1.ExternalIPPoolsUpdateRequest_builder{
+					Object: privatev1.ExternalIPPool_builder{
+						Id: id,
+						Spec: privatev1.ExternalIPPoolSpec_builder{
+							Cidrs:    []string{"10.0.1.0/24"},
+							IpFamily: privatev1.IPFamily_IP_FAMILY_IPV4,
+						}.Build(),
+					}.Build(),
+				}.Build())
+				Expect(err).To(HaveOccurred())
+				status, ok := grpcstatus.FromError(err)
+				Expect(ok).To(BeTrue())
+				Expect(status.Code()).To(Equal(grpccodes.InvalidArgument))
+				Expect(err.Error()).To(ContainSubstring("cidrs"))
+				Expect(err.Error()).To(ContainSubstring("immutable"))
+			})
+
+			It("prevents changing spec.ip_family after creation", func() {
+				createResponse, err := poolsServer.Create(ctx, privatev1.ExternalIPPoolsCreateRequest_builder{
+					Object: privatev1.ExternalIPPool_builder{
+						Spec: privatev1.ExternalIPPoolSpec_builder{
+							Cidrs:    []string{"10.0.0.0/24"},
+							IpFamily: privatev1.IPFamily_IP_FAMILY_IPV4,
+						}.Build(),
+					}.Build(),
+				}.Build())
+				Expect(err).ToNot(HaveOccurred())
+				id := createResponse.GetObject().GetId()
+
+				_, err = poolsServer.Update(ctx, privatev1.ExternalIPPoolsUpdateRequest_builder{
+					Object: privatev1.ExternalIPPool_builder{
+						Id: id,
+						Spec: privatev1.ExternalIPPoolSpec_builder{
+							IpFamily: privatev1.IPFamily_IP_FAMILY_IPV6,
+						}.Build(),
+					}.Build(),
+				}.Build())
+				Expect(err).To(HaveOccurred())
+				status, ok := grpcstatus.FromError(err)
+				Expect(ok).To(BeTrue())
+				Expect(status.Code()).To(Equal(grpccodes.InvalidArgument))
+				Expect(err.Error()).To(ContainSubstring("ip_family"))
+				Expect(err.Error()).To(ContainSubstring("immutable"))
+			})
+
+			It("allows metadata-only Update (spec fields omitted)", func() {
+				createResponse, err := poolsServer.Create(ctx, privatev1.ExternalIPPoolsCreateRequest_builder{
+					Object: privatev1.ExternalIPPool_builder{
+						Spec: privatev1.ExternalIPPoolSpec_builder{
+							Cidrs:    []string{"10.0.0.0/24"},
+							IpFamily: privatev1.IPFamily_IP_FAMILY_IPV4,
+						}.Build(),
+					}.Build(),
+				}.Build())
+				Expect(err).ToNot(HaveOccurred())
+				id := createResponse.GetObject().GetId()
+
+				updateResponse, err := poolsServer.Update(ctx, privatev1.ExternalIPPoolsUpdateRequest_builder{
+					Object: privatev1.ExternalIPPool_builder{
+						Id: id,
+						Metadata: privatev1.Metadata_builder{
+							Name: "my-pool",
+						}.Build(),
+					}.Build(),
+					UpdateMask: &fieldmaskpb.FieldMask{
+						Paths: []string{"metadata.name"},
+					},
+				}.Build())
+				Expect(err).ToNot(HaveOccurred())
+				Expect(updateResponse.GetObject().GetMetadata().GetName()).To(Equal("my-pool"))
+				Expect(updateResponse.GetObject().GetSpec().GetCidrs()).To(ConsistOf("10.0.0.0/24"))
+			})
+		})
+	})
+})

--- a/internal/servers/private_external_ips_server.go
+++ b/internal/servers/private_external_ips_server.go
@@ -1,0 +1,379 @@
+/*
+Copyright (c) 2026 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package servers
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"slices"
+
+	"github.com/prometheus/client_golang/prometheus"
+	grpccodes "google.golang.org/grpc/codes"
+	grpcstatus "google.golang.org/grpc/status"
+
+	privatev1 "github.com/osac-project/fulfillment-service/internal/api/osac/private/v1"
+	"github.com/osac-project/fulfillment-service/internal/auth"
+	"github.com/osac-project/fulfillment-service/internal/database/dao"
+	"github.com/osac-project/fulfillment-service/internal/events"
+)
+
+var validExternalIPTransitions = map[privatev1.ExternalIPState][]privatev1.ExternalIPState{
+	privatev1.ExternalIPState_EXTERNAL_IP_STATE_PENDING:   {privatev1.ExternalIPState_EXTERNAL_IP_STATE_ALLOCATED, privatev1.ExternalIPState_EXTERNAL_IP_STATE_FAILED},
+	privatev1.ExternalIPState_EXTERNAL_IP_STATE_ALLOCATED: {privatev1.ExternalIPState_EXTERNAL_IP_STATE_FAILED, privatev1.ExternalIPState_EXTERNAL_IP_STATE_DELETING},
+	privatev1.ExternalIPState_EXTERNAL_IP_STATE_FAILED:    {privatev1.ExternalIPState_EXTERNAL_IP_STATE_ALLOCATED},
+}
+
+type PrivateExternalIPsServerBuilder struct {
+	logger            *slog.Logger
+	notifier          events.Notifier
+	attributionLogic  auth.AttributionLogic
+	tenancyLogic      auth.TenancyLogic
+	metricsRegisterer prometheus.Registerer
+}
+
+var _ privatev1.ExternalIPsServer = (*PrivateExternalIPsServer)(nil)
+
+type PrivateExternalIPsServer struct {
+	privatev1.UnimplementedExternalIPsServer
+
+	logger            *slog.Logger
+	generic           *GenericServer[*privatev1.ExternalIP]
+	externalIPPoolDao *dao.GenericDAO[*privatev1.ExternalIPPool]
+}
+
+func NewPrivateExternalIPsServer() *PrivateExternalIPsServerBuilder {
+	return &PrivateExternalIPsServerBuilder{}
+}
+
+func (b *PrivateExternalIPsServerBuilder) SetLogger(value *slog.Logger) *PrivateExternalIPsServerBuilder {
+	b.logger = value
+	return b
+}
+
+func (b *PrivateExternalIPsServerBuilder) SetNotifier(value events.Notifier) *PrivateExternalIPsServerBuilder {
+	b.notifier = value
+	return b
+}
+
+func (b *PrivateExternalIPsServerBuilder) SetAttributionLogic(value auth.AttributionLogic) *PrivateExternalIPsServerBuilder {
+	b.attributionLogic = value
+	return b
+}
+
+func (b *PrivateExternalIPsServerBuilder) SetTenancyLogic(value auth.TenancyLogic) *PrivateExternalIPsServerBuilder {
+	b.tenancyLogic = value
+	return b
+}
+
+func (b *PrivateExternalIPsServerBuilder) SetMetricsRegisterer(value prometheus.Registerer) *PrivateExternalIPsServerBuilder {
+	b.metricsRegisterer = value
+	return b
+}
+
+func (b *PrivateExternalIPsServerBuilder) Build() (result *PrivateExternalIPsServer, err error) {
+	if b.logger == nil {
+		err = errors.New("logger is mandatory")
+		return
+	}
+	if b.tenancyLogic == nil {
+		err = errors.New("tenancy logic is mandatory")
+		return
+	}
+	if b.attributionLogic == nil {
+		err = errors.New("attribution logic is mandatory")
+		return
+	}
+
+	externalIPPoolDao, err := dao.NewGenericDAO[*privatev1.ExternalIPPool]().
+		SetLogger(b.logger).
+		SetTenancyLogic(b.tenancyLogic).
+		SetMetricsRegisterer(b.metricsRegisterer).
+		Build()
+	if err != nil {
+		return
+	}
+
+	generic, err := NewGenericServer[*privatev1.ExternalIP]().
+		SetLogger(b.logger).
+		SetService(privatev1.ExternalIPs_ServiceDesc.ServiceName).
+		SetNotifier(b.notifier).
+		SetAttributionLogic(b.attributionLogic).
+		SetTenancyLogic(b.tenancyLogic).
+		SetMetricsRegisterer(b.metricsRegisterer).
+		Build()
+	if err != nil {
+		return
+	}
+
+	result = &PrivateExternalIPsServer{
+		logger:            b.logger,
+		generic:           generic,
+		externalIPPoolDao: externalIPPoolDao,
+	}
+	return
+}
+
+func (s *PrivateExternalIPsServer) List(ctx context.Context,
+	request *privatev1.ExternalIPsListRequest) (response *privatev1.ExternalIPsListResponse, err error) {
+	err = s.generic.List(ctx, request, &response)
+	return
+}
+
+func (s *PrivateExternalIPsServer) Get(ctx context.Context,
+	request *privatev1.ExternalIPsGetRequest) (response *privatev1.ExternalIPsGetResponse, err error) {
+	err = s.generic.Get(ctx, request, &response)
+	return
+}
+
+func (s *PrivateExternalIPsServer) Create(ctx context.Context,
+	request *privatev1.ExternalIPsCreateRequest) (response *privatev1.ExternalIPsCreateResponse, err error) {
+	externalIP := request.GetObject()
+
+	err = s.validateExternalIP(ctx, externalIP)
+	if err != nil {
+		return
+	}
+
+	poolID := externalIP.GetSpec().GetPool()
+	err = s.validatePoolReference(ctx, poolID)
+	if err != nil {
+		return
+	}
+
+	if externalIP.GetStatus() == nil {
+		externalIP.SetStatus(privatev1.ExternalIPStatus_builder{
+			State: privatev1.ExternalIPState_EXTERNAL_IP_STATE_PENDING,
+		}.Build())
+	} else {
+		externalIP.GetStatus().SetState(privatev1.ExternalIPState_EXTERNAL_IP_STATE_PENDING)
+	}
+
+	err = s.generic.Create(ctx, request, &response)
+	if err != nil {
+		return
+	}
+
+	err = s.updatePoolCapacity(ctx, poolID, 1)
+	if err != nil {
+		return
+	}
+
+	return
+}
+
+func (s *PrivateExternalIPsServer) Update(ctx context.Context,
+	request *privatev1.ExternalIPsUpdateRequest) (response *privatev1.ExternalIPsUpdateResponse, err error) {
+	id := request.GetObject().GetId()
+	if id == "" {
+		err = grpcstatus.Errorf(grpccodes.InvalidArgument, "object identifier is mandatory")
+		return
+	}
+
+	getRequest := &privatev1.ExternalIPsGetRequest{}
+	getRequest.SetId(id)
+	var getResponse *privatev1.ExternalIPsGetResponse
+	err = s.generic.Get(ctx, getRequest, &getResponse)
+	if err != nil {
+		return
+	}
+
+	existingExternalIP := getResponse.GetObject()
+	mask := request.GetUpdateMask()
+
+	if updateIncludesField(mask, "spec.pool") {
+		if err = validateImmutableFieldsExternalIP(request.GetObject(), existingExternalIP); err != nil {
+			return
+		}
+	}
+
+	if updateIncludesField(mask, "status.state") {
+		newState := request.GetObject().GetStatus().GetState()
+		existingState := existingExternalIP.GetStatus().GetState()
+		if newState != existingState {
+			if err = validateExternalIPStateTransition(existingState, newState); err != nil {
+				return
+			}
+		}
+	}
+
+	err = s.generic.Update(ctx, request, &response)
+	return
+}
+
+func (s *PrivateExternalIPsServer) Delete(ctx context.Context,
+	request *privatev1.ExternalIPsDeleteRequest) (response *privatev1.ExternalIPsDeleteResponse, err error) {
+	id := request.GetId()
+	if id == "" {
+		err = grpcstatus.Errorf(grpccodes.InvalidArgument, "object identifier is mandatory")
+		return
+	}
+
+	getRequest := &privatev1.ExternalIPsGetRequest{}
+	getRequest.SetId(id)
+	var getResponse *privatev1.ExternalIPsGetResponse
+	err = s.generic.Get(ctx, getRequest, &getResponse)
+	if err != nil {
+		return
+	}
+
+	existingExternalIP := getResponse.GetObject()
+
+	state := existingExternalIP.GetStatus().GetState()
+	if state != privatev1.ExternalIPState_EXTERNAL_IP_STATE_ALLOCATED {
+		err = grpcstatus.Errorf(grpccodes.FailedPrecondition,
+			"cannot delete ExternalIP in state %s: must be in ALLOCATED state", state)
+		return
+	}
+
+	err = s.generic.Delete(ctx, request, &response)
+	if err != nil {
+		return
+	}
+
+	poolID := existingExternalIP.GetSpec().GetPool()
+	if poolID != "" {
+		err = s.updatePoolCapacity(ctx, poolID, -1)
+		if err != nil {
+			return
+		}
+	}
+
+	return
+}
+
+func (s *PrivateExternalIPsServer) Signal(ctx context.Context,
+	request *privatev1.ExternalIPsSignalRequest) (response *privatev1.ExternalIPsSignalResponse, err error) {
+	err = s.generic.Signal(ctx, request, &response)
+	return
+}
+
+func (s *PrivateExternalIPsServer) validateExternalIP(ctx context.Context,
+	externalIP *privatev1.ExternalIP) error {
+	if externalIP == nil {
+		return grpcstatus.Errorf(grpccodes.InvalidArgument, "external IP is mandatory")
+	}
+	spec := externalIP.GetSpec()
+	if spec == nil {
+		return grpcstatus.Errorf(grpccodes.InvalidArgument, "external IP spec is mandatory")
+	}
+	if spec.GetPool() == "" {
+		return grpcstatus.Errorf(grpccodes.InvalidArgument,
+			"field 'spec.pool' is required")
+	}
+	return nil
+}
+
+func (s *PrivateExternalIPsServer) validatePoolReference(ctx context.Context, poolID string) error {
+	getResponse, err := s.externalIPPoolDao.Get().
+		SetId(poolID).
+		Do(ctx)
+	if err != nil {
+		var notFoundErr *dao.ErrNotFound
+		if errors.As(err, &notFoundErr) {
+			return grpcstatus.Errorf(grpccodes.InvalidArgument,
+				"pool '%s' does not exist", poolID)
+		}
+		s.logger.ErrorContext(ctx, "Failed to query ExternalIPPool",
+			slog.String("pool_id", poolID),
+			slog.Any("error", err))
+		return grpcstatus.Errorf(grpccodes.Internal, "failed to validate pool")
+	}
+
+	pool := getResponse.GetObject()
+
+	if pool.GetStatus().GetState() != privatev1.ExternalIPPoolState_EXTERNAL_IP_POOL_STATE_READY {
+		return grpcstatus.Errorf(grpccodes.FailedPrecondition,
+			"pool '%s' is not in READY state (current state: %s)",
+			poolID, pool.GetStatus().GetState().String())
+	}
+
+	if pool.GetStatus().GetAvailable() <= 0 {
+		return grpcstatus.Errorf(grpccodes.FailedPrecondition,
+			"pool '%s' has no available capacity", poolID)
+	}
+
+	return nil
+}
+
+func (s *PrivateExternalIPsServer) updatePoolCapacity(ctx context.Context, poolID string, delta int64) error {
+	poolResponse, err := s.externalIPPoolDao.Get().
+		SetId(poolID).
+		SetLock(true).
+		Do(ctx)
+	if err != nil {
+		s.logger.ErrorContext(ctx, "Failed to get pool for capacity update",
+			slog.String("pool_id", poolID),
+			slog.Any("error", err))
+		return grpcstatus.Errorf(grpccodes.Internal, "failed to update pool capacity")
+	}
+
+	pool := poolResponse.GetObject()
+	newAllocated := pool.GetStatus().GetAllocated() + delta
+	newAvailable := pool.GetStatus().GetAvailable() - delta
+	if newAvailable < 0 {
+		return grpcstatus.Errorf(grpccodes.FailedPrecondition,
+			"pool '%s' has no available capacity", poolID)
+	}
+	if newAllocated < 0 {
+		return grpcstatus.Errorf(grpccodes.FailedPrecondition,
+			"pool '%s' capacity inconsistency: allocated would become %d (available: %d)",
+			poolID, newAllocated, newAvailable)
+	}
+	pool.GetStatus().SetAllocated(newAllocated)
+	pool.GetStatus().SetAvailable(newAvailable)
+
+	_, err = s.externalIPPoolDao.Update().
+		SetObject(pool).
+		Do(ctx)
+	if err != nil {
+		s.logger.ErrorContext(ctx, "Failed to update pool capacity",
+			slog.String("pool_id", poolID),
+			slog.Any("error", err))
+		var conflictErr *dao.ErrConflict
+		if errors.As(err, &conflictErr) {
+			return grpcstatus.Errorf(grpccodes.Aborted, "%s", conflictErr.Error())
+		}
+		return grpcstatus.Errorf(grpccodes.Internal, "failed to update pool capacity")
+	}
+
+	return nil
+}
+
+func validateImmutableFieldsExternalIP(newExternalIP, existingExternalIP *privatev1.ExternalIP) error {
+	if existingExternalIP == nil {
+		return nil
+	}
+
+	newPool := newExternalIP.GetSpec().GetPool()
+	existingPool := existingExternalIP.GetSpec().GetPool()
+
+	if newPool != existingPool {
+		return grpcstatus.Errorf(grpccodes.InvalidArgument,
+			"field 'spec.pool' is immutable and cannot be changed from '%s' to '%s'",
+			existingPool, newPool)
+	}
+
+	return nil
+}
+
+func validateExternalIPStateTransition(from, to privatev1.ExternalIPState) error {
+	allowed, exists := validExternalIPTransitions[from]
+	if !exists || !slices.Contains(allowed, to) {
+		return grpcstatus.Errorf(grpccodes.FailedPrecondition,
+			"invalid state transition from %s to %s", from.String(), to.String())
+	}
+
+	return nil
+}

--- a/internal/servers/private_external_ips_server_test.go
+++ b/internal/servers/private_external_ips_server_test.go
@@ -1,0 +1,554 @@
+/*
+Copyright (c) 2026 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package servers
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	grpccodes "google.golang.org/grpc/codes"
+	grpcstatus "google.golang.org/grpc/status"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/fieldmaskpb"
+
+	privatev1 "github.com/osac-project/fulfillment-service/internal/api/osac/private/v1"
+	"github.com/osac-project/fulfillment-service/internal/auth"
+	"github.com/osac-project/fulfillment-service/internal/database/dao"
+)
+
+var _ = Describe("Private external IPs server", func() {
+	var (
+		externalIPPoolDao *dao.GenericDAO[*privatev1.ExternalIPPool]
+		externalIPDao     *dao.GenericDAO[*privatev1.ExternalIP]
+	)
+
+	BeforeEach(func() {
+		var err error
+
+		externalIPPoolDao, err = dao.NewGenericDAO[*privatev1.ExternalIPPool]().
+			SetLogger(logger).
+			SetTenancyLogic(tenancy).
+			Build()
+		Expect(err).ToNot(HaveOccurred())
+
+		externalIPDao, err = dao.NewGenericDAO[*privatev1.ExternalIP]().
+			SetLogger(logger).
+			SetTenancyLogic(tenancy).
+			Build()
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	createReadyExternalIPPool := func(ctx context.Context, total int64, allocated int64) string {
+		resp, err := externalIPPoolDao.Create().SetObject(
+			privatev1.ExternalIPPool_builder{
+				Metadata: privatev1.Metadata_builder{
+					Tenant: auth.SharedTenant,
+				}.Build(),
+				Spec: privatev1.ExternalIPPoolSpec_builder{
+					Cidrs: []string{"10.0.0.0/24"},
+				}.Build(),
+				Status: privatev1.ExternalIPPoolStatus_builder{
+					State:     privatev1.ExternalIPPoolState_EXTERNAL_IP_POOL_STATE_READY,
+					Total:     total,
+					Allocated: allocated,
+					Available: total - allocated,
+				}.Build(),
+			}.Build(),
+		).Do(ctx)
+		Expect(err).ToNot(HaveOccurred())
+		return resp.GetObject().GetId()
+	}
+
+	createExternalIPInState := func(
+		server *PrivateExternalIPsServer,
+		state privatev1.ExternalIPState,
+	) *privatev1.ExternalIP {
+		poolID := createReadyExternalIPPool(ctx, 100, 0)
+		resp, err := server.Create(ctx, privatev1.ExternalIPsCreateRequest_builder{
+			Object: privatev1.ExternalIP_builder{
+				Metadata: privatev1.Metadata_builder{
+					Tenant: auth.SharedTenant,
+				}.Build(),
+				Spec: privatev1.ExternalIPSpec_builder{
+					Pool: poolID,
+				}.Build(),
+			}.Build(),
+		}.Build())
+		Expect(err).ToNot(HaveOccurred())
+		object := resp.GetObject()
+
+		object.SetStatus(privatev1.ExternalIPStatus_builder{
+			State: state,
+		}.Build())
+		daoResp, err := externalIPDao.Update().SetObject(object).Do(ctx)
+		Expect(err).ToNot(HaveOccurred())
+		return daoResp.GetObject()
+	}
+
+	Describe("Creation", func() {
+		It("Can be built if all the required parameters are set", func() {
+			server, err := NewPrivateExternalIPsServer().
+				SetLogger(logger).
+				SetAttributionLogic(attribution).
+				SetTenancyLogic(tenancy).
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(server).ToNot(BeNil())
+		})
+
+		It("Fails if logger is not set", func() {
+			server, err := NewPrivateExternalIPsServer().
+				SetAttributionLogic(attribution).
+				SetTenancyLogic(tenancy).
+				Build()
+			Expect(err).To(MatchError("logger is mandatory"))
+			Expect(server).To(BeNil())
+		})
+
+		It("Fails if tenancy logic is not set", func() {
+			server, err := NewPrivateExternalIPsServer().
+				SetLogger(logger).
+				SetAttributionLogic(attribution).
+				Build()
+			Expect(err).To(MatchError("tenancy logic is mandatory"))
+			Expect(server).To(BeNil())
+		})
+
+		It("Fails if attribution logic is not set", func() {
+			server, err := NewPrivateExternalIPsServer().
+				SetLogger(logger).
+				SetTenancyLogic(tenancy).
+				Build()
+			Expect(err).To(MatchError("attribution logic is mandatory"))
+			Expect(server).To(BeNil())
+		})
+	})
+
+	Describe("CRUD operations", func() {
+		var (
+			externalIPsServer *PrivateExternalIPsServer
+			poolID            string
+		)
+
+		BeforeEach(func() {
+			var err error
+			poolID = createReadyExternalIPPool(ctx, 100, 0)
+			externalIPsServer, err = NewPrivateExternalIPsServer().
+				SetLogger(logger).
+				SetAttributionLogic(attribution).
+				SetTenancyLogic(tenancy).
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("creates ExternalIP with PENDING initial state", func() {
+			response, err := externalIPsServer.Create(ctx, privatev1.ExternalIPsCreateRequest_builder{
+				Object: privatev1.ExternalIP_builder{
+					Metadata: privatev1.Metadata_builder{Tenant: auth.SharedTenant}.Build(),
+					Spec:     privatev1.ExternalIPSpec_builder{Pool: poolID}.Build(),
+				}.Build(),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+			Expect(response.GetObject().GetStatus().GetState()).To(
+				Equal(privatev1.ExternalIPState_EXTERNAL_IP_STATE_PENDING))
+		})
+
+		It("retrieves ExternalIP by ID", func() {
+			createResponse, err := externalIPsServer.Create(ctx, privatev1.ExternalIPsCreateRequest_builder{
+				Object: privatev1.ExternalIP_builder{
+					Metadata: privatev1.Metadata_builder{Tenant: auth.SharedTenant}.Build(),
+					Spec:     privatev1.ExternalIPSpec_builder{Pool: poolID}.Build(),
+				}.Build(),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+
+			getResponse, err := externalIPsServer.Get(ctx, privatev1.ExternalIPsGetRequest_builder{
+				Id: createResponse.GetObject().GetId(),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+			Expect(proto.Equal(createResponse.GetObject(), getResponse.GetObject())).To(BeTrue())
+		})
+
+		It("lists ExternalIPs", func() {
+			const count = 3
+			for range count {
+				_, err := externalIPsServer.Create(ctx, privatev1.ExternalIPsCreateRequest_builder{
+					Object: privatev1.ExternalIP_builder{
+						Metadata: privatev1.Metadata_builder{Tenant: auth.SharedTenant}.Build(),
+						Spec:     privatev1.ExternalIPSpec_builder{Pool: poolID}.Build(),
+					}.Build(),
+				}.Build())
+				Expect(err).ToNot(HaveOccurred())
+			}
+
+			response, err := externalIPsServer.List(ctx, privatev1.ExternalIPsListRequest_builder{}.Build())
+			Expect(err).ToNot(HaveOccurred())
+			Expect(response.GetItems()).To(HaveLen(count))
+		})
+
+		It("soft deletes ExternalIP in ALLOCATED state", func() {
+			createResponse, err := externalIPsServer.Create(ctx, privatev1.ExternalIPsCreateRequest_builder{
+				Object: privatev1.ExternalIP_builder{
+					Metadata: privatev1.Metadata_builder{
+						Finalizers: []string{"test-finalizer"},
+						Tenant:     auth.SharedTenant,
+					}.Build(),
+					Spec: privatev1.ExternalIPSpec_builder{Pool: poolID}.Build(),
+				}.Build(),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+			object := createResponse.GetObject()
+
+			object.GetStatus().SetState(privatev1.ExternalIPState_EXTERNAL_IP_STATE_ALLOCATED)
+			updateResponse, err := externalIPsServer.Update(ctx, privatev1.ExternalIPsUpdateRequest_builder{
+				Object: object,
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+			object = updateResponse.GetObject()
+
+			_, err = externalIPsServer.Delete(ctx, privatev1.ExternalIPsDeleteRequest_builder{
+				Id: object.GetId(),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+
+			getResponse, err := externalIPsServer.Get(ctx, privatev1.ExternalIPsGetRequest_builder{
+				Id: object.GetId(),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+			Expect(getResponse.GetObject().GetMetadata().GetDeletionTimestamp()).ToNot(BeNil())
+		})
+	})
+
+	Describe("Pool validation on Create", func() {
+		var externalIPsServer *PrivateExternalIPsServer
+
+		BeforeEach(func() {
+			var err error
+			externalIPsServer, err = NewPrivateExternalIPsServer().
+				SetLogger(logger).
+				SetAttributionLogic(attribution).
+				SetTenancyLogic(tenancy).
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("rejects Create when pool does not exist", func() {
+			_, err := externalIPsServer.Create(ctx, privatev1.ExternalIPsCreateRequest_builder{
+				Object: privatev1.ExternalIP_builder{
+					Metadata: privatev1.Metadata_builder{Tenant: auth.SharedTenant}.Build(),
+					Spec:     privatev1.ExternalIPSpec_builder{Pool: "nonexistent-pool-id"}.Build(),
+				}.Build(),
+			}.Build())
+			Expect(err).To(HaveOccurred())
+			status, ok := grpcstatus.FromError(err)
+			Expect(ok).To(BeTrue())
+			Expect(status.Code()).To(Equal(grpccodes.InvalidArgument))
+			Expect(err.Error()).To(ContainSubstring("does not exist"))
+		})
+
+		It("rejects Create when pool is not READY", func() {
+			resp, err := externalIPPoolDao.Create().SetObject(
+				privatev1.ExternalIPPool_builder{
+					Metadata: privatev1.Metadata_builder{Tenant: auth.SharedTenant}.Build(),
+					Spec:     privatev1.ExternalIPPoolSpec_builder{Cidrs: []string{"10.0.0.0/24"}}.Build(),
+					Status: privatev1.ExternalIPPoolStatus_builder{
+						State: privatev1.ExternalIPPoolState_EXTERNAL_IP_POOL_STATE_PENDING,
+						Total: 10, Allocated: 0, Available: 10,
+					}.Build(),
+				}.Build(),
+			).Do(ctx)
+			Expect(err).ToNot(HaveOccurred())
+
+			_, err = externalIPsServer.Create(ctx, privatev1.ExternalIPsCreateRequest_builder{
+				Object: privatev1.ExternalIP_builder{
+					Metadata: privatev1.Metadata_builder{Tenant: auth.SharedTenant}.Build(),
+					Spec:     privatev1.ExternalIPSpec_builder{Pool: resp.GetObject().GetId()}.Build(),
+				}.Build(),
+			}.Build())
+			Expect(err).To(HaveOccurred())
+			status, ok := grpcstatus.FromError(err)
+			Expect(ok).To(BeTrue())
+			Expect(status.Code()).To(Equal(grpccodes.FailedPrecondition))
+			Expect(err.Error()).To(ContainSubstring("not in READY state"))
+		})
+
+		It("rejects Create when pool has no available capacity", func() {
+			exhaustedPoolID := createReadyExternalIPPool(ctx, 10, 10)
+
+			_, err := externalIPsServer.Create(ctx, privatev1.ExternalIPsCreateRequest_builder{
+				Object: privatev1.ExternalIP_builder{
+					Metadata: privatev1.Metadata_builder{Tenant: auth.SharedTenant}.Build(),
+					Spec:     privatev1.ExternalIPSpec_builder{Pool: exhaustedPoolID}.Build(),
+				}.Build(),
+			}.Build())
+			Expect(err).To(HaveOccurred())
+			status, ok := grpcstatus.FromError(err)
+			Expect(ok).To(BeTrue())
+			Expect(status.Code()).To(Equal(grpccodes.FailedPrecondition))
+			Expect(err.Error()).To(ContainSubstring("no available capacity"))
+		})
+
+		It("rejects nil object on Create", func() {
+			_, err := externalIPsServer.Create(ctx, privatev1.ExternalIPsCreateRequest_builder{}.Build())
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("external IP is mandatory"))
+		})
+
+		It("rejects empty pool on Create", func() {
+			_, err := externalIPsServer.Create(ctx, privatev1.ExternalIPsCreateRequest_builder{
+				Object: privatev1.ExternalIP_builder{
+					Metadata: privatev1.Metadata_builder{Tenant: auth.SharedTenant}.Build(),
+					Spec:     privatev1.ExternalIPSpec_builder{}.Build(),
+				}.Build(),
+			}.Build())
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("spec.pool"))
+		})
+	})
+
+	Describe("Capacity tracking", func() {
+		var externalIPsServer *PrivateExternalIPsServer
+
+		BeforeEach(func() {
+			var err error
+			externalIPsServer, err = NewPrivateExternalIPsServer().
+				SetLogger(logger).
+				SetAttributionLogic(attribution).
+				SetTenancyLogic(tenancy).
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("decrements pool available on Create", func() {
+			poolID := createReadyExternalIPPool(ctx, 10, 2)
+
+			_, err := externalIPsServer.Create(ctx, privatev1.ExternalIPsCreateRequest_builder{
+				Object: privatev1.ExternalIP_builder{
+					Metadata: privatev1.Metadata_builder{Tenant: auth.SharedTenant}.Build(),
+					Spec:     privatev1.ExternalIPSpec_builder{Pool: poolID}.Build(),
+				}.Build(),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+
+			poolResp, err := externalIPPoolDao.Get().SetId(poolID).Do(ctx)
+			Expect(err).ToNot(HaveOccurred())
+			pool := poolResp.GetObject()
+			Expect(pool.GetStatus().GetAllocated()).To(Equal(int64(3)))
+			Expect(pool.GetStatus().GetAvailable()).To(Equal(int64(7)))
+		})
+
+		It("restores pool capacity on Delete", func() {
+			poolID := createReadyExternalIPPool(ctx, 10, 0)
+
+			createResponse, err := externalIPsServer.Create(ctx, privatev1.ExternalIPsCreateRequest_builder{
+				Object: privatev1.ExternalIP_builder{
+					Metadata: privatev1.Metadata_builder{Tenant: auth.SharedTenant}.Build(),
+					Spec:     privatev1.ExternalIPSpec_builder{Pool: poolID}.Build(),
+				}.Build(),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+			object := createResponse.GetObject()
+
+			object.GetStatus().SetState(privatev1.ExternalIPState_EXTERNAL_IP_STATE_ALLOCATED)
+			_, err = externalIPsServer.Update(ctx, privatev1.ExternalIPsUpdateRequest_builder{
+				Object: object,
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+
+			_, err = externalIPsServer.Delete(ctx, privatev1.ExternalIPsDeleteRequest_builder{
+				Id: object.GetId(),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+
+			poolResp, err := externalIPPoolDao.Get().SetId(poolID).Do(ctx)
+			Expect(err).ToNot(HaveOccurred())
+			pool := poolResp.GetObject()
+			Expect(pool.GetStatus().GetAllocated()).To(Equal(int64(0)))
+			Expect(pool.GetStatus().GetAvailable()).To(Equal(int64(10)))
+		})
+	})
+
+	Describe("State machine enforcement", func() {
+		var externalIPsServer *PrivateExternalIPsServer
+
+		BeforeEach(func() {
+			var err error
+			externalIPsServer, err = NewPrivateExternalIPsServer().
+				SetLogger(logger).
+				SetAttributionLogic(attribution).
+				SetTenancyLogic(tenancy).
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		setStateOnObject := func(object *privatev1.ExternalIP, state privatev1.ExternalIPState) {
+			if object.GetStatus() == nil {
+				object.SetStatus(privatev1.ExternalIPStatus_builder{State: state}.Build())
+			} else {
+				object.GetStatus().SetState(state)
+			}
+		}
+
+		transitionTo := func(object *privatev1.ExternalIP, state privatev1.ExternalIPState) *privatev1.ExternalIP {
+			setStateOnObject(object, state)
+			resp, err := externalIPsServer.Update(ctx, privatev1.ExternalIPsUpdateRequest_builder{
+				Object: object,
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+			return resp.GetObject()
+		}
+
+		It("accepts PENDING to ALLOCATED transition", func() {
+			object := createExternalIPInState(externalIPsServer, privatev1.ExternalIPState_EXTERNAL_IP_STATE_PENDING)
+			updated := transitionTo(object, privatev1.ExternalIPState_EXTERNAL_IP_STATE_ALLOCATED)
+			Expect(updated.GetStatus().GetState()).To(Equal(privatev1.ExternalIPState_EXTERNAL_IP_STATE_ALLOCATED))
+		})
+
+		It("accepts PENDING to FAILED transition", func() {
+			object := createExternalIPInState(externalIPsServer, privatev1.ExternalIPState_EXTERNAL_IP_STATE_PENDING)
+			updated := transitionTo(object, privatev1.ExternalIPState_EXTERNAL_IP_STATE_FAILED)
+			Expect(updated.GetStatus().GetState()).To(Equal(privatev1.ExternalIPState_EXTERNAL_IP_STATE_FAILED))
+		})
+
+		It("accepts ALLOCATED to FAILED transition", func() {
+			object := createExternalIPInState(externalIPsServer, privatev1.ExternalIPState_EXTERNAL_IP_STATE_ALLOCATED)
+			updated := transitionTo(object, privatev1.ExternalIPState_EXTERNAL_IP_STATE_FAILED)
+			Expect(updated.GetStatus().GetState()).To(Equal(privatev1.ExternalIPState_EXTERNAL_IP_STATE_FAILED))
+		})
+
+		It("accepts ALLOCATED to DELETING transition", func() {
+			object := createExternalIPInState(externalIPsServer, privatev1.ExternalIPState_EXTERNAL_IP_STATE_ALLOCATED)
+			updated := transitionTo(object, privatev1.ExternalIPState_EXTERNAL_IP_STATE_DELETING)
+			Expect(updated.GetStatus().GetState()).To(Equal(privatev1.ExternalIPState_EXTERNAL_IP_STATE_DELETING))
+		})
+
+		It("accepts FAILED to ALLOCATED transition", func() {
+			object := createExternalIPInState(externalIPsServer, privatev1.ExternalIPState_EXTERNAL_IP_STATE_FAILED)
+			updated := transitionTo(object, privatev1.ExternalIPState_EXTERNAL_IP_STATE_ALLOCATED)
+			Expect(updated.GetStatus().GetState()).To(Equal(privatev1.ExternalIPState_EXTERNAL_IP_STATE_ALLOCATED))
+		})
+
+		It("rejects FAILED to PENDING transition", func() {
+			object := createExternalIPInState(externalIPsServer, privatev1.ExternalIPState_EXTERNAL_IP_STATE_FAILED)
+			setStateOnObject(object, privatev1.ExternalIPState_EXTERNAL_IP_STATE_PENDING)
+			_, err := externalIPsServer.Update(ctx, privatev1.ExternalIPsUpdateRequest_builder{
+				Object: object,
+			}.Build())
+			Expect(err).To(HaveOccurred())
+			status, ok := grpcstatus.FromError(err)
+			Expect(ok).To(BeTrue())
+			Expect(status.Code()).To(Equal(grpccodes.FailedPrecondition))
+			Expect(err.Error()).To(ContainSubstring("invalid state transition"))
+		})
+
+		It("rejects PENDING to DELETING transition", func() {
+			object := createExternalIPInState(externalIPsServer, privatev1.ExternalIPState_EXTERNAL_IP_STATE_PENDING)
+			setStateOnObject(object, privatev1.ExternalIPState_EXTERNAL_IP_STATE_DELETING)
+			_, err := externalIPsServer.Update(ctx, privatev1.ExternalIPsUpdateRequest_builder{
+				Object: object,
+			}.Build())
+			Expect(err).To(HaveOccurred())
+			status, ok := grpcstatus.FromError(err)
+			Expect(ok).To(BeTrue())
+			Expect(status.Code()).To(Equal(grpccodes.FailedPrecondition))
+		})
+
+		It("skips state validation when UpdateMask excludes status.state", func() {
+			object := createExternalIPInState(externalIPsServer, privatev1.ExternalIPState_EXTERNAL_IP_STATE_ALLOCATED)
+
+			object.GetMetadata().Name = "updated-name"
+			resp, err := externalIPsServer.Update(ctx, privatev1.ExternalIPsUpdateRequest_builder{
+				Object: object,
+				UpdateMask: &fieldmaskpb.FieldMask{
+					Paths: []string{"metadata.name"},
+				},
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+			Expect(resp.GetObject().GetMetadata().GetName()).To(Equal("updated-name"))
+		})
+	})
+
+	Describe("Delete constraint", func() {
+		var externalIPsServer *PrivateExternalIPsServer
+
+		BeforeEach(func() {
+			var err error
+			externalIPsServer, err = NewPrivateExternalIPsServer().
+				SetLogger(logger).
+				SetAttributionLogic(attribution).
+				SetTenancyLogic(tenancy).
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("allows Delete when state is ALLOCATED", func() {
+			object := createExternalIPInState(externalIPsServer, privatev1.ExternalIPState_EXTERNAL_IP_STATE_ALLOCATED)
+			_, err := externalIPsServer.Delete(ctx, privatev1.ExternalIPsDeleteRequest_builder{
+				Id: object.GetId(),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("rejects Delete when state is PENDING", func() {
+			object := createExternalIPInState(externalIPsServer, privatev1.ExternalIPState_EXTERNAL_IP_STATE_PENDING)
+			_, err := externalIPsServer.Delete(ctx, privatev1.ExternalIPsDeleteRequest_builder{
+				Id: object.GetId(),
+			}.Build())
+			Expect(err).To(HaveOccurred())
+			status, ok := grpcstatus.FromError(err)
+			Expect(ok).To(BeTrue())
+			Expect(status.Code()).To(Equal(grpccodes.FailedPrecondition))
+			Expect(err.Error()).To(ContainSubstring("must be in ALLOCATED state"))
+		})
+	})
+
+	Describe("Pool immutability on Update", func() {
+		var externalIPsServer *PrivateExternalIPsServer
+
+		BeforeEach(func() {
+			var err error
+			externalIPsServer, err = NewPrivateExternalIPsServer().
+				SetLogger(logger).
+				SetAttributionLogic(attribution).
+				SetTenancyLogic(tenancy).
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("rejects Update that changes pool", func() {
+			poolA := createReadyExternalIPPool(ctx, 100, 0)
+			poolB := createReadyExternalIPPool(ctx, 100, 0)
+
+			createResp, err := externalIPsServer.Create(ctx, privatev1.ExternalIPsCreateRequest_builder{
+				Object: privatev1.ExternalIP_builder{
+					Metadata: privatev1.Metadata_builder{Tenant: auth.SharedTenant}.Build(),
+					Spec:     privatev1.ExternalIPSpec_builder{Pool: poolA}.Build(),
+				}.Build(),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+			object := createResp.GetObject()
+
+			object.GetSpec().SetPool(poolB)
+			_, err = externalIPsServer.Update(ctx, privatev1.ExternalIPsUpdateRequest_builder{
+				Object: object,
+			}.Build())
+			Expect(err).To(HaveOccurred())
+			status, ok := grpcstatus.FromError(err)
+			Expect(ok).To(BeTrue())
+			Expect(status.Code()).To(Equal(grpccodes.InvalidArgument))
+			Expect(err.Error()).To(ContainSubstring("spec.pool' is immutable"))
+		})
+	})
+})


### PR DESCRIPTION
## [OSAC-1476](https://redhat.atlassian.net/browse/OSAC-1476): Implement ExternalIPPool and ExternalIP public and private servers

**Jira:** https://redhat.atlassian.net/browse/OSAC-1476
**Epic:** [OSAC-1442](https://redhat.atlassian.net/browse/OSAC-1442) (ExternalIP Resources)

### Summary

Implements the gRPC server layer for ExternalIPPool and ExternalIP resources, following the established PublicIPPool/PublicIP patterns. This enables tenants to discover available IP pools and allocate/release IPs, while controllers can manage the full resource lifecycle through the private API.

### Changes

**ExternalIPPool servers:**
- Private server with full CRUD + Signal: CIDR validation, capacity calculation on Create, immutability enforcement (cidrs, ip_family), delete constraint (reject when IPs allocated)
- Public server (read-only List/Get): filters pools by READY state + available capacity, Go-level pagination

**ExternalIP servers:**
- Private server with full CRUD + Signal: pool reference validation (existence, READY, capacity), capacity tracking on Create/Delete, state machine enforcement on Update, immutable spec.pool field
- Public server with List/Get/Create/Update/Delete: delegates to private server via GenericMapper for type conversion

**Registration:**
- All 4 servers registered in `start_grpc_server_cmd.go`
- setPayload cases added for ExternalIPPool, ExternalIP, ExternalIPAttachment (no-op until Event proto updated)

### Testing
- **Unit tests:** 64 new tests covering builder validation, CRUD operations, CIDR validation, capacity tracking, state machine transitions, immutability enforcement, delete constraints, and public API filtering
- **Integration tests:** N/A — servers tested in-process with real database container
- **Regression:** Full unit test suite (71 suites, 1209 specs) passes with 0 failures

### Acceptance Criteria

- [x] AC-1: ExternalIPPool public server — List, Get (read-only)
- [x] AC-2: ExternalIPPool private server — List, Get, Create, Update, Delete, Signal
- [x] AC-3: ExternalIP public server — List, Get, Create, Update, Delete
- [x] AC-4: ExternalIP private server — List, Get, Create, Update, Delete, Signal
- [x] AC-5: All servers registered in start_grpc_server_cmd.go
