### PR TITLE
OSAC-1451: Add fabric_manager and k8s_manager validation to NetworkClass server

### DIFF
--- a/internal/servers/network_classes_server_test.go
+++ b/internal/servers/network_classes_server_test.go
@@ -103,6 +103,7 @@ var _ = Describe("Network classes server", func() {
 				Object: privatev1.NetworkClass_builder{
 					Title:                  "Test Network Class",
 					ImplementationStrategy: "ovn-kubernetes",
+					FabricManager:          "netris",
 				}.Build(),
 			}.Build())
 			Expect(err).ToNot(HaveOccurred())
@@ -115,6 +116,7 @@ var _ = Describe("Network classes server", func() {
 				Object: privatev1.NetworkClass_builder{
 					Title:                  "Default Network Class",
 					ImplementationStrategy: "ovn-kubernetes",
+					FabricManager:          "netris",
 					IsDefault:              new(true),
 				}.Build(),
 			}.Build())
@@ -264,6 +266,7 @@ var _ = Describe("Network classes server", func() {
 					Id:                     callerProvidedId,
 					Title:                  "Test Network Class",
 					ImplementationStrategy: "ovn-kubernetes",
+					FabricManager:          "netris",
 				}.Build(),
 			}.Build())
 			Expect(err).ToNot(HaveOccurred())
@@ -479,6 +482,7 @@ var _ = Describe("Network classes server", func() {
 					SetObject(privatev1.NetworkClass_builder{
 						Title:                  "NC-A",
 						ImplementationStrategy: "ovn-kubernetes",
+						FabricManager:          "netris",
 						IsDefault:              new(true),
 						Metadata: privatev1.Metadata_builder{
 							Tenant: auth.SharedTenant,
@@ -495,6 +499,7 @@ var _ = Describe("Network classes server", func() {
 					privatev1.NetworkClass_builder{
 						Title:                  "NC-B",
 						ImplementationStrategy: "ovn-kubernetes",
+						FabricManager:          "netris",
 						IsDefault:              new(true),
 						Metadata: privatev1.Metadata_builder{
 							Tenant: auth.SharedTenant,
@@ -620,6 +625,7 @@ var _ = Describe("Network classes server", func() {
 				ncA := privatev1.NetworkClass_builder{
 					Title:                  "NC-A",
 					ImplementationStrategy: "ovn-kubernetes",
+					FabricManager:          "netris",
 					IsDefault:              new(true),
 					Metadata: privatev1.Metadata_builder{
 						Tenant: auth.SharedTenant,
@@ -666,6 +672,7 @@ var _ = Describe("Network classes server", func() {
 				ncA := privatev1.NetworkClass_builder{
 					Title:                  "NC-A",
 					ImplementationStrategy: "ovn-kubernetes",
+					FabricManager:          "netris",
 					IsDefault:              new(true),
 					Metadata: privatev1.Metadata_builder{
 						Tenant: auth.SharedTenant,
@@ -681,6 +688,7 @@ var _ = Describe("Network classes server", func() {
 				ncB := privatev1.NetworkClass_builder{
 					Title:                  "NC-B",
 					ImplementationStrategy: "ovn-kubernetes",
+					FabricManager:          "netris",
 					IsDefault:              new(true),
 					Metadata: privatev1.Metadata_builder{
 						Tenant: auth.SharedTenant,
@@ -709,6 +717,7 @@ var _ = Describe("Network classes server", func() {
 					SetObject(privatev1.NetworkClass_builder{
 						Title:                  "Deleted Default",
 						ImplementationStrategy: "ovn-kubernetes",
+						FabricManager:          "netris",
 						IsDefault:              new(true),
 						Metadata: privatev1.Metadata_builder{
 							Finalizers: []string{"a"},
@@ -730,6 +739,7 @@ var _ = Describe("Network classes server", func() {
 					SetObject(privatev1.NetworkClass_builder{
 						Title:                  "Active Default",
 						ImplementationStrategy: "ovn-kubernetes",
+						FabricManager:          "netris",
 						IsDefault:              new(true),
 						Metadata: privatev1.Metadata_builder{
 							Tenant: auth.SharedTenant,
@@ -767,6 +777,179 @@ var _ = Describe("Network classes server", func() {
 				}.Build())
 				Expect(err).ToNot(HaveOccurred())
 				Expect(listResponse.GetItems()).To(BeEmpty())
+			})
+		})
+
+		Describe("Manager fields", func() {
+			It("Create with fabric_manager persists the value", func() {
+				response, err := privateServer.Create(ctx, privatev1.NetworkClassesCreateRequest_builder{
+					Object: privatev1.NetworkClass_builder{
+						Title:                  "NC with fabric manager",
+						ImplementationStrategy: "ovn-kubernetes",
+						FabricManager:          "netris",
+					}.Build(),
+				}.Build())
+				Expect(err).ToNot(HaveOccurred())
+				Expect(response.GetObject().GetFabricManager()).To(Equal("netris"))
+
+				getResponse, err := privateServer.Get(ctx, privatev1.NetworkClassesGetRequest_builder{
+					Id: response.GetObject().GetId(),
+				}.Build())
+				Expect(err).ToNot(HaveOccurred())
+				Expect(getResponse.GetObject().GetFabricManager()).To(Equal("netris"))
+			})
+
+			It("Create without fabric_manager fails", func() {
+				_, err := privateServer.Create(ctx, privatev1.NetworkClassesCreateRequest_builder{
+					Object: privatev1.NetworkClass_builder{
+						Title:                  "NC without fabric manager",
+						ImplementationStrategy: "ovn-kubernetes",
+					}.Build(),
+				}.Build())
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("fabric_manager"))
+			})
+
+			It("Create with k8s_manager persists the value", func() {
+				response, err := privateServer.Create(ctx, privatev1.NetworkClassesCreateRequest_builder{
+					Object: privatev1.NetworkClass_builder{
+						Title:                  "NC with k8s manager",
+						ImplementationStrategy: "ovn-kubernetes",
+						FabricManager:          "netris",
+						K8SManager:             new("cudn_localnet"),
+					}.Build(),
+				}.Build())
+				Expect(err).ToNot(HaveOccurred())
+				Expect(response.GetObject().GetK8SManager()).To(Equal("cudn_localnet"))
+
+				getResponse, err := privateServer.Get(ctx, privatev1.NetworkClassesGetRequest_builder{
+					Id: response.GetObject().GetId(),
+				}.Build())
+				Expect(err).ToNot(HaveOccurred())
+				Expect(getResponse.GetObject().GetK8SManager()).To(Equal("cudn_localnet"))
+			})
+
+			It("Create without k8s_manager succeeds", func() {
+				response, err := privateServer.Create(ctx, privatev1.NetworkClassesCreateRequest_builder{
+					Object: privatev1.NetworkClass_builder{
+						Title:                  "NC without k8s manager",
+						ImplementationStrategy: "ovn-kubernetes",
+						FabricManager:          "netris",
+					}.Build(),
+				}.Build())
+				Expect(err).ToNot(HaveOccurred())
+				Expect(response.GetObject().HasK8SManager()).To(BeFalse())
+			})
+
+			It("Update changing fabric_manager fails with immutability error", func() {
+				nc := createNetworkClass()
+				Expect(nc.GetFabricManager()).To(Equal("netris"))
+
+				_, err := privateServer.Update(ctx, privatev1.NetworkClassesUpdateRequest_builder{
+					Object: privatev1.NetworkClass_builder{
+						Id:            nc.GetId(),
+						FabricManager: "neutron",
+					}.Build(),
+					UpdateMask: &fieldmaskpb.FieldMask{Paths: []string{"fabric_manager"}},
+				}.Build())
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("fabric_manager"))
+				Expect(err.Error()).To(ContainSubstring("immutable"))
+			})
+
+			It("Update setting k8s_manager for the first time succeeds", func() {
+				// Create NC without k8s_manager (BM-only region):
+				nc := createNetworkClass()
+				Expect(nc.HasK8SManager()).To(BeFalse())
+
+				// Set k8s_manager for the first time (adding VM support):
+				updateResponse, err := privateServer.Update(ctx, privatev1.NetworkClassesUpdateRequest_builder{
+					Object: privatev1.NetworkClass_builder{
+						Id:         nc.GetId(),
+						K8SManager: new("cudn_localnet"),
+					}.Build(),
+					UpdateMask: &fieldmaskpb.FieldMask{Paths: []string{"k8s_manager"}},
+				}.Build())
+				Expect(err).ToNot(HaveOccurred())
+				Expect(updateResponse.GetObject().GetK8SManager()).To(Equal("cudn_localnet"))
+			})
+
+			It("Update changing k8s_manager fails with immutability error", func() {
+				response, err := privateServer.Create(ctx, privatev1.NetworkClassesCreateRequest_builder{
+					Object: privatev1.NetworkClass_builder{
+						Title:                  "NC for k8s update",
+						ImplementationStrategy: "ovn-kubernetes",
+						FabricManager:          "netris",
+						K8SManager:             new("cudn_localnet"),
+					}.Build(),
+				}.Build())
+				Expect(err).ToNot(HaveOccurred())
+				nc := response.GetObject()
+
+				_, err = privateServer.Update(ctx, privatev1.NetworkClassesUpdateRequest_builder{
+					Object: privatev1.NetworkClass_builder{
+						Id:         nc.GetId(),
+						K8SManager: new("ovn_evpn"),
+					}.Build(),
+					UpdateMask: &fieldmaskpb.FieldMask{Paths: []string{"k8s_manager"}},
+				}.Build())
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("k8s_manager"))
+				Expect(err.Error()).To(ContainSubstring("immutable"))
+			})
+
+			It("Update with field mask preserves unmasked manager fields", func() {
+				response, err := privateServer.Create(ctx, privatev1.NetworkClassesCreateRequest_builder{
+					Object: privatev1.NetworkClass_builder{
+						Title:                  "NC for mask test",
+						ImplementationStrategy: "ovn-kubernetes",
+						FabricManager:          "netris",
+						K8SManager:             new("cudn_localnet"),
+					}.Build(),
+				}.Build())
+				Expect(err).ToNot(HaveOccurred())
+				nc := response.GetObject()
+
+				updateResponse, err := privateServer.Update(ctx, privatev1.NetworkClassesUpdateRequest_builder{
+					Object: privatev1.NetworkClass_builder{
+						Id:    nc.GetId(),
+						Title: "Updated title",
+					}.Build(),
+					UpdateMask: &fieldmaskpb.FieldMask{Paths: []string{"title"}},
+				}.Build())
+				Expect(err).ToNot(HaveOccurred())
+				Expect(updateResponse.GetObject().GetFabricManager()).To(Equal("netris"))
+				Expect(updateResponse.GetObject().GetK8SManager()).To(Equal("cudn_localnet"))
+			})
+
+			It("Full replacement update with same fabric_manager succeeds", func() {
+				nc := createNetworkClass()
+				Expect(nc.GetFabricManager()).To(Equal("netris"))
+
+				updateResponse, err := privateServer.Update(ctx, privatev1.NetworkClassesUpdateRequest_builder{
+					Object: privatev1.NetworkClass_builder{
+						Id:            nc.GetId(),
+						Title:         "Updated",
+						FabricManager: "netris",
+					}.Build(),
+				}.Build())
+				Expect(err).ToNot(HaveOccurred())
+				Expect(updateResponse.GetObject().GetFabricManager()).To(Equal("netris"))
+			})
+
+			It("Full replacement update changing fabric_manager fails", func() {
+				nc := createNetworkClass()
+
+				_, err := privateServer.Update(ctx, privatev1.NetworkClassesUpdateRequest_builder{
+					Object: privatev1.NetworkClass_builder{
+						Id:            nc.GetId(),
+						Title:         nc.GetTitle(),
+						FabricManager: "neutron",
+					}.Build(),
+				}.Build())
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("fabric_manager"))
+				Expect(err.Error()).To(ContainSubstring("immutable"))
 			})
 		})
 	})

--- a/internal/servers/private_network_classes_server.go
+++ b/internal/servers/private_network_classes_server.go
@@ -355,6 +355,25 @@ func (s *PrivateNetworkClassesServer) validateNetworkClass(ctx context.Context,
 				"field 'implementation_strategy' is immutable and cannot be changed from '%s' to '%s'",
 				existingNC.GetImplementationStrategy(), newNC.GetImplementationStrategy())
 		}
+
+		// NC-VAL-06: fabric_manager is immutable
+		if newNC.GetFabricManager() != existingNC.GetFabricManager() {
+			return grpcstatus.Errorf(grpccodes.InvalidArgument,
+				"field 'fabric_manager' is immutable and cannot be changed from '%s' to '%s'",
+				existingNC.GetFabricManager(), newNC.GetFabricManager())
+		}
+
+		// NC-VAL-07: k8s_manager is immutable once set (but can be set for the first time)
+		if existingNC.HasK8SManager() && newNC.GetK8SManager() != existingNC.GetK8SManager() {
+			return grpcstatus.Errorf(grpccodes.InvalidArgument,
+				"field 'k8s_manager' is immutable and cannot be changed from '%s' to '%s'",
+				existingNC.GetK8SManager(), newNC.GetK8SManager())
+		}
+	}
+
+	// NC-VAL-05: fabric_manager is required
+	if newNC.GetFabricManager() == "" {
+		return grpcstatus.Errorf(grpccodes.InvalidArgument, "field 'fabric_manager' is required")
 	}
 
 	return nil
@@ -395,6 +414,14 @@ func applyNetworkClassUpdate(base, update *privatev1.NetworkClass, mask *fieldma
 			base.SetCapabilities(update.GetCapabilities())
 		case "is_default":
 			base.SetIsDefault(update.GetIsDefault())
+		case "fabric_manager":
+			base.SetFabricManager(update.GetFabricManager())
+		case "k8s_manager":
+			if update.HasK8SManager() {
+				base.SetK8SManager(update.GetK8SManager())
+			} else {
+				base.ClearK8SManager()
+			}
 		default:
 			// For unknown paths, fall through - the generic handler will
 			// reject invalid paths if needed.

--- a/it/it_compute_subnet_test.go
+++ b/it/it_compute_subnet_test.go
@@ -69,6 +69,7 @@ var _ = Describe("ComputeInstance with Subnet attachment", func() {
 			Object: privatev1.NetworkClass_builder{
 				Title:                  "Test CUDN Network Class",
 				ImplementationStrategy: "cudn",
+				FabricManager:          "netris",
 			}.Build(),
 		}.Build())
 		Expect(err).ToNot(HaveOccurred())


### PR DESCRIPTION
## Summary

- Add `fabric_manager` as a required field on NetworkClass Create (NC-VAL-05)
- Add `fabric_manager` immutability check on NetworkClass Update (NC-VAL-06)
- Add `k8s_manager` immutability check on NetworkClass Update (NC-VAL-07) — immutable once set, but can be set for the first time to support adding VM support to a BM-only region
- Add `fabric_manager` and `k8s_manager` field mask paths to `applyNetworkClassUpdate`
- Update all existing test helpers and DAO builders to include `fabric_manager`
- Add 10 new tests covering manager field validation and field mask handling

## Context

Part of the **NetworkClass Two-Manager Model** epic ([OSAC-1438](https://redhat.atlassian.net/browse/OSAC-1438)). This task implements server-side validation for the two-manager fields added in [OSAC-1449](https://redhat.atlassian.net/browse/OSAC-1449) (proto) and [OSAC-1452](https://redhat.atlassian.net/browse/OSAC-1452) (DB migration).

**Jira:** [OSAC-1451](https://redhat.atlassian.net/browse/OSAC-1451)

## Test plan

- [x] All 10 new manager field tests pass
- [x] All 28 existing NetworkClass server tests pass (no regressions)
- [x] Full unit test suite (71 suites) passes
- [x] `buf lint` clean
- [x] `golangci-lint` — 0 issues

Assisted-by: Claude Code <noreply@anthropic.com>

requires - https://github.com/osac-project/osac-aap/pull/388