### PR TITLE
NO-ISSUE: Decouple reflection package from config package

### DIFF
--- a/internal/cmd/cli/annotate/annotate_cmd.go
+++ b/internal/cmd/cli/annotate/annotate_cmd.go
@@ -85,6 +85,7 @@ func (c *runnerContext) run(cmd *cobra.Command, args []string) error {
 		SetLogger(c.logger).
 		SetConnection(c.conn).
 		AddPackages(cfg.Packages()).
+		SetTenantFunc(config.TenantFromContext).
 		Build()
 	if err != nil {
 		return fmt.Errorf("failed to create reflection tool: %w", err)

--- a/internal/cmd/cli/create/baremetalinstance/create_bare_metal_instance_cmd.go
+++ b/internal/cmd/cli/create/baremetalinstance/create_bare_metal_instance_cmd.go
@@ -24,7 +24,6 @@ import (
 	publicv1 "github.com/osac-project/fulfillment-service/internal/api/osac/public/v1"
 	"github.com/osac-project/fulfillment-service/internal/config"
 	"github.com/osac-project/fulfillment-service/internal/logging"
-	"github.com/osac-project/fulfillment-service/internal/reflection"
 	"github.com/osac-project/fulfillment-service/internal/terminal"
 )
 
@@ -104,16 +103,6 @@ func (c *runnerContext) run(cmd *cobra.Command, _ []string) error {
 		return fmt.Errorf("failed to create gRPC connection: %w", err)
 	}
 	defer conn.Close()
-
-	helper, err := reflection.NewHelper().
-		SetLogger(c.logger).
-		SetConnection(conn).
-		AddPackages(cfg.Packages()).
-		Build()
-	if err != nil {
-		return fmt.Errorf("failed to create reflection tool: %w", err)
-	}
-	console.SetHelper(helper)
 
 	spec := publicv1.BareMetalInstanceSpec_builder{
 		CatalogItem: c.args.catalogItem,

--- a/internal/cmd/cli/create/cluster/create_cluster_cmd.go
+++ b/internal/cmd/cli/create/cluster/create_cluster_cmd.go
@@ -154,6 +154,7 @@ type runnerContext struct {
 	}
 	logger          *slog.Logger
 	console         *terminal.Console
+	settings        *config.Settings
 	templatesClient publicv1.ClusterTemplatesClient
 	clustersClient  publicv1.ClustersClient
 }
@@ -189,13 +190,13 @@ func (c *runnerContext) run(cmd *cobra.Command, args []string) error {
 	}
 
 	// Get the configuration:
-	cfg := config.SettingsFromContext(ctx)
-	if !cfg.Armed() {
+	c.settings = config.SettingsFromContext(ctx)
+	if !c.settings.Armed() {
 		return fmt.Errorf("there is no configuration, run the 'login' command")
 	}
 
 	// Create the gRPC connection from the configuration:
-	conn, err := cfg.Connect(ctx, cmd.Flags())
+	conn, err := c.settings.Connect(ctx, cmd.Flags())
 	if err != nil {
 		return fmt.Errorf("failed to create gRPC connection: %w", err)
 	}
@@ -205,7 +206,8 @@ func (c *runnerContext) run(cmd *cobra.Command, args []string) error {
 	helper, err := reflection.NewHelper().
 		SetLogger(c.logger).
 		SetConnection(conn).
-		AddPackages(cfg.Packages()).
+		AddPackages(c.settings.Packages()).
+		SetTenantFunc(config.TenantFromContext).
 		Build()
 	if err != nil {
 		return fmt.Errorf("failed to create reflection tool: %w", err)
@@ -317,7 +319,7 @@ func (c *runnerContext) createCluster(ctx context.Context, spec *publicv1.Cluste
 	cluster := publicv1.Cluster_builder{
 		Metadata: publicv1.Metadata_builder{
 			Name:   c.args.name,
-			Tenant: config.TenantFromContext(ctx),
+			Tenant: c.settings.Tenant(),
 		}.Build(),
 		Spec: spec,
 	}.Build()

--- a/internal/cmd/cli/create/computeinstance/create_compute_instance_cmd.go
+++ b/internal/cmd/cli/create/computeinstance/create_compute_instance_cmd.go
@@ -192,6 +192,7 @@ type runnerContext struct {
 	}
 	logger                 *slog.Logger
 	console                *terminal.Console
+	settings               *config.Settings
 	templatesClient        publicv1.ComputeInstanceTemplatesClient
 	computeInstancesClient publicv1.ComputeInstancesClient
 }
@@ -227,13 +228,13 @@ func (c *runnerContext) run(cmd *cobra.Command, args []string) error {
 	}
 
 	// Get the configuration:
-	cfg := config.SettingsFromContext(ctx)
-	if !cfg.Armed() {
+	c.settings = config.SettingsFromContext(ctx)
+	if !c.settings.Armed() {
 		return fmt.Errorf("there is no configuration, run the 'login' command")
 	}
 
 	// Create the gRPC connection from the configuration:
-	conn, err := cfg.Connect(ctx, cmd.Flags())
+	conn, err := c.settings.Connect(ctx, cmd.Flags())
 	if err != nil {
 		return fmt.Errorf("failed to create gRPC connection: %w", err)
 	}
@@ -243,7 +244,8 @@ func (c *runnerContext) run(cmd *cobra.Command, args []string) error {
 	helper, err := reflection.NewHelper().
 		SetLogger(c.logger).
 		SetConnection(conn).
-		AddPackages(cfg.Packages()).
+		AddPackages(c.settings.Packages()).
+		SetTenantFunc(config.TenantFromContext).
 		Build()
 	if err != nil {
 		return fmt.Errorf("failed to create reflection tool: %w", err)
@@ -264,7 +266,7 @@ func (c *runnerContext) run(cmd *cobra.Command, args []string) error {
 		computeInstance := publicv1.ComputeInstance_builder{
 			Metadata: publicv1.Metadata_builder{
 				Name:   c.args.name,
-				Tenant: config.TenantFromContext(ctx),
+				Tenant: c.settings.Tenant(),
 			}.Build(),
 			Spec: specResult,
 		}.Build()

--- a/internal/cmd/cli/create/create_cmd.go
+++ b/internal/cmd/cli/create/create_cmd.go
@@ -84,9 +84,10 @@ type runnerContext struct {
 	args struct {
 		file string
 	}
-	logger  *slog.Logger
-	console *terminal.Console
-	conn    *grpc.ClientConn
+	logger   *slog.Logger
+	console  *terminal.Console
+	settings *config.Settings
+	conn     *grpc.ClientConn
 }
 
 func (c *runnerContext) run(cmd *cobra.Command, args []string) error {
@@ -98,14 +99,14 @@ func (c *runnerContext) run(cmd *cobra.Command, args []string) error {
 	c.console = terminal.ConsoleFromContext(ctx)
 
 	// Get the configuration:
-	cfg := config.SettingsFromContext(ctx)
-	if !cfg.Armed() {
+	c.settings = config.SettingsFromContext(ctx)
+	if !c.settings.Armed() {
 		return fmt.Errorf("there is no configuration, run the 'login' command")
 	}
 
 	// Create the gRPC connection from the configuration:
 	var err error
-	c.conn, err = cfg.Connect(ctx, cmd.Flags())
+	c.conn, err = c.settings.Connect(ctx, cmd.Flags())
 	if err != nil {
 		return fmt.Errorf("failed to create gRPC connection: %w", err)
 	}
@@ -115,7 +116,8 @@ func (c *runnerContext) run(cmd *cobra.Command, args []string) error {
 	helper, err := reflection.NewHelper().
 		SetLogger(c.logger).
 		SetConnection(c.conn).
-		AddPackages(cfg.Packages()).
+		AddPackages(c.settings.Packages()).
+		SetTenantFunc(config.TenantFromContext).
 		Build()
 	if err != nil {
 		return fmt.Errorf("failed to create reflection tool: %w", err)

--- a/internal/cmd/cli/create/publicip/create_publicip_cmd.go
+++ b/internal/cmd/cli/create/publicip/create_publicip_cmd.go
@@ -63,8 +63,9 @@ type runnerContext struct {
 		name string
 		pool string
 	}
-	logger  *slog.Logger
-	console *terminal.Console
+	logger   *slog.Logger
+	console  *terminal.Console
+	settings *config.Settings
 }
 
 func (c *runnerContext) run(cmd *cobra.Command, args []string) error {
@@ -73,12 +74,12 @@ func (c *runnerContext) run(cmd *cobra.Command, args []string) error {
 	c.logger = logging.LoggerFromContext(ctx)
 	c.console = terminal.ConsoleFromContext(ctx)
 
-	cfg := config.SettingsFromContext(ctx)
-	if !cfg.Armed() {
+	c.settings = config.SettingsFromContext(ctx)
+	if !c.settings.Armed() {
 		return fmt.Errorf("there is no configuration, run the 'login' command")
 	}
 
-	conn, err := cfg.Connect(ctx, cmd.Flags())
+	conn, err := c.settings.Connect(ctx, cmd.Flags())
 	if err != nil {
 		return fmt.Errorf("failed to create gRPC connection: %w", err)
 	}
@@ -105,8 +106,11 @@ func (c *runnerContext) run(cmd *cobra.Command, args []string) error {
 		Pool: pool.GetId(),
 	}
 	publicIP := publicv1.PublicIP_builder{
-		Metadata: publicv1.Metadata_builder{Name: c.args.name, Tenant: config.TenantFromContext(ctx)}.Build(),
-		Spec:     spec.Build(),
+		Metadata: publicv1.Metadata_builder{
+			Name:   c.args.name,
+			Tenant: c.settings.Tenant(),
+		}.Build(),
+		Spec: spec.Build(),
 	}.Build()
 
 	response, err := client.Create(ctx, publicv1.PublicIPsCreateRequest_builder{Object: publicIP}.Build())

--- a/internal/cmd/cli/create/securitygroup/create_securitygroup_cmd.go
+++ b/internal/cmd/cli/create/securitygroup/create_securitygroup_cmd.go
@@ -78,8 +78,9 @@ type runnerContext struct {
 		ingressRules   []string
 		egressRules    []string
 	}
-	logger  *slog.Logger
-	console *terminal.Console
+	logger   *slog.Logger
+	console  *terminal.Console
+	settings *config.Settings
 }
 
 func (c *runnerContext) run(cmd *cobra.Command, args []string) error {
@@ -88,8 +89,8 @@ func (c *runnerContext) run(cmd *cobra.Command, args []string) error {
 	c.logger = logging.LoggerFromContext(ctx)
 	c.console = terminal.ConsoleFromContext(ctx)
 
-	cfg := config.SettingsFromContext(ctx)
-	if !cfg.Armed() {
+	c.settings = config.SettingsFromContext(ctx)
+	if !c.settings.Armed() {
 		return fmt.Errorf("there is no configuration, run the 'login' command")
 	}
 
@@ -106,7 +107,7 @@ func (c *runnerContext) run(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("invalid egress rule: %w", err)
 	}
 
-	conn, err := cfg.Connect(ctx, cmd.Flags())
+	conn, err := c.settings.Connect(ctx, cmd.Flags())
 	if err != nil {
 		return fmt.Errorf("failed to create gRPC connection: %w", err)
 	}
@@ -130,7 +131,10 @@ func (c *runnerContext) run(cmd *cobra.Command, args []string) error {
 	client := publicv1.NewSecurityGroupsClient(conn)
 
 	sg := publicv1.SecurityGroup_builder{
-		Metadata: publicv1.Metadata_builder{Name: c.args.name, Tenant: config.TenantFromContext(ctx)}.Build(),
+		Metadata: publicv1.Metadata_builder{
+			Name:   c.args.name,
+			Tenant: c.settings.Tenant(),
+		}.Build(),
 		Spec: publicv1.SecurityGroupSpec_builder{
 			VirtualNetwork: vn.GetId(),
 			Ingress:        ingress,

--- a/internal/cmd/cli/create/subnet/create_subnet_cmd.go
+++ b/internal/cmd/cli/create/subnet/create_subnet_cmd.go
@@ -75,8 +75,9 @@ type runnerContext struct {
 		ipv4Cidr       string
 		ipv6Cidr       string
 	}
-	logger  *slog.Logger
-	console *terminal.Console
+	logger   *slog.Logger
+	console  *terminal.Console
+	settings *config.Settings
 }
 
 func (c *runnerContext) run(cmd *cobra.Command, args []string) error {
@@ -85,8 +86,8 @@ func (c *runnerContext) run(cmd *cobra.Command, args []string) error {
 	c.logger = logging.LoggerFromContext(ctx)
 	c.console = terminal.ConsoleFromContext(ctx)
 
-	cfg := config.SettingsFromContext(ctx)
-	if !cfg.Armed() {
+	c.settings = config.SettingsFromContext(ctx)
+	if !c.settings.Armed() {
 		return fmt.Errorf("there is no configuration, run the 'login' command")
 	}
 
@@ -97,7 +98,7 @@ func (c *runnerContext) run(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	conn, err := cfg.Connect(ctx, cmd.Flags())
+	conn, err := c.settings.Connect(ctx, cmd.Flags())
 	if err != nil {
 		return fmt.Errorf("failed to create gRPC connection: %w", err)
 	}
@@ -130,8 +131,11 @@ func (c *runnerContext) run(cmd *cobra.Command, args []string) error {
 		spec.Ipv6Cidr = &c.args.ipv6Cidr
 	}
 	subnet := publicv1.Subnet_builder{
-		Metadata: publicv1.Metadata_builder{Name: c.args.name, Tenant: config.TenantFromContext(ctx)}.Build(),
-		Spec:     spec.Build(),
+		Metadata: publicv1.Metadata_builder{
+			Name:   c.args.name,
+			Tenant: c.settings.Tenant(),
+		}.Build(),
+		Spec: spec.Build(),
 	}.Build()
 
 	response, err := client.Create(ctx, publicv1.SubnetsCreateRequest_builder{Object: subnet}.Build())

--- a/internal/cmd/cli/create/virtualnetwork/create_virtualnetwork_cmd.go
+++ b/internal/cmd/cli/create/virtualnetwork/create_virtualnetwork_cmd.go
@@ -74,8 +74,9 @@ type runnerContext struct {
 		ipv4Cidr     string
 		ipv6Cidr     string
 	}
-	logger  *slog.Logger
-	console *terminal.Console
+	logger   *slog.Logger
+	console  *terminal.Console
+	settings *config.Settings
 }
 
 func (c *runnerContext) run(cmd *cobra.Command, args []string) error {
@@ -84,8 +85,8 @@ func (c *runnerContext) run(cmd *cobra.Command, args []string) error {
 	c.logger = logging.LoggerFromContext(ctx)
 	c.console = terminal.ConsoleFromContext(ctx)
 
-	cfg := config.SettingsFromContext(ctx)
-	if !cfg.Armed() {
+	c.settings = config.SettingsFromContext(ctx)
+	if !c.settings.Armed() {
 		return fmt.Errorf("there is no configuration, run the 'login' command")
 	}
 
@@ -96,7 +97,7 @@ func (c *runnerContext) run(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	conn, err := cfg.Connect(ctx, cmd.Flags())
+	conn, err := c.settings.Connect(ctx, cmd.Flags())
 	if err != nil {
 		return fmt.Errorf("failed to create gRPC connection: %w", err)
 	}
@@ -123,8 +124,11 @@ func (c *runnerContext) run(cmd *cobra.Command, args []string) error {
 		spec.Ipv6Cidr = &c.args.ipv6Cidr
 	}
 	vn := publicv1.VirtualNetwork_builder{
-		Metadata: publicv1.Metadata_builder{Name: c.args.name, Tenant: config.TenantFromContext(ctx)}.Build(),
-		Spec:     spec.Build(),
+		Metadata: publicv1.Metadata_builder{
+			Name:   c.args.name,
+			Tenant: c.settings.Tenant(),
+		}.Build(),
+		Spec: spec.Build(),
 	}.Build()
 
 	response, err := client.Create(ctx, publicv1.VirtualNetworksCreateRequest_builder{Object: vn}.Build())

--- a/internal/cmd/cli/delete/delete_cmd.go
+++ b/internal/cmd/cli/delete/delete_cmd.go
@@ -90,6 +90,7 @@ func (c *runnerContext) run(cmd *cobra.Command, args []string) error {
 		SetLogger(c.logger).
 		SetConnection(c.conn).
 		AddPackages(cfg.Packages()).
+		SetTenantFunc(config.TenantFromContext).
 		Build()
 	if err != nil {
 		return fmt.Errorf("failed to create reflection tool: %w", err)

--- a/internal/cmd/cli/edit/edit_cmd.go
+++ b/internal/cmd/cli/edit/edit_cmd.go
@@ -115,6 +115,7 @@ func (c *runnerContext) run(cmd *cobra.Command, args []string) error {
 		SetLogger(c.logger).
 		SetConnection(c.conn).
 		AddPackages(cfg.Packages()).
+		SetTenantFunc(config.TenantFromContext).
 		Build()
 	if err != nil {
 		return fmt.Errorf("failed to create reflection tool: %w", err)

--- a/internal/cmd/cli/get/get_cmd.go
+++ b/internal/cmd/cli/get/get_cmd.go
@@ -143,6 +143,7 @@ func (c *runnerContext) run(cmd *cobra.Command, args []string) error {
 		SetLogger(c.logger).
 		SetConnection(c.conn).
 		AddPackages(cfg.Packages()).
+		SetTenantFunc(config.TenantFromContext).
 		Build()
 	if err != nil {
 		return fmt.Errorf("failed to create reflection tool: %w", err)

--- a/internal/cmd/cli/label/label_cmd.go
+++ b/internal/cmd/cli/label/label_cmd.go
@@ -85,6 +85,7 @@ func (c *runnerContext) run(cmd *cobra.Command, args []string) error {
 		SetLogger(c.logger).
 		SetConnection(c.conn).
 		AddPackages(cfg.Packages()).
+		SetTenantFunc(config.TenantFromContext).
 		Build()
 	if err != nil {
 		return fmt.Errorf("failed to create reflection tool: %w", err)

--- a/internal/cmd/cli/tenant/tenant_cmd.go
+++ b/internal/cmd/cli/tenant/tenant_cmd.go
@@ -174,6 +174,7 @@ func (c *runnerContext) findTenant(cmd *cobra.Command, settings *config.Settings
 		SetLogger(c.logger).
 		SetConnection(conn).
 		AddPackages(settings.Packages()).
+		SetTenantFunc(config.TenantFromContext).
 		Build()
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to create reflection tool: %w", err)

--- a/internal/config/config_settings_test.go
+++ b/internal/config/config_settings_test.go
@@ -164,16 +164,16 @@ var _ = Describe("Settings", func() {
 		})
 
 		It("Skips save when tokens have not changed", func(ctx context.Context) {
-			cfg, err := NewSettings().
+			settings, err := NewSettings().
 				SetLogger(logger).
 				SetDir(tmp).
 				Build()
 			Expect(err).ToNot(HaveOccurred())
-			cfg.SetAccessToken("access-abc")
-			cfg.SetRefreshToken("refresh-xyz")
-			cfg.SetTokenExpiry(time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC))
+			settings.SetAccessToken("access-abc")
+			settings.SetRefreshToken("refresh-xyz")
+			settings.SetTokenExpiry(time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC))
 
-			store := cfg.TokenStore()
+			store := settings.TokenStore()
 			err = store.Save(ctx, &auth.Token{
 				Access:  "access-abc",
 				Refresh: "refresh-xyz",

--- a/internal/reflection/reflection_functions.go
+++ b/internal/reflection/reflection_functions.go
@@ -1,0 +1,119 @@
+/*
+Copyright (c) 2026 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package reflection
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+)
+
+// NormalizeFunc takes a function value and wraps it into the canonical form func(context.Context) (T, error). The input
+// function must match one of the following signatures, where T is the type parameter:
+//
+//   - func() T
+//   - func(context.Context) T
+//   - func() (T, error)
+//   - func(context.Context) (T, error)
+func NormalizeFunc[T any](fn any) (result func(context.Context) (T, error), err error) {
+	// Check that the value is a non-nil function:
+	fnType := reflect.TypeOf(fn)
+	if fnType == nil || fnType.Kind() != reflect.Func {
+		err = fmt.Errorf("expected a function, got %T", fn)
+		return
+	}
+	fnValue := reflect.ValueOf(fn)
+	if fnValue.IsNil() {
+		err = fmt.Errorf("expected a non-nil function, got nil %s", fnType)
+		return
+	}
+	resultType := reflect.TypeFor[T]()
+
+	// Check if the function has a context parameter:
+	var hasCtx, hasErr bool
+	switch fnType.NumIn() {
+	case 0:
+		hasCtx = false
+	case 1:
+		if fnType.In(0) != contextType {
+			err = fmt.Errorf(
+				"function must have a context.Context parameter, but has %s",
+				fnType.In(0),
+			)
+			return
+		}
+		hasCtx = true
+	default:
+		err = fmt.Errorf(
+			"function must have at most one input parameter, but has %d",
+			fnType.NumIn(),
+		)
+		return
+	}
+
+	// Check if the function has a error return value:
+	switch fnType.NumOut() {
+	case 1:
+		if fnType.Out(0) != resultType {
+			err = fmt.Errorf(
+				"function must return %s, but returns %s",
+				resultType, fnType.Out(0),
+			)
+			return
+		}
+		hasErr = false
+	case 2:
+		if fnType.Out(0) != resultType || fnType.Out(1) != errorType {
+			err = fmt.Errorf(
+				"function must return %s and error, but returns %s and %s",
+				resultType, fnType.Out(0), fnType.Out(1),
+			)
+			return
+		}
+		hasErr = true
+	default:
+		err = fmt.Errorf(
+			"function must return at most two values, but returns %d",
+			fnType.NumOut(),
+		)
+		return
+	}
+
+	// Create a new function that calls the original function with the context parameter:
+	result = func(ctx context.Context) (result T, err error) {
+		var fnArgs []reflect.Value
+		if hasCtx {
+			fnArgs = []reflect.Value{
+				reflect.ValueOf(ctx),
+			}
+		}
+		fnResults := fnValue.Call(fnArgs)
+		if hasErr && !fnResults[1].IsNil() {
+			err = fnResults[1].Interface().(error)
+			return
+		}
+		fnResult := fnResults[0].Interface()
+		if fnResult != nil {
+			result = fnResult.(T)
+		}
+		return
+	}
+	return
+}
+
+// Well-known reflection types:
+var (
+	contextType = reflect.TypeFor[context.Context]()
+	errorType   = reflect.TypeFor[error]()
+)

--- a/internal/reflection/reflection_functions_test.go
+++ b/internal/reflection/reflection_functions_test.go
@@ -1,0 +1,196 @@
+/*
+Copyright (c) 2026 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package reflection
+
+import (
+	"context"
+	"errors"
+	"io"
+
+	. "github.com/onsi/ginkgo/v2/dsl/core"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Normalize function", func() {
+	It("Accepts function without context or error", func() {
+		fn, err := NormalizeFunc[string](
+			func() string {
+				return "hello"
+			},
+		)
+		Expect(err).ToNot(HaveOccurred())
+		result, err := fn(context.Background())
+		Expect(err).ToNot(HaveOccurred())
+		Expect(result).To(Equal("hello"))
+	})
+
+	It("Accepts function with context but without error", func() {
+		fn, err := NormalizeFunc[string](
+			func(_ context.Context) string {
+				return "ctx"
+			},
+		)
+		Expect(err).ToNot(HaveOccurred())
+		result, err := fn(context.Background())
+		Expect(err).ToNot(HaveOccurred())
+		Expect(result).To(Equal("ctx"))
+	})
+
+	It("Accepts function without context but with error", func() {
+		fn, err := NormalizeFunc[string](
+			func() (result string, err error) {
+				result = "ok"
+				return
+			},
+		)
+		Expect(err).ToNot(HaveOccurred())
+		result, err := fn(context.Background())
+		Expect(err).ToNot(HaveOccurred())
+		Expect(result).To(Equal("ok"))
+	})
+
+	It("Propagates error from function without context but with error", func() {
+		fn, err := NormalizeFunc[string](
+			func() (result string, err error) {
+				err = errors.New("boom")
+				return
+			},
+		)
+		Expect(err).ToNot(HaveOccurred())
+		_, err = fn(context.Background())
+		Expect(err).To(MatchError("boom"))
+	})
+
+	It("Accepts function with context and with error", func() {
+		fn, err := NormalizeFunc[string](
+			func(_ context.Context) (result string, err error) {
+				result = "full"
+				return
+			},
+		)
+		Expect(err).ToNot(HaveOccurred())
+		result, err := fn(context.Background())
+		Expect(err).ToNot(HaveOccurred())
+		Expect(result).To(Equal("full"))
+	})
+
+	It("Propagates error from function with context and with error", func() {
+		fn, err := NormalizeFunc[string](func(_ context.Context) (string, error) {
+			return "", errors.New("ctx-boom")
+		})
+		Expect(err).ToNot(HaveOccurred())
+		_, err = fn(context.Background())
+		Expect(err).To(MatchError("ctx-boom"))
+	})
+
+	It("Works with non-string types", func() {
+		fn, err := NormalizeFunc[int](
+			func() int {
+				return 42
+			},
+		)
+		Expect(err).ToNot(HaveOccurred())
+		result, err := fn(context.Background())
+		Expect(err).ToNot(HaveOccurred())
+		Expect(result).To(Equal(42))
+	})
+
+	It("Handles nil return for interface type", func() {
+		fn, err := NormalizeFunc[io.Reader](
+			func() io.Reader {
+				return nil
+			},
+		)
+		Expect(err).ToNot(HaveOccurred())
+		result, err := fn(context.Background())
+		Expect(err).ToNot(HaveOccurred())
+		Expect(result).To(BeNil())
+	})
+
+	It("Rejects nil", func() {
+		_, err := NormalizeFunc[string](nil)
+		Expect(err).To(MatchError("expected a function, got <nil>"))
+	})
+
+	It("Rejects typed-nil function", func() {
+		var fn func() string
+		_, err := NormalizeFunc[string](fn)
+		Expect(err).To(MatchError("expected a non-nil function, got nil func() string"))
+	})
+
+	It("Rejects non-function values", func() {
+		_, err := NormalizeFunc[string]("not-a-function")
+		Expect(err).To(MatchError("expected a function, got string"))
+	})
+
+	It("Rejects functions with wrong input type", func() {
+		_, err := NormalizeFunc[string](
+			func(int) string {
+				return ""
+			},
+		)
+		Expect(err).To(MatchError("function must have a context.Context parameter, but has int"))
+	})
+
+	It("Rejects functions with wrong return type", func() {
+		_, err := NormalizeFunc[string](
+			func() int {
+				return 0
+			},
+		)
+		Expect(err).To(MatchError("function must return string, but returns int"))
+	})
+
+	It("Rejects functions with too many inputs", func() {
+		_, err := NormalizeFunc[string](
+			func(context.Context, int) string {
+				return ""
+			},
+		)
+		Expect(err).To(MatchError("function must have at most one input parameter, but has 2"))
+	})
+
+	It("Rejects functions with concrete context type", func() {
+		type myCtx struct {
+			context.Context
+		}
+		_, err := NormalizeFunc[string](
+			func(myCtx) string {
+				return ""
+			},
+		)
+		Expect(err).To(HaveOccurred())
+	})
+
+	It("Rejects functions with concrete error type", func() {
+		type myErr struct {
+			error
+		}
+		_, err := NormalizeFunc[string](
+			func() (string, *myErr) {
+				return "", nil
+			},
+		)
+		Expect(err).To(HaveOccurred())
+	})
+
+	It("Rejects functions with too many outputs", func() {
+		_, err := NormalizeFunc[string](
+			func() (string, int, error) {
+				return "", 0, nil
+			},
+		)
+		Expect(err).To(MatchError("function must return at most two values, but returns 3"))
+	})
+})

--- a/internal/reflection/reflection_helper.go
+++ b/internal/reflection/reflection_helper.go
@@ -29,8 +29,6 @@ import (
 	"google.golang.org/protobuf/reflect/protoreflect"
 	"google.golang.org/protobuf/reflect/protoregistry"
 
-	"github.com/osac-project/fulfillment-service/internal/config"
-
 	// This is needed to ensure that the types and services are loaded into the protocol buffers registry, otherwise
 	// they will be visible only if they are explicitly used in some part of the code.
 	_ "github.com/osac-project/fulfillment-service/internal/api/osac/private/v1"
@@ -88,6 +86,7 @@ type HelperBuilder struct {
 	logger     *slog.Logger
 	connection *grpc.ClientConn
 	packages   map[string]int
+	tenantFunc any
 }
 
 // helper is the default implementation of the Helper interface.
@@ -97,6 +96,7 @@ type helper struct {
 	packages   map[protoreflect.FullName]int
 	scanOnce   *sync.Once
 	helpers    []objectHelper
+	tenantFunc func(context.Context) (string, error)
 }
 
 // NewHelper creates a builder that can then be used to configure a reflection helper.
@@ -138,6 +138,21 @@ func (b *HelperBuilder) AddPackages(values map[string]int) *HelperBuilder {
 	return b
 }
 
+// SetTenantFunc sets the function that returns the tenant. When this is set the helper will call the function to obtain
+// the tenant, and if it isn't empty, it will use it to automatically filter the results by tenant, as well as to set
+// automatically the tenant on new objects. The function can be of the following types:
+//
+//   - func() string
+//   - func(context.Context) string
+//   - func() (string, error)
+//   - func(context.Context) (string, error)
+//
+// The Build method will verify that the function matches one of these signatures.
+func (b *HelperBuilder) SetTenantFunc(value any) *HelperBuilder {
+	b.tenantFunc = value
+	return b
+}
+
 // Build uses the data stored in the builder to create a new reflection helper.
 func (b *HelperBuilder) Build() (result Helper, err error) {
 	// Check the parameters:
@@ -154,6 +169,15 @@ func (b *HelperBuilder) Build() (result Helper, err error) {
 		return
 	}
 
+	// Normalize the tenant function to a canonical signature:
+	var tenantFunc func(context.Context) (string, error)
+	if b.tenantFunc != nil {
+		tenantFunc, err = NormalizeFunc[string](b.tenantFunc)
+		if err != nil {
+			return
+		}
+	}
+
 	// Prepare the set of packages:
 	packages := make(map[protoreflect.FullName]int, len(b.packages))
 	for name, order := range b.packages {
@@ -167,6 +191,7 @@ func (b *HelperBuilder) Build() (result Helper, err error) {
 		connection: b.connection,
 		scanOnce:   &sync.Once{},
 		helpers:    []objectHelper{},
+		tenantFunc: tenantFunc,
 	}
 	return
 }
@@ -633,14 +658,20 @@ type ListResult struct {
 func (h *objectHelper) List(ctx context.Context, options ListOptions) (result ListResult, err error) {
 	filter := options.Filter
 
-	// Inject tenant filter from context if present:
-	tenant := config.TenantFromContext(ctx)
-	if tenant != "" && h.tenantScoped {
-		tenantFilter := fmt.Sprintf("this.metadata.tenant == %q", tenant)
-		if filter != "" {
-			filter = fmt.Sprintf("%s && (%s)", tenantFilter, filter)
-		} else {
-			filter = tenantFilter
+	// Inject tenant filter from tenant function if needed:
+	if h.IsTenantScoped() && h.parent.tenantFunc != nil {
+		var tenant string
+		tenant, err = h.parent.tenantFunc(ctx)
+		if err != nil {
+			return
+		}
+		if tenant != "" {
+			tenantFilter := fmt.Sprintf("this.metadata.tenant == %q", tenant)
+			if filter != "" {
+				filter = fmt.Sprintf("%s && (%s)", tenantFilter, filter)
+			} else {
+				filter = tenantFilter
+			}
 		}
 	}
 

--- a/internal/reflection/reflection_helper_test.go
+++ b/internal/reflection/reflection_helper_test.go
@@ -128,6 +128,7 @@ var _ = Describe("Reflection helper", func() {
 				SetLogger(logger).
 				SetConnection(connection).
 				AddPackage(packages.PublicV1, 1).
+				SetTenantFunc(config.TenantFromContext).
 				Build()
 			Expect(err).ToNot(HaveOccurred())
 		})


### PR DESCRIPTION
## Summary

- Removes the direct dependency from the `reflection` package to the `config` package by   introducing a `SetTenantFunc` method on `HelperBuilder`. The `reflection` package is lower-level and general-purpose, while `config` is closely tied to the CLI, so the coupling risked future dependency cycles.
- Extracts a reusable `reflection.Normalizefunc[T]` generic utility that validates and normalizes functions with optional `context.Context` input and optional `error` output into a canonical `func(context.Context) (T, error)` form.
- CLI command files now pass `config.TenantFromContext` via `SetTenantFunc`, keeping the wiring in the higher-level layer.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CLI commands now use the active request context to resolve tenant-specific behavior more consistently.
  * Improved handling for resource operations like create, get, edit, label, delete, and tenant lookup.

* **Bug Fixes**
  * Fixed tenant selection for created resources so metadata is assigned from the current configuration.
  * Updated filtering and lookup behavior to better respect tenant scope during list and match operations.

* **Tests**
  * Added and updated coverage for function normalization and tenant-related reflection behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->