### PR TITLE
OSAC-1579: Add `system:` prefix to built-in group names

### DIFF
--- a/internal/controllers/project/project_reconciler_function.go
+++ b/internal/controllers/project/project_reconciler_function.go
@@ -203,7 +203,7 @@ func (t *task) validateAndActivate(ctx context.Context) error {
 	}
 
 	// Create Keycloak groups for project authorization
-	// Returns the managers group ID to avoid timing issues with group lookup
+	// Returns the system:managers group ID to avoid timing issues with group lookup
 	managersGroupID, err := t.r.resourceManager.CreateProjectGroups(ctx,
 		t.project.GetMetadata().GetTenant(),
 		t.project.GetMetadata().GetName())
@@ -231,7 +231,7 @@ func (t *task) validateAndActivate(ctx context.Context) error {
 		return fmt.Errorf("failed to create Keycloak groups: %w", err)
 	}
 
-	// Add the project creator to the managers group using the ID from creation
+	// Add the project creator to the system:managers group using the ID from creation
 	// This avoids timing issues where the group isn't immediately visible in searches
 	creator := t.project.GetMetadata().GetCreator()
 	if creator != "" {

--- a/internal/controllers/project/project_reconciler_function_test.go
+++ b/internal/controllers/project/project_reconciler_function_test.go
@@ -206,12 +206,12 @@ var _ = Describe("Validation and Activation", func() {
 
 			// Expect viewers group creation
 			mockIdpClient.EXPECT().
-				CreateAuthorizationGroup(gomock.Any(), "acme", "viewers", "/test-project/viewers").
+				CreateAuthorizationGroup(gomock.Any(), "acme", "system:viewers", "/test-project/system:viewers").
 				Return("viewers-id", nil)
 
 			// Expect managers group creation
 			mockIdpClient.EXPECT().
-				CreateAuthorizationGroup(gomock.Any(), "acme", "managers", "/test-project/managers").
+				CreateAuthorizationGroup(gomock.Any(), "acme", "system:managers", "/test-project/system:managers").
 				Return("managers-id", nil)
 
 			task := &task{
@@ -242,12 +242,12 @@ var _ = Describe("Validation and Activation", func() {
 
 			// Expect viewers group creation
 			mockIdpClient.EXPECT().
-				CreateAuthorizationGroup(gomock.Any(), "acme", "viewers", "/test-project/viewers").
+				CreateAuthorizationGroup(gomock.Any(), "acme", "system:viewers", "/test-project/system:viewers").
 				Return("viewers-id", nil)
 
 			// Expect managers group creation
 			mockIdpClient.EXPECT().
-				CreateAuthorizationGroup(gomock.Any(), "acme", "managers", "/test-project/managers").
+				CreateAuthorizationGroup(gomock.Any(), "acme", "system:managers", "/test-project/system:managers").
 				Return("managers-id", nil)
 
 			task := &task{
@@ -311,12 +311,12 @@ var _ = Describe("Validation and Activation", func() {
 
 			// Expect viewers group creation
 			mockIdpClient.EXPECT().
-				CreateAuthorizationGroup(gomock.Any(), "acme", "viewers", "/parent-project.child-project/viewers").
+				CreateAuthorizationGroup(gomock.Any(), "acme", "system:viewers", "/parent-project.child-project/system:viewers").
 				Return("viewers-id", nil)
 
 			// Expect managers group creation
 			mockIdpClient.EXPECT().
-				CreateAuthorizationGroup(gomock.Any(), "acme", "managers", "/parent-project.child-project/managers").
+				CreateAuthorizationGroup(gomock.Any(), "acme", "system:managers", "/parent-project.child-project/system:managers").
 				Return("managers-id", nil)
 
 			task := &task{
@@ -393,8 +393,8 @@ var _ = Describe("Validation and Activation", func() {
 				CreateAuthorizationGroup(
 					gomock.Any(),
 					"acme",
-					"viewers",
-					"/root.parent.child/viewers",
+					"system:viewers",
+					"/root.parent.child/system:viewers",
 				).
 				Return("viewers-id", nil)
 
@@ -403,8 +403,8 @@ var _ = Describe("Validation and Activation", func() {
 				CreateAuthorizationGroup(
 					gomock.Any(),
 					"acme",
-					"managers",
-					"/root.parent.child/managers",
+					"system:managers",
+					"/root.parent.child/system:managers",
 				).
 				Return("managers-id", nil)
 
@@ -836,7 +836,7 @@ var _ = Describe("Deletion Cleanup", func() {
 			GetGroupIDByPath(gomock.Any(), "acme", "/test-project").
 			Return("project-group-id", nil)
 
-		// Expect parent project group deletion (cascades to delete viewers and managers subgroups)
+		// Expect parent project group deletion (cascades to delete system:viewers and system:managers subgroups)
 		mockIdpClient.EXPECT().
 			DeleteAuthorizationGroup(gomock.Any(), "acme", "project-group-id").
 			Return(nil)

--- a/internal/database/migrations/60_add_projects_immutable_trigger.up.sql
+++ b/internal/database/migrations/60_add_projects_immutable_trigger.up.sql
@@ -13,7 +13,7 @@
 
 -- Attach the immutable column trigger to the projects table to prevent mutation of server-assigned fields.
 -- The creator field is server-assigned at creation time and used by the project reconciler to grant
--- managers-group membership. Allowing clients to mutate this field would enable privilege escalation.
+-- system:managers group membership. Allowing clients to mutate this field would enable privilege escalation.
 create trigger check_immutable_columns
   before update on projects
   for each row

--- a/internal/idp/authz_constants.go
+++ b/internal/idp/authz_constants.go
@@ -13,12 +13,13 @@ language governing permissions and limitations under the License.
 
 package idp
 
-// Authorization group constants for hierarchical project access control.
-// These define the group names used in Keycloak organization groups.
+// Authorization group constants for hierarchical project access control. These define the group
+// names used in Keycloak organization groups. The "system:" prefix prevents collisions with
+// user-created project names, since the colon character is not valid in DNS labels.
 const (
-	// GroupNameViewers is the name for viewer access groups
-	GroupNameViewers = "viewers"
+	// GroupNameViewers is the name for viewer access groups.
+	GroupNameViewers = "system:viewers"
 
-	// GroupNameManagers is the name for manager access groups
-	GroupNameManagers = "managers"
+	// GroupNameManagers is the name for manager access groups.
+	GroupNameManagers = "system:managers"
 )

--- a/internal/idp/client.go
+++ b/internal/idp/client.go
@@ -83,7 +83,7 @@ type Client interface {
 	// These methods control who can access which resources with what scopes.
 	// CreateAuthorizationGroup creates a Keycloak organization group for authorization purposes.
 	// Organization groups are scoped to a specific organization and support hierarchical paths.
-	// Recommended path format: "/{project-name}/{viewers|managers}" for top-level projects.
+	// Recommended path format: "/{project-name}/{system:viewers|system:managers}" for top-level projects.
 	// Returns the created group ID.
 	CreateAuthorizationGroup(ctx context.Context, organizationName, groupName, groupPath string) (string, error)
 	// DeleteAuthorizationGroup deletes a Keycloak organization group by ID.

--- a/internal/idp/keycloak/authz_groups.go
+++ b/internal/idp/keycloak/authz_groups.go
@@ -30,12 +30,12 @@ import (
 // Organization groups are scoped to the organization and support hierarchical paths.
 //
 // Group path format examples:
-//   - Top-level project: "/{project-name}/{viewers|managers}"
-//     Example: "/web-app/viewers"
-//   - Nested project: "/{parent-project}/{sub-project}/{viewers|managers}"
-//     Example: "/web-app/api/viewers"
-//   - Deeper nesting: "/{project}/{sub-project}/{component}/{viewers|managers}"
-//     Example: "/platform/web-app/api/viewers"
+//   - Top-level project: "/{project-name}/{system:viewers|system:managers}"
+//     Example: "/web-app/system:viewers"
+//   - Nested project: "/{parent-project}/{sub-project}/{system:viewers|system:managers}"
+//     Example: "/web-app/api/system:viewers"
+//   - Deeper nesting: "/{project}/{sub-project}/{component}/{system:viewers|system:managers}"
+//     Example: "/platform/web-app/api/system:viewers"
 //
 // Organization groups are scoped per organization, so paths can be simple and readable.
 // This method creates the full hierarchy if parent groups don't exist.
@@ -54,8 +54,8 @@ func (c *Client) CreateAuthorizationGroup(ctx context.Context, organizationName,
 	}
 
 	// Parse the path to create parent groups if needed
-	// Path format: /web-app/viewers
-	// We need to ensure /web-app exists, then create viewers under it
+	// Path format: /web-app/system:viewers
+	// We need to ensure /web-app exists, then create system:viewers under it
 	// Use a cache to avoid redundant API calls within the same operation
 	cache := make(map[string]string) // path -> groupID
 	err = c.ensureGroupHierarchyWithCache(ctx, org.ID, groupPath, cache)
@@ -117,7 +117,7 @@ func (c *Client) DeleteAuthorizationGroup(ctx context.Context, organizationName,
 
 func (c *Client) ensureGroupHierarchyWithCache(ctx context.Context, orgID, groupPath string, cache map[string]string) error {
 	// Split path into segments (removing leading slash)
-	// "/web-app/viewers" -> ["web-app", "viewers"]
+	// "/web-app/system:viewers" -> ["web-app", "system:viewers"]
 	segments := strings.Split(strings.Trim(groupPath, "/"), "/")
 	if len(segments) == 0 {
 		return fmt.Errorf("invalid group path: %s", groupPath)

--- a/internal/idp/keycloak/authz_groups_test.go
+++ b/internal/idp/keycloak/authz_groups_test.go
@@ -36,12 +36,12 @@ var _ = Describe("searchGroupRecursively", func() {
 			Name: "web-app",
 			Path: "/web-app",
 			SubGroups: []groupNode{
-				{ID: "group-456", Name: "viewers", Path: "/web-app/viewers"},
-				{ID: "group-789", Name: "managers", Path: "/web-app/managers"},
+				{ID: "group-456", Name: "system:viewers", Path: "/web-app/system:viewers"},
+				{ID: "group-789", Name: "system:managers", Path: "/web-app/system:managers"},
 			},
 		}
 
-		id := searchGroupRecursively(group, "/web-app/viewers")
+		id := searchGroupRecursively(group, "/web-app/system:viewers")
 		Expect(id).To(Equal("group-456"))
 	})
 
@@ -56,14 +56,14 @@ var _ = Describe("searchGroupRecursively", func() {
 					Name: "child-project",
 					Path: "/parent-project/child-project",
 					SubGroups: []groupNode{
-						{ID: "group-viewers", Name: "viewers", Path: "/parent-project/child-project/viewers"},
-						{ID: "group-managers", Name: "managers", Path: "/parent-project/child-project/managers"},
+						{ID: "group-viewers", Name: "system:viewers", Path: "/parent-project/child-project/system:viewers"},
+						{ID: "group-managers", Name: "system:managers", Path: "/parent-project/child-project/system:managers"},
 					},
 				},
 			},
 		}
 
-		id := searchGroupRecursively(group, "/parent-project/child-project/viewers")
+		id := searchGroupRecursively(group, "/parent-project/child-project/system:viewers")
 		Expect(id).To(Equal("group-viewers"))
 	})
 
@@ -73,7 +73,7 @@ var _ = Describe("searchGroupRecursively", func() {
 			Name: "web-app",
 			Path: "/web-app",
 			SubGroups: []groupNode{
-				{ID: "group-456", Name: "viewers", Path: "/web-app/viewers"},
+				{ID: "group-456", Name: "system:viewers", Path: "/web-app/system:viewers"},
 			},
 		}
 
@@ -126,7 +126,7 @@ var _ = Describe("searchGroupRecursively", func() {
 		id := searchGroupRecursively(group, "/web-app")
 		Expect(id).To(Equal("group-123"))
 
-		id = searchGroupRecursively(group, "/web-app/viewers")
+		id = searchGroupRecursively(group, "/web-app/system:viewers")
 		Expect(id).To(Equal(""))
 	})
 })

--- a/internal/idp/keycloak/client_test.go
+++ b/internal/idp/keycloak/client_test.go
@@ -2480,7 +2480,7 @@ var _ = Describe("Keycloak Client", func() {
 						w.WriteHeader(http.StatusCreated)
 						return
 					}
-					// Create child group: viewers under /web-app
+					// Create child group: system:viewers under /web-app
 					if r.Method == http.MethodPost && strings.Contains(r.URL.Path, "/children") {
 						var payload map[string]interface{}
 						if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
@@ -2499,11 +2499,11 @@ var _ = Describe("Keycloak Client", func() {
 
 				client = createTestClient(server.URL)
 
-				groupID, err := client.CreateAuthorizationGroup(ctx, "acme-corp", "viewers", "/web-app/viewers")
+				groupID, err := client.CreateAuthorizationGroup(ctx, "acme-corp", "system:viewers", "/web-app/system:viewers")
 				Expect(err).ToNot(HaveOccurred())
-				Expect(groupID).To(Equal(createdGroups["viewers"]))
+				Expect(groupID).To(Equal(createdGroups["system:viewers"]))
 				Expect(createdGroups).To(HaveKey("web-app"))
-				Expect(createdGroups).To(HaveKey("viewers"))
+				Expect(createdGroups).To(HaveKey("system:viewers"))
 			})
 
 			It("should return error when organization is not found", func() {
@@ -2522,7 +2522,7 @@ var _ = Describe("Keycloak Client", func() {
 
 				client = createTestClient(server.URL)
 
-				groupID, err := client.CreateAuthorizationGroup(ctx, "nonexistent-org", "viewers", "/web-app/viewers")
+				groupID, err := client.CreateAuthorizationGroup(ctx, "nonexistent-org", "system:viewers", "/web-app/system:viewers")
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("failed to get organization"))
 				Expect(groupID).To(BeEmpty())
@@ -2587,10 +2587,10 @@ var _ = Describe("Keycloak Client", func() {
 
 				client = createTestClient(server.URL)
 
-				groupID, err := client.CreateAuthorizationGroup(ctx, "acme-corp", "viewers", "/web-app/viewers")
+				groupID, err := client.CreateAuthorizationGroup(ctx, "acme-corp", "system:viewers", "/web-app/system:viewers")
 				Expect(err).ToNot(HaveOccurred())
-				Expect(groupID).To(Equal(createdGroups["viewers"]))
-				Expect(createdGroups).To(HaveKey("viewers"))
+				Expect(groupID).To(Equal(createdGroups["system:viewers"]))
+				Expect(createdGroups).To(HaveKey("system:viewers"))
 			})
 		})
 
@@ -2702,8 +2702,8 @@ var _ = Describe("Keycloak Client", func() {
 							ID   string `json:"id"`
 							Path string `json:"path"`
 						}{
-							{ID: "group-123", Path: "/web-app/viewers"},
-							{ID: "group-456", Path: "/web-app/managers"},
+							{ID: "group-123", Path: "/web-app/system:viewers"},
+							{ID: "group-456", Path: "/web-app/system:managers"},
 						}
 						w.Header().Set("Content-Type", "application/json")
 						w.WriteHeader(http.StatusOK)
@@ -2718,7 +2718,7 @@ var _ = Describe("Keycloak Client", func() {
 
 				client = createTestClient(server.URL)
 
-				groupID, err := client.GetGroupIDByPath(ctx, "acme-corp", "/web-app/viewers")
+				groupID, err := client.GetGroupIDByPath(ctx, "acme-corp", "/web-app/system:viewers")
 				Expect(err).ToNot(HaveOccurred())
 				Expect(groupID).To(Equal("group-123"))
 			})
@@ -2739,7 +2739,7 @@ var _ = Describe("Keycloak Client", func() {
 
 				client = createTestClient(server.URL)
 
-				_, err := client.GetGroupIDByPath(ctx, "nonexistent-org", "/web-app/viewers")
+				_, err := client.GetGroupIDByPath(ctx, "nonexistent-org", "/web-app/system:viewers")
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("failed to get organization"))
 			})
@@ -2808,7 +2808,7 @@ var _ = Describe("Keycloak Client", func() {
 
 				client = createTestClient(server.URL)
 
-				_, err := client.GetGroupIDByPath(ctx, "acme-corp", "/web-app/viewers")
+				_, err := client.GetGroupIDByPath(ctx, "acme-corp", "/web-app/system:viewers")
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("failed to list organization groups"))
 			})

--- a/internal/idp/resource_manager.go
+++ b/internal/idp/resource_manager.go
@@ -96,7 +96,7 @@ func (m *ResourceManager) DeleteProjectGroups(ctx context.Context, tenant, proje
 		return fmt.Errorf("project name cannot contain '/' character")
 	}
 
-	// Delete the parent project group, which will cascade delete the viewers and managers subgroups
+	// Delete the parent project group, which will cascade delete the system:viewers and system:managers subgroups
 	projectGroupPath := fmt.Sprintf("/%s", projectName)
 
 	projectGroupID, err := m.getGroupIDByPath(ctx, tenant, projectGroupPath)
@@ -141,7 +141,7 @@ func (m *ResourceManager) getGroupIDByPath(ctx context.Context, organizationName
 }
 
 // CreateProjectGroups creates Keycloak organization groups for a project.
-// Creates hierarchical groups: /{project-name}/viewers and /{project-name}/managers
+// Creates hierarchical groups: /{project-name}/system:viewers and /{project-name}/system:managers
 // These groups are used by Authorino OPA policies for authorization.
 // Returns the managers group ID for immediate use (avoids timing issues with group lookup).
 func (m *ResourceManager) CreateProjectGroups(ctx context.Context, tenant, projectName string) (string, error) {
@@ -201,7 +201,7 @@ func (m *ResourceManager) CreateProjectGroups(ctx context.Context, tenant, proje
 	return managersGroupID, nil
 }
 
-// AddUserToProjectGroup adds a user to a project group (viewers or managers).
+// AddUserToProjectGroup adds a user to a project group (system:viewers or system:managers).
 func (m *ResourceManager) AddUserToProjectGroup(ctx context.Context, tenant, projectName, username, groupType string) error {
 	if tenant == "" {
 		return fmt.Errorf("tenant is required")
@@ -270,7 +270,7 @@ func (m *ResourceManager) AddUserToGroupByID(ctx context.Context, tenant, userna
 	return nil
 }
 
-// RemoveUserFromProjectGroup removes a user from a project group (viewers or managers).
+// RemoveUserFromProjectGroup removes a user from a project group (system:viewers or system:managers).
 func (m *ResourceManager) RemoveUserFromProjectGroup(ctx context.Context, tenant, projectName, username, groupType string) error {
 	if tenant == "" {
 		return fmt.Errorf("tenant is required")

--- a/internal/idp/resource_manager_test.go
+++ b/internal/idp/resource_manager_test.go
@@ -154,11 +154,11 @@ var _ = Describe("ResourceManager", func() {
 
 		It("should create hierarchical viewers and managers groups", func() {
 			mockClient.EXPECT().
-				CreateAuthorizationGroup(gomock.Any(), "test-org", GroupNameViewers, "/test-project/viewers").
+				CreateAuthorizationGroup(gomock.Any(), "test-org", GroupNameViewers, "/test-project/system:viewers").
 				Return("viewers-group-id", nil)
 
 			mockClient.EXPECT().
-				CreateAuthorizationGroup(gomock.Any(), "test-org", GroupNameManagers, "/test-project/managers").
+				CreateAuthorizationGroup(gomock.Any(), "test-org", GroupNameManagers, "/test-project/system:managers").
 				Return("managers-group-id", nil)
 
 			managersID, err := manager.CreateProjectGroups(ctx, "test-org", "test-project")
@@ -168,11 +168,11 @@ var _ = Describe("ResourceManager", func() {
 
 		It("should rollback viewers group when managers group creation fails", func() {
 			mockClient.EXPECT().
-				CreateAuthorizationGroup(gomock.Any(), "test-org", GroupNameViewers, "/test-project/viewers").
+				CreateAuthorizationGroup(gomock.Any(), "test-org", GroupNameViewers, "/test-project/system:viewers").
 				Return("viewers-group-id", nil)
 
 			mockClient.EXPECT().
-				CreateAuthorizationGroup(gomock.Any(), "test-org", GroupNameManagers, "/test-project/managers").
+				CreateAuthorizationGroup(gomock.Any(), "test-org", GroupNameManagers, "/test-project/system:managers").
 				Return("", errors.New("keycloak error"))
 
 			mockClient.EXPECT().
@@ -187,7 +187,7 @@ var _ = Describe("ResourceManager", func() {
 
 		It("should return error when viewers group creation fails", func() {
 			mockClient.EXPECT().
-				CreateAuthorizationGroup(gomock.Any(), "test-org", GroupNameViewers, "/test-project/viewers").
+				CreateAuthorizationGroup(gomock.Any(), "test-org", GroupNameViewers, "/test-project/system:viewers").
 				Return("", errors.New("keycloak error"))
 
 			managersID, err := manager.CreateProjectGroups(ctx, "test-org", "test-project")
@@ -239,7 +239,7 @@ var _ = Describe("ResourceManager", func() {
 
 		It("should add user to managers group", func() {
 			mockClient.EXPECT().
-				GetGroupIDByPath(gomock.Any(), "test-org", "/test-project/managers").
+				GetGroupIDByPath(gomock.Any(), "test-org", "/test-project/system:managers").
 				Return("managers-group-id", nil)
 
 			mockClient.EXPECT().
@@ -252,7 +252,7 @@ var _ = Describe("ResourceManager", func() {
 
 		It("should add user to viewers group", func() {
 			mockClient.EXPECT().
-				GetGroupIDByPath(gomock.Any(), "test-org", "/test-project/viewers").
+				GetGroupIDByPath(gomock.Any(), "test-org", "/test-project/system:viewers").
 				Return("viewers-group-id", nil)
 
 			mockClient.EXPECT().
@@ -289,7 +289,7 @@ var _ = Describe("ResourceManager", func() {
 
 		It("should return error when group lookup fails", func() {
 			mockClient.EXPECT().
-				GetGroupIDByPath(gomock.Any(), "test-org", "/test-project/managers").
+				GetGroupIDByPath(gomock.Any(), "test-org", "/test-project/system:managers").
 				Return("", errors.New("group not found"))
 
 			err := manager.AddUserToProjectGroup(ctx, "test-org", "test-project", "user-123", GroupNameManagers)
@@ -299,7 +299,7 @@ var _ = Describe("ResourceManager", func() {
 
 		It("should return error when adding user to group fails", func() {
 			mockClient.EXPECT().
-				GetGroupIDByPath(gomock.Any(), "test-org", "/test-project/managers").
+				GetGroupIDByPath(gomock.Any(), "test-org", "/test-project/system:managers").
 				Return("managers-group-id", nil)
 
 			mockClient.EXPECT().
@@ -338,7 +338,7 @@ var _ = Describe("ResourceManager", func() {
 
 		It("should remove user from managers group", func() {
 			mockClient.EXPECT().
-				GetGroupIDByPath(gomock.Any(), "test-org", "/test-project/managers").
+				GetGroupIDByPath(gomock.Any(), "test-org", "/test-project/system:managers").
 				Return("managers-group-id", nil)
 
 			mockClient.EXPECT().
@@ -351,7 +351,7 @@ var _ = Describe("ResourceManager", func() {
 
 		It("should remove user from viewers group", func() {
 			mockClient.EXPECT().
-				GetGroupIDByPath(gomock.Any(), "test-org", "/test-project/viewers").
+				GetGroupIDByPath(gomock.Any(), "test-org", "/test-project/system:viewers").
 				Return("viewers-group-id", nil)
 
 			mockClient.EXPECT().
@@ -388,7 +388,7 @@ var _ = Describe("ResourceManager", func() {
 
 		It("should return error when group lookup fails", func() {
 			mockClient.EXPECT().
-				GetGroupIDByPath(gomock.Any(), "test-org", "/test-project/managers").
+				GetGroupIDByPath(gomock.Any(), "test-org", "/test-project/system:managers").
 				Return("", errors.New("group not found"))
 
 			err := manager.RemoveUserFromProjectGroup(ctx, "test-org", "test-project", "user-123", GroupNameManagers)
@@ -398,7 +398,7 @@ var _ = Describe("ResourceManager", func() {
 
 		It("should return error when removing user from group fails", func() {
 			mockClient.EXPECT().
-				GetGroupIDByPath(gomock.Any(), "test-org", "/test-project/managers").
+				GetGroupIDByPath(gomock.Any(), "test-org", "/test-project/system:managers").
 				Return("managers-group-id", nil)
 
 			mockClient.EXPECT().


### PR DESCRIPTION
## Summary

The built-in authorization group names `viewers` and `managers` can clash with user-created project
names. For example, if a user creates a project named "managers", the service will attempt to create
a Keycloak group with the same name as the built-in one, causing failures or unexpected behavior.

This adds a `system:` prefix to the built-in group name constants, changing them to
`system:viewers` and `system:managers`. The colon character is not allowed in DNS labels, so
user-created project names can never collide with these prefixed names.

## Test plan

- [x] Unit tests pass for `internal/idp`, `internal/idp/keycloak`, and
  `internal/controllers/project` packages (179 tests).
- [x] All pre-commit hooks pass, including `golangci-lint`.

Related: https://redhat.atlassian.net/browse/OSAC-1579

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Project access groups now use the `system:` prefix, making viewer and manager group names more consistent across hierarchies.
  * Group path examples and guidance have been updated to reflect the new naming format.

* **Bug Fixes**
  * Improved consistency in project group creation, lookup, and deletion behavior for nested projects.
  * Updated project validation and activation handling to align with the revised group naming scheme.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->