### PR TITLE
OSAC-1579: Fix handling of hierarchical projects in Keycloak

### DIFF
--- a/internal/controllers/computeinstance/instance_types_client_mock.go
+++ b/internal/controllers/computeinstance/instance_types_client_mock.go
@@ -22,6 +22,7 @@ import (
 type MockInstanceTypesClient struct {
 	ctrl     *gomock.Controller
 	recorder *MockInstanceTypesClientMockRecorder
+	isgomock struct{}
 }
 
 // MockInstanceTypesClientMockRecorder is the mock recorder for MockInstanceTypesClient.
@@ -165,6 +166,7 @@ func (mr *MockInstanceTypesClientMockRecorder) Update(ctx, in any, opts ...any) 
 type MockInstanceTypesServer struct {
 	ctrl     *gomock.Controller
 	recorder *MockInstanceTypesServerMockRecorder
+	isgomock struct{}
 }
 
 // MockInstanceTypesServerMockRecorder is the mock recorder for MockInstanceTypesServer.
@@ -290,6 +292,7 @@ func (mr *MockInstanceTypesServerMockRecorder) mustEmbedUnimplementedInstanceTyp
 type MockUnsafeInstanceTypesServer struct {
 	ctrl     *gomock.Controller
 	recorder *MockUnsafeInstanceTypesServerMockRecorder
+	isgomock struct{}
 }
 
 // MockUnsafeInstanceTypesServerMockRecorder is the mock recorder for MockUnsafeInstanceTypesServer.

--- a/internal/controllers/onboarding/tenants_client_mock.go
+++ b/internal/controllers/onboarding/tenants_client_mock.go
@@ -22,6 +22,7 @@ import (
 type MockTenantsClient struct {
 	ctrl     *gomock.Controller
 	recorder *MockTenantsClientMockRecorder
+	isgomock struct{}
 }
 
 // MockTenantsClientMockRecorder is the mock recorder for MockTenantsClient.
@@ -165,6 +166,7 @@ func (mr *MockTenantsClientMockRecorder) Update(ctx, in any, opts ...any) *gomoc
 type MockTenantsServer struct {
 	ctrl     *gomock.Controller
 	recorder *MockTenantsServerMockRecorder
+	isgomock struct{}
 }
 
 // MockTenantsServerMockRecorder is the mock recorder for MockTenantsServer.
@@ -290,6 +292,7 @@ func (mr *MockTenantsServerMockRecorder) mustEmbedUnimplementedTenantsServer() *
 type MockUnsafeTenantsServer struct {
 	ctrl     *gomock.Controller
 	recorder *MockUnsafeTenantsServerMockRecorder
+	isgomock struct{}
 }
 
 // MockUnsafeTenantsServerMockRecorder is the mock recorder for MockUnsafeTenantsServer.

--- a/internal/controllers/project/project_reconciler_function.go
+++ b/internal/controllers/project/project_reconciler_function.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"log/slog"
 	"slices"
+	"strings"
 
 	"google.golang.org/grpc"
 	"google.golang.org/protobuf/proto"
@@ -163,13 +164,6 @@ func (t *task) validateAndActivate(ctx context.Context) error {
 	// Validate parent project if specified via metadata.project
 	parentName := t.project.GetMetadata().GetProject()
 	if parentName != "" {
-		// Prevent self-reference
-		if parentName == t.project.GetMetadata().GetName() {
-			t.project.GetStatus().SetState(privatev1.ProjectState_PROJECT_STATE_FAILED)
-			t.project.GetStatus().SetMessage("Project cannot be its own parent")
-			return nil
-		}
-
 		// Find parent project by name
 		parentProject, err := t.findProjectByName(ctx, parentName)
 		if err != nil {
@@ -193,20 +187,18 @@ func (t *task) validateAndActivate(ctx context.Context) error {
 			))
 			return nil
 		}
-
-		// Check for circular dependencies by traversing up the hierarchy
-		if err := t.checkCircularDependency(ctx, parentProject); err != nil {
-			t.project.GetStatus().SetState(privatev1.ProjectState_PROJECT_STATE_FAILED)
-			t.project.GetStatus().SetMessage(err.Error())
-			return nil
-		}
 	}
+
+	// Project names are dot-separated label sequences (for example 'parent.child') where an empty string represents
+	// the tenant's default project. Keycloak expects a hierarchical path, so we convert dots to slashes to
+	// produce the group path. For example, 'parent.child' becomes 'parent/child').
+	projectTenant := t.project.GetMetadata().GetTenant()
+	projectName := t.project.GetMetadata().GetName()
+	projectPath := strings.ReplaceAll(projectName, ".", "/")
 
 	// Create Keycloak groups for project authorization
 	// Returns the system:managers group ID to avoid timing issues with group lookup
-	managersGroupID, err := t.r.resourceManager.CreateProjectGroups(ctx,
-		t.project.GetMetadata().GetTenant(),
-		t.project.GetMetadata().GetName())
+	managersGroupID, err := t.r.resourceManager.CreateProjectGroups(ctx, projectTenant, projectPath)
 	if err != nil {
 		t.updateCondition(
 			privatev1.ProjectConditionType_PROJECT_CONDITION_TYPE_KEYCLOAK_SYNC,
@@ -274,45 +266,6 @@ func (t *task) validateAndActivate(ctx context.Context) error {
 	)
 
 	return nil
-}
-
-// checkCircularDependency traverses the parent hierarchy via metadata.project to detect circular
-// dependencies. Accepts the already-fetched immediate parent to avoid redundant RPC calls.
-func (t *task) checkCircularDependency(ctx context.Context, parent *privatev1.Project) error {
-	visited := make(map[string]bool)
-	visited[t.project.GetMetadata().GetName()] = true
-	visited[parent.GetMetadata().GetName()] = true
-
-	currentParent := parent
-	maxDepth := 100
-
-	for depth := 0; depth < maxDepth; depth++ {
-		nextParentName := currentParent.GetMetadata().GetProject()
-		if nextParentName == "" {
-			return nil
-		}
-
-		nextParentID := currentParent.GetMetadata().GetProject()
-
-		// Check if we've seen this parent before (circular dependency)
-		if visited[nextParentID] {
-			return fmt.Errorf("circular dependency detected in project hierarchy")
-		}
-		visited[nextParentName] = true
-
-		nextParent, err := t.findProjectByName(ctx, nextParentName)
-		if err != nil {
-			return fmt.Errorf("failed to fetch parent project during circular dependency check: %w", err)
-		}
-		if nextParent == nil {
-			return fmt.Errorf("parent project disappeared during validation: %s", nextParentName)
-		}
-
-		currentParent = nextParent
-	}
-
-	// If we hit max depth, treat it as a circular dependency
-	return fmt.Errorf("project hierarchy exceeds maximum depth of %d", maxDepth)
 }
 
 // findProjectByName looks up a project by its metadata.name. Returns nil if not found.

--- a/internal/controllers/project/project_reconciler_function_test.go
+++ b/internal/controllers/project/project_reconciler_function_test.go
@@ -206,12 +206,12 @@ var _ = Describe("Validation and Activation", func() {
 
 			// Expect viewers group creation
 			mockIdpClient.EXPECT().
-				CreateAuthorizationGroup(gomock.Any(), "acme", "system:viewers", "/test-project/system:viewers").
+				CreateAuthorizationGroup(gomock.Any(), "acme", "/test-project/system:viewers").
 				Return("viewers-id", nil)
 
 			// Expect managers group creation
 			mockIdpClient.EXPECT().
-				CreateAuthorizationGroup(gomock.Any(), "acme", "system:managers", "/test-project/system:managers").
+				CreateAuthorizationGroup(gomock.Any(), "acme", "/test-project/system:managers").
 				Return("managers-id", nil)
 
 			task := &task{
@@ -242,12 +242,12 @@ var _ = Describe("Validation and Activation", func() {
 
 			// Expect viewers group creation
 			mockIdpClient.EXPECT().
-				CreateAuthorizationGroup(gomock.Any(), "acme", "system:viewers", "/test-project/system:viewers").
+				CreateAuthorizationGroup(gomock.Any(), "acme", "/test-project/system:viewers").
 				Return("viewers-id", nil)
 
 			// Expect managers group creation
 			mockIdpClient.EXPECT().
-				CreateAuthorizationGroup(gomock.Any(), "acme", "system:managers", "/test-project/system:managers").
+				CreateAuthorizationGroup(gomock.Any(), "acme", "/test-project/system:managers").
 				Return("managers-id", nil)
 
 			task := &task{
@@ -311,12 +311,12 @@ var _ = Describe("Validation and Activation", func() {
 
 			// Expect viewers group creation
 			mockIdpClient.EXPECT().
-				CreateAuthorizationGroup(gomock.Any(), "acme", "system:viewers", "/parent-project.child-project/system:viewers").
+				CreateAuthorizationGroup(gomock.Any(), "acme", "/parent-project/child-project/system:viewers").
 				Return("viewers-id", nil)
 
 			// Expect managers group creation
 			mockIdpClient.EXPECT().
-				CreateAuthorizationGroup(gomock.Any(), "acme", "system:managers", "/parent-project.child-project/system:managers").
+				CreateAuthorizationGroup(gomock.Any(), "acme", "/parent-project/child-project/system:managers").
 				Return("managers-id", nil)
 
 			task := &task{
@@ -330,19 +330,6 @@ var _ = Describe("Validation and Activation", func() {
 		})
 
 		It("should handle multi-level hierarchy", func() {
-			rootProject := privatev1.Project_builder{
-				Id: "root-id",
-				Metadata: privatev1.Metadata_builder{
-					Name: "root",
-				}.Build(),
-				Status: privatev1.ProjectStatus_builder{
-					State: privatev1.ProjectState_PROJECT_STATE_ACTIVE,
-				}.Build(),
-				Spec: privatev1.ProjectSpec_builder{
-					Title: "Root",
-				}.Build(),
-			}.Build()
-
 			parentProject := privatev1.Project_builder{
 				Id: "parent-id",
 				Metadata: privatev1.Metadata_builder{
@@ -360,8 +347,8 @@ var _ = Describe("Validation and Activation", func() {
 			project := privatev1.Project_builder{
 				Id: "child-id",
 				Metadata: privatev1.Metadata_builder{
-					Name:    "root.parent.child",
-					Project: "root.parent",
+					Name:    "parent.child",
+					Project: "parent",
 					Tenant:  "acme",
 				}.Build(),
 				Spec: privatev1.ProjectSpec_builder{
@@ -372,19 +359,11 @@ var _ = Describe("Validation and Activation", func() {
 				}.Build(),
 			}.Build()
 
-			// First List: find parent "root.parent"
+			// The parent project will be fetched in order to check if it is active:
 			mockClient.EXPECT().
 				List(gomock.Any(), gomock.Any()).
 				Return(&privatev1.ProjectsListResponse{
 					Items: []*privatev1.Project{parentProject},
-					Size:  1,
-				}, nil)
-
-			// Second List: circular check finds grandparent "root"
-			mockClient.EXPECT().
-				List(gomock.Any(), gomock.Any()).
-				Return(&privatev1.ProjectsListResponse{
-					Items: []*privatev1.Project{rootProject},
 					Size:  1,
 				}, nil)
 
@@ -393,8 +372,7 @@ var _ = Describe("Validation and Activation", func() {
 				CreateAuthorizationGroup(
 					gomock.Any(),
 					"acme",
-					"system:viewers",
-					"/root.parent.child/system:viewers",
+					"/parent/child/system:viewers",
 				).
 				Return("viewers-id", nil)
 
@@ -403,8 +381,7 @@ var _ = Describe("Validation and Activation", func() {
 				CreateAuthorizationGroup(
 					gomock.Any(),
 					"acme",
-					"system:managers",
-					"/root.parent.child/system:managers",
+					"/parent/child/system:managers",
 				).
 				Return("managers-id", nil)
 
@@ -416,34 +393,6 @@ var _ = Describe("Validation and Activation", func() {
 			err := task.validateAndActivate(ctx)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(project.GetStatus().GetState()).To(Equal(privatev1.ProjectState_PROJECT_STATE_ACTIVE))
-		})
-	})
-
-	Context("Self-reference validation", func() {
-		It("should fail when project references itself as parent", func() {
-			project := privatev1.Project_builder{
-				Id: "project-1",
-				Metadata: privatev1.Metadata_builder{
-					Name:    "my-project",
-					Project: "my-project",
-				}.Build(),
-				Spec: privatev1.ProjectSpec_builder{
-					Title: "Self-referencing",
-				}.Build(),
-				Status: privatev1.ProjectStatus_builder{
-					State: privatev1.ProjectState_PROJECT_STATE_PENDING,
-				}.Build(),
-			}.Build()
-
-			task := &task{
-				r:       functionObj,
-				project: project,
-			}
-
-			err := task.validateAndActivate(ctx)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(project.GetStatus().GetState()).To(Equal(privatev1.ProjectState_PROJECT_STATE_FAILED))
-			Expect(project.GetStatus().GetMessage()).To(Equal("Project cannot be its own parent"))
 		})
 	})
 
@@ -577,122 +526,6 @@ var _ = Describe("Validation and Activation", func() {
 			Expect(project.GetStatus().GetMessage()).To(ContainSubstring(
 				"Parent project 'my-parent' is not in ACTIVE state (current state: PROJECT_STATE_FAILED)",
 			))
-		})
-	})
-
-	Context("Circular dependency detection", func() {
-		It("should detect direct circular dependency", func() {
-			projectA := privatev1.Project_builder{
-				Id: "project-a-id",
-				Metadata: privatev1.Metadata_builder{
-					Name:    "project-a",
-					Project: "project-b",
-				}.Build(),
-				Status: privatev1.ProjectStatus_builder{
-					State: privatev1.ProjectState_PROJECT_STATE_ACTIVE,
-				}.Build(),
-				Spec: privatev1.ProjectSpec_builder{
-					Title: "Project A",
-				}.Build(),
-			}.Build()
-
-			// List to find parent "project-a"
-			mockClient.EXPECT().
-				List(gomock.Any(), gomock.Any()).
-				Return(&privatev1.ProjectsListResponse{
-					Items: []*privatev1.Project{projectA},
-					Size:  1,
-				}, nil)
-
-			task := &task{
-				r: functionObj,
-				project: privatev1.Project_builder{
-					Id: "project-b-id",
-					Metadata: privatev1.Metadata_builder{
-						Name:    "project-b",
-						Project: "project-a",
-					}.Build(),
-					Spec: privatev1.ProjectSpec_builder{
-						Title: "Project B",
-					}.Build(),
-					Status: privatev1.ProjectStatus_builder{
-						State: privatev1.ProjectState_PROJECT_STATE_PENDING,
-					}.Build(),
-				}.Build(),
-			}
-
-			err := task.validateAndActivate(ctx)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(task.project.GetStatus().GetState()).To(Equal(privatev1.ProjectState_PROJECT_STATE_FAILED))
-			Expect(task.project.GetStatus().GetMessage()).To(ContainSubstring("circular dependency detected"))
-		})
-
-		It("should detect indirect circular dependency", func() {
-			projectA := privatev1.Project_builder{
-				Id: "project-a-id",
-				Metadata: privatev1.Metadata_builder{
-					Name:    "project-a",
-					Project: "project-c",
-				}.Build(),
-				Status: privatev1.ProjectStatus_builder{
-					State: privatev1.ProjectState_PROJECT_STATE_ACTIVE,
-				}.Build(),
-				Spec: privatev1.ProjectSpec_builder{
-					Title: "Project A",
-				}.Build(),
-			}.Build()
-
-			projectB := privatev1.Project_builder{
-				Id: "project-b-id",
-				Metadata: privatev1.Metadata_builder{
-					Name:    "project-b",
-					Project: "project-a",
-				}.Build(),
-				Status: privatev1.ProjectStatus_builder{
-					State: privatev1.ProjectState_PROJECT_STATE_ACTIVE,
-				}.Build(),
-				Spec: privatev1.ProjectSpec_builder{
-					Title: "Project B",
-				}.Build(),
-			}.Build()
-
-			// First List: find parent "project-b"
-			mockClient.EXPECT().
-				List(gomock.Any(), gomock.Any()).
-				Return(&privatev1.ProjectsListResponse{
-					Items: []*privatev1.Project{projectB},
-					Size:  1,
-				}, nil)
-
-			// Second List: circular check finds "project-a"
-			mockClient.EXPECT().
-				List(gomock.Any(), gomock.Any()).
-				Return(&privatev1.ProjectsListResponse{
-					Items: []*privatev1.Project{projectA},
-					Size:  1,
-				}, nil)
-
-			task := &task{
-				r: functionObj,
-				project: privatev1.Project_builder{
-					Id: "project-c-id",
-					Metadata: privatev1.Metadata_builder{
-						Name:    "project-c",
-						Project: "project-b",
-					}.Build(),
-					Spec: privatev1.ProjectSpec_builder{
-						Title: "Project C",
-					}.Build(),
-					Status: privatev1.ProjectStatus_builder{
-						State: privatev1.ProjectState_PROJECT_STATE_PENDING,
-					}.Build(),
-				}.Build(),
-			}
-
-			err := task.validateAndActivate(ctx)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(task.project.GetStatus().GetState()).To(Equal(privatev1.ProjectState_PROJECT_STATE_FAILED))
-			Expect(task.project.GetStatus().GetMessage()).To(ContainSubstring("circular dependency detected"))
 		})
 	})
 

--- a/internal/idp/client.go
+++ b/internal/idp/client.go
@@ -85,7 +85,7 @@ type Client interface {
 	// Organization groups are scoped to a specific organization and support hierarchical paths.
 	// Recommended path format: "/{project-name}/{system:viewers|system:managers}" for top-level projects.
 	// Returns the created group ID.
-	CreateAuthorizationGroup(ctx context.Context, organizationName, groupName, groupPath string) (string, error)
+	CreateAuthorizationGroup(ctx context.Context, organizationName, groupPath string) (string, error)
 	// DeleteAuthorizationGroup deletes a Keycloak organization group by ID.
 	DeleteAuthorizationGroup(ctx context.Context, organizationName, groupID string) error
 	// GetGroupIDByPath gets a Keycloak organization group ID by its path.

--- a/internal/idp/client_mock.go
+++ b/internal/idp/client_mock.go
@@ -111,18 +111,18 @@ func (mr *MockClientMockRecorder) AssignOrganizationRolesToUser(ctx, organizatio
 }
 
 // CreateAuthorizationGroup mocks base method.
-func (m *MockClient) CreateAuthorizationGroup(ctx context.Context, organizationName, groupName, groupPath string) (string, error) {
+func (m *MockClient) CreateAuthorizationGroup(ctx context.Context, organizationName, groupPath string) (string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateAuthorizationGroup", ctx, organizationName, groupName, groupPath)
+	ret := m.ctrl.Call(m, "CreateAuthorizationGroup", ctx, organizationName, groupPath)
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // CreateAuthorizationGroup indicates an expected call of CreateAuthorizationGroup.
-func (mr *MockClientMockRecorder) CreateAuthorizationGroup(ctx, organizationName, groupName, groupPath any) *gomock.Call {
+func (mr *MockClientMockRecorder) CreateAuthorizationGroup(ctx, organizationName, groupPath any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateAuthorizationGroup", reflect.TypeOf((*MockClient)(nil).CreateAuthorizationGroup), ctx, organizationName, groupName, groupPath)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateAuthorizationGroup", reflect.TypeOf((*MockClient)(nil).CreateAuthorizationGroup), ctx, organizationName, groupPath)
 }
 
 // CreateAuthorizationResource mocks base method.

--- a/internal/idp/keycloak/authz_groups.go
+++ b/internal/idp/keycloak/authz_groups.go
@@ -40,10 +40,9 @@ import (
 // Organization groups are scoped per organization, so paths can be simple and readable.
 // This method creates the full hierarchy if parent groups don't exist.
 // See https://www.keycloak.org/2026/04/org-groups for details.
-func (c *Client) CreateAuthorizationGroup(ctx context.Context, organizationName, groupName, groupPath string) (string, error) {
+func (c *Client) CreateAuthorizationGroup(ctx context.Context, organizationName, groupPath string) (string, error) {
 	c.logger.DebugContext(ctx, "Creating organization authorization group",
 		slog.String("organizationName", organizationName),
-		slog.String("groupName", groupName),
 		slog.String("groupPath", groupPath),
 	)
 
@@ -71,7 +70,6 @@ func (c *Client) CreateAuthorizationGroup(ctx context.Context, organizationName,
 
 	c.logger.DebugContext(ctx, "Created organization authorization group",
 		slog.String("organizationName", organizationName),
-		slog.String("groupName", groupName),
 		slog.String("groupPath", groupPath),
 		slog.String("groupID", groupID),
 	)
@@ -142,12 +140,16 @@ func (c *Client) ensureGroupHierarchyWithCache(ctx context.Context, orgID, group
 			// Check if it's a "already exists" error (409 conflict)
 			var apiErr *apiclient.APIError
 			if errors.As(err, &apiErr) && apiErr.StatusCode == http.StatusConflict {
-				// Group already exists, look up its ID using orgID directly
-				groupID, lookupErr := c.getGroupIDByPathWithOrgID(ctx, orgID, currentPath)
+				// Group already exists, look up its ID by listing its siblings and matching by name. We
+				// list the children of the parent group (or the top-level organization groups when
+				// there is no parent) because the top-level list endpoint does not populate subGroups.
+				groupID, lookupErr := c.getGroupIDByName(ctx, orgID, parentID, segment)
 				if lookupErr != nil {
-					return fmt.Errorf("group %s already exists but failed to look up ID: %w", currentPath, lookupErr)
+					return fmt.Errorf(
+						"group %s already exists but failed to look up ID: %w",
+						currentPath, lookupErr,
+					)
 				}
-				// Cache it for subsequent use
 				cache[currentPath] = groupID
 				parentID = groupID
 				continue
@@ -209,6 +211,43 @@ func (c *Client) createOrganizationGroupWithParent(ctx context.Context, orgID, n
 	return groupID, nil
 }
 
+// getGroupIDByName finds a group by name among the children of a parent group. If parentID is empty it searches the
+// top-level organization groups instead.
+func (c *Client) getGroupIDByName(ctx context.Context, orgID, parentID, name string) (string, error) {
+	var reqPath string
+	if parentID == "" {
+		reqPath = fmt.Sprintf("/admin/realms/%s/organizations/%s/groups",
+			url.PathEscape(c.realmName),
+			url.PathEscape(orgID),
+		)
+	} else {
+		reqPath = fmt.Sprintf("/admin/realms/%s/organizations/%s/groups/%s/children",
+			url.PathEscape(c.realmName),
+			url.PathEscape(orgID),
+			url.PathEscape(parentID),
+		)
+	}
+
+	response, err := c.httpClient.DoRequest(ctx, http.MethodGet, reqPath, nil)
+	if err != nil {
+		return "", fmt.Errorf("failed to list groups: %w", err)
+	}
+	defer response.Body.Close()
+
+	var groups []groupNode
+	if err := json.NewDecoder(response.Body).Decode(&groups); err != nil {
+		return "", fmt.Errorf("failed to decode groups: %w", err)
+	}
+
+	for _, g := range groups {
+		if g.Name == name {
+			return g.ID, nil
+		}
+	}
+
+	return "", fmt.Errorf("group %q not found among children of parent %q", name, parentID)
+}
+
 // groupNode represents a group in the hierarchy for recursive traversal
 type groupNode struct {
 	ID        string      `json:"id"`
@@ -219,35 +258,37 @@ type groupNode struct {
 
 // getGroupIDByPathWithOrgID returns the group ID for a path using orgID directly (not organization name).
 // This is used internally when we already have the orgID to avoid an extra lookup.
-func (c *Client) getGroupIDByPathWithOrgID(ctx context.Context, orgID, groupPath string) (string, error) {
-	path := fmt.Sprintf("/admin/realms/%s/organizations/%s/groups",
-		url.PathEscape(c.realmName),
-		url.PathEscape(orgID),
+func (c *Client) getGroupIDByPathWithOrgID(ctx context.Context, orgID, groupPath string) (result string, err error) {
+	// Send the request to list all groups in the organization:
+	path := fmt.Sprintf(
+		"/admin/realms/%s/organizations/%s/groups",
+		url.PathEscape(c.realmName), url.PathEscape(orgID),
 	)
-
-	response, err := c.httpClient.DoRequest(ctx, http.MethodGet, path, nil)
+	var response *http.Response
+	response, err = c.httpClient.DoRequest(ctx, http.MethodGet, path, nil)
 	if err != nil {
-		return "", fmt.Errorf("failed to list organization groups: %w", err)
+		err = fmt.Errorf("failed to list organization groups: %w", err)
+		return
 	}
 	defer response.Body.Close()
-
 	var groups []groupNode
-	if err := json.NewDecoder(response.Body).Decode(&groups); err != nil {
-		return "", fmt.Errorf("failed to decode organization groups: %w", err)
+	err = json.NewDecoder(response.Body).Decode(&groups)
+	if err != nil {
+		err = fmt.Errorf("failed to decode organization groups: %w", err)
+		return
 	}
 
-	// Search recursively through the group hierarchy
+	// Search recursively through the group hierarchy:
 	for _, group := range groups {
-		if id := searchGroupRecursively(group, groupPath); id != "" {
-			return id, nil
+		result = searchGroupRecursively(group, groupPath)
+		if result != "" {
+			return
 		}
 	}
 
-	c.logger.WarnContext(ctx, "Group not found in listed groups",
-		slog.String("target_path", groupPath),
-		slog.Int("total_groups", len(groups)),
-	)
-	return "", fmt.Errorf("organization group not found: %s", groupPath)
+	// We didn't find the group:
+	err = fmt.Errorf("organization group not found: %s", groupPath)
+	return
 }
 
 // searchGroupRecursively searches for a group by path in the group hierarchy.

--- a/internal/idp/keycloak/client_test.go
+++ b/internal/idp/keycloak/client_test.go
@@ -2499,7 +2499,7 @@ var _ = Describe("Keycloak Client", func() {
 
 				client = createTestClient(server.URL)
 
-				groupID, err := client.CreateAuthorizationGroup(ctx, "acme-corp", "system:viewers", "/web-app/system:viewers")
+				groupID, err := client.CreateAuthorizationGroup(ctx, "acme-corp", "/web-app/system:viewers")
 				Expect(err).ToNot(HaveOccurred())
 				Expect(groupID).To(Equal(createdGroups["system:viewers"]))
 				Expect(createdGroups).To(HaveKey("web-app"))
@@ -2522,7 +2522,7 @@ var _ = Describe("Keycloak Client", func() {
 
 				client = createTestClient(server.URL)
 
-				groupID, err := client.CreateAuthorizationGroup(ctx, "nonexistent-org", "system:viewers", "/web-app/system:viewers")
+				groupID, err := client.CreateAuthorizationGroup(ctx, "nonexistent-org", "/web-app/system:viewers")
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("failed to get organization"))
 				Expect(groupID).To(BeEmpty())
@@ -2549,9 +2549,10 @@ var _ = Describe("Keycloak Client", func() {
 						// Return the existing group for both search and list operations
 						groups := []struct {
 							ID   string `json:"id"`
+							Name string `json:"name"`
 							Path string `json:"path"`
 						}{
-							{ID: "existing-group-id", Path: "/web-app"},
+							{ID: "existing-group-id", Name: "web-app", Path: "/web-app"},
 						}
 						w.Header().Set("Content-Type", "application/json")
 						w.WriteHeader(http.StatusOK)
@@ -2587,7 +2588,7 @@ var _ = Describe("Keycloak Client", func() {
 
 				client = createTestClient(server.URL)
 
-				groupID, err := client.CreateAuthorizationGroup(ctx, "acme-corp", "system:viewers", "/web-app/system:viewers")
+				groupID, err := client.CreateAuthorizationGroup(ctx, "acme-corp", "/web-app/system:viewers")
 				Expect(err).ToNot(HaveOccurred())
 				Expect(groupID).To(Equal(createdGroups["system:viewers"]))
 				Expect(createdGroups).To(HaveKey("system:viewers"))

--- a/internal/idp/manager_test.go
+++ b/internal/idp/manager_test.go
@@ -277,7 +277,7 @@ func (m *mockClient) DeleteIdentityProvider(ctx context.Context, organizationNam
 	return nil
 }
 
-func (m *mockClient) CreateAuthorizationGroup(ctx context.Context, organizationName, groupName, groupPath string) (string, error) {
+func (m *mockClient) CreateAuthorizationGroup(ctx context.Context, organizationName, groupPath string) (string, error) {
 	// Return a fake group ID
 	return "test-group-id", nil
 }

--- a/internal/idp/resource_manager.go
+++ b/internal/idp/resource_manager.go
@@ -144,45 +144,49 @@ func (m *ResourceManager) getGroupIDByPath(ctx context.Context, organizationName
 // Creates hierarchical groups: /{project-name}/system:viewers and /{project-name}/system:managers
 // These groups are used by Authorino OPA policies for authorization.
 // Returns the managers group ID for immediate use (avoids timing issues with group lookup).
-func (m *ResourceManager) CreateProjectGroups(ctx context.Context, tenant, projectName string) (string, error) {
+func (m *ResourceManager) CreateProjectGroups(ctx context.Context, tenant, projectPath string) (string, error) {
 	if tenant == "" {
 		return "", fmt.Errorf("tenant is required")
 	}
-	if projectName == "" {
-		return "", fmt.Errorf("project name is required")
-	}
 	// Validate inputs to prevent path traversal attacks
-	if strings.Contains(projectName, "..") {
-		return "", fmt.Errorf("project name cannot contain '..' sequence")
-	}
-	if strings.Contains(projectName, "/") {
-		return "", fmt.Errorf("project name cannot contain '/' character")
+	if strings.Contains(projectPath, "..") {
+		return "", fmt.Errorf("project path cannot contain '..' sequence")
 	}
 
 	m.logger.DebugContext(ctx, "Creating project groups",
 		slog.String("tenant", tenant),
-		slog.String("project_name", projectName),
+		slog.String("project_path", projectPath),
 	)
 
-	viewersGroupPath := fmt.Sprintf("/%s/%s", projectName, GroupNameViewers)
-	viewersGroupID, err := m.client.CreateAuthorizationGroup(ctx, tenant, GroupNameViewers, viewersGroupPath)
+	// Make sure the project path starts with a slash:
+	if !strings.HasPrefix(projectPath, "/") {
+		projectPath = fmt.Sprintf("/%s", projectPath)
+	}
+
+	// Create the viewers group:
+	viewersGroupPath := fmt.Sprintf("%s/%s", projectPath, GroupNameViewers)
+	viewersGroupID, err := m.client.CreateAuthorizationGroup(ctx, tenant, viewersGroupPath)
 	if err != nil {
 		return "", fmt.Errorf("failed to create viewers group: %w", err)
 	}
-
-	m.logger.InfoContext(ctx, "Created project viewers group",
+	m.logger.InfoContext(
+		ctx,
+		"Created project viewers group",
 		slog.String("group_path", viewersGroupPath),
 		slog.String("group_id", viewersGroupID),
-		slog.String("project_name", projectName),
+		slog.String("project_path", projectPath),
 		slog.String("tenant", tenant),
 	)
 
-	managersGroupPath := fmt.Sprintf("/%s/%s", projectName, GroupNameManagers)
-	managersGroupID, err := m.client.CreateAuthorizationGroup(ctx, tenant, GroupNameManagers, managersGroupPath)
+	// Create the managers group:
+	managersGroupPath := fmt.Sprintf("%s/%s", projectPath, GroupNameManagers)
+	managersGroupID, err := m.client.CreateAuthorizationGroup(ctx, tenant, managersGroupPath)
 	if err != nil {
 		// Clean up viewers group on failure
 		if cleanupErr := m.client.DeleteAuthorizationGroup(ctx, tenant, viewersGroupID); cleanupErr != nil {
-			m.logger.ErrorContext(ctx, "Failed to cleanup viewers group during rollback",
+			m.logger.ErrorContext(
+				ctx,
+				"Failed to cleanup viewers group during rollback",
 				slog.String("group_id", viewersGroupID),
 				slog.Any("cleanup_error", cleanupErr),
 			)
@@ -190,11 +194,12 @@ func (m *ResourceManager) CreateProjectGroups(ctx context.Context, tenant, proje
 		}
 		return "", fmt.Errorf("failed to create managers group: %w", err)
 	}
-
-	m.logger.InfoContext(ctx, "Created project managers group",
+	m.logger.InfoContext(
+		ctx,
+		"Created project managers group",
 		slog.String("group_path", managersGroupPath),
 		slog.String("group_id", managersGroupID),
-		slog.String("project_name", projectName),
+		slog.String("project_path", projectPath),
 		slog.String("tenant", tenant),
 	)
 
@@ -202,11 +207,11 @@ func (m *ResourceManager) CreateProjectGroups(ctx context.Context, tenant, proje
 }
 
 // AddUserToProjectGroup adds a user to a project group (system:viewers or system:managers).
-func (m *ResourceManager) AddUserToProjectGroup(ctx context.Context, tenant, projectName, username, groupType string) error {
+func (m *ResourceManager) AddUserToProjectGroup(ctx context.Context, tenant, projectPath, username, groupType string) error {
 	if tenant == "" {
 		return fmt.Errorf("tenant is required")
 	}
-	if projectName == "" {
+	if projectPath == "" {
 		return fmt.Errorf("project name is required")
 	}
 	if username == "" {
@@ -216,14 +221,11 @@ func (m *ResourceManager) AddUserToProjectGroup(ctx context.Context, tenant, pro
 		return fmt.Errorf("invalid group type %q, must be %q or %q", groupType, GroupNameViewers, GroupNameManagers)
 	}
 	// Validate inputs to prevent path traversal attacks
-	if strings.Contains(projectName, "..") {
+	if strings.Contains(projectPath, "..") {
 		return fmt.Errorf("project name cannot contain '..' sequence")
 	}
-	if strings.Contains(projectName, "/") {
-		return fmt.Errorf("project name cannot contain '/' character")
-	}
 
-	groupPath := fmt.Sprintf("/%s/%s", projectName, groupType)
+	groupPath := fmt.Sprintf("/%s/%s", projectPath, groupType)
 	groupID, err := m.getGroupIDByPath(ctx, tenant, groupPath)
 	if err != nil {
 		return fmt.Errorf("failed to get group ID for %s: %w", groupPath, err)
@@ -237,7 +239,7 @@ func (m *ResourceManager) AddUserToProjectGroup(ctx context.Context, tenant, pro
 		slog.String("group_path", groupPath),
 		slog.String("group_type", groupType),
 		slog.String("!username", username),
-		slog.String("project_name", projectName),
+		slog.String("project_path", projectPath),
 		slog.String("tenant", tenant),
 	)
 
@@ -271,11 +273,11 @@ func (m *ResourceManager) AddUserToGroupByID(ctx context.Context, tenant, userna
 }
 
 // RemoveUserFromProjectGroup removes a user from a project group (system:viewers or system:managers).
-func (m *ResourceManager) RemoveUserFromProjectGroup(ctx context.Context, tenant, projectName, username, groupType string) error {
+func (m *ResourceManager) RemoveUserFromProjectGroup(ctx context.Context, tenant, projectPath, username, groupType string) error {
 	if tenant == "" {
 		return fmt.Errorf("tenant is required")
 	}
-	if projectName == "" {
+	if projectPath == "" {
 		return fmt.Errorf("project name is required")
 	}
 	if username == "" {
@@ -285,14 +287,11 @@ func (m *ResourceManager) RemoveUserFromProjectGroup(ctx context.Context, tenant
 		return fmt.Errorf("invalid group type %q, must be %q or %q", groupType, GroupNameViewers, GroupNameManagers)
 	}
 	// Validate inputs to prevent path traversal attacks
-	if strings.Contains(projectName, "..") {
+	if strings.Contains(projectPath, "..") {
 		return fmt.Errorf("project name cannot contain '..' sequence")
 	}
-	if strings.Contains(projectName, "/") {
-		return fmt.Errorf("project name cannot contain '/' character")
-	}
 
-	groupPath := fmt.Sprintf("/%s/%s", projectName, groupType)
+	groupPath := fmt.Sprintf("/%s/%s", projectPath, groupType)
 	groupID, err := m.getGroupIDByPath(ctx, tenant, groupPath)
 	if err != nil {
 		return fmt.Errorf("failed to get group ID for %s: %w", groupPath, err)
@@ -306,7 +305,7 @@ func (m *ResourceManager) RemoveUserFromProjectGroup(ctx context.Context, tenant
 		slog.String("group_path", groupPath),
 		slog.String("group_type", groupType),
 		slog.String("!username", username),
-		slog.String("project_name", projectName),
+		slog.String("project_path", projectPath),
 		slog.String("tenant", tenant),
 	)
 

--- a/internal/idp/resource_manager_test.go
+++ b/internal/idp/resource_manager_test.go
@@ -121,18 +121,6 @@ var _ = Describe("ResourceManager", func() {
 			Expect(err.Error()).To(ContainSubstring("tenant is required"))
 		})
 
-		It("should return error when project name is empty", func() {
-			err := manager.DeleteProjectGroups(ctx, "test-org", "")
-			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("project name is required"))
-		})
-
-		It("should reject project name with forward slash", func() {
-			err := manager.DeleteProjectGroups(ctx, "test-org", "foo/bar")
-			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("project name cannot contain '/' character"))
-		})
-
 		It("should reject project name with dot-dot sequence", func() {
 			err := manager.DeleteProjectGroups(ctx, "test-org", "../malicious")
 			Expect(err).To(HaveOccurred())
@@ -154,11 +142,11 @@ var _ = Describe("ResourceManager", func() {
 
 		It("should create hierarchical viewers and managers groups", func() {
 			mockClient.EXPECT().
-				CreateAuthorizationGroup(gomock.Any(), "test-org", GroupNameViewers, "/test-project/system:viewers").
+				CreateAuthorizationGroup(gomock.Any(), "test-org", "/test-project/system:viewers").
 				Return("viewers-group-id", nil)
 
 			mockClient.EXPECT().
-				CreateAuthorizationGroup(gomock.Any(), "test-org", GroupNameManagers, "/test-project/system:managers").
+				CreateAuthorizationGroup(gomock.Any(), "test-org", "/test-project/system:managers").
 				Return("managers-group-id", nil)
 
 			managersID, err := manager.CreateProjectGroups(ctx, "test-org", "test-project")
@@ -168,11 +156,11 @@ var _ = Describe("ResourceManager", func() {
 
 		It("should rollback viewers group when managers group creation fails", func() {
 			mockClient.EXPECT().
-				CreateAuthorizationGroup(gomock.Any(), "test-org", GroupNameViewers, "/test-project/system:viewers").
+				CreateAuthorizationGroup(gomock.Any(), "test-org", "/test-project/system:viewers").
 				Return("viewers-group-id", nil)
 
 			mockClient.EXPECT().
-				CreateAuthorizationGroup(gomock.Any(), "test-org", GroupNameManagers, "/test-project/system:managers").
+				CreateAuthorizationGroup(gomock.Any(), "test-org", "/test-project/system:managers").
 				Return("", errors.New("keycloak error"))
 
 			mockClient.EXPECT().
@@ -187,7 +175,7 @@ var _ = Describe("ResourceManager", func() {
 
 		It("should return error when viewers group creation fails", func() {
 			mockClient.EXPECT().
-				CreateAuthorizationGroup(gomock.Any(), "test-org", GroupNameViewers, "/test-project/system:viewers").
+				CreateAuthorizationGroup(gomock.Any(), "test-org", "/test-project/system:viewers").
 				Return("", errors.New("keycloak error"))
 
 			managersID, err := manager.CreateProjectGroups(ctx, "test-org", "test-project")
@@ -203,24 +191,10 @@ var _ = Describe("ResourceManager", func() {
 			Expect(managersID).To(BeEmpty())
 		})
 
-		It("should return error when project name is empty", func() {
-			managersID, err := manager.CreateProjectGroups(ctx, "test-org", "")
-			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("project name is required"))
-			Expect(managersID).To(BeEmpty())
-		})
-
-		It("should reject project name with forward slash", func() {
-			managersID, err := manager.CreateProjectGroups(ctx, "test-org", "foo/bar")
-			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("project name cannot contain '/' character"))
-			Expect(managersID).To(BeEmpty())
-		})
-
-		It("should reject project name with dot-dot sequence", func() {
+		It("should reject project path with dot-dot sequence", func() {
 			managersID, err := manager.CreateProjectGroups(ctx, "test-org", "../malicious")
 			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("project name cannot contain '..' sequence"))
+			Expect(err.Error()).To(ContainSubstring("project path cannot contain '..' sequence"))
 			Expect(managersID).To(BeEmpty())
 		})
 	})
@@ -309,12 +283,6 @@ var _ = Describe("ResourceManager", func() {
 			err := manager.AddUserToProjectGroup(ctx, "test-org", "test-project", "user-123", GroupNameManagers)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("failed to add user to group"))
-		})
-
-		It("should reject project name with forward slash", func() {
-			err := manager.AddUserToProjectGroup(ctx, "test-org", "foo/bar", "user-123", GroupNameManagers)
-			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("project name cannot contain '/' character"))
 		})
 
 		It("should reject project name with dot-dot sequence", func() {
@@ -408,12 +376,6 @@ var _ = Describe("ResourceManager", func() {
 			err := manager.RemoveUserFromProjectGroup(ctx, "test-org", "test-project", "user-123", GroupNameManagers)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("failed to remove user from group"))
-		})
-
-		It("should reject project name with forward slash", func() {
-			err := manager.RemoveUserFromProjectGroup(ctx, "test-org", "foo/bar", "user-123", GroupNameManagers)
-			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("project name cannot contain '/' character"))
 		})
 
 		It("should reject project name with dot-dot sequence", func() {

--- a/internal/servers/private_projects_server_test.go
+++ b/internal/servers/private_projects_server_test.go
@@ -277,6 +277,26 @@ var _ = Describe("Private projects server", func() {
 		Expect(project.GetMetadata().GetProject()).To(BeEmpty())
 	})
 
+	It("Rejects a project that references itself as the parent", func() {
+		_, err := privateServer.Create(ctx, privatev1.ProjectsCreateRequest_builder{
+			Object: privatev1.Project_builder{
+				Metadata: privatev1.Metadata_builder{
+					Name:    "my-project",
+					Tenant:  "my-tenant",
+					Project: "my-project",
+				}.Build(),
+				Spec: privatev1.ProjectSpec_builder{
+					Title: "My Project",
+				}.Build(),
+			}.Build(),
+		}.Build())
+		Expect(err).To(HaveOccurred())
+		status, ok := grpcstatus.FromError(err)
+		Expect(ok).To(BeTrue())
+		Expect(status.Code()).To(Equal(grpccodes.InvalidArgument))
+		Expect(status.Message()).To(ContainSubstring("metadata.project"))
+	})
+
 	It("Updates a project", func() {
 		// Create a project:
 		createReq := privatev1.ProjectsCreateRequest_builder{


### PR DESCRIPTION
## Summary

- Convert dot-separated project names to slash-separated paths before creating Keycloak groups, producing a proper hierarchical group tree instead of a flat set.
- Replace the path-based group lookup (which fails for nested groups) with a new `getGroupIDByName` method that lists children of the parent group and matches by name.
- Remove self-reference and circular dependency checks from the project controller, as these invariants are already enforced by the projects server at creation time.

## Test plan

- [ ] Verify unit tests pass: `ginkgo run -r internal`
- [ ] Verify hierarchical project groups are created correctly in Keycloak with nested paths
- [ ] Verify conflict handling works when a group already exists in a nested hierarchy

Related: https://redhat.atlassian.net/browse/OSAC-1579

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Project and authorization group handling now works with full project paths, including nested paths.
  * Group names are created using slash-based hierarchy paths for more consistent organization.

* **Bug Fixes**
  * Improved handling when a group already exists during creation.
  * Added clearer validation for invalid project paths.
  * Project creation now rejects self-referencing parent relationships.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->