### PR TITLE
OSAC-1637: ensure tenant namespace lifecycle on hub clusters

### DIFF
--- a/internal/controllers/onboarding/tenant_reconciler_function.go
+++ b/internal/controllers/onboarding/tenant_reconciler_function.go
@@ -25,6 +25,7 @@ import (
 
 	"google.golang.org/grpc"
 	"google.golang.org/protobuf/proto"
+	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clnt "sigs.k8s.io/controller-runtime/pkg/client"
@@ -189,6 +190,46 @@ func (t *task) createOrUpdateOnHub(ctx context.Context, hubId string, hubEntry *
 			slog.String("name", existing.GetName()),
 		)
 	}
+
+	if err := t.ensureNamespaceOnHub(ctx, hubId, hubEntry); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (t *task) ensureNamespaceOnHub(ctx context.Context, hubId string, hubEntry *controllers.HubEntry) error {
+	tenantName := t.tenant.GetMetadata().GetName()
+	ns := &corev1.Namespace{}
+	err := hubEntry.Client.Get(ctx, clnt.ObjectKey{Name: tenantName}, ns)
+	if err == nil {
+		t.r.logger.DebugContext(ctx, "Tenant namespace already exists on hub",
+			slog.String("hub_id", hubId),
+			slog.String("name", tenantName),
+		)
+		return nil
+	}
+	if !apierrors.IsNotFound(err) {
+		return fmt.Errorf("failed to get namespace on hub %s: %w", hubId, err)
+	}
+
+	ns = &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: tenantName,
+			Labels: map[string]string{
+				labels.TenantRef: tenantName,
+				labels.Project:   hubEntry.Namespace,
+			},
+		},
+	}
+	err = hubEntry.Client.Create(ctx, ns)
+	if err != nil {
+		return fmt.Errorf("failed to create namespace on hub %s: %w", hubId, err)
+	}
+	t.r.logger.DebugContext(ctx, "Created tenant namespace",
+		slog.String("hub_id", hubId),
+		slog.String("name", tenantName),
+	)
 	return nil
 }
 
@@ -236,10 +277,43 @@ func (t *task) delete(ctx context.Context) error {
 				slog.String("name", existing.GetName()),
 			)
 		}
+
+		if err := t.deleteNamespaceOnHub(ctx, hub.GetId(), hubEntry); err != nil {
+			return err
+		}
+
 		return nil
 	}
 
 	t.removeFinalizer()
+	return nil
+}
+
+func (t *task) deleteNamespaceOnHub(ctx context.Context, hubId string, hubEntry *controllers.HubEntry) error {
+	tenantName := t.tenant.GetMetadata().GetName()
+	ns := &corev1.Namespace{}
+	err := hubEntry.Client.Get(ctx, clnt.ObjectKey{Name: tenantName}, ns)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil
+		}
+		return fmt.Errorf("failed to get namespace on hub %s: %w", hubId, err)
+	}
+	if ns.GetDeletionTimestamp() != nil {
+		t.r.logger.DebugContext(ctx, "Tenant namespace is already being deleted",
+			slog.String("hub_id", hubId),
+			slog.String("name", tenantName),
+		)
+		return nil
+	}
+	err = hubEntry.Client.Delete(ctx, ns)
+	if err != nil {
+		return fmt.Errorf("failed to delete namespace on hub %s: %w", hubId, err)
+	}
+	t.r.logger.DebugContext(ctx, "Deleted tenant namespace",
+		slog.String("hub_id", hubId),
+		slog.String("name", tenantName),
+	)
 	return nil
 }
 

--- a/internal/controllers/onboarding/tenant_reconciler_function_test.go
+++ b/internal/controllers/onboarding/tenant_reconciler_function_test.go
@@ -24,6 +24,7 @@ import (
 	"go.uber.org/mock/gomock"
 	"google.golang.org/grpc"
 	"google.golang.org/protobuf/types/known/timestamppb"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	clnt "sigs.k8s.io/controller-runtime/pkg/client"
@@ -61,6 +62,7 @@ func newTenantCR(tenantID, namespace, name string, deletionTimestamp *metav1.Tim
 func newScheme() *runtime.Scheme {
 	scheme := runtime.NewScheme()
 	Expect(osacv1alpha1.AddToScheme(scheme)).To(Succeed())
+	Expect(corev1.AddToScheme(scheme)).To(Succeed())
 	return scheme
 }
 
@@ -275,11 +277,21 @@ var _ = Describe("run", func() {
 				Expect(list2.Items).To(HaveLen(1))
 				Expect(list2.Items[0].Labels[labels.TenantUuid]).To(Equal(tenantID))
 				Expect(list2.Items[0].Namespace).To(Equal(namespace2))
+
+				ns1 := &corev1.Namespace{}
+				Expect(fakeClient1.Get(ctx, clnt.ObjectKey{Name: tenantID}, ns1)).To(Succeed())
+				Expect(ns1.Labels[labels.TenantRef]).To(Equal(tenantID))
+				Expect(ns1.Labels[labels.Project]).To(Equal(namespace1))
+
+				ns2 := &corev1.Namespace{}
+				Expect(fakeClient2.Get(ctx, clnt.ObjectKey{Name: tenantID}, ns2)).To(Succeed())
+				Expect(ns2.Labels[labels.TenantRef]).To(Equal(tenantID))
+				Expect(ns2.Labels[labels.Project]).To(Equal(namespace2))
 			})
 		})
 
 		When("Tenant CRD already exists on a hub", func() {
-			It("does not create a duplicate", func() {
+			It("does not create a duplicate but still ensures namespace", func() {
 				existing := newTenantCR(tenantID, namespace1, tenantID, nil)
 				fakeClient := fake.NewClientBuilder().
 					WithScheme(scheme).
@@ -323,6 +335,66 @@ var _ = Describe("run", func() {
 				list := &osacv1alpha1.TenantList{}
 				Expect(fakeClient.List(ctx, list)).To(Succeed())
 				Expect(list.Items).To(HaveLen(1))
+
+				ns := &corev1.Namespace{}
+				Expect(fakeClient.Get(ctx, clnt.ObjectKey{Name: tenantID}, ns)).To(Succeed())
+				Expect(ns.Labels[labels.TenantRef]).To(Equal(tenantID))
+			})
+		})
+
+		When("tenant namespace already exists on a hub", func() {
+			It("does not create a duplicate namespace", func() {
+				existingNS := &corev1.Namespace{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: tenantID,
+						Labels: map[string]string{
+							labels.TenantRef: tenantID,
+							labels.Project:   namespace1,
+						},
+					},
+				}
+				fakeClient := fake.NewClientBuilder().
+					WithScheme(scheme).
+					WithObjects(existingNS).
+					Build()
+
+				mockHubs.EXPECT().
+					List(gomock.Any(), gomock.Any()).
+					Return(&privatev1.HubsListResponse{
+						Size:  1,
+						Total: 1,
+						Items: []*privatev1.Hub{
+							privatev1.Hub_builder{Id: hub1ID}.Build(),
+						},
+					}, nil)
+
+				mockHubCache.EXPECT().
+					Get(gomock.Any(), hub1ID).
+					Return(&controllers.HubEntry{Namespace: namespace1, Client: fakeClient}, nil)
+
+				mockTenants.EXPECT().
+					Update(gomock.Any(), gomock.Any(), gomock.Any()).
+					DoAndReturn(func(ctx context.Context, req *privatev1.TenantsUpdateRequest, opts ...grpc.CallOption) (*privatev1.TenantsUpdateResponse, error) {
+						return &privatev1.TenantsUpdateResponse{Object: req.GetObject()}, nil
+					}).AnyTimes()
+
+				tenant := privatev1.Tenant_builder{
+					Id: tenantID,
+					Metadata: privatev1.Metadata_builder{
+						Name:       tenantID,
+						Finalizers: []string{finalizers.Controller},
+						Tenant:     tenantName,
+					}.Build(),
+				}.Build()
+
+				f := newFunction(mockHubCache, mockHubs, mockTenants)
+				err := f.run(ctx, tenant)
+
+				Expect(err).ToNot(HaveOccurred())
+
+				nsList := &corev1.NamespaceList{}
+				Expect(fakeClient.List(ctx, nsList)).To(Succeed())
+				Expect(nsList.Items).To(HaveLen(1))
 			})
 		})
 
@@ -428,6 +500,10 @@ var _ = Describe("run", func() {
 				Expect(fakeClient.List(ctx, list)).To(Succeed())
 				Expect(list.Items).To(HaveLen(1))
 				Expect(list.Items[0].Labels[labels.TenantUuid]).To(Equal(tenantID))
+
+				ns := &corev1.Namespace{}
+				Expect(fakeClient.Get(ctx, clnt.ObjectKey{Name: tenantID}, ns)).To(Succeed())
+				Expect(ns.Labels[labels.TenantRef]).To(Equal(tenantID))
 			})
 		})
 
@@ -476,9 +552,18 @@ var _ = Describe("run", func() {
 
 	Describe("delete path", func() {
 		When("tenant is deleted and Tenant CRD exists on a hub", func() {
-			It("issues delete and keeps finalizer until object is gone", func() {
+			It("issues delete for tenant and namespace, keeps finalizer until object is gone", func() {
 				existing := newTenantCR(tenantID, namespace1, tenantID, nil)
-				fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(existing).Build()
+				existingNS := &corev1.Namespace{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: tenantID,
+						Labels: map[string]string{
+							labels.TenantRef: tenantID,
+							labels.Project:   namespace1,
+						},
+					},
+				}
+				fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(existing, existingNS).Build()
 
 				mockHubs.EXPECT().
 					List(gomock.Any(), gomock.Any()).

--- a/internal/kubernetes/labels/kubernetes_labels.go
+++ b/internal/kubernetes/labels/kubernetes_labels.go
@@ -56,3 +56,9 @@ var BareMetalInstanceUuid = fmt.Sprintf("%s/%s", group, "baremetalinstance-uuid"
 
 // TenantUuid is the label where the fulfillment API will write the identifier of the tenant.
 var TenantUuid = fmt.Sprintf("%s/%s", group, "tenant-uuid")
+
+// TenantRef is the label used to reference the tenant object from associated resources (e.g., namespaces).
+var TenantRef = fmt.Sprintf("%s/%s", group, "tenant-ref")
+
+// Project is the label used to reference the project (namespace) in which the tenant object lives.
+var Project = fmt.Sprintf("%s/%s", group, "project")


### PR DESCRIPTION
## Summary

When a tenant is onboarded, the tenant reconciler creates a `Tenant` CR on each hub cluster, but it does not create a corresponding namespace. As documented in the [Tenant Setup Guide](https://github.com/osac-project/docs/blob/main/guides/developer/tenant-setup.md#tenant-cr-and-namespace-coupling), a Tenant CR is **coupled by name to a namespace on the target cluster** (I.e. the namespace must exist and match the Tenant CR name exactly). Without it, the OSAC components (networking, storage) fail to reconcile, and the **Tenant cannot reach `Ready` phase** (the `NamespaceReady` condition remains unmet).

Previously, this namespace had to be created manually. This PR automates it by extending the tenant reconciler to manage the full namespace lifecycle on hub clusters.

## Changes

- **Create**: After creating/updating the `Tenant` CR on a hub, `ensureNamespaceOnHub()` creates a namespace named after the tenant (if it doesn't already exist), labeled with `osac.openshift.io/tenant-ref` and `osac.openshift.io/project` for proper scoping. This satisfies the namespace prerequisite for the Tenant to reach `Ready` phase.
- **Delete**: When a tenant is deleted, `deleteNamespaceOnHub()` cleans up the namespace on each hub before the finalizer is removed.
- **Idempotent**: Both create and delete paths handle already-exists / already-deleted / in-deletion states gracefully.

### Files changed

- `internal/controllers/onboarding/tenant_reconciler_function.go` — Added `ensureNamespaceOnHub()` and `deleteNamespaceOnHub()` methods to the reconciler task, called during create and delete paths respectively.
- `internal/kubernetes/labels/kubernetes_labels.go` — Added `TenantRef` and `Project` label constants for namespace labeling.
- `internal/controllers/onboarding/tenant_reconciler_function_test.go` — Added test cases for namespace creation (new tenant, existing tenant, existing namespace) and namespace deletion. Updated existing tests to verify namespace side effects.

## Context

This is part of the [OSAC-24: Tenant On-boarding](https://redhat.atlassian.net/browse/OSAC-24) epic. The tenant reconciler already handles the `Tenant` CR lifecycle on hubs (see [OSAC-66](https://redhat.atlassian.net/browse/OSAC-66)); this PR adds the namespace piece so that downstream components have a target namespace for tenant-scoped resources on hub clusters.

Per the [Tenant Setup Guide — Tenant Ready Condition](https://github.com/osac-project/docs/blob/main/guides/developer/tenant-setup.md), a Tenant reaches `Ready` phase only when both the `NamespaceReady` and `StorageClassReady` conditions are satisfied. The namespace existence on the target cluster is a hard prerequisite — without it, the Tenant stays in `Progressing` phase indefinitely. This PR ensures the namespace is created automatically as part of tenant onboarding, removing the manual step documented in the guide.

## Test plan

- [x] Unit tests for namespace creation on new tenant onboarding (single and multi-hub)
- [x] Unit tests for idempotency when namespace already exists
- [x] Unit tests for namespace deletion on tenant teardown
- [x] Existing tenant reconciler tests updated and passing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Tenant reconciliation now creates a dedicated Kubernetes namespace on hub clusters when a tenant is created or updated.
  * Newly created namespaces are labeled for tenant reference and project association.

* **Bug Fixes**
  * Tenant namespaces are now cleaned up during tenant deletion, including cases where deletion is already in progress or the namespace is missing.

* **Tests**
  * Expanded coverage to verify namespace creation, labeling, reuse of existing namespaces, and cleanup behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->