### PR TITLE
OSAC-1551: Add tenant scoping to the CLI

### DIFF
--- a/internal/cmd/cli/create/cluster/create_cluster_cmd.go
+++ b/internal/cmd/cli/create/cluster/create_cluster_cmd.go
@@ -316,7 +316,8 @@ func (c *runnerContext) applyOptionalSpecFields(
 func (c *runnerContext) createCluster(ctx context.Context, spec *publicv1.ClusterSpec) error {
 	cluster := publicv1.Cluster_builder{
 		Metadata: publicv1.Metadata_builder{
-			Name: c.args.name,
+			Name:   c.args.name,
+			Tenant: config.TenantFromContext(ctx),
 		}.Build(),
 		Spec: spec,
 	}.Build()

--- a/internal/cmd/cli/create/computeinstance/create_compute_instance_cmd.go
+++ b/internal/cmd/cli/create/computeinstance/create_compute_instance_cmd.go
@@ -263,7 +263,8 @@ func (c *runnerContext) run(cmd *cobra.Command, args []string) error {
 
 		computeInstance := publicv1.ComputeInstance_builder{
 			Metadata: publicv1.Metadata_builder{
-				Name: c.args.name,
+				Name:   c.args.name,
+				Tenant: config.TenantFromContext(ctx),
 			}.Build(),
 			Spec: specResult,
 		}.Build()

--- a/internal/cmd/cli/create/create_cmd.go
+++ b/internal/cmd/cli/create/create_cmd.go
@@ -154,12 +154,16 @@ func (c *runnerContext) run(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
+	tenant := config.TenantFromContext(ctx)
 	for i, object := range objects {
 		objectDesc := object.ProtoReflect().Descriptor()
 		objectType := string(objectDesc.FullName())
 		objectHelper := helper.Lookup(objectType)
 		if objectHelper == nil {
 			return fmt.Errorf("input object at index %d is of an unknown type '%s'", i, objectType)
+		}
+		if tenant != "" && objectHelper.IsTenantScoped() {
+			objectHelper.SetTenant(object, tenant)
 		}
 		object, err = objectHelper.Create(ctx, object)
 		if err != nil {

--- a/internal/cmd/cli/create/publicip/create_publicip_cmd.go
+++ b/internal/cmd/cli/create/publicip/create_publicip_cmd.go
@@ -105,7 +105,7 @@ func (c *runnerContext) run(cmd *cobra.Command, args []string) error {
 		Pool: pool.GetId(),
 	}
 	publicIP := publicv1.PublicIP_builder{
-		Metadata: publicv1.Metadata_builder{Name: c.args.name}.Build(),
+		Metadata: publicv1.Metadata_builder{Name: c.args.name, Tenant: config.TenantFromContext(ctx)}.Build(),
 		Spec:     spec.Build(),
 	}.Build()
 

--- a/internal/cmd/cli/create/securitygroup/create_securitygroup_cmd.go
+++ b/internal/cmd/cli/create/securitygroup/create_securitygroup_cmd.go
@@ -130,7 +130,7 @@ func (c *runnerContext) run(cmd *cobra.Command, args []string) error {
 	client := publicv1.NewSecurityGroupsClient(conn)
 
 	sg := publicv1.SecurityGroup_builder{
-		Metadata: publicv1.Metadata_builder{Name: c.args.name}.Build(),
+		Metadata: publicv1.Metadata_builder{Name: c.args.name, Tenant: config.TenantFromContext(ctx)}.Build(),
 		Spec: publicv1.SecurityGroupSpec_builder{
 			VirtualNetwork: vn.GetId(),
 			Ingress:        ingress,

--- a/internal/cmd/cli/create/subnet/create_subnet_cmd.go
+++ b/internal/cmd/cli/create/subnet/create_subnet_cmd.go
@@ -130,7 +130,7 @@ func (c *runnerContext) run(cmd *cobra.Command, args []string) error {
 		spec.Ipv6Cidr = &c.args.ipv6Cidr
 	}
 	subnet := publicv1.Subnet_builder{
-		Metadata: publicv1.Metadata_builder{Name: c.args.name}.Build(),
+		Metadata: publicv1.Metadata_builder{Name: c.args.name, Tenant: config.TenantFromContext(ctx)}.Build(),
 		Spec:     spec.Build(),
 	}.Build()
 

--- a/internal/cmd/cli/create/virtualnetwork/create_virtualnetwork_cmd.go
+++ b/internal/cmd/cli/create/virtualnetwork/create_virtualnetwork_cmd.go
@@ -123,7 +123,7 @@ func (c *runnerContext) run(cmd *cobra.Command, args []string) error {
 		spec.Ipv6Cidr = &c.args.ipv6Cidr
 	}
 	vn := publicv1.VirtualNetwork_builder{
-		Metadata: publicv1.Metadata_builder{Name: c.args.name}.Build(),
+		Metadata: publicv1.Metadata_builder{Name: c.args.name, Tenant: config.TenantFromContext(ctx)}.Build(),
 		Spec:     spec.Build(),
 	}.Build()
 

--- a/internal/cmd/cli/root_cmd.go
+++ b/internal/cmd/cli/root_cmd.go
@@ -32,6 +32,7 @@ import (
 	"github.com/osac-project/fulfillment-service/internal/cmd/cli/label"
 	"github.com/osac-project/fulfillment-service/internal/cmd/cli/login"
 	"github.com/osac-project/fulfillment-service/internal/cmd/cli/logout"
+	"github.com/osac-project/fulfillment-service/internal/cmd/cli/tenant"
 	"github.com/osac-project/fulfillment-service/internal/cmd/cli/version"
 	"github.com/osac-project/fulfillment-service/internal/config"
 	"github.com/osac-project/fulfillment-service/internal/logging"
@@ -85,6 +86,12 @@ func Root() (result *cobra.Command, err error) {
 		defaultCacheDir,
 		cacheFlagHelp,
 	)
+	flags.StringVar(
+		&runner.args.tenant,
+		tenantFlag,
+		"",
+		tenantFlagHelp,
+	)
 
 	// Add commands:
 	result.AddCommand(annotate.Cmd())
@@ -97,6 +104,7 @@ func Root() (result *cobra.Command, err error) {
 	result.AddCommand(label.Cmd())
 	result.AddCommand(login.Cmd())
 	result.AddCommand(logout.Cmd())
+	result.AddCommand(tenant.Cmd())
 	result.AddCommand(version.Cmd())
 
 	// Configure the root command, and therefore all its subcommands, to use Markdown for their help output:
@@ -110,6 +118,7 @@ type runnerContext struct {
 	args       struct {
 		configDir string
 		cacheDir  string
+		tenant    string
 	}
 }
 
@@ -197,11 +206,21 @@ func (c *runnerContext) persistentPreRun(cmd *cobra.Command, args []string) erro
 		return fmt.Errorf("failed to create console: %w", err)
 	}
 
-	// Replace the default context with one that contains the logger, the settings, and the console:
+	// Resolve the effective tenant: flag takes precedence over saved setting.
+	tenant := settings.Tenant()
+	if flags.Changed(tenantFlag) {
+		tenant = c.args.tenant
+	}
+
+	// Replace the default context with one that contains the logger, the settings, the console,
+	// and the resolved tenant:
 	ctx := cmd.Context()
 	ctx = logging.LoggerIntoContext(ctx, logger)
 	ctx = config.SettingsIntoContext(ctx, settings)
 	ctx = terminal.ConsoleIntoContext(ctx, console)
+	if tenant != "" {
+		ctx = config.TenantIntoContext(ctx, tenant)
+	}
 	cmd.SetContext(ctx)
 
 	return nil
@@ -211,6 +230,7 @@ func (c *runnerContext) persistentPreRun(cmd *cobra.Command, args []string) erro
 const (
 	configFlag = "config"
 	cacheFlag  = "cache"
+	tenantFlag = "tenant"
 )
 
 // Names of the environment variables:
@@ -233,6 +253,12 @@ Configuration is stored in a file named {{ bt }}config.json{{ bt }} inside this 
 
 Secrets, such as tokens and passwords, are stored in the operating system keyring. If the keyring is not available,
 they are stored in a file named {{ bt }}secrets.json{{ bt }} inside this directory.
+`
+
+const tenantFlagHelp = `
+_NAME_ - Scope operations to the specified tenant. When set, list operations automatically filter by tenant,
+and create operations populate {{ bt }}metadata.tenant{{ bt }} on new objects. If a current tenant has been
+saved with {{ bt }}{{ binary }} tenant <name>{{ bt }}, the flag takes precedence.
 `
 
 const cacheFlagHelp = `

--- a/internal/cmd/cli/tenant/templates/current_tenant.txt
+++ b/internal/cmd/cli/tenant/templates/current_tenant.txt
@@ -1,0 +1,1 @@
+Current tenant: {{ .Tenant }}

--- a/internal/cmd/cli/tenant/templates/multiple_matches.txt
+++ b/internal/cmd/cli/tenant/templates/multiple_matches.txt
@@ -1,0 +1,14 @@
+Name '{{ .Ref }}' is ambiguous.
+
+{{ if lt (len .Matches) .Total }}
+There are {{ .Total }} matching tenants, these are the first {{ len .Matches }}:
+{{ else }}
+There are {{ .Total }} matching tenants:
+{{ end }}
+
+{{ table .Matches }}
+
+{{ $first := index .Matches 0 }}
+Use the identifier instead of the name to avoid ambiguity:
+
+  {{ binary }} tenant {{ $first.GetId }}

--- a/internal/cmd/cli/tenant/templates/no_matches.txt
+++ b/internal/cmd/cli/tenant/templates/no_matches.txt
@@ -1,0 +1,5 @@
+Tenant '{{ .Ref }}' not found.
+
+Use the 'get' command to list available tenants:
+
+  {{ binary }} get tenants

--- a/internal/cmd/cli/tenant/templates/no_tenant.txt
+++ b/internal/cmd/cli/tenant/templates/no_tenant.txt
@@ -1,0 +1,9 @@
+No tenant is currently set.
+
+To list available tenants:
+
+  {{ binary }} get tenants
+
+To set a tenant:
+
+  {{ binary }} tenant <name>

--- a/internal/cmd/cli/tenant/templates/tenant_cleared.txt
+++ b/internal/cmd/cli/tenant/templates/tenant_cleared.txt
@@ -1,0 +1,1 @@
+Tenant cleared.

--- a/internal/cmd/cli/tenant/templates/tenant_set.txt
+++ b/internal/cmd/cli/tenant/templates/tenant_set.txt
@@ -1,0 +1,1 @@
+Tenant '{{ .Tenant }}' saved. It will be used as the default for subsequent commands.

--- a/internal/cmd/cli/tenant/tenant_cmd.go
+++ b/internal/cmd/cli/tenant/tenant_cmd.go
@@ -1,0 +1,244 @@
+/*
+Copyright (c) 2026 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package tenant
+
+import (
+	"embed"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+
+	"github.com/spf13/cobra"
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/proto"
+
+	"github.com/osac-project/fulfillment-service/internal/config"
+	"github.com/osac-project/fulfillment-service/internal/logging"
+	"github.com/osac-project/fulfillment-service/internal/reflection"
+	"github.com/osac-project/fulfillment-service/internal/terminal"
+)
+
+//go:embed templates
+var templatesFS embed.FS
+
+func Cmd() *cobra.Command {
+	runner := &runnerContext{
+		marshalOptions: protojson.MarshalOptions{
+			UseProtoNames: true,
+		},
+	}
+	result := &cobra.Command{
+		Use:                   "tenant [FLAG...] [NAME]",
+		DisableFlagsInUseLine: true,
+		Short:                 shortHelp,
+		Long:                  longHelp,
+		RunE:                  runner.run,
+	}
+	flags := result.Flags()
+	flags.BoolVar(
+		&runner.args.clear,
+		"clear",
+		false,
+		clearFlagHelp,
+	)
+	flags.StringVarP(
+		&runner.args.format,
+		"output",
+		"o",
+		"",
+		outputFlagHelp,
+	)
+	return result
+}
+
+type runnerContext struct {
+	args struct {
+		clear  bool
+		format string
+	}
+	logger         *slog.Logger
+	console        *terminal.Console
+	marshalOptions protojson.MarshalOptions
+}
+
+func (c *runnerContext) run(cmd *cobra.Command, args []string) error {
+	ctx := cmd.Context()
+
+	c.logger = logging.LoggerFromContext(ctx)
+	c.console = terminal.ConsoleFromContext(ctx)
+
+	err := c.console.AddTemplates(templatesFS, "templates")
+	if err != nil {
+		return fmt.Errorf("failed to load templates: %w", err)
+	}
+
+	settings := config.SettingsFromContext(ctx)
+
+	if c.args.clear {
+		settings.SetTenant("")
+		err = settings.Save(ctx)
+		if err != nil {
+			return fmt.Errorf("failed to save settings: %w", err)
+		}
+		c.console.Render(ctx, "tenant_cleared.txt", nil)
+		return nil
+	}
+
+	if len(args) == 0 {
+		return c.showCurrentTenant(cmd, settings)
+	}
+
+	return c.setTenant(cmd, settings, args[0])
+}
+
+func (c *runnerContext) showCurrentTenant(cmd *cobra.Command, settings *config.Settings) error {
+	ctx := cmd.Context()
+	tenant := settings.Tenant()
+
+	if tenant == "" {
+		c.console.Render(ctx, "no_tenant.txt", nil)
+		return nil
+	}
+
+	if c.args.format == "" {
+		c.console.Render(ctx, "current_tenant.txt", map[string]any{
+			"Tenant": tenant,
+		})
+		return nil
+	}
+
+	object, err := c.findTenant(cmd, settings, tenant)
+	if err != nil {
+		return err
+	}
+
+	return c.renderObject(cmd, object)
+}
+
+func (c *runnerContext) setTenant(cmd *cobra.Command, settings *config.Settings, name string) error {
+	ctx := cmd.Context()
+
+	_, err := c.findTenant(cmd, settings, name)
+	if err != nil {
+		return err
+	}
+
+	settings.SetTenant(name)
+	err = settings.Save(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to save settings: %w", err)
+	}
+
+	c.console.Render(ctx, "tenant_set.txt", map[string]any{
+		"Tenant": name,
+	})
+	return nil
+}
+
+// findTenant connects to the server and resolves a tenant name or ID to a single object.
+func (c *runnerContext) findTenant(cmd *cobra.Command, settings *config.Settings, ref string) (proto.Message, error) {
+	ctx := cmd.Context()
+
+	if !settings.Armed() {
+		return nil, fmt.Errorf("there is no configuration, run the 'login' command")
+	}
+
+	conn, err := settings.Connect(ctx, cmd.Flags())
+	if err != nil {
+		return nil, fmt.Errorf("failed to create gRPC connection: %w", err)
+	}
+	defer conn.Close()
+
+	helper, err := reflection.NewHelper().
+		SetLogger(c.logger).
+		SetConnection(conn).
+		AddPackages(settings.Packages()).
+		Build()
+	if err != nil {
+		return nil, fmt.Errorf("failed to create reflection tool: %w", err)
+	}
+
+	objectHelper := helper.Lookup("tenant")
+	if objectHelper == nil {
+		return nil, fmt.Errorf("tenant resource type not found on the server")
+	}
+
+	return objectHelper.FindObject(ctx, ref, c.console)
+}
+
+func (c *runnerContext) renderObject(cmd *cobra.Command, object proto.Message) error {
+	ctx := cmd.Context()
+
+	data, err := c.marshalOptions.Marshal(object)
+	if err != nil {
+		return err
+	}
+	var value any
+	err = json.Unmarshal(data, &value)
+	if err != nil {
+		return err
+	}
+
+	switch c.args.format {
+	case "json":
+		c.console.RenderJson(ctx, value)
+	case "yaml":
+		c.console.RenderYaml(ctx, value)
+	default:
+		return fmt.Errorf("unknown output format '%s', should be 'json' or 'yaml'", c.args.format)
+	}
+
+	return nil
+}
+
+const shortHelp = `Manage the current tenant`
+
+const longHelp = `
+Manage the current tenant for CLI operations.
+
+To see the current tenant:
+
+{{ bt 3 }}shell
+{{ binary }} tenant
+{{ bt 3 }}
+
+To set the current tenant:
+
+{{ bt 3 }}shell
+{{ binary }} tenant my-tenant
+{{ bt 3 }}
+
+To clear the current tenant:
+
+{{ bt 3 }}shell
+{{ binary }} tenant --clear
+{{ bt 3 }}
+
+To view the full tenant object:
+
+{{ bt 3 }}shell
+{{ binary }} tenant -o yaml
+{{ bt 3 }}
+
+When a tenant is set, it is used as the default for all operations. The
+{{ bt }}--tenant{{ bt }} global flag overrides the saved tenant.
+`
+
+const clearFlagHelp = `
+_[BOOLEAN]_ - Clear the saved tenant.
+`
+
+const outputFlagHelp = `
+_FORMAT_ - Output format for the tenant object. Must be {{ bt }}json{{ bt }} or {{ bt }}yaml{{ bt }}.
+`

--- a/internal/cmd/cli/tenant/tenant_cmd_test.go
+++ b/internal/cmd/cli/tenant/tenant_cmd_test.go
@@ -1,0 +1,45 @@
+/*
+Copyright (c) 2026 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package tenant
+
+import (
+	. "github.com/onsi/ginkgo/v2/dsl/core"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Tenant command", func() {
+	It("Has the expected use string", func() {
+		cmd := Cmd()
+		Expect(cmd.Use).To(Equal("tenant [FLAG...] [NAME]"))
+	})
+
+	It("Has a --clear flag", func() {
+		cmd := Cmd()
+		flag := cmd.Flags().Lookup("clear")
+		Expect(flag).ToNot(BeNil())
+		Expect(flag.DefValue).To(Equal("false"))
+	})
+
+	It("Has an --output flag", func() {
+		cmd := Cmd()
+		flag := cmd.Flags().Lookup("output")
+		Expect(flag).ToNot(BeNil())
+		Expect(flag.Shorthand).To(Equal("o"))
+	})
+
+	It("Looks up tenant resource type directly", func() {
+		runner := &runnerContext{}
+		_ = runner
+	})
+})

--- a/internal/cmd/cli/tenant/tenant_suite_test.go
+++ b/internal/cmd/cli/tenant/tenant_suite_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2025 Red Hat Inc.
+Copyright (c) 2026 Red Hat Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
 License. You may obtain a copy of the License at
@@ -11,16 +11,16 @@ Unless required by applicable law or agreed to in writing, software distributed 
 language governing permissions and limitations under the License.
 */
 
-package reflection
+package tenant
 
-// Metadata is an interface that provides access to common metadata fields in protobuf messages.
-type Metadata interface {
-	GetName() string
-	GetTenant() string
-	SetTenant(string)
-	GetLabels() map[string]string
-	SetLabels(map[string]string)
-	GetAnnotations() map[string]string
-	SetAnnotations(map[string]string)
-	GetVersion() int32
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2/dsl/core"
+	. "github.com/onsi/gomega"
+)
+
+func TestTenant(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Tenant command")
 }

--- a/internal/config/config_context.go
+++ b/internal/config/config_context.go
@@ -22,6 +22,7 @@ type contextKey int
 
 const (
 	contextSettingsKey contextKey = iota
+	contextTenantKey
 )
 
 // SettingsFromContext returns the settings from the context. It panics if the given context doesn't contain settings.
@@ -36,4 +37,15 @@ func SettingsFromContext(ctx context.Context) *Settings {
 // SettingsIntoContext creates a new context that contains the given settings.
 func SettingsIntoContext(ctx context.Context, settings *Settings) context.Context {
 	return context.WithValue(ctx, contextSettingsKey, settings)
+}
+
+// TenantFromContext returns the resolved tenant from the context. Returns an empty string if no tenant is set.
+func TenantFromContext(ctx context.Context) string {
+	v, _ := ctx.Value(contextTenantKey).(string)
+	return v
+}
+
+// TenantIntoContext creates a new context that contains the given tenant.
+func TenantIntoContext(ctx context.Context, tenant string) context.Context {
+	return context.WithValue(ctx, contextTenantKey, tenant)
 }

--- a/internal/config/config_context_test.go
+++ b/internal/config/config_context_test.go
@@ -42,4 +42,14 @@ var _ = Describe("Context", func() {
 			SettingsFromContext(ctx)
 		}).To(Panic())
 	})
+
+	It("Returns empty string when no tenant in context", func() {
+		ctx := context.Background()
+		Expect(TenantFromContext(ctx)).To(BeEmpty())
+	})
+
+	It("Returns the tenant stored by TenantIntoContext", func() {
+		ctx := TenantIntoContext(context.Background(), "my-tenant")
+		Expect(TenantFromContext(ctx)).To(Equal("my-tenant"))
+	})
 })

--- a/internal/config/config_settings.go
+++ b/internal/config/config_settings.go
@@ -115,6 +115,7 @@ type secretSettings struct {
 	ClientSecret string    `json:"client_secret,omitempty"`
 	User         string    `json:"user,omitempty"`
 	Password     string    `json:"password,omitempty"`
+	Tenant       string    `json:"tenant,omitempty"`
 }
 
 // CaFile represents a CA certificate file with its name and optionally its content. The content is stored for relative
@@ -270,6 +271,16 @@ func (s *Settings) SetUser(value string) {
 // SetPassword sets the OAuth password.
 func (s *Settings) SetPassword(value string) {
 	s.secret.Password = value
+}
+
+// Tenant returns the saved tenant name.
+func (s *Settings) Tenant() string {
+	return s.secret.Tenant
+}
+
+// SetTenant sets the saved tenant name.
+func (s *Settings) SetTenant(value string) {
+	s.secret.Tenant = value
 }
 
 // Load populates the settings from the configuration file and the secret store.

--- a/internal/config/config_settings_test.go
+++ b/internal/config/config_settings_test.go
@@ -445,6 +445,67 @@ var _ = Describe("Settings", func() {
 		})
 	})
 
+	Describe("Tenant", func() {
+		BeforeEach(func() {
+			keyring.MockInit()
+		})
+
+		It("Returns empty string when no tenant is saved", func(ctx context.Context) {
+			settings, err := NewSettings().
+				SetLogger(logger).
+				SetDir(tmp).
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+			err = settings.Load(ctx)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(settings.Tenant()).To(BeEmpty())
+		})
+
+		It("Round-trips the tenant through the secret store", func(ctx context.Context) {
+			settings, err := NewSettings().
+				SetLogger(logger).
+				SetDir(tmp).
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+			settings.SetTenant("my-tenant")
+			err = settings.Save(ctx)
+			Expect(err).ToNot(HaveOccurred())
+
+			settings2, err := NewSettings().
+				SetLogger(logger).
+				SetDir(tmp).
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+			err = settings2.Load(ctx)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(settings2.Tenant()).To(Equal("my-tenant"))
+		})
+
+		It("Clears the tenant when set to empty string", func(ctx context.Context) {
+			settings, err := NewSettings().
+				SetLogger(logger).
+				SetDir(tmp).
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+			settings.SetTenant("my-tenant")
+			err = settings.Save(ctx)
+			Expect(err).ToNot(HaveOccurred())
+
+			settings.SetTenant("")
+			err = settings.Save(ctx)
+			Expect(err).ToNot(HaveOccurred())
+
+			settings2, err := NewSettings().
+				SetLogger(logger).
+				SetDir(tmp).
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+			err = settings2.Load(ctx)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(settings2.Tenant()).To(BeEmpty())
+		})
+	})
+
 	Describe("Armed check", func() {
 		It("Returns false when settings are nil", func() {
 			var settings *Settings

--- a/internal/reflection/reflection_helper.go
+++ b/internal/reflection/reflection_helper.go
@@ -29,6 +29,8 @@ import (
 	"google.golang.org/protobuf/reflect/protoreflect"
 	"google.golang.org/protobuf/reflect/protoregistry"
 
+	"github.com/osac-project/fulfillment-service/internal/config"
+
 	// This is needed to ensure that the types and services are loaded into the protocol buffers registry, otherwise
 	// they will be visible only if they are explicitly used in some part of the code.
 	_ "github.com/osac-project/fulfillment-service/internal/api/osac/private/v1"
@@ -74,6 +76,9 @@ type ObjectHelper interface {
 	Update(ctx context.Context, object proto.Message) (proto.Message, error)
 	Delete(ctx context.Context, id string) error
 	FindObject(ctx context.Context, ref string, console Renderer) (proto.Message, error)
+	SetTenant(object proto.Message, tenant string)
+	GetTenant(object proto.Message) string
+	IsTenantScoped() bool
 }
 
 // HelperBuilder contains the data and logic needed to create a reflection helper.
@@ -335,6 +340,7 @@ func (h *helper) scanService(serviceDesc protoreflect.ServiceDescriptor) {
 		metadataField: metadataFieldDesc,
 		singular:      objectNameSingular,
 		plural:        objectNamePlural,
+		tenantScoped:  tenantScopedTypes[objectDesc.FullName()],
 		template:      objectTemplate,
 		get: getInfo{
 			methodInfo: methodInfo{
@@ -503,15 +509,15 @@ func (h *helper) Plurals() []string {
 
 func (h *helper) Lookup(objectType string) ObjectHelper {
 	h.scanIfNeeded()
-	for i, objectInfo := range h.helpers {
+	for _, objectInfo := range h.helpers {
 		if objectType == string(objectInfo.descriptor.FullName()) {
-			return &h.helpers[i]
+			return &objectInfo
 		}
 		if strings.EqualFold(objectType, objectInfo.singular) {
-			return &h.helpers[i]
+			return &objectInfo
 		}
 		if strings.EqualFold(objectType, objectInfo.plural) {
-			return &h.helpers[i]
+			return &objectInfo
 		}
 	}
 	return nil
@@ -542,6 +548,7 @@ type objectHelper struct {
 	descriptor    protoreflect.MessageDescriptor
 	singular      string
 	plural        string
+	tenantScoped  bool
 	template      proto.Message
 	list          listInfo
 	get           getInfo
@@ -625,6 +632,18 @@ type ListResult struct {
 
 func (h *objectHelper) List(ctx context.Context, options ListOptions) (result ListResult, err error) {
 	filter := options.Filter
+
+	// Inject tenant filter from context if present:
+	tenant := config.TenantFromContext(ctx)
+	if tenant != "" && h.tenantScoped {
+		tenantFilter := fmt.Sprintf("this.metadata.tenant == %q", tenant)
+		if filter != "" {
+			filter = fmt.Sprintf("%s && (%s)", tenantFilter, filter)
+		} else {
+			filter = tenantFilter
+		}
+	}
+
 	request := proto.Clone(h.list.request)
 	if filter != "" {
 		request.ProtoReflect().Set(h.list.filter, protoreflect.ValueOfString(filter))
@@ -705,6 +724,34 @@ func (h *objectHelper) Delete(ctx context.Context, id string) error {
 	return h.parent.connection.Invoke(ctx, h.delete.path, request, response)
 }
 
+// tenantFieldName is the name of the tenant field in the metadata message.
+const tenantFieldName = protoreflect.Name("tenant")
+
+// SetTenant sets the tenant field on the object's metadata. If the metadata submessage does not
+// exist it is created.
+func (h *objectHelper) SetTenant(object proto.Message, tenant string) {
+	metadata := object.ProtoReflect().Mutable(h.metadataField).Message()
+	field := metadata.Descriptor().Fields().ByName(tenantFieldName)
+	if field != nil {
+		metadata.Set(field, protoreflect.ValueOfString(tenant))
+	}
+}
+
+// GetTenant returns the tenant field from the object's metadata.
+func (h *objectHelper) GetTenant(object proto.Message) string {
+	metadata := object.ProtoReflect().Get(h.metadataField).Message()
+	field := metadata.Descriptor().Fields().ByName(tenantFieldName)
+	if field == nil {
+		return ""
+	}
+	return metadata.Get(field).String()
+}
+
+// IsTenantScoped returns true if this resource type is scoped to a tenant.
+func (h *objectHelper) IsTenantScoped() bool {
+	return h.tenantScoped
+}
+
 func (h *objectHelper) setId(message proto.Message, field protoreflect.FieldDescriptor, value string) {
 	message.ProtoReflect().Set(field, protoreflect.ValueOfString(value))
 }
@@ -735,3 +782,47 @@ const (
 	objectFieldName   = protoreflect.Name("object")
 	totalFieldName    = protoreflect.Name("total")
 )
+
+// tenantScopedTypes lists the resource types that are scoped to a tenant. Only these types get
+// automatic tenant filter injection on List, automatic tenant field setting on generic Create,
+// and the TENANT column in table output. Types not listed here are platform-scoped.
+var tenantScopedTypes = map[protoreflect.FullName]bool{
+	"osac.public.v1.BareMetalInstance":             true,
+	"osac.public.v1.BareMetalInstanceCatalogItem":  true,
+	"osac.public.v1.BareMetalInstanceTemplate":     true,
+	"osac.public.v1.Cluster":                       true,
+	"osac.public.v1.ClusterCatalogItem":            true,
+	"osac.public.v1.ClusterTemplate":               true,
+	"osac.public.v1.ComputeInstance":                true,
+	"osac.public.v1.ComputeInstanceCatalogItem":    true,
+	"osac.public.v1.ComputeInstanceTemplate":       true,
+	"osac.public.v1.ExternalIP":                    true,
+	"osac.public.v1.ExternalIPAttachment":          true,
+	"osac.public.v1.Project":                       true,
+	"osac.public.v1.ProjectMembership":             true,
+	"osac.public.v1.PublicIP":                      true,
+	"osac.public.v1.PublicIPAttachment":            true,
+	"osac.public.v1.RoleBinding":                   true,
+	"osac.public.v1.SecurityGroup":                 true,
+	"osac.public.v1.Subnet":                        true,
+	"osac.public.v1.VirtualNetwork":                true,
+	"osac.private.v1.BareMetalInstance":             true,
+	"osac.private.v1.BareMetalInstanceCatalogItem":  true,
+	"osac.private.v1.BareMetalInstanceTemplate":     true,
+	"osac.private.v1.Cluster":                       true,
+	"osac.private.v1.ClusterCatalogItem":            true,
+	"osac.private.v1.ClusterTemplate":               true,
+	"osac.private.v1.ComputeInstance":                true,
+	"osac.private.v1.ComputeInstanceCatalogItem":    true,
+	"osac.private.v1.ComputeInstanceTemplate":       true,
+	"osac.private.v1.ExternalIP":                    true,
+	"osac.private.v1.ExternalIPAttachment":          true,
+	"osac.private.v1.Project":                       true,
+	"osac.private.v1.ProjectMembership":             true,
+	"osac.private.v1.PublicIP":                      true,
+	"osac.private.v1.PublicIPAttachment":            true,
+	"osac.private.v1.RoleBinding":                   true,
+	"osac.private.v1.SecurityGroup":                 true,
+	"osac.private.v1.Subnet":                        true,
+	"osac.private.v1.VirtualNetwork":                true,
+}

--- a/internal/reflection/reflection_helper_mock.go
+++ b/internal/reflection/reflection_helper_mock.go
@@ -19,7 +19,6 @@ import (
 type MockHelper struct {
 	ctrl     *gomock.Controller
 	recorder *MockHelperMockRecorder
-	isgomock struct{}
 }
 
 // MockHelperMockRecorder is the mock recorder for MockHelper.
@@ -40,17 +39,17 @@ func (m *MockHelper) EXPECT() *MockHelperMockRecorder {
 }
 
 // Lookup mocks base method.
-func (m *MockHelper) Lookup(objectType string) ObjectHelper {
+func (m *MockHelper) Lookup(arg0 string) ObjectHelper {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Lookup", objectType)
+	ret := m.ctrl.Call(m, "Lookup", arg0)
 	ret0, _ := ret[0].(ObjectHelper)
 	return ret0
 }
 
 // Lookup indicates an expected call of Lookup.
-func (mr *MockHelperMockRecorder) Lookup(objectType any) *gomock.Call {
+func (mr *MockHelperMockRecorder) Lookup(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Lookup", reflect.TypeOf((*MockHelper)(nil).Lookup), objectType)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Lookup", reflect.TypeOf((*MockHelper)(nil).Lookup), arg0)
 }
 
 // Names mocks base method.

--- a/internal/reflection/reflection_helper_test.go
+++ b/internal/reflection/reflection_helper_test.go
@@ -25,6 +25,7 @@ import (
 	"google.golang.org/protobuf/proto"
 
 	publicv1 "github.com/osac-project/fulfillment-service/internal/api/osac/public/v1"
+	"github.com/osac-project/fulfillment-service/internal/config"
 	"github.com/osac-project/fulfillment-service/internal/packages"
 	"github.com/osac-project/fulfillment-service/internal/testing"
 )
@@ -219,6 +220,21 @@ var _ = Describe("Reflection helper", func() {
 				"Host type in plural",
 				"hosttypes",
 				"osac.public.v1.HostType",
+			),
+			Entry(
+				"Tenant in singular",
+				"tenant",
+				"osac.public.v1.Tenant",
+			),
+			Entry(
+				"Tenant in plural",
+				"tenants",
+				"osac.public.v1.Tenant",
+			),
+			Entry(
+				"Tenant in upper case",
+				"TENANT",
+				"osac.public.v1.Tenant",
 			),
 		)
 
@@ -624,6 +640,128 @@ var _ = Describe("Reflection helper", func() {
 					)
 				}
 			}
+		})
+
+		It("Sets tenant on an object with existing metadata", func() {
+			objectHelper := helper.Lookup("cluster")
+			Expect(objectHelper).ToNot(BeNil())
+			object := publicv1.Cluster_builder{
+				Metadata: publicv1.Metadata_builder{
+					Name: "my-cluster",
+				}.Build(),
+			}.Build()
+			objectHelper.SetTenant(object, "my-tenant")
+			Expect(objectHelper.GetTenant(object)).To(Equal("my-tenant"))
+			Expect(objectHelper.GetMetadata(object).GetName()).To(Equal("my-cluster"))
+		})
+
+		It("Sets tenant on an object without metadata", func() {
+			objectHelper := helper.Lookup("cluster")
+			Expect(objectHelper).ToNot(BeNil())
+			object := publicv1.Cluster_builder{
+				Id: "123",
+			}.Build()
+			objectHelper.SetTenant(object, "my-tenant")
+			Expect(objectHelper.GetTenant(object)).To(Equal("my-tenant"))
+		})
+
+		It("Returns empty tenant when none is set", func() {
+			objectHelper := helper.Lookup("cluster")
+			Expect(objectHelper).ToNot(BeNil())
+			object := publicv1.Cluster_builder{
+				Metadata: publicv1.Metadata_builder{
+					Name: "my-cluster",
+				}.Build(),
+			}.Build()
+			Expect(objectHelper.GetTenant(object)).To(BeEmpty())
+		})
+
+		It("Injects tenant filter into list when tenant is in context", func() {
+			var capturedFilter string
+			publicv1.RegisterClustersServer(server.Registrar(), &testing.ClustersServerFuncs{
+				ListFunc: func(ctx context.Context, request *publicv1.ClustersListRequest,
+				) (response *publicv1.ClustersListResponse, err error) {
+					capturedFilter = request.GetFilter()
+					response = publicv1.ClustersListResponse_builder{
+						Size:  0,
+						Total: 0,
+					}.Build()
+					return
+				},
+			})
+			server.Start()
+
+			tenantCtx := config.TenantIntoContext(ctx, "acme")
+			objectHelper := helper.Lookup("cluster")
+			Expect(objectHelper).ToNot(BeNil())
+			_, err := objectHelper.List(tenantCtx, ListOptions{})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(capturedFilter).To(Equal(`this.metadata.tenant == "acme"`))
+		})
+
+		It("Combines tenant filter with user-provided filter", func() {
+			var capturedFilter string
+			publicv1.RegisterClustersServer(server.Registrar(), &testing.ClustersServerFuncs{
+				ListFunc: func(ctx context.Context, request *publicv1.ClustersListRequest,
+				) (response *publicv1.ClustersListResponse, err error) {
+					capturedFilter = request.GetFilter()
+					response = publicv1.ClustersListResponse_builder{
+						Size:  0,
+						Total: 0,
+					}.Build()
+					return
+				},
+			})
+			server.Start()
+
+			tenantCtx := config.TenantIntoContext(ctx, "acme")
+			objectHelper := helper.Lookup("cluster")
+			Expect(objectHelper).ToNot(BeNil())
+			_, err := objectHelper.List(tenantCtx, ListOptions{
+				Filter: `this.metadata.name == "my-cluster"`,
+			})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(capturedFilter).To(Equal(
+				`this.metadata.tenant == "acme" && (this.metadata.name == "my-cluster")`,
+			))
+		})
+
+		It("Reports tenant-scoped types correctly", func() {
+			Expect(helper.Lookup("cluster").IsTenantScoped()).To(BeTrue())
+			Expect(helper.Lookup("virtualnetwork").IsTenantScoped()).To(BeTrue())
+			Expect(helper.Lookup("subnet").IsTenantScoped()).To(BeTrue())
+			Expect(helper.Lookup("project").IsTenantScoped()).To(BeTrue())
+		})
+
+		It("Reports platform-scoped types correctly", func() {
+			Expect(helper.Lookup("hosttype").IsTenantScoped()).To(BeFalse())
+			Expect(helper.Lookup("tenant").IsTenantScoped()).To(BeFalse())
+			Expect(helper.Lookup("networkclass").IsTenantScoped()).To(BeFalse())
+			Expect(helper.Lookup("role").IsTenantScoped()).To(BeFalse())
+		})
+
+		It("Does not inject tenant filter when no tenant in context", func() {
+			var capturedFilter string
+			publicv1.RegisterClustersServer(server.Registrar(), &testing.ClustersServerFuncs{
+				ListFunc: func(ctx context.Context, request *publicv1.ClustersListRequest,
+				) (response *publicv1.ClustersListResponse, err error) {
+					capturedFilter = request.GetFilter()
+					response = publicv1.ClustersListResponse_builder{
+						Size:  0,
+						Total: 0,
+					}.Build()
+					return
+				},
+			})
+			server.Start()
+
+			objectHelper := helper.Lookup("cluster")
+			Expect(objectHelper).ToNot(BeNil())
+			_, err := objectHelper.List(ctx, ListOptions{
+				Filter: `this.metadata.name == "my-cluster"`,
+			})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(capturedFilter).To(Equal(`this.metadata.name == "my-cluster"`))
 		})
 
 		It("Sorts types according to package order when adding packages", func() {

--- a/internal/reflection/reflection_object_helper_mock.go
+++ b/internal/reflection/reflection_object_helper_mock.go
@@ -14,7 +14,6 @@ import (
 	reflect "reflect"
 
 	gomock "go.uber.org/mock/gomock"
-	proto "google.golang.org/protobuf/proto"
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 )
 
@@ -22,7 +21,6 @@ import (
 type MockObjectHelper struct {
 	ctrl     *gomock.Controller
 	recorder *MockObjectHelperMockRecorder
-	isgomock struct{}
 }
 
 // MockObjectHelperMockRecorder is the mock recorder for MockObjectHelper.
@@ -43,32 +41,32 @@ func (m *MockObjectHelper) EXPECT() *MockObjectHelperMockRecorder {
 }
 
 // Create mocks base method.
-func (m *MockObjectHelper) Create(ctx context.Context, object proto.Message) (proto.Message, error) {
+func (m *MockObjectHelper) Create(arg0 context.Context, arg1 protoreflect.ProtoMessage) (protoreflect.ProtoMessage, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Create", ctx, object)
-	ret0, _ := ret[0].(proto.Message)
+	ret := m.ctrl.Call(m, "Create", arg0, arg1)
+	ret0, _ := ret[0].(protoreflect.ProtoMessage)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Create indicates an expected call of Create.
-func (mr *MockObjectHelperMockRecorder) Create(ctx, object any) *gomock.Call {
+func (mr *MockObjectHelperMockRecorder) Create(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Create", reflect.TypeOf((*MockObjectHelper)(nil).Create), ctx, object)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Create", reflect.TypeOf((*MockObjectHelper)(nil).Create), arg0, arg1)
 }
 
 // Delete mocks base method.
-func (m *MockObjectHelper) Delete(ctx context.Context, id string) error {
+func (m *MockObjectHelper) Delete(arg0 context.Context, arg1 string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Delete", ctx, id)
+	ret := m.ctrl.Call(m, "Delete", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Delete indicates an expected call of Delete.
-func (mr *MockObjectHelperMockRecorder) Delete(ctx, id any) *gomock.Call {
+func (mr *MockObjectHelperMockRecorder) Delete(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockObjectHelper)(nil).Delete), ctx, id)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockObjectHelper)(nil).Delete), arg0, arg1)
 }
 
 // Descriptor mocks base method.
@@ -86,18 +84,18 @@ func (mr *MockObjectHelperMockRecorder) Descriptor() *gomock.Call {
 }
 
 // FindObject mocks base method.
-func (m *MockObjectHelper) FindObject(ctx context.Context, ref string, console Renderer) (proto.Message, error) {
+func (m *MockObjectHelper) FindObject(arg0 context.Context, arg1 string, arg2 Renderer) (protoreflect.ProtoMessage, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "FindObject", ctx, ref, console)
-	ret0, _ := ret[0].(proto.Message)
+	ret := m.ctrl.Call(m, "FindObject", arg0, arg1, arg2)
+	ret0, _ := ret[0].(protoreflect.ProtoMessage)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // FindObject indicates an expected call of FindObject.
-func (mr *MockObjectHelperMockRecorder) FindObject(ctx, ref, console any) *gomock.Call {
+func (mr *MockObjectHelperMockRecorder) FindObject(arg0, arg1, arg2 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindObject", reflect.TypeOf((*MockObjectHelper)(nil).FindObject), ctx, ref, console)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindObject", reflect.TypeOf((*MockObjectHelper)(nil).FindObject), arg0, arg1, arg2)
 }
 
 // FullName mocks base method.
@@ -115,67 +113,81 @@ func (mr *MockObjectHelperMockRecorder) FullName() *gomock.Call {
 }
 
 // Get mocks base method.
-func (m *MockObjectHelper) Get(ctx context.Context, id string) (proto.Message, error) {
+func (m *MockObjectHelper) Get(arg0 context.Context, arg1 string) (protoreflect.ProtoMessage, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Get", ctx, id)
-	ret0, _ := ret[0].(proto.Message)
+	ret := m.ctrl.Call(m, "Get", arg0, arg1)
+	ret0, _ := ret[0].(protoreflect.ProtoMessage)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Get indicates an expected call of Get.
-func (mr *MockObjectHelperMockRecorder) Get(ctx, id any) *gomock.Call {
+func (mr *MockObjectHelperMockRecorder) Get(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockObjectHelper)(nil).Get), ctx, id)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockObjectHelper)(nil).Get), arg0, arg1)
 }
 
 // GetId mocks base method.
-func (m *MockObjectHelper) GetId(object proto.Message) string {
+func (m *MockObjectHelper) GetId(arg0 protoreflect.ProtoMessage) string {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetId", object)
+	ret := m.ctrl.Call(m, "GetId", arg0)
 	ret0, _ := ret[0].(string)
 	return ret0
 }
 
 // GetId indicates an expected call of GetId.
-func (mr *MockObjectHelperMockRecorder) GetId(object any) *gomock.Call {
+func (mr *MockObjectHelperMockRecorder) GetId(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetId", reflect.TypeOf((*MockObjectHelper)(nil).GetId), object)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetId", reflect.TypeOf((*MockObjectHelper)(nil).GetId), arg0)
 }
 
 // GetMetadata mocks base method.
-func (m *MockObjectHelper) GetMetadata(object proto.Message) Metadata {
+func (m *MockObjectHelper) GetMetadata(arg0 protoreflect.ProtoMessage) Metadata {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetMetadata", object)
+	ret := m.ctrl.Call(m, "GetMetadata", arg0)
 	ret0, _ := ret[0].(Metadata)
 	return ret0
 }
 
 // GetMetadata indicates an expected call of GetMetadata.
-func (mr *MockObjectHelperMockRecorder) GetMetadata(object any) *gomock.Call {
+func (mr *MockObjectHelperMockRecorder) GetMetadata(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMetadata", reflect.TypeOf((*MockObjectHelper)(nil).GetMetadata), object)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMetadata", reflect.TypeOf((*MockObjectHelper)(nil).GetMetadata), arg0)
 }
 
 // GetName mocks base method.
-func (m *MockObjectHelper) GetName(object proto.Message) string {
+func (m *MockObjectHelper) GetName(arg0 protoreflect.ProtoMessage) string {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetName", object)
+	ret := m.ctrl.Call(m, "GetName", arg0)
 	ret0, _ := ret[0].(string)
 	return ret0
 }
 
 // GetName indicates an expected call of GetName.
-func (mr *MockObjectHelperMockRecorder) GetName(object any) *gomock.Call {
+func (mr *MockObjectHelperMockRecorder) GetName(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetName", reflect.TypeOf((*MockObjectHelper)(nil).GetName), object)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetName", reflect.TypeOf((*MockObjectHelper)(nil).GetName), arg0)
+}
+
+// GetTenant mocks base method.
+func (m *MockObjectHelper) GetTenant(arg0 protoreflect.ProtoMessage) string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetTenant", arg0)
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// GetTenant indicates an expected call of GetTenant.
+func (mr *MockObjectHelperMockRecorder) GetTenant(arg0 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTenant", reflect.TypeOf((*MockObjectHelper)(nil).GetTenant), arg0)
 }
 
 // Instance mocks base method.
-func (m *MockObjectHelper) Instance() proto.Message {
+func (m *MockObjectHelper) Instance() protoreflect.ProtoMessage {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Instance")
-	ret0, _ := ret[0].(proto.Message)
+	ret0, _ := ret[0].(protoreflect.ProtoMessage)
 	return ret0
 }
 
@@ -185,19 +197,33 @@ func (mr *MockObjectHelperMockRecorder) Instance() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Instance", reflect.TypeOf((*MockObjectHelper)(nil).Instance))
 }
 
-// List mocks base method.
-func (m *MockObjectHelper) List(ctx context.Context, options ListOptions) (ListResult, error) {
+// IsTenantScoped mocks base method.
+func (m *MockObjectHelper) IsTenantScoped() bool {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "List", ctx, options)
+	ret := m.ctrl.Call(m, "IsTenantScoped")
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// IsTenantScoped indicates an expected call of IsTenantScoped.
+func (mr *MockObjectHelperMockRecorder) IsTenantScoped() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsTenantScoped", reflect.TypeOf((*MockObjectHelper)(nil).IsTenantScoped))
+}
+
+// List mocks base method.
+func (m *MockObjectHelper) List(arg0 context.Context, arg1 ListOptions) (ListResult, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "List", arg0, arg1)
 	ret0, _ := ret[0].(ListResult)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // List indicates an expected call of List.
-func (mr *MockObjectHelperMockRecorder) List(ctx, options any) *gomock.Call {
+func (mr *MockObjectHelperMockRecorder) List(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "List", reflect.TypeOf((*MockObjectHelper)(nil).List), ctx, options)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "List", reflect.TypeOf((*MockObjectHelper)(nil).List), arg0, arg1)
 }
 
 // Plural mocks base method.
@@ -212,6 +238,18 @@ func (m *MockObjectHelper) Plural() string {
 func (mr *MockObjectHelperMockRecorder) Plural() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Plural", reflect.TypeOf((*MockObjectHelper)(nil).Plural))
+}
+
+// SetTenant mocks base method.
+func (m *MockObjectHelper) SetTenant(arg0 protoreflect.ProtoMessage, arg1 string) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "SetTenant", arg0, arg1)
+}
+
+// SetTenant indicates an expected call of SetTenant.
+func (mr *MockObjectHelperMockRecorder) SetTenant(arg0, arg1 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetTenant", reflect.TypeOf((*MockObjectHelper)(nil).SetTenant), arg0, arg1)
 }
 
 // Singular mocks base method.
@@ -243,16 +281,16 @@ func (mr *MockObjectHelperMockRecorder) String() *gomock.Call {
 }
 
 // Update mocks base method.
-func (m *MockObjectHelper) Update(ctx context.Context, object proto.Message) (proto.Message, error) {
+func (m *MockObjectHelper) Update(arg0 context.Context, arg1 protoreflect.ProtoMessage) (protoreflect.ProtoMessage, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Update", ctx, object)
-	ret0, _ := ret[0].(proto.Message)
+	ret := m.ctrl.Call(m, "Update", arg0, arg1)
+	ret0, _ := ret[0].(protoreflect.ProtoMessage)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Update indicates an expected call of Update.
-func (mr *MockObjectHelperMockRecorder) Update(ctx, object any) *gomock.Call {
+func (mr *MockObjectHelperMockRecorder) Update(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Update", reflect.TypeOf((*MockObjectHelper)(nil).Update), ctx, object)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Update", reflect.TypeOf((*MockObjectHelper)(nil).Update), arg0, arg1)
 }

--- a/internal/rendering/table_renderer.go
+++ b/internal/rendering/table_renderer.go
@@ -36,6 +36,7 @@ import (
 	"google.golang.org/protobuf/types/dynamicpb"
 	"gopkg.in/yaml.v3"
 
+	"github.com/osac-project/fulfillment-service/internal/config"
 	"github.com/osac-project/fulfillment-service/internal/reflection"
 )
 
@@ -183,6 +184,21 @@ func (r *TableRenderer) Render(ctx context.Context, objects any) error {
 	}
 	if table == nil {
 		table = r.defaultTable()
+	}
+
+	// When no tenant is selected, inject a TENANT column for tenant-scoped types so users can
+	// see which tenant each resource belongs to.
+	if config.TenantFromContext(ctx) == "" && helper.IsTenantScoped() {
+		hasTenantCol := slices.ContainsFunc(table.Columns, func(c *columnLayout) bool {
+			return c.Header == "TENANT"
+		})
+		if !hasTenantCol {
+			tenantCol := &columnLayout{
+				Header: "TENANT",
+				Value:  "has(this.metadata.tenant)? this.metadata.tenant: '-'",
+			}
+			table.Columns = slices.Insert(table.Columns, 0, tenantCol)
+		}
 	}
 
 	// Always show a DELETING column so users can see objects being torn down.
@@ -447,7 +463,8 @@ func (r *TableRenderer) lookupName(ctx context.Context, messageFullName protoref
 		"this.id == %[1]q || this.metadata.name == %[1]q",
 		key,
 	)
-	listResult, err := helper.List(ctx, reflection.ListOptions{
+	lookupCtx := config.TenantIntoContext(ctx, "")
+	listResult, err := helper.List(lookupCtx, reflection.ListOptions{
 		Filter: filter,
 	})
 	if err != nil {

--- a/internal/rendering/table_renderer_compute_instance_test.go
+++ b/internal/rendering/table_renderer_compute_instance_test.go
@@ -61,6 +61,9 @@ var _ = Describe("Compute instance table rendering", func() {
 			templateHelper.EXPECT().String().
 				Return(string(templateFullName)).
 				AnyTimes()
+			templateHelper.EXPECT().IsTenantScoped().
+				Return(true).
+				AnyTimes()
 			templateHelper.EXPECT().
 				List(gomock.Any(), gomock.Any()).
 				Return(
@@ -99,6 +102,9 @@ var _ = Describe("Compute instance table rendering", func() {
 				AnyTimes()
 			computeHelper.EXPECT().String().
 				Return(string(computeDescriptor.FullName())).
+				AnyTimes()
+			computeHelper.EXPECT().IsTenantScoped().
+				Return(true).
 				AnyTimes()
 
 			// Create a helper that returns compute instances or templates based on the object type:

--- a/internal/rendering/table_renderer_test.go
+++ b/internal/rendering/table_renderer_test.go
@@ -54,6 +54,9 @@ var _ = Describe("Table renderer", func() {
 		helper.EXPECT().String().
 			Return(string(fullName)).
 			AnyTimes()
+		helper.EXPECT().IsTenantScoped().
+			Return(true).
+			AnyTimes()
 		return helper
 	}
 
@@ -63,6 +66,9 @@ var _ = Describe("Table renderer", func() {
 		helper.EXPECT().
 			List(gomock.Any(), gomock.Any()).
 			Return(reflection.ListResult{}, nil).
+			AnyTimes()
+		helper.EXPECT().IsTenantScoped().
+			Return(false).
 			AnyTimes()
 		return helper
 	}
@@ -140,7 +146,7 @@ var _ = Describe("Table renderer", func() {
 					}.Build(),
 				})
 			Expect(output).To(ContainSubstring("DELETING"))
-			Expect(output).To(MatchRegexp(`Yes\s+subnet-2\s`))
+			Expect(output).To(MatchRegexp(`Yes\s+.*subnet-2\s`))
 		})
 	})
 


### PR DESCRIPTION
Add multi-tenant support to the osac CLI, enabling users to scope operations to a specific tenant via a saved setting or a per-command flag.

Core changes:
- Add `osac tenant` command to view, set, and clear the active tenant (persisted in the OS keyring alongside credentials)
- Add global `--tenant` flag with precedence over the saved setting
- Add TENANT column into CLI display tables when no tenant is selected and the resource is tenant-scoped


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a tenant selector in the CLI to scope operations and save a default tenant for future commands.
  * Added tenant management commands and messages for viewing, setting, clearing, and resolving the current tenant.
  * Tenant-aware creation and list views now better reflect the selected tenant, including clearer table output when no tenant is set.

* **Bug Fixes**
  * Objects created from the CLI now consistently carry tenant information where applicable, improving tenant-scoped resource handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->