### PR TITLE
OSAC-1579: Normalize project paths

### DIFF
--- a/internal/idp/keycloak/authz_groups.go
+++ b/internal/idp/keycloak/authz_groups.go
@@ -62,10 +62,13 @@ func (c *Client) CreateAuthorizationGroup(ctx context.Context, tenantName, group
 		return "", fmt.Errorf("failed to ensure group hierarchy: %w", err)
 	}
 
-	// Get the created group ID from the cache
-	groupID, ok := cache[groupPath]
+	// Get the created group ID from the cache using the normalized path
+	// Normalize the path the same way ensureGroupHierarchyWithCache does
+	normalizedPath := "/" + strings.Trim(groupPath, "/")
+	normalizedPath = strings.ReplaceAll(normalizedPath, "//", "/")
+	groupID, ok := cache[normalizedPath]
 	if !ok {
-		return "", fmt.Errorf("group was created but ID not found in cache: %s", groupPath)
+		return "", fmt.Errorf("group was created but ID not found in cache: %s (normalized: %s)", groupPath, normalizedPath)
 	}
 
 	c.logger.DebugContext(ctx, "Created tenant authorization group",
@@ -114,10 +117,16 @@ func (c *Client) DeleteAuthorizationGroup(ctx context.Context, tenantName, group
 // Helper methods
 
 func (c *Client) ensureGroupHierarchyWithCache(ctx context.Context, orgID, groupPath string, cache map[string]string) error {
-	// Split path into segments (removing leading slash)
-	// "/web-app/system:viewers" -> ["web-app", "system:viewers"]
-	segments := strings.Split(strings.Trim(groupPath, "/"), "/")
-	if len(segments) == 0 {
+	// Normalize the path: remove leading/trailing slashes and collapse multiple slashes
+	// "//system:viewers" -> "system:viewers"
+	// "/web-app/system:viewers" -> "web-app/system:viewers"
+	normalizedPath := strings.Trim(groupPath, "/")
+	normalizedPath = strings.ReplaceAll(normalizedPath, "//", "/")
+
+	// Split path into segments
+	// "web-app/system:viewers" -> ["web-app", "system:viewers"]
+	segments := strings.Split(normalizedPath, "/")
+	if len(segments) == 0 || (len(segments) == 1 && segments[0] == "") {
 		return fmt.Errorf("invalid group path: %s", groupPath)
 	}
 

--- a/internal/idp/keycloak/authz_groups_test.go
+++ b/internal/idp/keycloak/authz_groups_test.go
@@ -14,9 +14,87 @@ language governing permissions and limitations under the License.
 package keycloak
 
 import (
+	"strings"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
+
+var _ = Describe("ensureGroupHierarchyWithCache path normalization", func() {
+	It("should normalize path with double leading slashes", func() {
+		// When a project path is empty, we might get "//system:viewers"
+		// This should be normalized to "/system:viewers"
+		groupPath := "//system:viewers"
+
+		// The normalization should:
+		// 1. Trim leading/trailing slashes: "system:viewers"
+		// 2. Replace double slashes: (already done after trim)
+		// 3. Split into segments: ["system:viewers"]
+		// 4. Build path as "/system:viewers"
+
+		// We expect the normalized path to be stored in cache as "/system:viewers"
+		expectedNormalizedPath := "/system:viewers"
+
+		// Verify the normalization logic matches what we expect
+		normalizedPath := strings.Trim(groupPath, "/")
+		normalizedPath = strings.ReplaceAll(normalizedPath, "//", "/")
+		Expect(normalizedPath).To(Equal("system:viewers"))
+
+		// After building the path, it should be stored with leading slash
+		segments := strings.Split(normalizedPath, "/")
+		Expect(segments).To(Equal([]string{"system:viewers"}))
+
+		builtPath := "/" + segments[0]
+		Expect(builtPath).To(Equal(expectedNormalizedPath))
+	})
+
+	It("should normalize path with double slashes", func() {
+		// The main use case is handling empty project paths that result in "//system:viewers"
+		groupPath := "/web-app//system:viewers"
+
+		normalizedPath := strings.Trim(groupPath, "/")
+		normalizedPath = strings.ReplaceAll(normalizedPath, "//", "/")
+
+		// After trimming: "web-app//system:viewers"
+		// After replacing "//": "web-app/system:viewers"
+		Expect(normalizedPath).To(Equal("web-app/system:viewers"))
+	})
+
+	It("should handle normal path without modification", func() {
+		groupPath := "/web-app/system:viewers"
+
+		normalizedPath := strings.Trim(groupPath, "/")
+		normalizedPath = strings.ReplaceAll(normalizedPath, "//", "/")
+
+		Expect(normalizedPath).To(Equal("web-app/system:viewers"))
+	})
+
+	It("should handle single segment path", func() {
+		groupPath := "/system:viewers"
+
+		normalizedPath := strings.Trim(groupPath, "/")
+		normalizedPath = strings.ReplaceAll(normalizedPath, "//", "/")
+
+		segments := strings.Split(normalizedPath, "/")
+		Expect(segments).To(Equal([]string{"system:viewers"}))
+	})
+
+	It("should detect empty path as invalid", func() {
+		groupPath := "/"
+
+		normalizedPath := strings.Trim(groupPath, "/")
+		segments := strings.Split(normalizedPath, "/")
+
+		// Empty string splits into one segment with empty string
+		Expect(segments).To(HaveLen(1))
+		Expect(segments[0]).To(Equal(""))
+
+		// This should trigger the error condition:
+		// len(segments) == 1 && segments[0] == ""
+		isInvalid := len(segments) == 0 || (len(segments) == 1 && segments[0] == "")
+		Expect(isInvalid).To(BeTrue())
+	})
+})
 
 var _ = Describe("searchGroupRecursively", func() {
 	It("should find a top-level group", func() {

--- a/internal/idp/resource_manager.go
+++ b/internal/idp/resource_manager.go
@@ -158,13 +158,19 @@ func (m *ResourceManager) CreateProjectGroups(ctx context.Context, tenant, proje
 		slog.String("project_path", projectPath),
 	)
 
-	// Make sure the project path starts with a slash:
-	if !strings.HasPrefix(projectPath, "/") {
+	// Make sure the project path starts with a slash (unless it's empty for tenant-level groups):
+	if projectPath != "" && !strings.HasPrefix(projectPath, "/") {
 		projectPath = fmt.Sprintf("/%s", projectPath)
 	}
 
 	// Create the viewers group:
-	viewersGroupPath := fmt.Sprintf("%s/%s", projectPath, GroupNameViewers)
+	var viewersGroupPath string
+	if projectPath == "" {
+		// Tenant-level project (empty name) - create group at root level
+		viewersGroupPath = fmt.Sprintf("/%s", GroupNameViewers)
+	} else {
+		viewersGroupPath = fmt.Sprintf("%s/%s", projectPath, GroupNameViewers)
+	}
 	viewersGroupID, err := m.client.CreateAuthorizationGroup(ctx, tenant, viewersGroupPath)
 	if err != nil {
 		return "", fmt.Errorf("failed to create viewers group: %w", err)
@@ -179,7 +185,13 @@ func (m *ResourceManager) CreateProjectGroups(ctx context.Context, tenant, proje
 	)
 
 	// Create the managers group:
-	managersGroupPath := fmt.Sprintf("%s/%s", projectPath, GroupNameManagers)
+	var managersGroupPath string
+	if projectPath == "" {
+		// Tenant-level project (empty name) - create group at root level
+		managersGroupPath = fmt.Sprintf("/%s", GroupNameManagers)
+	} else {
+		managersGroupPath = fmt.Sprintf("%s/%s", projectPath, GroupNameManagers)
+	}
 	managersGroupID, err := m.client.CreateAuthorizationGroup(ctx, tenant, managersGroupPath)
 	if err != nil {
 		// Clean up viewers group on failure

--- a/internal/idp/resource_manager_test.go
+++ b/internal/idp/resource_manager_test.go
@@ -197,6 +197,36 @@ var _ = Describe("ResourceManager", func() {
 			Expect(err.Error()).To(ContainSubstring("project path cannot contain '..' sequence"))
 			Expect(managersID).To(BeEmpty())
 		})
+
+		It("should handle empty project path for tenant-level groups", func() {
+			// When project path is empty, groups should be created at root level
+			// without double slashes (was "//system:viewers", should be "/system:viewers")
+			mockClient.EXPECT().
+				CreateAuthorizationGroup(gomock.Any(), "test-org", "/system:viewers").
+				Return("viewers-group-id", nil)
+
+			mockClient.EXPECT().
+				CreateAuthorizationGroup(gomock.Any(), "test-org", "/system:managers").
+				Return("managers-group-id", nil)
+
+			managersID, err := manager.CreateProjectGroups(ctx, "test-org", "")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(managersID).To(Equal("managers-group-id"))
+		})
+
+		It("should add leading slash to project path if missing", func() {
+			mockClient.EXPECT().
+				CreateAuthorizationGroup(gomock.Any(), "test-org", "/test-project/system:viewers").
+				Return("viewers-group-id", nil)
+
+			mockClient.EXPECT().
+				CreateAuthorizationGroup(gomock.Any(), "test-org", "/test-project/system:managers").
+				Return("managers-group-id", nil)
+
+			managersID, err := manager.CreateProjectGroups(ctx, "test-org", "test-project")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(managersID).To(Equal("managers-group-id"))
+		})
 	})
 
 	Describe("AddUserToProjectGroup", func() {


### PR DESCRIPTION
# Description
If a project path was empty, the final path sent to keycloak might look like this "//system:manager" which
causes the project to fail to be created.

This makes sure to remove the additional slash to "normalize" the path.

# Testing

Deployed integration environment, created tenant, get projects, verified project was created fine in Keycloak console

Assisted-by: Claude Code <noreply@anthropic.com>

/cc @jhernand (sorry I missed this in your original PR)