### PR TITLE
OSAC-1904: fix integer column rendering in CLI table output

### DIFF
--- a/internal/rendering/table_renderer.go
+++ b/internal/rendering/table_renderer.go
@@ -480,6 +480,6 @@ func (r *TableRenderer) lookupName(ctx context.Context, messageFullName protoref
 
 // renderCellAny renders any value type as a string.
 func (r *TableRenderer) renderCellAny(val ref.Val) error {
-	_, err := fmt.Fprintf(r.writer, "%s", val)
+	_, err := fmt.Fprintf(r.writer, "%v", val)
 	return err
 }

--- a/internal/rendering/table_renderer_test.go
+++ b/internal/rendering/table_renderer_test.go
@@ -144,6 +144,55 @@ var _ = Describe("Table renderer", func() {
 		})
 	})
 
+	Describe("Integer columns", func() {
+		renderInstanceTypes := func(ctx context.Context, items []*publicv1.InstanceType) string {
+			objectHelper := makeObjectHelper(&publicv1.InstanceType{})
+			lookupHelper := makeLookupHelper()
+
+			helper := reflection.NewMockHelper(ctrl)
+			helper.EXPECT().
+				Lookup(objectHelper.String()).
+				Return(objectHelper).
+				AnyTimes()
+			helper.EXPECT().
+				Lookup(gomock.Any()).
+				Return(lookupHelper).
+				AnyTimes()
+
+			buffer := &bytes.Buffer{}
+			renderer, err := NewTableRenderer().
+				SetLogger(logger).
+				SetHelper(helper).
+				SetWriter(buffer).
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+			err = renderer.Render(ctx, items)
+			Expect(err).ToNot(HaveOccurred())
+			return buffer.String()
+		}
+
+		It("Renders integer fields as plain numbers", func(ctx context.Context) {
+			output := renderInstanceTypes(
+				ctx,
+				[]*publicv1.InstanceType{
+					publicv1.InstanceType_builder{
+						Id: "standard-4-16",
+						Metadata: publicv1.Metadata_builder{
+							Name: "standard-4-16",
+						}.Build(),
+						Spec: publicv1.InstanceTypeSpec_builder{
+							Cores:     4,
+							MemoryGib: 16,
+							State:     publicv1.InstanceTypeState_INSTANCE_TYPE_STATE_ACTIVE,
+						}.Build(),
+					}.Build(),
+				},
+			)
+			Expect(output).To(MatchRegexp(`4\s+16\s+ACTIVE`))
+			Expect(output).ToNot(ContainSubstring("%!s"))
+		})
+	})
+
 	It("Compiles CEL expressions successfully for all table definitions", func(ctx context.Context) {
 		// Collect all table definition files:
 		tableFiles, err := filepath.Glob("tables/*.yaml")


### PR DESCRIPTION
## Problem

`osac get instancetype` displays cores and memory columns as `%!s(types.Int=1)` instead of plain numbers.

## Root Cause

`renderCellAny` in `internal/rendering/table_renderer.go` used `%s` format for all fallback cell values. CEL's `types.Int` (the type returned for `int32` proto fields like `cores` and `memory_gib`) does not implement `fmt.Stringer`, so Go produces the `%!s(types.Int=N)` representation.

This is the first resource with plain integer columns in a table definition — all prior `types.Int` values were handled by the enum rendering code path.

## Fix

Change `%s` to `%v` in `renderCellAny`. The `%v` format uses Go's default representation for each type: decimal for integers, plain text for strings. No behavior change for existing string or enum columns.

## Testing

- Added regression test: "Renders integer fields as plain numbers" — verifies `cores=4, memory=16` render as `4  16  ACTIVE` with no `%!s` artifacts
- All 7 rendering tests pass
- Build passes

## Confidence

HIGH — single-character fix with clear root cause and regression test.

## Risk Assessment

LOW — `%v` is strictly more correct than `%s` for non-string types, and identical for strings.

Fixes: https://redhat.atlassian.net/browse/OSAC-1904

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Table cells now display non-text values, such as numbers, in a cleaner format.
  * Fixed an issue that could show formatting artifacts in rendered tables.
* **Tests**
  * Added coverage for integer column rendering to confirm values appear as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->