### PR TITLE
OSAC-1477: Implement ExternalIPAttachment servers with cross-resource validation

### DIFF
--- a/internal/cmd/service/start/grpcserver/start_grpc_server_cmd.go
+++ b/internal/cmd/service/start/grpcserver/start_grpc_server_cmd.go
@@ -1148,6 +1148,34 @@ func (c *runnerContext) run(cmd *cobra.Command, argv []string) error { //nolint:
 	}
 	privatev1.RegisterExternalIPsServer(grpcServer, privateExternalIPsServer)
 
+	// Create the external IP attachments server:
+	c.logger.InfoContext(ctx, "Creating external IP attachments server")
+	externalIPAttachmentsServer, err := servers.NewExternalIPAttachmentsServer().
+		SetLogger(c.logger).
+		SetNotifier(notifier).
+		SetAttributionLogic(publicAttributionLogic).
+		SetTenancyLogic(tenancyLogic).
+		SetMetricsRegisterer(metricsRegisterer).
+		Build()
+	if err != nil {
+		return fmt.Errorf("failed to create external IP attachments server: %w", err)
+	}
+	publicv1.RegisterExternalIPAttachmentsServer(grpcServer, externalIPAttachmentsServer)
+
+	// Create the private external IP attachments server:
+	c.logger.InfoContext(ctx, "Creating private external IP attachments server")
+	privateExternalIPAttachmentsServer, err := servers.NewPrivateExternalIPAttachmentsServer().
+		SetLogger(c.logger).
+		SetNotifier(notifier).
+		SetAttributionLogic(privateAttributionLogic).
+		SetTenancyLogic(tenancyLogic).
+		SetMetricsRegisterer(metricsRegisterer).
+		Build()
+	if err != nil {
+		return fmt.Errorf("failed to create private external IP attachments server: %w", err)
+	}
+	privatev1.RegisterExternalIPAttachmentsServer(grpcServer, privateExternalIPAttachmentsServer)
+
 	// Create the public tenants server:
 	c.logger.InfoContext(ctx, "Creating public tenants server")
 	publicTenantsServer, err := servers.NewTenantsServer().

--- a/internal/servers/external_ip_attachments_server.go
+++ b/internal/servers/external_ip_attachments_server.go
@@ -1,0 +1,279 @@
+/*
+Copyright (c) 2026 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package servers
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+
+	"github.com/prometheus/client_golang/prometheus"
+	grpccodes "google.golang.org/grpc/codes"
+	grpcstatus "google.golang.org/grpc/status"
+
+	privatev1 "github.com/osac-project/fulfillment-service/internal/api/osac/private/v1"
+	publicv1 "github.com/osac-project/fulfillment-service/internal/api/osac/public/v1"
+	"github.com/osac-project/fulfillment-service/internal/auth"
+	"github.com/osac-project/fulfillment-service/internal/events"
+)
+
+type ExternalIPAttachmentsServerBuilder struct {
+	logger            *slog.Logger
+	notifier          events.Notifier
+	attributionLogic  auth.AttributionLogic
+	tenancyLogic      auth.TenancyLogic
+	metricsRegisterer prometheus.Registerer
+}
+
+var _ publicv1.ExternalIPAttachmentsServer = (*ExternalIPAttachmentsServer)(nil)
+
+type ExternalIPAttachmentsServer struct {
+	publicv1.UnimplementedExternalIPAttachmentsServer
+
+	logger    *slog.Logger
+	delegate  privatev1.ExternalIPAttachmentsServer
+	inMapper  *GenericMapper[*publicv1.ExternalIPAttachment, *privatev1.ExternalIPAttachment]
+	outMapper *GenericMapper[*privatev1.ExternalIPAttachment, *publicv1.ExternalIPAttachment]
+}
+
+func NewExternalIPAttachmentsServer() *ExternalIPAttachmentsServerBuilder {
+	return &ExternalIPAttachmentsServerBuilder{}
+}
+
+func (b *ExternalIPAttachmentsServerBuilder) SetLogger(value *slog.Logger) *ExternalIPAttachmentsServerBuilder {
+	b.logger = value
+	return b
+}
+
+func (b *ExternalIPAttachmentsServerBuilder) SetNotifier(value events.Notifier) *ExternalIPAttachmentsServerBuilder {
+	b.notifier = value
+	return b
+}
+
+func (b *ExternalIPAttachmentsServerBuilder) SetAttributionLogic(value auth.AttributionLogic) *ExternalIPAttachmentsServerBuilder {
+	b.attributionLogic = value
+	return b
+}
+
+func (b *ExternalIPAttachmentsServerBuilder) SetTenancyLogic(value auth.TenancyLogic) *ExternalIPAttachmentsServerBuilder {
+	b.tenancyLogic = value
+	return b
+}
+
+func (b *ExternalIPAttachmentsServerBuilder) SetMetricsRegisterer(value prometheus.Registerer) *ExternalIPAttachmentsServerBuilder {
+	b.metricsRegisterer = value
+	return b
+}
+
+func (b *ExternalIPAttachmentsServerBuilder) Build() (result *ExternalIPAttachmentsServer, err error) {
+	if b.logger == nil {
+		err = errors.New("logger is mandatory")
+		return
+	}
+	if b.tenancyLogic == nil {
+		err = errors.New("tenancy logic is mandatory")
+		return
+	}
+	if b.attributionLogic == nil {
+		err = errors.New("attribution logic is mandatory")
+		return
+	}
+
+	inMapper, err := NewGenericMapper[*publicv1.ExternalIPAttachment, *privatev1.ExternalIPAttachment]().
+		SetLogger(b.logger).
+		SetStrict(true).
+		Build()
+	if err != nil {
+		return
+	}
+	outMapper, err := NewGenericMapper[*privatev1.ExternalIPAttachment, *publicv1.ExternalIPAttachment]().
+		SetLogger(b.logger).
+		SetStrict(false).
+		Build()
+	if err != nil {
+		return
+	}
+
+	delegate, err := NewPrivateExternalIPAttachmentsServer().
+		SetLogger(b.logger).
+		SetNotifier(b.notifier).
+		SetAttributionLogic(b.attributionLogic).
+		SetTenancyLogic(b.tenancyLogic).
+		SetMetricsRegisterer(b.metricsRegisterer).
+		Build()
+	if err != nil {
+		return
+	}
+
+	result = &ExternalIPAttachmentsServer{
+		logger:    b.logger,
+		delegate:  delegate,
+		inMapper:  inMapper,
+		outMapper: outMapper,
+	}
+	return
+}
+
+func (s *ExternalIPAttachmentsServer) List(ctx context.Context,
+	request *publicv1.ExternalIPAttachmentsListRequest) (*publicv1.ExternalIPAttachmentsListResponse, error) {
+	privateRequest := &privatev1.ExternalIPAttachmentsListRequest{}
+	privateRequest.SetOffset(request.GetOffset())
+	privateRequest.SetLimit(request.GetLimit())
+	privateRequest.SetFilter(request.GetFilter())
+	privateRequest.SetOrder(request.GetOrder())
+
+	privateResponse, err := s.delegate.List(ctx, privateRequest)
+	if err != nil {
+		return nil, err
+	}
+
+	privateItems := privateResponse.GetItems()
+	publicItems := make([]*publicv1.ExternalIPAttachment, len(privateItems))
+	for i, privateItem := range privateItems {
+		publicItem, err := s.attachmentFromPrivate(ctx, privateItem)
+		if err != nil {
+			return nil, grpcstatus.Errorf(grpccodes.Internal, "failed to process external IP attachment")
+		}
+		publicItems[i] = publicItem
+	}
+
+	response := &publicv1.ExternalIPAttachmentsListResponse{}
+	response.SetSize(privateResponse.GetSize())
+	response.SetTotal(privateResponse.GetTotal())
+	response.SetItems(publicItems)
+	return response, nil
+}
+
+func (s *ExternalIPAttachmentsServer) Get(ctx context.Context,
+	request *publicv1.ExternalIPAttachmentsGetRequest) (*publicv1.ExternalIPAttachmentsGetResponse, error) {
+	privateRequest := &privatev1.ExternalIPAttachmentsGetRequest{}
+	privateRequest.SetId(request.GetId())
+
+	privateResponse, err := s.delegate.Get(ctx, privateRequest)
+	if err != nil {
+		return nil, err
+	}
+
+	privateObject := privateResponse.GetObject()
+	publicObject, err := s.attachmentFromPrivate(ctx, privateObject)
+	if err != nil {
+		return nil, grpcstatus.Errorf(grpccodes.Internal, "failed to process external IP attachment")
+	}
+
+	response := &publicv1.ExternalIPAttachmentsGetResponse{}
+	response.SetObject(publicObject)
+	return response, nil
+}
+
+func (s *ExternalIPAttachmentsServer) Create(ctx context.Context,
+	request *publicv1.ExternalIPAttachmentsCreateRequest) (*publicv1.ExternalIPAttachmentsCreateResponse, error) {
+	publicObject := request.GetObject()
+	if publicObject == nil {
+		return nil, grpcstatus.Errorf(grpccodes.InvalidArgument, "object is mandatory")
+	}
+	privateObject, err := s.attachmentToPrivate(ctx, publicObject)
+	if err != nil {
+		return nil, grpcstatus.Errorf(grpccodes.Internal, "failed to process external IP attachment")
+	}
+
+	privateRequest := &privatev1.ExternalIPAttachmentsCreateRequest{}
+	privateRequest.SetObject(privateObject)
+	privateResponse, err := s.delegate.Create(ctx, privateRequest)
+	if err != nil {
+		return nil, err
+	}
+
+	createdPrivateObject := privateResponse.GetObject()
+	createdPublicObject, err := s.attachmentFromPrivate(ctx, createdPrivateObject)
+	if err != nil {
+		return nil, grpcstatus.Errorf(grpccodes.Internal, "failed to process external IP attachment")
+	}
+
+	response := &publicv1.ExternalIPAttachmentsCreateResponse{}
+	response.SetObject(createdPublicObject)
+	return response, nil
+}
+
+func (s *ExternalIPAttachmentsServer) Update(ctx context.Context,
+	request *publicv1.ExternalIPAttachmentsUpdateRequest) (*publicv1.ExternalIPAttachmentsUpdateResponse, error) {
+	publicObject := request.GetObject()
+	if publicObject == nil {
+		return nil, grpcstatus.Errorf(grpccodes.InvalidArgument, "object is mandatory")
+	}
+	privateObject, err := s.attachmentToPrivate(ctx, publicObject)
+	if err != nil {
+		return nil, grpcstatus.Errorf(grpccodes.Internal, "failed to process external IP attachment")
+	}
+
+	privateRequest := &privatev1.ExternalIPAttachmentsUpdateRequest{}
+	privateRequest.SetObject(privateObject)
+	privateRequest.SetUpdateMask(request.GetUpdateMask())
+	privateRequest.SetLock(request.GetLock())
+	privateResponse, err := s.delegate.Update(ctx, privateRequest)
+	if err != nil {
+		return nil, err
+	}
+
+	updatedPrivateObject := privateResponse.GetObject()
+	updatedPublicObject, err := s.attachmentFromPrivate(ctx, updatedPrivateObject)
+	if err != nil {
+		return nil, grpcstatus.Errorf(grpccodes.Internal, "failed to process external IP attachment")
+	}
+
+	response := &publicv1.ExternalIPAttachmentsUpdateResponse{}
+	response.SetObject(updatedPublicObject)
+	return response, nil
+}
+
+func (s *ExternalIPAttachmentsServer) Delete(ctx context.Context,
+	request *publicv1.ExternalIPAttachmentsDeleteRequest) (*publicv1.ExternalIPAttachmentsDeleteResponse, error) {
+	privateRequest := &privatev1.ExternalIPAttachmentsDeleteRequest{}
+	privateRequest.SetId(request.GetId())
+
+	_, err := s.delegate.Delete(ctx, privateRequest)
+	if err != nil {
+		return nil, err
+	}
+
+	response := &publicv1.ExternalIPAttachmentsDeleteResponse{}
+	return response, nil
+}
+
+func (s *ExternalIPAttachmentsServer) attachmentFromPrivate(ctx context.Context, privateObj *privatev1.ExternalIPAttachment) (*publicv1.ExternalIPAttachment, error) {
+	publicObj := &publicv1.ExternalIPAttachment{}
+	err := s.outMapper.Copy(ctx, privateObj, publicObj)
+	if err != nil {
+		s.logger.ErrorContext(
+			ctx,
+			"Failed to map private external IP attachment to public",
+			slog.Any("error", err),
+		)
+		return nil, err
+	}
+	return publicObj, nil
+}
+
+func (s *ExternalIPAttachmentsServer) attachmentToPrivate(ctx context.Context, publicObj *publicv1.ExternalIPAttachment) (*privatev1.ExternalIPAttachment, error) {
+	privateObj := &privatev1.ExternalIPAttachment{}
+	err := s.inMapper.Copy(ctx, publicObj, privateObj)
+	if err != nil {
+		s.logger.ErrorContext(
+			ctx,
+			"Failed to map external IP attachment to private",
+			slog.Any("error", err),
+		)
+		return nil, err
+	}
+	return privateObj, nil
+}

--- a/internal/servers/external_ip_attachments_server.go
+++ b/internal/servers/external_ip_attachments_server.go
@@ -141,9 +141,15 @@ func (s *ExternalIPAttachmentsServer) List(ctx context.Context,
 	privateItems := privateResponse.GetItems()
 	publicItems := make([]*publicv1.ExternalIPAttachment, len(privateItems))
 	for i, privateItem := range privateItems {
-		publicItem, err := s.attachmentFromPrivate(ctx, privateItem)
+		publicItem := &publicv1.ExternalIPAttachment{}
+		err = s.outMapper.Copy(ctx, privateItem, publicItem)
 		if err != nil {
-			return nil, grpcstatus.Errorf(grpccodes.Internal, "failed to process external IP attachment")
+			s.logger.ErrorContext(
+				ctx,
+				"Failed to map private external IP attachment to public",
+				slog.Any("error", err),
+			)
+			return nil, grpcstatus.Errorf(grpccodes.Internal, "failed to process external IP attachments")
 		}
 		publicItems[i] = publicItem
 	}
@@ -165,59 +171,83 @@ func (s *ExternalIPAttachmentsServer) Get(ctx context.Context,
 		return nil, err
 	}
 
-	privateObject := privateResponse.GetObject()
-	publicObject, err := s.attachmentFromPrivate(ctx, privateObject)
+	privateAttachment := privateResponse.GetObject()
+	publicAttachment := &publicv1.ExternalIPAttachment{}
+	err = s.outMapper.Copy(ctx, privateAttachment, publicAttachment)
 	if err != nil {
+		s.logger.ErrorContext(
+			ctx,
+			"Failed to map private external IP attachment to public",
+			slog.Any("error", err),
+		)
 		return nil, grpcstatus.Errorf(grpccodes.Internal, "failed to process external IP attachment")
 	}
 
 	response := &publicv1.ExternalIPAttachmentsGetResponse{}
-	response.SetObject(publicObject)
+	response.SetObject(publicAttachment)
 	return response, nil
 }
 
 func (s *ExternalIPAttachmentsServer) Create(ctx context.Context,
 	request *publicv1.ExternalIPAttachmentsCreateRequest) (*publicv1.ExternalIPAttachmentsCreateResponse, error) {
-	publicObject := request.GetObject()
-	if publicObject == nil {
+	publicAttachment := request.GetObject()
+	if publicAttachment == nil {
 		return nil, grpcstatus.Errorf(grpccodes.InvalidArgument, "object is mandatory")
 	}
-	privateObject, err := s.attachmentToPrivate(ctx, publicObject)
+	privateAttachment := &privatev1.ExternalIPAttachment{}
+	err := s.inMapper.Copy(ctx, publicAttachment, privateAttachment)
 	if err != nil {
+		s.logger.ErrorContext(
+			ctx,
+			"Failed to map public external IP attachment to private",
+			slog.Any("error", err),
+		)
 		return nil, grpcstatus.Errorf(grpccodes.Internal, "failed to process external IP attachment")
 	}
 
 	privateRequest := &privatev1.ExternalIPAttachmentsCreateRequest{}
-	privateRequest.SetObject(privateObject)
+	privateRequest.SetObject(privateAttachment)
 	privateResponse, err := s.delegate.Create(ctx, privateRequest)
 	if err != nil {
 		return nil, err
 	}
 
-	createdPrivateObject := privateResponse.GetObject()
-	createdPublicObject, err := s.attachmentFromPrivate(ctx, createdPrivateObject)
+	createdPrivateAttachment := privateResponse.GetObject()
+	createdPublicAttachment := &publicv1.ExternalIPAttachment{}
+	err = s.outMapper.Copy(ctx, createdPrivateAttachment, createdPublicAttachment)
 	if err != nil {
+		s.logger.ErrorContext(
+			ctx,
+			"Failed to map private external IP attachment to public",
+			slog.Any("error", err),
+		)
 		return nil, grpcstatus.Errorf(grpccodes.Internal, "failed to process external IP attachment")
 	}
 
 	response := &publicv1.ExternalIPAttachmentsCreateResponse{}
-	response.SetObject(createdPublicObject)
+	response.SetObject(createdPublicAttachment)
 	return response, nil
 }
 
 func (s *ExternalIPAttachmentsServer) Update(ctx context.Context,
 	request *publicv1.ExternalIPAttachmentsUpdateRequest) (*publicv1.ExternalIPAttachmentsUpdateResponse, error) {
-	publicObject := request.GetObject()
-	if publicObject == nil {
+	publicAttachment := request.GetObject()
+	if publicAttachment == nil {
 		return nil, grpcstatus.Errorf(grpccodes.InvalidArgument, "object is mandatory")
 	}
-	privateObject, err := s.attachmentToPrivate(ctx, publicObject)
+	privateAttachment := &privatev1.ExternalIPAttachment{}
+	err := s.inMapper.Copy(ctx, publicAttachment, privateAttachment)
 	if err != nil {
+		s.logger.ErrorContext(
+			ctx,
+			"Failed to map public external IP attachment to private",
+			slog.Any("error", err),
+		)
 		return nil, grpcstatus.Errorf(grpccodes.Internal, "failed to process external IP attachment")
 	}
 
 	privateRequest := &privatev1.ExternalIPAttachmentsUpdateRequest{}
-	privateRequest.SetObject(privateObject)
+	privateRequest.SetObject(privateAttachment)
 	privateRequest.SetUpdateMask(request.GetUpdateMask())
 	privateRequest.SetLock(request.GetLock())
 	privateResponse, err := s.delegate.Update(ctx, privateRequest)
@@ -225,14 +255,20 @@ func (s *ExternalIPAttachmentsServer) Update(ctx context.Context,
 		return nil, err
 	}
 
-	updatedPrivateObject := privateResponse.GetObject()
-	updatedPublicObject, err := s.attachmentFromPrivate(ctx, updatedPrivateObject)
+	updatedPrivateAttachment := privateResponse.GetObject()
+	updatedPublicAttachment := &publicv1.ExternalIPAttachment{}
+	err = s.outMapper.Copy(ctx, updatedPrivateAttachment, updatedPublicAttachment)
 	if err != nil {
+		s.logger.ErrorContext(
+			ctx,
+			"Failed to map private external IP attachment to public",
+			slog.Any("error", err),
+		)
 		return nil, grpcstatus.Errorf(grpccodes.Internal, "failed to process external IP attachment")
 	}
 
 	response := &publicv1.ExternalIPAttachmentsUpdateResponse{}
-	response.SetObject(updatedPublicObject)
+	response.SetObject(updatedPublicAttachment)
 	return response, nil
 }
 
@@ -248,32 +284,4 @@ func (s *ExternalIPAttachmentsServer) Delete(ctx context.Context,
 
 	response := &publicv1.ExternalIPAttachmentsDeleteResponse{}
 	return response, nil
-}
-
-func (s *ExternalIPAttachmentsServer) attachmentFromPrivate(ctx context.Context, privateObj *privatev1.ExternalIPAttachment) (*publicv1.ExternalIPAttachment, error) {
-	publicObj := &publicv1.ExternalIPAttachment{}
-	err := s.outMapper.Copy(ctx, privateObj, publicObj)
-	if err != nil {
-		s.logger.ErrorContext(
-			ctx,
-			"Failed to map private external IP attachment to public",
-			slog.Any("error", err),
-		)
-		return nil, err
-	}
-	return publicObj, nil
-}
-
-func (s *ExternalIPAttachmentsServer) attachmentToPrivate(ctx context.Context, publicObj *publicv1.ExternalIPAttachment) (*privatev1.ExternalIPAttachment, error) {
-	privateObj := &privatev1.ExternalIPAttachment{}
-	err := s.inMapper.Copy(ctx, publicObj, privateObj)
-	if err != nil {
-		s.logger.ErrorContext(
-			ctx,
-			"Failed to map external IP attachment to private",
-			slog.Any("error", err),
-		)
-		return nil, err
-	}
-	return privateObj, nil
 }

--- a/internal/servers/external_ip_attachments_server_test.go
+++ b/internal/servers/external_ip_attachments_server_test.go
@@ -72,6 +72,8 @@ var _ = Describe("External IP attachments server", func() {
 			externalIPAttachmentsServer *ExternalIPAttachmentsServer
 			externalIPDao               *dao.GenericDAO[*privatev1.ExternalIP]
 			computeInstanceDao          *dao.GenericDAO[*privatev1.ComputeInstance]
+			clusterDao                  *dao.GenericDAO[*privatev1.Cluster]
+			bareMetalInstanceDao        *dao.GenericDAO[*privatev1.BareMetalInstance]
 			sharedPoolID                string
 		)
 
@@ -85,6 +87,18 @@ var _ = Describe("External IP attachments server", func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			computeInstanceDao, err = dao.NewGenericDAO[*privatev1.ComputeInstance]().
+				SetLogger(logger).
+				SetTenancyLogic(tenancy).
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+
+			clusterDao, err = dao.NewGenericDAO[*privatev1.Cluster]().
+				SetLogger(logger).
+				SetTenancyLogic(tenancy).
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+
+			bareMetalInstanceDao, err = dao.NewGenericDAO[*privatev1.BareMetalInstance]().
 				SetLogger(logger).
 				SetTenancyLogic(tenancy).
 				Build()
@@ -143,12 +157,67 @@ var _ = Describe("External IP attachments server", func() {
 			return response.GetObject()
 		}
 
-		It("Creates object", func() {
+		It("Creates object with ComputeInstance target", func() {
 			object := createAttachment()
 			Expect(object).ToNot(BeNil())
 			Expect(object.GetId()).ToNot(BeEmpty())
 			Expect(object.GetSpec().GetExternalIp()).ToNot(BeEmpty())
 			Expect(object.GetSpec().GetComputeInstance()).ToNot(BeEmpty())
+		})
+
+		It("Creates and gets object with Cluster target", func() {
+			eip := createExternalIPInState(ctx, externalIPDao, sharedPoolID,
+				privatev1.ExternalIPState_EXTERNAL_IP_STATE_ALLOCATED, false)
+			cluster := createClusterInState(ctx, clusterDao)
+
+			createResponse, err := externalIPAttachmentsServer.Create(ctx,
+				publicv1.ExternalIPAttachmentsCreateRequest_builder{
+					Object: publicv1.ExternalIPAttachment_builder{
+						Spec: publicv1.ExternalIPAttachmentSpec_builder{
+							ExternalIp:     eip.GetId(),
+							Cluster:        new(cluster.GetId()),
+							TargetEndpoint: publicv1.ExternalIPAttachmentEndpoint_EXTERNAL_IP_ATTACHMENT_ENDPOINT_API,
+						}.Build(),
+					}.Build(),
+				}.Build())
+			Expect(err).ToNot(HaveOccurred())
+			Expect(createResponse.GetObject().GetSpec().GetCluster()).To(Equal(cluster.GetId()))
+			Expect(createResponse.GetObject().GetSpec().GetTargetEndpoint()).To(
+				Equal(publicv1.ExternalIPAttachmentEndpoint_EXTERNAL_IP_ATTACHMENT_ENDPOINT_API))
+
+			getResponse, err := externalIPAttachmentsServer.Get(ctx,
+				publicv1.ExternalIPAttachmentsGetRequest_builder{
+					Id: createResponse.GetObject().GetId(),
+				}.Build())
+			Expect(err).ToNot(HaveOccurred())
+			Expect(getResponse.GetObject().GetSpec().GetCluster()).To(Equal(cluster.GetId()))
+			Expect(getResponse.GetObject().GetSpec().GetTargetEndpoint()).To(
+				Equal(publicv1.ExternalIPAttachmentEndpoint_EXTERNAL_IP_ATTACHMENT_ENDPOINT_API))
+		})
+
+		It("Creates and gets object with BareMetalInstance target", func() {
+			eip := createExternalIPInState(ctx, externalIPDao, sharedPoolID,
+				privatev1.ExternalIPState_EXTERNAL_IP_STATE_ALLOCATED, false)
+			bmi := createBareMetalInstanceInState(ctx, bareMetalInstanceDao)
+
+			createResponse, err := externalIPAttachmentsServer.Create(ctx,
+				publicv1.ExternalIPAttachmentsCreateRequest_builder{
+					Object: publicv1.ExternalIPAttachment_builder{
+						Spec: publicv1.ExternalIPAttachmentSpec_builder{
+							ExternalIp:        eip.GetId(),
+							BaremetalInstance: new(bmi.GetId()),
+						}.Build(),
+					}.Build(),
+				}.Build())
+			Expect(err).ToNot(HaveOccurred())
+			Expect(createResponse.GetObject().GetSpec().GetBaremetalInstance()).To(Equal(bmi.GetId()))
+
+			getResponse, err := externalIPAttachmentsServer.Get(ctx,
+				publicv1.ExternalIPAttachmentsGetRequest_builder{
+					Id: createResponse.GetObject().GetId(),
+				}.Build())
+			Expect(err).ToNot(HaveOccurred())
+			Expect(getResponse.GetObject().GetSpec().GetBaremetalInstance()).To(Equal(bmi.GetId()))
 		})
 
 		It("List objects", func() {

--- a/internal/servers/external_ip_attachments_server_test.go
+++ b/internal/servers/external_ip_attachments_server_test.go
@@ -1,0 +1,290 @@
+/*
+Copyright (c) 2026 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package servers
+
+import (
+	"fmt"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/fieldmaskpb"
+
+	privatev1 "github.com/osac-project/fulfillment-service/internal/api/osac/private/v1"
+	publicv1 "github.com/osac-project/fulfillment-service/internal/api/osac/public/v1"
+	"github.com/osac-project/fulfillment-service/internal/auth"
+	"github.com/osac-project/fulfillment-service/internal/database/dao"
+)
+
+var _ = Describe("External IP attachments server", func() {
+	Describe("Creation", func() {
+		It("Can be built if all the required parameters are set", func() {
+			server, err := NewExternalIPAttachmentsServer().
+				SetLogger(logger).
+				SetAttributionLogic(attribution).
+				SetTenancyLogic(tenancy).
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(server).ToNot(BeNil())
+		})
+
+		It("Fails if logger is not set", func() {
+			server, err := NewExternalIPAttachmentsServer().
+				SetAttributionLogic(attribution).
+				SetTenancyLogic(tenancy).
+				Build()
+			Expect(err).To(MatchError("logger is mandatory"))
+			Expect(server).To(BeNil())
+		})
+
+		It("Fails if tenancy logic is not set", func() {
+			server, err := NewExternalIPAttachmentsServer().
+				SetLogger(logger).
+				SetAttributionLogic(attribution).
+				Build()
+			Expect(err).To(MatchError("tenancy logic is mandatory"))
+			Expect(server).To(BeNil())
+		})
+
+		It("Fails if attribution logic is not set", func() {
+			server, err := NewExternalIPAttachmentsServer().
+				SetLogger(logger).
+				SetTenancyLogic(tenancy).
+				Build()
+			Expect(err).To(MatchError("attribution logic is mandatory"))
+			Expect(server).To(BeNil())
+		})
+	})
+
+	Describe("Behaviour", func() {
+		var (
+			externalIPAttachmentsServer *ExternalIPAttachmentsServer
+			externalIPDao               *dao.GenericDAO[*privatev1.ExternalIP]
+			computeInstanceDao          *dao.GenericDAO[*privatev1.ComputeInstance]
+			sharedPoolID                string
+		)
+
+		BeforeEach(func() {
+			var err error
+
+			externalIPDao, err = dao.NewGenericDAO[*privatev1.ExternalIP]().
+				SetLogger(logger).
+				SetTenancyLogic(tenancy).
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+
+			computeInstanceDao, err = dao.NewGenericDAO[*privatev1.ComputeInstance]().
+				SetLogger(logger).
+				SetTenancyLogic(tenancy).
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+
+			externalIPPoolDao, err := dao.NewGenericDAO[*privatev1.ExternalIPPool]().
+				SetLogger(logger).
+				SetTenancyLogic(tenancy).
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+
+			poolResp, err := externalIPPoolDao.Create().SetObject(
+				privatev1.ExternalIPPool_builder{
+					Metadata: privatev1.Metadata_builder{
+						Tenant: auth.SharedTenant,
+					}.Build(),
+					Spec: privatev1.ExternalIPPoolSpec_builder{
+						Cidrs: []string{"203.0.113.0/24"},
+					}.Build(),
+					Status: privatev1.ExternalIPPoolStatus_builder{
+						State:     privatev1.ExternalIPPoolState_EXTERNAL_IP_POOL_STATE_READY,
+						Total:     100,
+						Allocated: 0,
+						Available: 100,
+					}.Build(),
+				}.Build(),
+			).Do(ctx)
+			Expect(err).ToNot(HaveOccurred())
+			sharedPoolID = poolResp.GetObject().GetId()
+
+			externalIPAttachmentsServer, err = NewExternalIPAttachmentsServer().
+				SetLogger(logger).
+				SetAttributionLogic(attribution).
+				SetTenancyLogic(tenancy).
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		createAttachment := func() *publicv1.ExternalIPAttachment {
+			eip := createExternalIPInState(ctx, externalIPDao, sharedPoolID,
+				privatev1.ExternalIPState_EXTERNAL_IP_STATE_ALLOCATED, false)
+			ci := createComputeInstanceInState(ctx, computeInstanceDao,
+				privatev1.ComputeInstanceState_COMPUTE_INSTANCE_STATE_RUNNING)
+
+			response, err := externalIPAttachmentsServer.Create(ctx,
+				publicv1.ExternalIPAttachmentsCreateRequest_builder{
+					Object: publicv1.ExternalIPAttachment_builder{
+						Spec: publicv1.ExternalIPAttachmentSpec_builder{
+							ExternalIp:      eip.GetId(),
+							ComputeInstance: new(ci.GetId()),
+						}.Build(),
+					}.Build(),
+				}.Build())
+			Expect(err).ToNot(HaveOccurred())
+			Expect(response).ToNot(BeNil())
+			return response.GetObject()
+		}
+
+		It("Creates object", func() {
+			object := createAttachment()
+			Expect(object).ToNot(BeNil())
+			Expect(object.GetId()).ToNot(BeEmpty())
+			Expect(object.GetSpec().GetExternalIp()).ToNot(BeEmpty())
+			Expect(object.GetSpec().GetComputeInstance()).ToNot(BeEmpty())
+		})
+
+		It("List objects", func() {
+			const count = 10
+			for range count {
+				createAttachment()
+			}
+
+			response, err := externalIPAttachmentsServer.List(ctx,
+				publicv1.ExternalIPAttachmentsListRequest_builder{}.Build())
+			Expect(err).ToNot(HaveOccurred())
+			Expect(response).ToNot(BeNil())
+			items := response.GetItems()
+			Expect(items).To(HaveLen(count))
+		})
+
+		It("List objects with limit", func() {
+			const count = 10
+			for range count {
+				createAttachment()
+			}
+
+			response, err := externalIPAttachmentsServer.List(ctx,
+				publicv1.ExternalIPAttachmentsListRequest_builder{
+					Limit: new(int32(1)),
+				}.Build())
+			Expect(err).ToNot(HaveOccurred())
+			Expect(response.GetSize()).To(BeNumerically("==", 1))
+		})
+
+		It("List objects with offset", func() {
+			const count = 10
+			for range count {
+				createAttachment()
+			}
+
+			response, err := externalIPAttachmentsServer.List(ctx,
+				publicv1.ExternalIPAttachmentsListRequest_builder{
+					Offset: new(int32(1)),
+				}.Build())
+			Expect(err).ToNot(HaveOccurred())
+			Expect(response.GetSize()).To(BeNumerically("==", count-1))
+		})
+
+		It("List objects with filter", func() {
+			const count = 10
+			var objects []*publicv1.ExternalIPAttachment
+			for range count {
+				objects = append(objects, createAttachment())
+			}
+
+			for _, object := range objects {
+				response, err := externalIPAttachmentsServer.List(ctx,
+					publicv1.ExternalIPAttachmentsListRequest_builder{
+						Filter: new(fmt.Sprintf("this.id == '%s'", object.GetId())),
+					}.Build())
+				Expect(err).ToNot(HaveOccurred())
+				Expect(response.GetSize()).To(BeNumerically("==", 1))
+				Expect(response.GetItems()[0].GetId()).To(Equal(object.GetId()))
+			}
+		})
+
+		It("Get object", func() {
+			created := createAttachment()
+
+			getResponse, err := externalIPAttachmentsServer.Get(ctx,
+				publicv1.ExternalIPAttachmentsGetRequest_builder{
+					Id: created.GetId(),
+				}.Build())
+			Expect(err).ToNot(HaveOccurred())
+			Expect(proto.Equal(created, getResponse.GetObject())).To(BeTrue())
+		})
+
+		It("Updates labels on an external IP attachment", func() {
+			created := createAttachment()
+
+			updateResponse, err := externalIPAttachmentsServer.Update(ctx,
+				publicv1.ExternalIPAttachmentsUpdateRequest_builder{
+					Object: publicv1.ExternalIPAttachment_builder{
+						Id: created.GetId(),
+						Metadata: publicv1.Metadata_builder{
+							Labels: map[string]string{
+								"env": "test",
+							},
+						}.Build(),
+					}.Build(),
+					UpdateMask: &fieldmaskpb.FieldMask{
+						Paths: []string{"metadata.labels"},
+					},
+				}.Build())
+			Expect(err).ToNot(HaveOccurred())
+			Expect(updateResponse.GetObject().GetMetadata().GetLabels()).To(
+				HaveKeyWithValue("env", "test"),
+			)
+
+			getResponse, err := externalIPAttachmentsServer.Get(ctx,
+				publicv1.ExternalIPAttachmentsGetRequest_builder{
+					Id: created.GetId(),
+				}.Build())
+			Expect(err).ToNot(HaveOccurred())
+			Expect(getResponse.GetObject().GetMetadata().GetLabels()).To(
+				HaveKeyWithValue("env", "test"),
+			)
+		})
+
+		It("Rejects update with nil object", func() {
+			_, err := externalIPAttachmentsServer.Update(ctx,
+				publicv1.ExternalIPAttachmentsUpdateRequest_builder{}.Build())
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("object is mandatory"))
+		})
+
+		It("Propagates immutable field rejection from private server", func() {
+			created := createAttachment()
+
+			_, err := externalIPAttachmentsServer.Update(ctx,
+				publicv1.ExternalIPAttachmentsUpdateRequest_builder{
+					Object: publicv1.ExternalIPAttachment_builder{
+						Id: created.GetId(),
+						Spec: publicv1.ExternalIPAttachmentSpec_builder{
+							ExternalIp: "different-ip-id",
+						}.Build(),
+					}.Build(),
+				}.Build())
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("immutable"))
+		})
+
+		It("Delete object", func() {
+			created := createAttachment()
+
+			_, err := externalIPAttachmentsServer.Delete(ctx,
+				publicv1.ExternalIPAttachmentsDeleteRequest_builder{
+					Id: created.GetId(),
+				}.Build())
+			Expect(err).ToNot(HaveOccurred())
+		})
+	})
+})

--- a/internal/servers/private_external_ip_attachments_server.go
+++ b/internal/servers/private_external_ip_attachments_server.go
@@ -16,8 +16,8 @@ package servers
 import (
 	"context"
 	"errors"
+	"fmt"
 	"log/slog"
-	"strconv"
 
 	"github.com/prometheus/client_golang/prometheus"
 	grpccodes "google.golang.org/grpc/codes"
@@ -377,6 +377,7 @@ func (s *PrivateExternalIPAttachmentsServer) validateExternalIPReference(
 	ctx context.Context, externalIPID string) error {
 	getResponse, err := s.externalIPDao.Get().
 		SetId(externalIPID).
+		SetLock(true).
 		Do(ctx)
 	if err != nil {
 		var notFoundErr *dao.ErrNotFound
@@ -425,6 +426,7 @@ func (s *PrivateExternalIPAttachmentsServer) validateComputeInstanceReference(
 	ctx context.Context, computeInstanceID string) error {
 	_, err := s.computeInstanceDao.Get().
 		SetId(computeInstanceID).
+		SetLock(true).
 		Do(ctx)
 	if err != nil {
 		var notFoundErr *dao.ErrNotFound
@@ -444,6 +446,7 @@ func (s *PrivateExternalIPAttachmentsServer) validateClusterReference(
 	ctx context.Context, clusterID string) error {
 	_, err := s.clusterDao.Get().
 		SetId(clusterID).
+		SetLock(true).
 		Do(ctx)
 	if err != nil {
 		var notFoundErr *dao.ErrNotFound
@@ -463,6 +466,7 @@ func (s *PrivateExternalIPAttachmentsServer) validateBareMetalInstanceReference(
 	ctx context.Context, bareMetalInstanceID string) error {
 	_, err := s.bareMetalInstanceDao.Get().
 		SetId(bareMetalInstanceID).
+		SetLock(true).
 		Do(ctx)
 	if err != nil {
 		var notFoundErr *dao.ErrNotFound
@@ -494,7 +498,7 @@ func (s *PrivateExternalIPAttachmentsServer) getTargetID(
 
 func (s *PrivateExternalIPAttachmentsServer) validateUniqueness(
 	ctx context.Context, externalIPID string, targetID string) error {
-	eipFilter := "this.spec.external_ip == " + strconv.Quote(externalIPID)
+	eipFilter := fmt.Sprintf("this.spec.external_ip == %q", externalIPID)
 	eipResp, err := s.externalIPAttachmentDao.List().
 		SetFilter(eipFilter).
 		SetLimit(1).
@@ -505,7 +509,7 @@ func (s *PrivateExternalIPAttachmentsServer) validateUniqueness(
 			slog.Any("error", err))
 		return grpcstatus.Errorf(grpccodes.Internal, "failed to validate uniqueness")
 	}
-	if eipResp.GetSize() > 0 {
+	if eipResp.GetTotal() > 0 {
 		return grpcstatus.Errorf(grpccodes.AlreadyExists,
 			"an ExternalIPAttachment already exists for ExternalIP '%s'", externalIPID)
 	}
@@ -517,6 +521,7 @@ func (s *PrivateExternalIPAttachmentsServer) updateExternalIPAttachedFlag(
 	ctx context.Context, externalIPID string, attached bool) error {
 	getResponse, err := s.externalIPDao.Get().
 		SetId(externalIPID).
+		SetLock(true).
 		Do(ctx)
 	if err != nil {
 		s.logger.ErrorContext(ctx, "Failed to get ExternalIP for attached flag update",

--- a/internal/servers/private_external_ip_attachments_server.go
+++ b/internal/servers/private_external_ip_attachments_server.go
@@ -1,0 +1,543 @@
+/*
+Copyright (c) 2026 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package servers
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"strconv"
+
+	"github.com/prometheus/client_golang/prometheus"
+	grpccodes "google.golang.org/grpc/codes"
+	grpcstatus "google.golang.org/grpc/status"
+
+	privatev1 "github.com/osac-project/fulfillment-service/internal/api/osac/private/v1"
+	"github.com/osac-project/fulfillment-service/internal/auth"
+	"github.com/osac-project/fulfillment-service/internal/database/dao"
+	"github.com/osac-project/fulfillment-service/internal/events"
+)
+
+type PrivateExternalIPAttachmentsServerBuilder struct {
+	logger            *slog.Logger
+	notifier          events.Notifier
+	attributionLogic  auth.AttributionLogic
+	tenancyLogic      auth.TenancyLogic
+	metricsRegisterer prometheus.Registerer
+}
+
+var _ privatev1.ExternalIPAttachmentsServer = (*PrivateExternalIPAttachmentsServer)(nil)
+
+type PrivateExternalIPAttachmentsServer struct {
+	privatev1.UnimplementedExternalIPAttachmentsServer
+
+	logger                  *slog.Logger
+	generic                 *GenericServer[*privatev1.ExternalIPAttachment]
+	externalIPDao           *dao.GenericDAO[*privatev1.ExternalIP]
+	computeInstanceDao      *dao.GenericDAO[*privatev1.ComputeInstance]
+	clusterDao              *dao.GenericDAO[*privatev1.Cluster]
+	bareMetalInstanceDao    *dao.GenericDAO[*privatev1.BareMetalInstance]
+	externalIPAttachmentDao *dao.GenericDAO[*privatev1.ExternalIPAttachment]
+}
+
+func NewPrivateExternalIPAttachmentsServer() *PrivateExternalIPAttachmentsServerBuilder {
+	return &PrivateExternalIPAttachmentsServerBuilder{}
+}
+
+func (b *PrivateExternalIPAttachmentsServerBuilder) SetLogger(value *slog.Logger) *PrivateExternalIPAttachmentsServerBuilder {
+	b.logger = value
+	return b
+}
+
+func (b *PrivateExternalIPAttachmentsServerBuilder) SetNotifier(value events.Notifier) *PrivateExternalIPAttachmentsServerBuilder {
+	b.notifier = value
+	return b
+}
+
+func (b *PrivateExternalIPAttachmentsServerBuilder) SetAttributionLogic(value auth.AttributionLogic) *PrivateExternalIPAttachmentsServerBuilder {
+	b.attributionLogic = value
+	return b
+}
+
+func (b *PrivateExternalIPAttachmentsServerBuilder) SetTenancyLogic(value auth.TenancyLogic) *PrivateExternalIPAttachmentsServerBuilder {
+	b.tenancyLogic = value
+	return b
+}
+
+func (b *PrivateExternalIPAttachmentsServerBuilder) SetMetricsRegisterer(value prometheus.Registerer) *PrivateExternalIPAttachmentsServerBuilder {
+	b.metricsRegisterer = value
+	return b
+}
+
+func (b *PrivateExternalIPAttachmentsServerBuilder) Build() (*PrivateExternalIPAttachmentsServer, error) {
+	if b.logger == nil {
+		return nil, errors.New("logger is mandatory")
+	}
+	if b.tenancyLogic == nil {
+		return nil, errors.New("tenancy logic is mandatory")
+	}
+
+	externalIPDao, err := dao.NewGenericDAO[*privatev1.ExternalIP]().
+		SetLogger(b.logger).
+		SetTenancyLogic(b.tenancyLogic).
+		SetMetricsRegisterer(b.metricsRegisterer).
+		Build()
+	if err != nil {
+		return nil, err
+	}
+
+	computeInstanceDao, err := dao.NewGenericDAO[*privatev1.ComputeInstance]().
+		SetLogger(b.logger).
+		SetTenancyLogic(b.tenancyLogic).
+		SetMetricsRegisterer(b.metricsRegisterer).
+		Build()
+	if err != nil {
+		return nil, err
+	}
+
+	clusterDao, err := dao.NewGenericDAO[*privatev1.Cluster]().
+		SetLogger(b.logger).
+		SetTenancyLogic(b.tenancyLogic).
+		SetMetricsRegisterer(b.metricsRegisterer).
+		Build()
+	if err != nil {
+		return nil, err
+	}
+
+	bareMetalInstanceDao, err := dao.NewGenericDAO[*privatev1.BareMetalInstance]().
+		SetLogger(b.logger).
+		SetTenancyLogic(b.tenancyLogic).
+		SetMetricsRegisterer(b.metricsRegisterer).
+		Build()
+	if err != nil {
+		return nil, err
+	}
+
+	externalIPAttachmentDao, err := dao.NewGenericDAO[*privatev1.ExternalIPAttachment]().
+		SetLogger(b.logger).
+		SetTenancyLogic(b.tenancyLogic).
+		SetMetricsRegisterer(b.metricsRegisterer).
+		Build()
+	if err != nil {
+		return nil, err
+	}
+
+	generic, err := NewGenericServer[*privatev1.ExternalIPAttachment]().
+		SetLogger(b.logger).
+		SetService(privatev1.ExternalIPAttachments_ServiceDesc.ServiceName).
+		SetNotifier(b.notifier).
+		SetAttributionLogic(b.attributionLogic).
+		SetTenancyLogic(b.tenancyLogic).
+		SetMetricsRegisterer(b.metricsRegisterer).
+		Build()
+	if err != nil {
+		return nil, err
+	}
+
+	result := &PrivateExternalIPAttachmentsServer{
+		logger:                  b.logger,
+		generic:                 generic,
+		externalIPDao:           externalIPDao,
+		computeInstanceDao:      computeInstanceDao,
+		clusterDao:              clusterDao,
+		bareMetalInstanceDao:    bareMetalInstanceDao,
+		externalIPAttachmentDao: externalIPAttachmentDao,
+	}
+	return result, nil
+}
+
+func (s *PrivateExternalIPAttachmentsServer) List(ctx context.Context,
+	request *privatev1.ExternalIPAttachmentsListRequest) (response *privatev1.ExternalIPAttachmentsListResponse, err error) {
+	err = s.generic.List(ctx, request, &response)
+	return
+}
+
+func (s *PrivateExternalIPAttachmentsServer) Get(ctx context.Context,
+	request *privatev1.ExternalIPAttachmentsGetRequest) (response *privatev1.ExternalIPAttachmentsGetResponse, err error) {
+	err = s.generic.Get(ctx, request, &response)
+	return
+}
+
+func (s *PrivateExternalIPAttachmentsServer) Create(ctx context.Context,
+	request *privatev1.ExternalIPAttachmentsCreateRequest) (response *privatev1.ExternalIPAttachmentsCreateResponse, err error) {
+	attachment := request.GetObject()
+
+	err = s.validateExternalIPAttachment(attachment)
+	if err != nil {
+		return
+	}
+
+	spec := attachment.GetSpec()
+	externalIPID := spec.GetExternalIp()
+
+	err = s.validateExternalIPReference(ctx, externalIPID)
+	if err != nil {
+		return
+	}
+
+	err = s.validateTargetReference(ctx, spec)
+	if err != nil {
+		return
+	}
+
+	targetID := s.getTargetID(spec)
+	err = s.validateUniqueness(ctx, externalIPID, targetID)
+	if err != nil {
+		return
+	}
+
+	if attachment.GetStatus() == nil {
+		attachment.SetStatus(privatev1.ExternalIPAttachmentStatus_builder{
+			State: privatev1.ExternalIPAttachmentState_EXTERNAL_IP_ATTACHMENT_STATE_PENDING,
+		}.Build())
+	} else {
+		attachment.GetStatus().SetState(
+			privatev1.ExternalIPAttachmentState_EXTERNAL_IP_ATTACHMENT_STATE_PENDING)
+	}
+
+	err = s.generic.Create(ctx, request, &response)
+	if err != nil {
+		return
+	}
+
+	err = s.updateExternalIPAttachedFlag(ctx, externalIPID, true)
+	if err != nil {
+		return
+	}
+
+	return
+}
+
+func (s *PrivateExternalIPAttachmentsServer) Update(ctx context.Context,
+	request *privatev1.ExternalIPAttachmentsUpdateRequest) (response *privatev1.ExternalIPAttachmentsUpdateResponse, err error) {
+	id := request.GetObject().GetId()
+	if id == "" {
+		err = grpcstatus.Errorf(grpccodes.InvalidArgument, "object identifier is mandatory")
+		return
+	}
+
+	mask := request.GetUpdateMask()
+	if updateIncludesField(mask,
+		"spec.external_ip", "spec.compute_instance", "spec.cluster",
+		"spec.baremetal_instance", "spec.target_endpoint") {
+		getRequest := &privatev1.ExternalIPAttachmentsGetRequest{}
+		getRequest.SetId(id)
+		var getResponse *privatev1.ExternalIPAttachmentsGetResponse
+		err = s.generic.Get(ctx, getRequest, &getResponse)
+		if err != nil {
+			return
+		}
+		err = validateImmutableFieldsExternalIPAttachment(request.GetObject(), getResponse.GetObject())
+		if err != nil {
+			return
+		}
+	}
+
+	err = s.generic.Update(ctx, request, &response)
+	return
+}
+
+func (s *PrivateExternalIPAttachmentsServer) Delete(ctx context.Context,
+	request *privatev1.ExternalIPAttachmentsDeleteRequest) (response *privatev1.ExternalIPAttachmentsDeleteResponse, err error) {
+	id := request.GetId()
+	if id == "" {
+		err = grpcstatus.Errorf(grpccodes.InvalidArgument, "object identifier is mandatory")
+		return
+	}
+
+	getRequest := &privatev1.ExternalIPAttachmentsGetRequest{}
+	getRequest.SetId(id)
+	var getResponse *privatev1.ExternalIPAttachmentsGetResponse
+	err = s.generic.Get(ctx, getRequest, &getResponse)
+	if err != nil {
+		return
+	}
+
+	externalIPID := getResponse.GetObject().GetSpec().GetExternalIp()
+
+	err = s.generic.Delete(ctx, request, &response)
+	if err != nil {
+		return
+	}
+
+	if externalIPID != "" {
+		err = s.updateExternalIPAttachedFlag(ctx, externalIPID, false)
+		if err != nil {
+			return
+		}
+	}
+
+	return
+}
+
+func (s *PrivateExternalIPAttachmentsServer) Signal(ctx context.Context,
+	request *privatev1.ExternalIPAttachmentsSignalRequest) (response *privatev1.ExternalIPAttachmentsSignalResponse, err error) {
+	err = s.generic.Signal(ctx, request, &response)
+	return
+}
+
+func (s *PrivateExternalIPAttachmentsServer) validateExternalIPAttachment(
+	attachment *privatev1.ExternalIPAttachment) error {
+	if attachment == nil {
+		return grpcstatus.Errorf(grpccodes.InvalidArgument, "external IP attachment is mandatory")
+	}
+	spec := attachment.GetSpec()
+	if spec == nil {
+		return grpcstatus.Errorf(grpccodes.InvalidArgument, "external IP attachment spec is mandatory")
+	}
+	if spec.GetExternalIp() == "" {
+		return grpcstatus.Errorf(grpccodes.InvalidArgument,
+			"field 'spec.external_ip' is required")
+	}
+	if !spec.HasComputeInstance() && !spec.HasCluster() && !spec.HasBaremetalInstance() {
+		return grpcstatus.Errorf(grpccodes.InvalidArgument,
+			"exactly one target must be set (compute_instance, cluster, or baremetal_instance)")
+	}
+
+	targetCount := 0
+	if spec.HasComputeInstance() {
+		targetCount++
+	}
+	if spec.HasCluster() {
+		targetCount++
+	}
+	if spec.HasBaremetalInstance() {
+		targetCount++
+	}
+	if targetCount > 1 {
+		return grpcstatus.Errorf(grpccodes.InvalidArgument,
+			"exactly one target must be set (compute_instance, cluster, or baremetal_instance)")
+	}
+
+	if spec.HasCluster() {
+		if spec.GetTargetEndpoint() == privatev1.ExternalIPAttachmentEndpoint_EXTERNAL_IP_ATTACHMENT_ENDPOINT_UNSPECIFIED {
+			return grpcstatus.Errorf(grpccodes.InvalidArgument,
+				"field 'spec.target_endpoint' is required when target is cluster")
+		}
+	} else {
+		if spec.GetTargetEndpoint() != privatev1.ExternalIPAttachmentEndpoint_EXTERNAL_IP_ATTACHMENT_ENDPOINT_UNSPECIFIED {
+			return grpcstatus.Errorf(grpccodes.InvalidArgument,
+				"field 'spec.target_endpoint' must be UNSPECIFIED for non-cluster targets")
+		}
+	}
+
+	return nil
+}
+
+func validateImmutableFieldsExternalIPAttachment(
+	newAttachment, existingAttachment *privatev1.ExternalIPAttachment) error {
+	newSpec := newAttachment.GetSpec()
+	existingSpec := existingAttachment.GetSpec()
+
+	if newExternalIP := newSpec.GetExternalIp(); newExternalIP != existingSpec.GetExternalIp() {
+		return grpcstatus.Errorf(grpccodes.InvalidArgument,
+			"field 'spec.external_ip' is immutable and cannot be changed from '%s' to '%s'",
+			existingSpec.GetExternalIp(), newExternalIP)
+	}
+
+	if newSpec.GetComputeInstance() != existingSpec.GetComputeInstance() {
+		return grpcstatus.Errorf(grpccodes.InvalidArgument,
+			"field 'spec.compute_instance' is immutable and cannot be changed from '%s' to '%s'",
+			existingSpec.GetComputeInstance(), newSpec.GetComputeInstance())
+	}
+
+	if newSpec.GetCluster() != existingSpec.GetCluster() {
+		return grpcstatus.Errorf(grpccodes.InvalidArgument,
+			"field 'spec.cluster' is immutable and cannot be changed from '%s' to '%s'",
+			existingSpec.GetCluster(), newSpec.GetCluster())
+	}
+
+	if newSpec.GetBaremetalInstance() != existingSpec.GetBaremetalInstance() {
+		return grpcstatus.Errorf(grpccodes.InvalidArgument,
+			"field 'spec.baremetal_instance' is immutable and cannot be changed from '%s' to '%s'",
+			existingSpec.GetBaremetalInstance(), newSpec.GetBaremetalInstance())
+	}
+
+	if newSpec.GetTargetEndpoint() != existingSpec.GetTargetEndpoint() {
+		return grpcstatus.Errorf(grpccodes.InvalidArgument,
+			"field 'spec.target_endpoint' is immutable and cannot be changed from '%s' to '%s'",
+			existingSpec.GetTargetEndpoint().String(), newSpec.GetTargetEndpoint().String())
+	}
+
+	return nil
+}
+
+func (s *PrivateExternalIPAttachmentsServer) validateExternalIPReference(
+	ctx context.Context, externalIPID string) error {
+	getResponse, err := s.externalIPDao.Get().
+		SetId(externalIPID).
+		Do(ctx)
+	if err != nil {
+		var notFoundErr *dao.ErrNotFound
+		if errors.As(err, &notFoundErr) {
+			return grpcstatus.Errorf(grpccodes.InvalidArgument,
+				"ExternalIP '%s' does not exist", externalIPID)
+		}
+		s.logger.ErrorContext(ctx, "Failed to query ExternalIP",
+			slog.String("external_ip_id", externalIPID),
+			slog.Any("error", err))
+		return grpcstatus.Errorf(grpccodes.Internal, "failed to validate external_ip")
+	}
+
+	externalIP := getResponse.GetObject()
+
+	if externalIP.GetStatus().GetState() != privatev1.ExternalIPState_EXTERNAL_IP_STATE_ALLOCATED {
+		return grpcstatus.Errorf(grpccodes.FailedPrecondition,
+			"ExternalIP '%s' is not in ALLOCATED state (current state: %s)",
+			externalIPID, externalIP.GetStatus().GetState().String())
+	}
+
+	if externalIP.GetStatus().GetAttached() {
+		return grpcstatus.Errorf(grpccodes.FailedPrecondition,
+			"ExternalIP '%s' is already attached", externalIPID)
+	}
+
+	return nil
+}
+
+func (s *PrivateExternalIPAttachmentsServer) validateTargetReference(
+	ctx context.Context, spec *privatev1.ExternalIPAttachmentSpec) error {
+	switch {
+	case spec.HasComputeInstance():
+		return s.validateComputeInstanceReference(ctx, spec.GetComputeInstance())
+	case spec.HasCluster():
+		return s.validateClusterReference(ctx, spec.GetCluster())
+	case spec.HasBaremetalInstance():
+		return s.validateBareMetalInstanceReference(ctx, spec.GetBaremetalInstance())
+	default:
+		return grpcstatus.Errorf(grpccodes.InvalidArgument,
+			"exactly one target must be set (compute_instance, cluster, or baremetal_instance)")
+	}
+}
+
+func (s *PrivateExternalIPAttachmentsServer) validateComputeInstanceReference(
+	ctx context.Context, computeInstanceID string) error {
+	_, err := s.computeInstanceDao.Get().
+		SetId(computeInstanceID).
+		Do(ctx)
+	if err != nil {
+		var notFoundErr *dao.ErrNotFound
+		if errors.As(err, &notFoundErr) {
+			return grpcstatus.Errorf(grpccodes.InvalidArgument,
+				"ComputeInstance '%s' does not exist", computeInstanceID)
+		}
+		s.logger.ErrorContext(ctx, "Failed to query ComputeInstance",
+			slog.String("compute_instance_id", computeInstanceID),
+			slog.Any("error", err))
+		return grpcstatus.Errorf(grpccodes.Internal, "failed to validate compute_instance")
+	}
+	return nil
+}
+
+func (s *PrivateExternalIPAttachmentsServer) validateClusterReference(
+	ctx context.Context, clusterID string) error {
+	_, err := s.clusterDao.Get().
+		SetId(clusterID).
+		Do(ctx)
+	if err != nil {
+		var notFoundErr *dao.ErrNotFound
+		if errors.As(err, &notFoundErr) {
+			return grpcstatus.Errorf(grpccodes.InvalidArgument,
+				"Cluster '%s' does not exist", clusterID)
+		}
+		s.logger.ErrorContext(ctx, "Failed to query Cluster",
+			slog.String("cluster_id", clusterID),
+			slog.Any("error", err))
+		return grpcstatus.Errorf(grpccodes.Internal, "failed to validate cluster")
+	}
+	return nil
+}
+
+func (s *PrivateExternalIPAttachmentsServer) validateBareMetalInstanceReference(
+	ctx context.Context, bareMetalInstanceID string) error {
+	_, err := s.bareMetalInstanceDao.Get().
+		SetId(bareMetalInstanceID).
+		Do(ctx)
+	if err != nil {
+		var notFoundErr *dao.ErrNotFound
+		if errors.As(err, &notFoundErr) {
+			return grpcstatus.Errorf(grpccodes.InvalidArgument,
+				"BareMetalInstance '%s' does not exist", bareMetalInstanceID)
+		}
+		s.logger.ErrorContext(ctx, "Failed to query BareMetalInstance",
+			slog.String("baremetal_instance_id", bareMetalInstanceID),
+			slog.Any("error", err))
+		return grpcstatus.Errorf(grpccodes.Internal, "failed to validate baremetal_instance")
+	}
+	return nil
+}
+
+func (s *PrivateExternalIPAttachmentsServer) getTargetID(
+	spec *privatev1.ExternalIPAttachmentSpec) string {
+	switch {
+	case spec.HasComputeInstance():
+		return spec.GetComputeInstance()
+	case spec.HasCluster():
+		return spec.GetCluster()
+	case spec.HasBaremetalInstance():
+		return spec.GetBaremetalInstance()
+	default:
+		return ""
+	}
+}
+
+func (s *PrivateExternalIPAttachmentsServer) validateUniqueness(
+	ctx context.Context, externalIPID string, targetID string) error {
+	eipFilter := "this.spec.external_ip == " + strconv.Quote(externalIPID)
+	eipResp, err := s.externalIPAttachmentDao.List().
+		SetFilter(eipFilter).
+		SetLimit(1).
+		Do(ctx)
+	if err != nil {
+		s.logger.ErrorContext(ctx, "Failed to list attachments for uniqueness check",
+			slog.String("external_ip_id", externalIPID),
+			slog.Any("error", err))
+		return grpcstatus.Errorf(grpccodes.Internal, "failed to validate uniqueness")
+	}
+	if eipResp.GetSize() > 0 {
+		return grpcstatus.Errorf(grpccodes.AlreadyExists,
+			"an ExternalIPAttachment already exists for ExternalIP '%s'", externalIPID)
+	}
+
+	return nil
+}
+
+func (s *PrivateExternalIPAttachmentsServer) updateExternalIPAttachedFlag(
+	ctx context.Context, externalIPID string, attached bool) error {
+	getResponse, err := s.externalIPDao.Get().
+		SetId(externalIPID).
+		Do(ctx)
+	if err != nil {
+		s.logger.ErrorContext(ctx, "Failed to get ExternalIP for attached flag update",
+			slog.String("external_ip_id", externalIPID),
+			slog.Any("error", err))
+		return grpcstatus.Errorf(grpccodes.Internal, "failed to update ExternalIP attached status")
+	}
+
+	externalIP := getResponse.GetObject()
+	externalIP.GetStatus().SetAttached(attached)
+
+	_, err = s.externalIPDao.Update().
+		SetObject(externalIP).
+		Do(ctx)
+	if err != nil {
+		s.logger.ErrorContext(ctx, "Failed to update ExternalIP attached flag",
+			slog.String("external_ip_id", externalIPID),
+			slog.Bool("attached", attached),
+			slog.Any("error", err))
+		return grpcstatus.Errorf(grpccodes.Internal, "failed to update ExternalIP attached status")
+	}
+
+	return nil
+}

--- a/internal/servers/private_external_ip_attachments_server_test.go
+++ b/internal/servers/private_external_ip_attachments_server_test.go
@@ -1,0 +1,818 @@
+/*
+Copyright (c) 2026 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package servers
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	grpccodes "google.golang.org/grpc/codes"
+	grpcstatus "google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/fieldmaskpb"
+
+	privatev1 "github.com/osac-project/fulfillment-service/internal/api/osac/private/v1"
+	"github.com/osac-project/fulfillment-service/internal/auth"
+	"github.com/osac-project/fulfillment-service/internal/database/dao"
+)
+
+func createExternalIPInState(
+	ctx context.Context,
+	externalIPDao *dao.GenericDAO[*privatev1.ExternalIP],
+	poolID string,
+	state privatev1.ExternalIPState,
+	attached bool,
+) *privatev1.ExternalIP {
+	resp, err := externalIPDao.Create().SetObject(
+		privatev1.ExternalIP_builder{
+			Metadata: privatev1.Metadata_builder{
+				Tenant: auth.SharedTenant,
+			}.Build(),
+			Spec: privatev1.ExternalIPSpec_builder{
+				Pool: poolID,
+			}.Build(),
+			Status: privatev1.ExternalIPStatus_builder{
+				State:    state,
+				Address:  "203.0.113.1",
+				Attached: attached,
+			}.Build(),
+		}.Build(),
+	).Do(ctx)
+	ExpectWithOffset(1, err).ToNot(HaveOccurred())
+	return resp.GetObject()
+}
+
+func createClusterInState(
+	ctx context.Context,
+	clusterDao *dao.GenericDAO[*privatev1.Cluster],
+) *privatev1.Cluster {
+	resp, err := clusterDao.Create().SetObject(
+		privatev1.Cluster_builder{
+			Metadata: privatev1.Metadata_builder{
+				Tenant: auth.SharedTenant,
+			}.Build(),
+			Spec: privatev1.ClusterSpec_builder{
+				Template: "ocp_4_17_small",
+			}.Build(),
+		}.Build(),
+	).Do(ctx)
+	ExpectWithOffset(1, err).ToNot(HaveOccurred())
+	return resp.GetObject()
+}
+
+func createBareMetalInstanceInState(
+	ctx context.Context,
+	bareMetalInstanceDao *dao.GenericDAO[*privatev1.BareMetalInstance],
+) *privatev1.BareMetalInstance {
+	resp, err := bareMetalInstanceDao.Create().SetObject(
+		privatev1.BareMetalInstance_builder{
+			Metadata: privatev1.Metadata_builder{
+				Tenant: auth.SharedTenant,
+			}.Build(),
+			Spec: privatev1.BareMetalInstanceSpec_builder{
+				CatalogItem: "bcm_h100",
+			}.Build(),
+		}.Build(),
+	).Do(ctx)
+	ExpectWithOffset(1, err).ToNot(HaveOccurred())
+	return resp.GetObject()
+}
+
+var _ = Describe("Private external IP attachments server", func() {
+	var (
+		server               *PrivateExternalIPAttachmentsServer
+		externalIPPoolDao    *dao.GenericDAO[*privatev1.ExternalIPPool]
+		externalIPDao        *dao.GenericDAO[*privatev1.ExternalIP]
+		computeInstanceDao   *dao.GenericDAO[*privatev1.ComputeInstance]
+		clusterDao           *dao.GenericDAO[*privatev1.Cluster]
+		bareMetalInstanceDao *dao.GenericDAO[*privatev1.BareMetalInstance]
+		sharedPool           *privatev1.ExternalIPPool
+	)
+
+	BeforeEach(func() {
+		var err error
+
+		externalIPPoolDao, err = dao.NewGenericDAO[*privatev1.ExternalIPPool]().
+			SetLogger(logger).
+			SetTenancyLogic(tenancy).
+			Build()
+		Expect(err).ToNot(HaveOccurred())
+
+		externalIPDao, err = dao.NewGenericDAO[*privatev1.ExternalIP]().
+			SetLogger(logger).
+			SetTenancyLogic(tenancy).
+			Build()
+		Expect(err).ToNot(HaveOccurred())
+
+		computeInstanceDao, err = dao.NewGenericDAO[*privatev1.ComputeInstance]().
+			SetLogger(logger).
+			SetTenancyLogic(tenancy).
+			Build()
+		Expect(err).ToNot(HaveOccurred())
+
+		clusterDao, err = dao.NewGenericDAO[*privatev1.Cluster]().
+			SetLogger(logger).
+			SetTenancyLogic(tenancy).
+			Build()
+		Expect(err).ToNot(HaveOccurred())
+
+		bareMetalInstanceDao, err = dao.NewGenericDAO[*privatev1.BareMetalInstance]().
+			SetLogger(logger).
+			SetTenancyLogic(tenancy).
+			Build()
+		Expect(err).ToNot(HaveOccurred())
+
+		poolResp, err := externalIPPoolDao.Create().SetObject(
+			privatev1.ExternalIPPool_builder{
+				Metadata: privatev1.Metadata_builder{
+					Tenant: auth.SharedTenant,
+				}.Build(),
+				Spec: privatev1.ExternalIPPoolSpec_builder{
+					Cidrs: []string{"203.0.113.0/24"},
+				}.Build(),
+				Status: privatev1.ExternalIPPoolStatus_builder{
+					State:     privatev1.ExternalIPPoolState_EXTERNAL_IP_POOL_STATE_READY,
+					Total:     100,
+					Allocated: 0,
+					Available: 100,
+				}.Build(),
+			}.Build(),
+		).Do(ctx)
+		Expect(err).ToNot(HaveOccurred())
+		sharedPool = poolResp.GetObject()
+
+		server, err = NewPrivateExternalIPAttachmentsServer().
+			SetLogger(logger).
+			SetAttributionLogic(attribution).
+			SetTenancyLogic(tenancy).
+			Build()
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	Describe("Creation", func() {
+		It("Can be built if all required parameters are set", func() {
+			s, err := NewPrivateExternalIPAttachmentsServer().
+				SetLogger(logger).
+				SetAttributionLogic(attribution).
+				SetTenancyLogic(tenancy).
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(s).ToNot(BeNil())
+		})
+
+		It("Fails if logger is not set", func() {
+			s, err := NewPrivateExternalIPAttachmentsServer().
+				SetAttributionLogic(attribution).
+				SetTenancyLogic(tenancy).
+				Build()
+			Expect(err).To(MatchError("logger is mandatory"))
+			Expect(s).To(BeNil())
+		})
+
+		It("Fails if tenancy logic is not set", func() {
+			s, err := NewPrivateExternalIPAttachmentsServer().
+				SetLogger(logger).
+				SetAttributionLogic(attribution).
+				Build()
+			Expect(err).To(MatchError("tenancy logic is mandatory"))
+			Expect(s).To(BeNil())
+		})
+	})
+
+	Describe("Behaviour", func() {
+		It("Creates an attachment with a ComputeInstance target", func() {
+			eip := createExternalIPInState(ctx, externalIPDao, sharedPool.GetId(),
+				privatev1.ExternalIPState_EXTERNAL_IP_STATE_ALLOCATED, false)
+			ci := createComputeInstanceInState(ctx, computeInstanceDao,
+				privatev1.ComputeInstanceState_COMPUTE_INSTANCE_STATE_RUNNING)
+
+			response, err := server.Create(ctx, privatev1.ExternalIPAttachmentsCreateRequest_builder{
+				Object: privatev1.ExternalIPAttachment_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name: "ci-attachment",
+					}.Build(),
+					Spec: privatev1.ExternalIPAttachmentSpec_builder{
+						ExternalIp:      eip.GetId(),
+						ComputeInstance: new(ci.GetId()),
+					}.Build(),
+				}.Build(),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+			Expect(response.GetObject().GetId()).ToNot(BeEmpty())
+			Expect(response.GetObject().GetSpec().GetExternalIp()).To(Equal(eip.GetId()))
+			Expect(response.GetObject().GetSpec().GetComputeInstance()).To(Equal(ci.GetId()))
+			Expect(response.GetObject().GetStatus().GetState()).To(
+				Equal(privatev1.ExternalIPAttachmentState_EXTERNAL_IP_ATTACHMENT_STATE_PENDING))
+		})
+
+		It("Creates an attachment with a Cluster target and API endpoint", func() {
+			eip := createExternalIPInState(ctx, externalIPDao, sharedPool.GetId(),
+				privatev1.ExternalIPState_EXTERNAL_IP_STATE_ALLOCATED, false)
+			cluster := createClusterInState(ctx, clusterDao)
+
+			response, err := server.Create(ctx, privatev1.ExternalIPAttachmentsCreateRequest_builder{
+				Object: privatev1.ExternalIPAttachment_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name: "cluster-api-attachment",
+					}.Build(),
+					Spec: privatev1.ExternalIPAttachmentSpec_builder{
+						ExternalIp:     eip.GetId(),
+						Cluster:        new(cluster.GetId()),
+						TargetEndpoint: privatev1.ExternalIPAttachmentEndpoint_EXTERNAL_IP_ATTACHMENT_ENDPOINT_API,
+					}.Build(),
+				}.Build(),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+			Expect(response.GetObject().GetSpec().GetCluster()).To(Equal(cluster.GetId()))
+			Expect(response.GetObject().GetSpec().GetTargetEndpoint()).To(
+				Equal(privatev1.ExternalIPAttachmentEndpoint_EXTERNAL_IP_ATTACHMENT_ENDPOINT_API))
+		})
+
+		It("Creates an attachment with a Cluster target and ingress endpoint", func() {
+			eip := createExternalIPInState(ctx, externalIPDao, sharedPool.GetId(),
+				privatev1.ExternalIPState_EXTERNAL_IP_STATE_ALLOCATED, false)
+			cluster := createClusterInState(ctx, clusterDao)
+
+			response, err := server.Create(ctx, privatev1.ExternalIPAttachmentsCreateRequest_builder{
+				Object: privatev1.ExternalIPAttachment_builder{
+					Spec: privatev1.ExternalIPAttachmentSpec_builder{
+						ExternalIp:     eip.GetId(),
+						Cluster:        new(cluster.GetId()),
+						TargetEndpoint: privatev1.ExternalIPAttachmentEndpoint_EXTERNAL_IP_ATTACHMENT_ENDPOINT_INGRESS,
+					}.Build(),
+				}.Build(),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+			Expect(response.GetObject().GetSpec().GetTargetEndpoint()).To(
+				Equal(privatev1.ExternalIPAttachmentEndpoint_EXTERNAL_IP_ATTACHMENT_ENDPOINT_INGRESS))
+		})
+
+		It("Creates an attachment with a BareMetalInstance target", func() {
+			eip := createExternalIPInState(ctx, externalIPDao, sharedPool.GetId(),
+				privatev1.ExternalIPState_EXTERNAL_IP_STATE_ALLOCATED, false)
+			bmi := createBareMetalInstanceInState(ctx, bareMetalInstanceDao)
+
+			response, err := server.Create(ctx, privatev1.ExternalIPAttachmentsCreateRequest_builder{
+				Object: privatev1.ExternalIPAttachment_builder{
+					Spec: privatev1.ExternalIPAttachmentSpec_builder{
+						ExternalIp:        eip.GetId(),
+						BaremetalInstance: new(bmi.GetId()),
+					}.Build(),
+				}.Build(),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+			Expect(response.GetObject().GetSpec().GetBaremetalInstance()).To(Equal(bmi.GetId()))
+		})
+
+		It("Lists external IP attachments", func() {
+			eip1 := createExternalIPInState(ctx, externalIPDao, sharedPool.GetId(),
+				privatev1.ExternalIPState_EXTERNAL_IP_STATE_ALLOCATED, false)
+			ci1 := createComputeInstanceInState(ctx, computeInstanceDao,
+				privatev1.ComputeInstanceState_COMPUTE_INSTANCE_STATE_RUNNING)
+			eip2 := createExternalIPInState(ctx, externalIPDao, sharedPool.GetId(),
+				privatev1.ExternalIPState_EXTERNAL_IP_STATE_ALLOCATED, false)
+			ci2 := createComputeInstanceInState(ctx, computeInstanceDao,
+				privatev1.ComputeInstanceState_COMPUTE_INSTANCE_STATE_RUNNING)
+
+			_, err := server.Create(ctx, privatev1.ExternalIPAttachmentsCreateRequest_builder{
+				Object: privatev1.ExternalIPAttachment_builder{
+					Spec: privatev1.ExternalIPAttachmentSpec_builder{
+						ExternalIp:      eip1.GetId(),
+						ComputeInstance: new(ci1.GetId()),
+					}.Build(),
+				}.Build(),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+
+			_, err = server.Create(ctx, privatev1.ExternalIPAttachmentsCreateRequest_builder{
+				Object: privatev1.ExternalIPAttachment_builder{
+					Spec: privatev1.ExternalIPAttachmentSpec_builder{
+						ExternalIp:      eip2.GetId(),
+						ComputeInstance: new(ci2.GetId()),
+					}.Build(),
+				}.Build(),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+
+			listResponse, err := server.List(ctx, privatev1.ExternalIPAttachmentsListRequest_builder{}.Build())
+			Expect(err).ToNot(HaveOccurred())
+			Expect(listResponse.GetSize()).To(Equal(int32(2)))
+			Expect(listResponse.GetItems()).To(HaveLen(2))
+		})
+
+		It("Gets an external IP attachment", func() {
+			eip := createExternalIPInState(ctx, externalIPDao, sharedPool.GetId(),
+				privatev1.ExternalIPState_EXTERNAL_IP_STATE_ALLOCATED, false)
+			ci := createComputeInstanceInState(ctx, computeInstanceDao,
+				privatev1.ComputeInstanceState_COMPUTE_INSTANCE_STATE_RUNNING)
+
+			createResponse, err := server.Create(ctx, privatev1.ExternalIPAttachmentsCreateRequest_builder{
+				Object: privatev1.ExternalIPAttachment_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name: "my-attachment",
+					}.Build(),
+					Spec: privatev1.ExternalIPAttachmentSpec_builder{
+						ExternalIp:      eip.GetId(),
+						ComputeInstance: new(ci.GetId()),
+					}.Build(),
+				}.Build(),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+
+			getResponse, err := server.Get(ctx, privatev1.ExternalIPAttachmentsGetRequest_builder{
+				Id: createResponse.GetObject().GetId(),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+			Expect(getResponse.GetObject().GetId()).To(Equal(createResponse.GetObject().GetId()))
+			Expect(getResponse.GetObject().GetSpec().GetExternalIp()).To(Equal(eip.GetId()))
+			Expect(getResponse.GetObject().GetSpec().GetComputeInstance()).To(Equal(ci.GetId()))
+		})
+
+		It("Updates metadata of an external IP attachment", func() {
+			eip := createExternalIPInState(ctx, externalIPDao, sharedPool.GetId(),
+				privatev1.ExternalIPState_EXTERNAL_IP_STATE_ALLOCATED, false)
+			ci := createComputeInstanceInState(ctx, computeInstanceDao,
+				privatev1.ComputeInstanceState_COMPUTE_INSTANCE_STATE_RUNNING)
+
+			createResponse, err := server.Create(ctx, privatev1.ExternalIPAttachmentsCreateRequest_builder{
+				Object: privatev1.ExternalIPAttachment_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name: "my-attachment",
+					}.Build(),
+					Spec: privatev1.ExternalIPAttachmentSpec_builder{
+						ExternalIp:      eip.GetId(),
+						ComputeInstance: new(ci.GetId()),
+					}.Build(),
+				}.Build(),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+
+			updateResponse, err := server.Update(ctx, privatev1.ExternalIPAttachmentsUpdateRequest_builder{
+				Object: privatev1.ExternalIPAttachment_builder{
+					Id: createResponse.GetObject().GetId(),
+					Metadata: privatev1.Metadata_builder{
+						Name: "renamed-attachment",
+					}.Build(),
+				}.Build(),
+				UpdateMask: &fieldmaskpb.FieldMask{
+					Paths: []string{"metadata.name"},
+				},
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+			Expect(updateResponse.GetObject().GetMetadata().GetName()).To(Equal("renamed-attachment"))
+		})
+
+		It("Deletes an external IP attachment", func() {
+			eip := createExternalIPInState(ctx, externalIPDao, sharedPool.GetId(),
+				privatev1.ExternalIPState_EXTERNAL_IP_STATE_ALLOCATED, false)
+			ci := createComputeInstanceInState(ctx, computeInstanceDao,
+				privatev1.ComputeInstanceState_COMPUTE_INSTANCE_STATE_RUNNING)
+
+			createResponse, err := server.Create(ctx, privatev1.ExternalIPAttachmentsCreateRequest_builder{
+				Object: privatev1.ExternalIPAttachment_builder{
+					Spec: privatev1.ExternalIPAttachmentSpec_builder{
+						ExternalIp:      eip.GetId(),
+						ComputeInstance: new(ci.GetId()),
+					}.Build(),
+				}.Build(),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+
+			_, err = server.Delete(ctx, privatev1.ExternalIPAttachmentsDeleteRequest_builder{
+				Id: createResponse.GetObject().GetId(),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("Signals an external IP attachment", func() {
+			eip := createExternalIPInState(ctx, externalIPDao, sharedPool.GetId(),
+				privatev1.ExternalIPState_EXTERNAL_IP_STATE_ALLOCATED, false)
+			ci := createComputeInstanceInState(ctx, computeInstanceDao,
+				privatev1.ComputeInstanceState_COMPUTE_INSTANCE_STATE_RUNNING)
+
+			createResponse, err := server.Create(ctx, privatev1.ExternalIPAttachmentsCreateRequest_builder{
+				Object: privatev1.ExternalIPAttachment_builder{
+					Spec: privatev1.ExternalIPAttachmentSpec_builder{
+						ExternalIp:      eip.GetId(),
+						ComputeInstance: new(ci.GetId()),
+					}.Build(),
+				}.Build(),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+
+			_, err = server.Signal(ctx, privatev1.ExternalIPAttachmentsSignalRequest_builder{
+				Id: createResponse.GetObject().GetId(),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+		})
+	})
+
+	Describe("Validation", func() {
+		It("Rejects Create with nil object", func() {
+			_, err := server.Create(ctx, privatev1.ExternalIPAttachmentsCreateRequest_builder{}.Build())
+			Expect(err).To(HaveOccurred())
+			status, ok := grpcstatus.FromError(err)
+			Expect(ok).To(BeTrue())
+			Expect(status.Code()).To(Equal(grpccodes.InvalidArgument))
+			Expect(err.Error()).To(ContainSubstring("is mandatory"))
+		})
+
+		It("Rejects Create with nil spec", func() {
+			_, err := server.Create(ctx, privatev1.ExternalIPAttachmentsCreateRequest_builder{
+				Object: privatev1.ExternalIPAttachment_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name: "my-attachment",
+					}.Build(),
+				}.Build(),
+			}.Build())
+			Expect(err).To(HaveOccurred())
+			status, ok := grpcstatus.FromError(err)
+			Expect(ok).To(BeTrue())
+			Expect(status.Code()).To(Equal(grpccodes.InvalidArgument))
+			Expect(err.Error()).To(ContainSubstring("spec is mandatory"))
+		})
+
+		It("Rejects Create with empty spec.external_ip", func() {
+			_, err := server.Create(ctx, privatev1.ExternalIPAttachmentsCreateRequest_builder{
+				Object: privatev1.ExternalIPAttachment_builder{
+					Spec: privatev1.ExternalIPAttachmentSpec_builder{
+						ComputeInstance: new("some-ci"),
+					}.Build(),
+				}.Build(),
+			}.Build())
+			Expect(err).To(HaveOccurred())
+			status, ok := grpcstatus.FromError(err)
+			Expect(ok).To(BeTrue())
+			Expect(status.Code()).To(Equal(grpccodes.InvalidArgument))
+			Expect(err.Error()).To(ContainSubstring("spec.external_ip"))
+		})
+
+		It("Rejects Create with no target set", func() {
+			_, err := server.Create(ctx, privatev1.ExternalIPAttachmentsCreateRequest_builder{
+				Object: privatev1.ExternalIPAttachment_builder{
+					Spec: privatev1.ExternalIPAttachmentSpec_builder{
+						ExternalIp: "some-ip",
+					}.Build(),
+				}.Build(),
+			}.Build())
+			Expect(err).To(HaveOccurred())
+			status, ok := grpcstatus.FromError(err)
+			Expect(ok).To(BeTrue())
+			Expect(status.Code()).To(Equal(grpccodes.InvalidArgument))
+			Expect(err.Error()).To(ContainSubstring("exactly one target must be set"))
+		})
+
+		It("Rejects Create when cluster target has no target_endpoint", func() {
+			eip := createExternalIPInState(ctx, externalIPDao, sharedPool.GetId(),
+				privatev1.ExternalIPState_EXTERNAL_IP_STATE_ALLOCATED, false)
+			cluster := createClusterInState(ctx, clusterDao)
+
+			_, err := server.Create(ctx, privatev1.ExternalIPAttachmentsCreateRequest_builder{
+				Object: privatev1.ExternalIPAttachment_builder{
+					Spec: privatev1.ExternalIPAttachmentSpec_builder{
+						ExternalIp: eip.GetId(),
+						Cluster:    new(cluster.GetId()),
+					}.Build(),
+				}.Build(),
+			}.Build())
+			Expect(err).To(HaveOccurred())
+			status, ok := grpcstatus.FromError(err)
+			Expect(ok).To(BeTrue())
+			Expect(status.Code()).To(Equal(grpccodes.InvalidArgument))
+			Expect(err.Error()).To(ContainSubstring("target_endpoint"))
+			Expect(err.Error()).To(ContainSubstring("required when target is cluster"))
+		})
+
+		It("Rejects Create when non-cluster target has target_endpoint set", func() {
+			eip := createExternalIPInState(ctx, externalIPDao, sharedPool.GetId(),
+				privatev1.ExternalIPState_EXTERNAL_IP_STATE_ALLOCATED, false)
+			ci := createComputeInstanceInState(ctx, computeInstanceDao,
+				privatev1.ComputeInstanceState_COMPUTE_INSTANCE_STATE_RUNNING)
+
+			_, err := server.Create(ctx, privatev1.ExternalIPAttachmentsCreateRequest_builder{
+				Object: privatev1.ExternalIPAttachment_builder{
+					Spec: privatev1.ExternalIPAttachmentSpec_builder{
+						ExternalIp:      eip.GetId(),
+						ComputeInstance: new(ci.GetId()),
+						TargetEndpoint:  privatev1.ExternalIPAttachmentEndpoint_EXTERNAL_IP_ATTACHMENT_ENDPOINT_API,
+					}.Build(),
+				}.Build(),
+			}.Build())
+			Expect(err).To(HaveOccurred())
+			status, ok := grpcstatus.FromError(err)
+			Expect(ok).To(BeTrue())
+			Expect(status.Code()).To(Equal(grpccodes.InvalidArgument))
+			Expect(err.Error()).To(ContainSubstring("target_endpoint"))
+			Expect(err.Error()).To(ContainSubstring("UNSPECIFIED for non-cluster"))
+		})
+	})
+
+	Describe("ExternalIP reference validation", func() {
+		It("Rejects Create when ExternalIP does not exist", func() {
+			ci := createComputeInstanceInState(ctx, computeInstanceDao,
+				privatev1.ComputeInstanceState_COMPUTE_INSTANCE_STATE_RUNNING)
+
+			_, err := server.Create(ctx, privatev1.ExternalIPAttachmentsCreateRequest_builder{
+				Object: privatev1.ExternalIPAttachment_builder{
+					Spec: privatev1.ExternalIPAttachmentSpec_builder{
+						ExternalIp:      "nonexistent-external-ip-id",
+						ComputeInstance: new(ci.GetId()),
+					}.Build(),
+				}.Build(),
+			}.Build())
+			Expect(err).To(HaveOccurred())
+			status, ok := grpcstatus.FromError(err)
+			Expect(ok).To(BeTrue())
+			Expect(status.Code()).To(Equal(grpccodes.InvalidArgument))
+			Expect(err.Error()).To(ContainSubstring("does not exist"))
+		})
+
+		It("Rejects Create when ExternalIP is not in ALLOCATED state", func() {
+			eip := createExternalIPInState(ctx, externalIPDao, sharedPool.GetId(),
+				privatev1.ExternalIPState_EXTERNAL_IP_STATE_PENDING, false)
+			ci := createComputeInstanceInState(ctx, computeInstanceDao,
+				privatev1.ComputeInstanceState_COMPUTE_INSTANCE_STATE_RUNNING)
+
+			_, err := server.Create(ctx, privatev1.ExternalIPAttachmentsCreateRequest_builder{
+				Object: privatev1.ExternalIPAttachment_builder{
+					Spec: privatev1.ExternalIPAttachmentSpec_builder{
+						ExternalIp:      eip.GetId(),
+						ComputeInstance: new(ci.GetId()),
+					}.Build(),
+				}.Build(),
+			}.Build())
+			Expect(err).To(HaveOccurred())
+			status, ok := grpcstatus.FromError(err)
+			Expect(ok).To(BeTrue())
+			Expect(status.Code()).To(Equal(grpccodes.FailedPrecondition))
+			Expect(err.Error()).To(ContainSubstring("not in ALLOCATED state"))
+		})
+
+		It("Rejects Create when ExternalIP is already attached", func() {
+			eip := createExternalIPInState(ctx, externalIPDao, sharedPool.GetId(),
+				privatev1.ExternalIPState_EXTERNAL_IP_STATE_ALLOCATED, true)
+			ci := createComputeInstanceInState(ctx, computeInstanceDao,
+				privatev1.ComputeInstanceState_COMPUTE_INSTANCE_STATE_RUNNING)
+
+			_, err := server.Create(ctx, privatev1.ExternalIPAttachmentsCreateRequest_builder{
+				Object: privatev1.ExternalIPAttachment_builder{
+					Spec: privatev1.ExternalIPAttachmentSpec_builder{
+						ExternalIp:      eip.GetId(),
+						ComputeInstance: new(ci.GetId()),
+					}.Build(),
+				}.Build(),
+			}.Build())
+			Expect(err).To(HaveOccurred())
+			status, ok := grpcstatus.FromError(err)
+			Expect(ok).To(BeTrue())
+			Expect(status.Code()).To(Equal(grpccodes.FailedPrecondition))
+			Expect(err.Error()).To(ContainSubstring("already attached"))
+		})
+	})
+
+	Describe("Target reference validation", func() {
+		It("Rejects Create when ComputeInstance does not exist", func() {
+			eip := createExternalIPInState(ctx, externalIPDao, sharedPool.GetId(),
+				privatev1.ExternalIPState_EXTERNAL_IP_STATE_ALLOCATED, false)
+
+			_, err := server.Create(ctx, privatev1.ExternalIPAttachmentsCreateRequest_builder{
+				Object: privatev1.ExternalIPAttachment_builder{
+					Spec: privatev1.ExternalIPAttachmentSpec_builder{
+						ExternalIp:      eip.GetId(),
+						ComputeInstance: new("nonexistent-ci-id"),
+					}.Build(),
+				}.Build(),
+			}.Build())
+			Expect(err).To(HaveOccurred())
+			status, ok := grpcstatus.FromError(err)
+			Expect(ok).To(BeTrue())
+			Expect(status.Code()).To(Equal(grpccodes.InvalidArgument))
+			Expect(err.Error()).To(ContainSubstring("ComputeInstance"))
+			Expect(err.Error()).To(ContainSubstring("does not exist"))
+		})
+
+		It("Rejects Create when Cluster does not exist", func() {
+			eip := createExternalIPInState(ctx, externalIPDao, sharedPool.GetId(),
+				privatev1.ExternalIPState_EXTERNAL_IP_STATE_ALLOCATED, false)
+
+			_, err := server.Create(ctx, privatev1.ExternalIPAttachmentsCreateRequest_builder{
+				Object: privatev1.ExternalIPAttachment_builder{
+					Spec: privatev1.ExternalIPAttachmentSpec_builder{
+						ExternalIp:     eip.GetId(),
+						Cluster:        new("nonexistent-cluster-id"),
+						TargetEndpoint: privatev1.ExternalIPAttachmentEndpoint_EXTERNAL_IP_ATTACHMENT_ENDPOINT_API,
+					}.Build(),
+				}.Build(),
+			}.Build())
+			Expect(err).To(HaveOccurred())
+			status, ok := grpcstatus.FromError(err)
+			Expect(ok).To(BeTrue())
+			Expect(status.Code()).To(Equal(grpccodes.InvalidArgument))
+			Expect(err.Error()).To(ContainSubstring("Cluster"))
+			Expect(err.Error()).To(ContainSubstring("does not exist"))
+		})
+
+		It("Rejects Create when BareMetalInstance does not exist", func() {
+			eip := createExternalIPInState(ctx, externalIPDao, sharedPool.GetId(),
+				privatev1.ExternalIPState_EXTERNAL_IP_STATE_ALLOCATED, false)
+
+			_, err := server.Create(ctx, privatev1.ExternalIPAttachmentsCreateRequest_builder{
+				Object: privatev1.ExternalIPAttachment_builder{
+					Spec: privatev1.ExternalIPAttachmentSpec_builder{
+						ExternalIp:        eip.GetId(),
+						BaremetalInstance: new("nonexistent-bmi-id"),
+					}.Build(),
+				}.Build(),
+			}.Build())
+			Expect(err).To(HaveOccurred())
+			status, ok := grpcstatus.FromError(err)
+			Expect(ok).To(BeTrue())
+			Expect(status.Code()).To(Equal(grpccodes.InvalidArgument))
+			Expect(err.Error()).To(ContainSubstring("BareMetalInstance"))
+			Expect(err.Error()).To(ContainSubstring("does not exist"))
+		})
+	})
+
+	Describe("Uniqueness constraints", func() {
+		It("Rejects Create when ExternalIP already has an attachment", func() {
+			eip := createExternalIPInState(ctx, externalIPDao, sharedPool.GetId(),
+				privatev1.ExternalIPState_EXTERNAL_IP_STATE_ALLOCATED, false)
+			ci1 := createComputeInstanceInState(ctx, computeInstanceDao,
+				privatev1.ComputeInstanceState_COMPUTE_INSTANCE_STATE_RUNNING)
+			ci2 := createComputeInstanceInState(ctx, computeInstanceDao,
+				privatev1.ComputeInstanceState_COMPUTE_INSTANCE_STATE_RUNNING)
+
+			_, err := server.Create(ctx, privatev1.ExternalIPAttachmentsCreateRequest_builder{
+				Object: privatev1.ExternalIPAttachment_builder{
+					Spec: privatev1.ExternalIPAttachmentSpec_builder{
+						ExternalIp:      eip.GetId(),
+						ComputeInstance: new(ci1.GetId()),
+					}.Build(),
+				}.Build(),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+
+			_, err = server.Create(ctx, privatev1.ExternalIPAttachmentsCreateRequest_builder{
+				Object: privatev1.ExternalIPAttachment_builder{
+					Spec: privatev1.ExternalIPAttachmentSpec_builder{
+						ExternalIp:      eip.GetId(),
+						ComputeInstance: new(ci2.GetId()),
+					}.Build(),
+				}.Build(),
+			}.Build())
+			Expect(err).To(HaveOccurred())
+			status, ok := grpcstatus.FromError(err)
+			Expect(ok).To(BeTrue())
+			Expect(status.Code()).To(Equal(grpccodes.FailedPrecondition))
+			Expect(err.Error()).To(ContainSubstring("already attached"))
+		})
+	})
+
+	Describe("Immutable fields", func() {
+		It("Rejects update of spec.external_ip", func() {
+			eip := createExternalIPInState(ctx, externalIPDao, sharedPool.GetId(),
+				privatev1.ExternalIPState_EXTERNAL_IP_STATE_ALLOCATED, false)
+			ci := createComputeInstanceInState(ctx, computeInstanceDao,
+				privatev1.ComputeInstanceState_COMPUTE_INSTANCE_STATE_RUNNING)
+
+			createResponse, err := server.Create(ctx, privatev1.ExternalIPAttachmentsCreateRequest_builder{
+				Object: privatev1.ExternalIPAttachment_builder{
+					Spec: privatev1.ExternalIPAttachmentSpec_builder{
+						ExternalIp:      eip.GetId(),
+						ComputeInstance: new(ci.GetId()),
+					}.Build(),
+				}.Build(),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+
+			eip2 := createExternalIPInState(ctx, externalIPDao, sharedPool.GetId(),
+				privatev1.ExternalIPState_EXTERNAL_IP_STATE_ALLOCATED, false)
+			_, err = server.Update(ctx, privatev1.ExternalIPAttachmentsUpdateRequest_builder{
+				Object: privatev1.ExternalIPAttachment_builder{
+					Id: createResponse.GetObject().GetId(),
+					Spec: privatev1.ExternalIPAttachmentSpec_builder{
+						ExternalIp: eip2.GetId(),
+					}.Build(),
+				}.Build(),
+				UpdateMask: &fieldmaskpb.FieldMask{
+					Paths: []string{"spec.external_ip"},
+				},
+			}.Build())
+			Expect(err).To(HaveOccurred())
+			status, ok := grpcstatus.FromError(err)
+			Expect(ok).To(BeTrue())
+			Expect(status.Code()).To(Equal(grpccodes.InvalidArgument))
+			Expect(err.Error()).To(ContainSubstring("spec.external_ip"))
+			Expect(err.Error()).To(ContainSubstring("immutable"))
+		})
+
+		It("Rejects update of spec.compute_instance", func() {
+			eip := createExternalIPInState(ctx, externalIPDao, sharedPool.GetId(),
+				privatev1.ExternalIPState_EXTERNAL_IP_STATE_ALLOCATED, false)
+			ci := createComputeInstanceInState(ctx, computeInstanceDao,
+				privatev1.ComputeInstanceState_COMPUTE_INSTANCE_STATE_RUNNING)
+
+			createResponse, err := server.Create(ctx, privatev1.ExternalIPAttachmentsCreateRequest_builder{
+				Object: privatev1.ExternalIPAttachment_builder{
+					Spec: privatev1.ExternalIPAttachmentSpec_builder{
+						ExternalIp:      eip.GetId(),
+						ComputeInstance: new(ci.GetId()),
+					}.Build(),
+				}.Build(),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+
+			ci2 := createComputeInstanceInState(ctx, computeInstanceDao,
+				privatev1.ComputeInstanceState_COMPUTE_INSTANCE_STATE_RUNNING)
+			_, err = server.Update(ctx, privatev1.ExternalIPAttachmentsUpdateRequest_builder{
+				Object: privatev1.ExternalIPAttachment_builder{
+					Id: createResponse.GetObject().GetId(),
+					Spec: privatev1.ExternalIPAttachmentSpec_builder{
+						ExternalIp:      eip.GetId(),
+						ComputeInstance: new(ci2.GetId()),
+					}.Build(),
+				}.Build(),
+				UpdateMask: &fieldmaskpb.FieldMask{
+					Paths: []string{"spec.compute_instance"},
+				},
+			}.Build())
+			Expect(err).To(HaveOccurred())
+			status, ok := grpcstatus.FromError(err)
+			Expect(ok).To(BeTrue())
+			Expect(status.Code()).To(Equal(grpccodes.InvalidArgument))
+			Expect(err.Error()).To(ContainSubstring("spec.compute_instance"))
+			Expect(err.Error()).To(ContainSubstring("immutable"))
+		})
+	})
+
+	Describe("Attached flag management", func() {
+		It("Sets ExternalIP.status.attached to true on Create", func() {
+			eip := createExternalIPInState(ctx, externalIPDao, sharedPool.GetId(),
+				privatev1.ExternalIPState_EXTERNAL_IP_STATE_ALLOCATED, false)
+			ci := createComputeInstanceInState(ctx, computeInstanceDao,
+				privatev1.ComputeInstanceState_COMPUTE_INSTANCE_STATE_RUNNING)
+
+			_, err := server.Create(ctx, privatev1.ExternalIPAttachmentsCreateRequest_builder{
+				Object: privatev1.ExternalIPAttachment_builder{
+					Spec: privatev1.ExternalIPAttachmentSpec_builder{
+						ExternalIp:      eip.GetId(),
+						ComputeInstance: new(ci.GetId()),
+					}.Build(),
+				}.Build(),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+
+			ipResp, err := externalIPDao.Get().SetId(eip.GetId()).Do(ctx)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(ipResp.GetObject().GetStatus().GetAttached()).To(BeTrue())
+		})
+
+		It("Sets ExternalIP.status.attached to false on Delete", func() {
+			eip := createExternalIPInState(ctx, externalIPDao, sharedPool.GetId(),
+				privatev1.ExternalIPState_EXTERNAL_IP_STATE_ALLOCATED, false)
+			ci := createComputeInstanceInState(ctx, computeInstanceDao,
+				privatev1.ComputeInstanceState_COMPUTE_INSTANCE_STATE_RUNNING)
+
+			createResp, err := server.Create(ctx, privatev1.ExternalIPAttachmentsCreateRequest_builder{
+				Object: privatev1.ExternalIPAttachment_builder{
+					Spec: privatev1.ExternalIPAttachmentSpec_builder{
+						ExternalIp:      eip.GetId(),
+						ComputeInstance: new(ci.GetId()),
+					}.Build(),
+				}.Build(),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+
+			_, err = server.Delete(ctx, privatev1.ExternalIPAttachmentsDeleteRequest_builder{
+				Id: createResp.GetObject().GetId(),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+
+			ipResp, err := externalIPDao.Get().SetId(eip.GetId()).Do(ctx)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(ipResp.GetObject().GetStatus().GetAttached()).To(BeFalse())
+		})
+	})
+
+	Describe("Delete behaviour", func() {
+		It("Returns error for empty ID on Delete", func() {
+			_, err := server.Delete(ctx, privatev1.ExternalIPAttachmentsDeleteRequest_builder{}.Build())
+			Expect(err).To(HaveOccurred())
+			status, ok := grpcstatus.FromError(err)
+			Expect(ok).To(BeTrue())
+			Expect(status.Code()).To(Equal(grpccodes.InvalidArgument))
+			Expect(err.Error()).To(ContainSubstring("identifier is mandatory"))
+		})
+	})
+})

--- a/internal/servers/private_external_ip_attachments_server_test.go
+++ b/internal/servers/private_external_ip_attachments_server_test.go
@@ -645,7 +645,7 @@ var _ = Describe("Private external IP attachments server", func() {
 	})
 
 	Describe("Uniqueness constraints", func() {
-		It("Rejects Create when ExternalIP already has an attachment", func() {
+		It("Rejects Create when ExternalIP is already attached (attached flag)", func() {
 			eip := createExternalIPInState(ctx, externalIPDao, sharedPool.GetId(),
 				privatev1.ExternalIPState_EXTERNAL_IP_STATE_ALLOCATED, false)
 			ci1 := createComputeInstanceInState(ctx, computeInstanceDao,
@@ -676,6 +676,46 @@ var _ = Describe("Private external IP attachments server", func() {
 			Expect(ok).To(BeTrue())
 			Expect(status.Code()).To(Equal(grpccodes.FailedPrecondition))
 			Expect(err.Error()).To(ContainSubstring("already attached"))
+		})
+
+		It("Rejects Create when ExternalIP already has an attachment (uniqueness check)", func() {
+			eip := createExternalIPInState(ctx, externalIPDao, sharedPool.GetId(),
+				privatev1.ExternalIPState_EXTERNAL_IP_STATE_ALLOCATED, false)
+			ci1 := createComputeInstanceInState(ctx, computeInstanceDao,
+				privatev1.ComputeInstanceState_COMPUTE_INSTANCE_STATE_RUNNING)
+			ci2 := createComputeInstanceInState(ctx, computeInstanceDao,
+				privatev1.ComputeInstanceState_COMPUTE_INSTANCE_STATE_RUNNING)
+
+			_, err := server.Create(ctx, privatev1.ExternalIPAttachmentsCreateRequest_builder{
+				Object: privatev1.ExternalIPAttachment_builder{
+					Spec: privatev1.ExternalIPAttachmentSpec_builder{
+						ExternalIp:      eip.GetId(),
+						ComputeInstance: new(ci1.GetId()),
+					}.Build(),
+				}.Build(),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+
+			// Reset the attached flag so the uniqueness check path is exercised
+			ipResp, err := externalIPDao.Get().SetId(eip.GetId()).Do(ctx)
+			Expect(err).ToNot(HaveOccurred())
+			ipResp.GetObject().GetStatus().SetAttached(false)
+			_, err = externalIPDao.Update().SetObject(ipResp.GetObject()).Do(ctx)
+			Expect(err).ToNot(HaveOccurred())
+
+			_, err = server.Create(ctx, privatev1.ExternalIPAttachmentsCreateRequest_builder{
+				Object: privatev1.ExternalIPAttachment_builder{
+					Spec: privatev1.ExternalIPAttachmentSpec_builder{
+						ExternalIp:      eip.GetId(),
+						ComputeInstance: new(ci2.GetId()),
+					}.Build(),
+				}.Build(),
+			}.Build())
+			Expect(err).To(HaveOccurred())
+			status, ok := grpcstatus.FromError(err)
+			Expect(ok).To(BeTrue())
+			Expect(status.Code()).To(Equal(grpccodes.AlreadyExists))
+			Expect(err.Error()).To(ContainSubstring("ExternalIP"))
 		})
 	})
 


### PR DESCRIPTION
## Summary

- Add public and private ExternalIPAttachment gRPC servers with full CRUD + Signal operations
- Support three target types: ComputeInstance, Cluster, and BareMetalInstance via oneof target field
- Cross-resource validation: ExternalIP existence/ALLOCATED state/attached flag, target resource existence, ExternalIP uniqueness, target_endpoint required for cluster targets
- Immutability enforcement for all spec fields (external_ip, target, target_endpoint)
- ExternalIP attached flag management on create/delete
- Register both servers in gRPC startup

## Test plan

- [x] Unit tests for private server: create with all 3 target types, list, get, update metadata, delete, signal
- [x] Unit tests for validation: nil object, nil spec, missing external_ip, no target, missing target_endpoint for cluster, target_endpoint set for non-cluster
- [x] Unit tests for ExternalIP reference: not found, not ALLOCATED, already attached
- [x] Unit tests for target reference: ComputeInstance/Cluster/BareMetalInstance not found
- [x] Unit tests for uniqueness: ExternalIP already has attachment
- [x] Unit tests for immutable fields: external_ip, compute_instance changes rejected
- [x] Unit tests for attached flag: set to true on create, false on delete
- [x] Unit tests for public server: create, list, get, update, delete, immutable field propagation
- [x] All 1253 server package tests pass
- [x] Build passes, gofmt clean

Jira: https://redhat.atlassian.net/browse/OSAC-1477

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added gRPC API support for external IP attachments via both public and private access paths.
  * Supports listing, getting, creating, updating metadata/labels (with field mask), deleting, and private signaling for attachments.
* **Bug Fixes**
  * Added stronger validation for attachment creation and updates, including correct target rules, immutable fields, and uniqueness checks.
  * Attachment lifecycle now keeps external IP attachment status synchronized (attached on create, detached on delete).
* **Tests**
  * Added end-to-end test coverage for public and private attachment server behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->