### PR TITLE
NO-ISSUE: Use reflection to set event payload in GenericServer

### DIFF
--- a/internal/servers/events_server.go
+++ b/internal/servers/events_server.go
@@ -59,6 +59,7 @@ type EventsServer struct {
 	celEnv       *cel.Env
 	mapper       *GenericMapper[*privatev1.Event, *publicv1.Event]
 	tenancyLogic auth.TenancyLogic
+	payloadOneof protoreflect.OneofDescriptor
 }
 
 type eventsServerSubInfo struct {
@@ -120,7 +121,13 @@ func (b *EventsServerBuilder) Build() (result *EventsServer, err error) {
 		return
 	}
 
-	// Create the object early so that whe can use its methods as callback functions:
+	// Look up the payload oneof and metadata field descriptors:
+	payloadOneof, err := b.findPayloadOneof()
+	if err != nil {
+		return
+	}
+
+	// Create the object early so that we can use its methods as callback functions:
 	result = &EventsServer{
 		logger:       b.logger,
 		listener:     b.listener,
@@ -129,7 +136,25 @@ func (b *EventsServerBuilder) Build() (result *EventsServer, err error) {
 		celEnv:       celEnv,
 		mapper:       mapper,
 		tenancyLogic: b.tenancyLogic,
+		payloadOneof: payloadOneof,
 	}
+	return
+}
+
+// findPayloadOneof returns the descriptor of the payload oneof field in the event message. Returns an error if the
+// oneof is not found.
+func (b *EventsServerBuilder) findPayloadOneof() (result protoreflect.OneofDescriptor, err error) {
+	var eventTempl *privatev1.Event
+	eventDesc := eventTempl.ProtoReflect().Descriptor()
+	payloadDesc := eventDesc.Oneofs().ByName(eventsServerPayloadOneofField)
+	if payloadDesc == nil {
+		err = fmt.Errorf(
+			"event message '%s' has no '%s' oneof",
+			eventDesc.FullName(), eventsServerPayloadOneofField,
+		)
+		return
+	}
+	result = payloadDesc
 	return
 }
 
@@ -177,6 +202,14 @@ func (b *EventsServerBuilder) createCelEnv() (result *cel.Env, err error) {
 // operation, and will return only when the context is canceled.
 func (s *EventsServer) Start(ctx context.Context) error {
 	return s.listener.Listen(ctx, s.processPayload)
+}
+
+// Subscriptions returns the number of active subscriptions. This is intended for use in tests, where it is important
+// to wait for a subscription to be registered before sending events.
+func (s *EventsServer) Subscriptions() int {
+	s.subsLock.RLock()
+	defer s.subsLock.RUnlock()
+	return len(s.subs)
 }
 
 func (s *EventsServer) Watch(request *publicv1.EventsWatchRequest,
@@ -235,7 +268,7 @@ func (s *EventsServer) Watch(request *publicv1.EventsWatchRequest,
 	s.subsLock.Lock()
 	s.subs[subId] = subInfo
 	s.subsLock.Unlock()
-	logger.DebugContext(ctx, "Created subcription")
+	logger.DebugContext(ctx, "Created subscription")
 	defer func() {
 		s.subsLock.Lock()
 		defer s.subsLock.Unlock()
@@ -327,36 +360,43 @@ func (s *EventsServer) processPayload(ctx context.Context, payload proto.Message
 	return s.processEvent(ctx, public, private)
 }
 
+// extractMetadata extracts the metadata from the event payload. Returns nil if the metadata is not found.
 func (s *EventsServer) extractMetadata(ctx context.Context, event *privatev1.Event) *privatev1.Metadata {
-	switch {
-	case event.HasCluster():
-		return event.GetCluster().GetMetadata()
-	case event.HasClusterTemplate():
-		return event.GetClusterTemplate().GetMetadata()
-	case event.HasHostType():
-		return event.GetHostType().GetMetadata()
-	case event.HasComputeInstanceTemplate():
-		return event.GetComputeInstanceTemplate().GetMetadata()
-	case event.HasComputeInstance():
-		return event.GetComputeInstance().GetMetadata()
-	case event.HasTenant():
-		return event.GetTenant().GetMetadata()
-	case event.HasUser():
-		return event.GetUser().GetMetadata()
-	case event.HasRole():
-		return event.GetRole().GetMetadata()
-	case event.HasRoleBinding():
-		return event.GetRoleBinding().GetMetadata()
-	case event.HasProject():
-		return event.GetProject().GetMetadata()
-	default:
+	payloadMessage, err := s.extractPayload(ctx, event)
+	if err != nil || payloadMessage == nil {
+		return nil
+	}
+	type payloadIface interface {
+		GetMetadata() *privatev1.Metadata
+	}
+	payload, ok := payloadMessage.(payloadIface)
+	if !ok {
 		s.logger.ErrorContext(
 			ctx,
-			"Unexpected event type",
-			slog.Any("event", event),
+			"Event payload does not have a method to get the metadata",
+			slog.Any("payload", fmt.Sprintf("%T", payloadMessage)),
 		)
 		return nil
 	}
+	return payload.GetMetadata()
+}
+
+// extractPayload extracts the payload from the event message. For example, if the event is about a cluster, it will
+// get the value of the 'cluster' field of the payload oneof. Returns nil if there is no payload.
+func (s *EventsServer) extractPayload(ctx context.Context, event *privatev1.Event) (result proto.Message, err error) {
+	eventReflect := event.ProtoReflect()
+	payloadDesc := eventReflect.WhichOneof(s.payloadOneof)
+	if payloadDesc == nil {
+		s.logger.ErrorContext(
+			ctx,
+			"Event has no payload field",
+		)
+		return
+	}
+	payloadValue := eventReflect.Get(payloadDesc)
+	payloadReflect := payloadValue.Message()
+	result = payloadReflect.Interface()
+	return
 }
 
 func (s *EventsServer) processEvent(ctx context.Context, public *publicv1.Event, private *privatev1.Event) error {
@@ -406,3 +446,8 @@ func (s *EventsServer) processEvent(ctx context.Context, public *publicv1.Event,
 	}
 	return nil
 }
+
+// Names of fields:
+const (
+	eventsServerPayloadOneofField = "payload"
+)

--- a/internal/servers/events_server_test.go
+++ b/internal/servers/events_server_test.go
@@ -69,25 +69,23 @@ func (c *eventsCollector) Events() []*publicv1.Event {
 
 var _ = Describe("Events server visibility", func() {
 	var (
-		ctrl     *gomock.Controller
 		listener *events.MockListener
 		callback events.Callback
 	)
 
 	BeforeEach(func() {
-		// Create the mock controller:
-		ctrl = gomock.NewController(GinkgoT())
-		DeferCleanup(ctrl.Finish)
-
 		// Create a mock listener that captures the callback and blocks until the context is canceled:
 		listener = events.NewMockListener(ctrl)
-		listener.EXPECT().Listen(gomock.Any(), gomock.Any()).DoAndReturn(
-			func(ctx context.Context, cb events.Callback) error {
-				callback = cb
-				<-ctx.Done()
-				return ctx.Err()
-			},
-		).AnyTimes()
+		listener.EXPECT().
+			Listen(gomock.Any(), gomock.Any()).
+			DoAndReturn(
+				func(ctx context.Context, cb events.Callback) error {
+					callback = cb
+					<-ctx.Done()
+					return ctx.Err()
+				},
+			).
+			AnyTimes()
 	})
 
 	// sendEvent delivers an event directly through the captured listener callback.
@@ -96,23 +94,9 @@ var _ = Describe("Events server visibility", func() {
 		Expect(err).ToNot(HaveOccurred())
 	}
 
-	// makeEvent builds a private event with the given tenant and project.
-	makeEvent := func(tenant string) *privatev1.Event {
-		return privatev1.Event_builder{
-			Id:   uuid.New(),
-			Type: privatev1.EventType_EVENT_TYPE_OBJECT_CREATED,
-			Cluster: privatev1.Cluster_builder{
-				Id: uuid.New(),
-				Metadata: privatev1.Metadata_builder{
-					Tenant: tenant,
-				}.Build(),
-			}.Build(),
-		}.Build()
-	}
-
 	// startServer creates an events server with the mock listener and given tenancy, starts it behind a bufconn
-	// gRPC server, and returns a connected client.
-	startServer := func(tenancy auth.TenancyLogic) publicv1.EventsClient {
+	// gRPC server, and returns the events server and a connected client.
+	startServer := func(tenancy auth.TenancyLogic) (*EventsServer, publicv1.EventsClient) {
 		// Create the events server:
 		eventsServer, err := NewEventsServer().
 			SetLogger(logger).
@@ -153,7 +137,7 @@ var _ = Describe("Events server visibility", func() {
 		Expect(err).ToNot(HaveOccurred())
 		DeferCleanup(grpcConnection.Close)
 
-		return publicv1.NewEventsClient(grpcConnection)
+		return eventsServer, publicv1.NewEventsClient(grpcConnection)
 	}
 
 	// makeTenancy creates a mock tenancy logic returning the given visible tenants:
@@ -165,54 +149,169 @@ var _ = Describe("Events server visibility", func() {
 		return mock
 	}
 
-	// startWatch opens a Watch stream and returns a collector that accumulates received events.
-	startWatch := func(client publicv1.EventsClient) (collector *eventsCollector, cancel context.CancelFunc) {
+	// startWatch opens a Watch stream, waits for the subscription to be registered server-side, and returns a
+	// collector that accumulates received events.
+	startWatch := func(server *EventsServer, client publicv1.EventsClient) (collector *eventsCollector,
+		cancel context.CancelFunc) {
+		// Start the watch stream. Note that due to the way gRPC works, this will return immediately once the
+		// transport is established, even though the subscription is not yet registered. That is why we need to
+		// explicitly wait for the subscription to be registered.
 		watchCtx, watchCancel := context.WithCancel(context.Background())
-		stream, err := client.Watch(watchCtx, publicv1.EventsWatchRequest_builder{}.Build())
+		watchStream, err := client.Watch(watchCtx, publicv1.EventsWatchRequest_builder{}.Build())
 		Expect(err).ToNot(HaveOccurred())
-		collector = &eventsCollector{}
-		collector.Collect(stream)
-		return collector, watchCancel
+
+		// Start collecting events from the stream:
+		watchCollector := &eventsCollector{}
+		watchCollector.Collect(watchStream)
+
+		// Wait for the subscription to be registered:
+		Eventually(server.Subscriptions, time.Second).Should(BeNumerically(">=", 1))
+
+		// Return the collector and the context cancel function:
+		collector = watchCollector
+		cancel = watchCancel
+		return
 	}
 
 	It("Delivers events when tenant is visible", func() {
-		client := startServer(makeTenancy(
+		// Send an event for a visible tenant:
+		server, client := startServer(makeTenancy(
 			collections.NewSet("tenant-a"),
 		))
-		collector, cancel := startWatch(client)
+		collector, cancel := startWatch(server, client)
 		defer cancel()
-		Eventually(
-			func() int {
-				sendEvent(makeEvent("tenant-a"))
-				return len(collector.Events())
-			},
-			10*time.Second,
-		).Should(BeNumerically(">=", 1))
+		sendEvent(
+			privatev1.Event_builder{
+				Id:   uuid.New(),
+				Type: privatev1.EventType_EVENT_TYPE_OBJECT_CREATED,
+				Cluster: privatev1.Cluster_builder{
+					Id: uuid.New(),
+					Metadata: privatev1.Metadata_builder{
+						Tenant: "tenant-a",
+					}.Build(),
+				}.Build(),
+			}.Build(),
+		)
+
+		// Wait till there is one event in the collector:
+		Eventually(collector.Events, time.Second).Should(HaveLen(1))
+
+		// Verify that the event is for the visible tenant:
+		Expect(collector.Events()[0].GetCluster().GetMetadata().GetTenant()).To(Equal("tenant-a"))
 	})
 
 	It("Filters out events when tenant is not visible", func() {
-		client := startServer(makeTenancy(
+		server, client := startServer(makeTenancy(
 			collections.NewSet("tenant-b"),
 		))
-		collector, cancel := startWatch(client)
+		collector, cancel := startWatch(server, client)
 		defer cancel()
-		sendEvent(makeEvent("tenant-a"))
+		sendEvent(
+			privatev1.Event_builder{
+				Id:   uuid.New(),
+				Type: privatev1.EventType_EVENT_TYPE_OBJECT_CREATED,
+				Cluster: privatev1.Cluster_builder{
+					Id: uuid.New(),
+					Metadata: privatev1.Metadata_builder{
+						Tenant: "tenant-a",
+					}.Build(),
+				}.Build(),
+			}.Build(),
+		)
 		Consistently(collector.Events, time.Second).Should(BeEmpty())
 	})
 
 	It("Delivers only visible events when multiple are sent", func() {
-		client := startServer(makeTenancy(
+		// Send two events, one for a visible tenant and one for a non-visible tenant:
+		server, client := startServer(makeTenancy(
 			collections.NewSet("tenant-a"),
 		))
-		collector, cancel := startWatch(client)
+		collector, cancel := startWatch(server, client)
 		defer cancel()
-		Eventually(
-			func() int {
-				sendEvent(makeEvent("tenant-a"))
-				sendEvent(makeEvent("tenant-b"))
-				return len(collector.Events())
-			},
-			10*time.Second,
-		).Should(BeNumerically("==", 1))
+		sendEvent(
+			privatev1.Event_builder{
+				Id:   uuid.New(),
+				Type: privatev1.EventType_EVENT_TYPE_OBJECT_CREATED,
+				Cluster: privatev1.Cluster_builder{
+					Id: uuid.New(),
+					Metadata: privatev1.Metadata_builder{
+						Tenant: "tenant-a",
+					}.Build(),
+				}.Build(),
+			}.Build(),
+		)
+		sendEvent(
+			privatev1.Event_builder{
+				Id:   uuid.New(),
+				Type: privatev1.EventType_EVENT_TYPE_OBJECT_CREATED,
+				Cluster: privatev1.Cluster_builder{
+					Id: uuid.New(),
+					Metadata: privatev1.Metadata_builder{
+						Tenant: "tenant-b",
+					}.Build(),
+				}.Build(),
+			}.Build(),
+		)
+
+		// Wait till there is one event in the collector:
+		Eventually(collector.Events, time.Second).Should(HaveLen(1))
+		Expect(collector.Events()[0].GetCluster().GetMetadata().GetTenant()).To(Equal("tenant-a"))
+
+		// Verify that no more events are delivered:
+		Consistently(collector.Events, time.Second).Should(HaveLen(1))
+	})
+
+	It("Delivers event with cluster payload", func() {
+		// Send an event with cluster payload:
+		server, client := startServer(makeTenancy(
+			collections.NewSet("tenant-a"),
+		))
+		collector, cancel := startWatch(server, client)
+		defer cancel()
+		sendEvent(
+			privatev1.Event_builder{
+				Id:   uuid.New(),
+				Type: privatev1.EventType_EVENT_TYPE_OBJECT_CREATED,
+				Cluster: privatev1.Cluster_builder{
+					Id: uuid.New(),
+					Metadata: privatev1.Metadata_builder{
+						Tenant: "tenant-a",
+					}.Build(),
+				}.Build(),
+			}.Build(),
+		)
+
+		// Wait till the event is delivered:
+		Eventually(collector.Events, time.Second).Should(HaveLen(1))
+
+		// Verify that the payload of the event is a cluster:
+		Expect(collector.Events()[0].HasCluster()).To(BeTrue())
+	})
+
+	It("Delivers event with compute instance payload", func() {
+		// Send an event with compute instance payload:
+		server, client := startServer(makeTenancy(
+			collections.NewSet("tenant-a"),
+		))
+		collector, cancel := startWatch(server, client)
+		defer cancel()
+		sendEvent(
+			privatev1.Event_builder{
+				Id:   uuid.New(),
+				Type: privatev1.EventType_EVENT_TYPE_OBJECT_CREATED,
+				ComputeInstance: privatev1.ComputeInstance_builder{
+					Id: uuid.New(),
+					Metadata: privatev1.Metadata_builder{
+						Tenant: "tenant-a",
+					}.Build(),
+				}.Build(),
+			}.Build(),
+		)
+
+		// Wait till the event is delivered:
+		Eventually(collector.Events, time.Second).Should(HaveLen(1))
+
+		// Verify that the payload of the event is a compute instance:
+		Expect(collector.Events()[0].HasComputeInstance()).To(BeTrue())
 	})
 })

--- a/internal/servers/generic_server.go
+++ b/internal/servers/generic_server.go
@@ -47,6 +47,7 @@ type GenericServerBuilder[O dao.Object] struct {
 	ignoredFields     []any
 	notifier          events.Notifier
 	nameValidator     func(context.Context, string) error
+	redactFunc        func(O) O
 	attributionLogic  auth.AttributionLogic
 	tenancyLogic      auth.TenancyLogic
 	metricsRegisterer prometheus.Registerer
@@ -76,6 +77,8 @@ type GenericServer[O dao.Object] struct {
 	signalRequest    proto.Message
 	signalResponse   proto.Message
 	notifier         events.Notifier
+	redactFunc       func(O) O
+	payloadField     protoreflect.FieldDescriptor
 	pathCompiler     *masks.PathCompiler[O]
 	pathCache        map[string]*masks.Path[O]
 	pathCacheLock    *sync.Mutex
@@ -148,6 +151,14 @@ func (b *GenericServerBuilder[O]) SetNameValidator(value func(context.Context, s
 	return b
 }
 
+// SetRedactFunc sets a function that will be called to redact sensitive fields from objects before they are included in
+// event notification payloads. The function receives a clone of the object and should return it with the sensitive
+// fields cleared. This is optional.
+func (b *GenericServerBuilder[O]) SetRedactFunc(value func(O) O) *GenericServerBuilder[O] {
+	b.redactFunc = value
+	return b
+}
+
 // SetAttributionLogic sets the logic that will be used to determine the creator for objects.
 func (b *GenericServerBuilder[O]) SetAttributionLogic(value auth.AttributionLogic) *GenericServerBuilder[O] {
 	b.attributionLogic = value
@@ -216,6 +227,9 @@ func (b *GenericServerBuilder[O]) Build() (result *GenericServer[O], err error) 
 		s.nameValidator = s.validateName
 	}
 
+	// Set the redact function:
+	s.redactFunc = b.redactFunc
+
 	// Create the DAO:
 	daoBuilder := dao.NewGenericDAO[O]()
 	daoBuilder.SetLogger(b.logger)
@@ -282,6 +296,12 @@ func (b *GenericServerBuilder[O]) Build() (result *GenericServer[O], err error) 
 		return
 	}
 
+	// Find the payload field in the event message:
+	s.payloadField, err = b.findPayloadField()
+	if err != nil {
+		return
+	}
+
 	result = s
 	return
 }
@@ -305,16 +325,6 @@ func (b *GenericServerBuilder[O]) findService() (result protoreflect.ServiceDesc
 	}
 	return
 }
-
-// Names of gRPC methods:
-const (
-	listMethod   = "List"
-	getMethod    = "Get"
-	createMethod = "Create"
-	updateMethod = "Update"
-	deleteMethod = "Delete"
-	signalMethod = "Signal"
-)
 
 // findRequestAndResponse finds the request and response message types for the given method.
 func (b *GenericServerBuilder[O]) findRequestAndResponse(service protoreflect.ServiceDescriptor,
@@ -342,6 +352,30 @@ func (b *GenericServerBuilder[O]) findRequestAndResponse(service protoreflect.Se
 		}
 	}
 	err = fmt.Errorf("failed to find method '%s' in service '%s'", methodName, service.FullName())
+	return
+}
+
+// findPayloadField finds the field in the event message that corresponds to this object type. This is used later to
+// set the payload of event notifications without having to iterate the oneof fields every time. Returns nil if there
+// is no such field.
+func (b *GenericServerBuilder[O]) findPayloadField() (result protoreflect.FieldDescriptor, err error) {
+	var objectTempl O
+	objectDesc := objectTempl.ProtoReflect().Descriptor()
+	var eventTempl *privatev1.Event
+	eventDesc := eventTempl.ProtoReflect().Descriptor()
+	oneofDesc := eventDesc.Oneofs().ByName(eventPayloadField)
+	if oneofDesc == nil {
+		err = fmt.Errorf("failed to find the 'payload' field of the event type '%s'", eventDesc.FullName())
+		return
+	}
+	oneofFields := oneofDesc.Fields()
+	for i := range oneofFields.Len() {
+		payloadField := oneofFields.Get(i)
+		if payloadField.Message() != nil && payloadField.Message() == objectDesc {
+			result = payloadField
+			break
+		}
+	}
 	return
 }
 
@@ -857,96 +891,16 @@ func (s *GenericServer[O]) notifyEvent(ctx context.Context, e dao.Event) error {
 	return s.notifier.Notify(ctx, event)
 }
 
-func (s *GenericServer[O]) setPayload(event *privatev1.Event, object proto.Message) error { //nolint:gocyclo
-	// TODO: This is the only part of the generic server that depends on specific object types. Is there a way
-	// to avoid that?
-	switch object := object.(type) {
-	case *privatev1.ClusterTemplate:
-		event.SetClusterTemplate(object)
-	case *privatev1.Cluster:
-		event.SetCluster(object)
-	case *privatev1.HostType:
-		event.SetHostType(object)
-	case *privatev1.Hub:
-		// TODO: We need to remove the Kubeconfig from the payload of the notification because that usually
-		// exceeds the default limit of 8000 bytes of the PostgreSQL notification mechanism. A better way to
-		// do this would be to store the payloads in a separate table. We will do that later.
-		object = proto.Clone(object).(*privatev1.Hub)
-		spec := object.GetSpec()
-		if spec != nil {
-			spec.SetKubeconfig(nil)
-		}
-		event.SetHub(object)
-	case *privatev1.InstanceType:
-		event.SetInstanceType(object)
-	case *privatev1.ComputeInstanceTemplate:
-		event.SetComputeInstanceTemplate(object)
-	case *privatev1.ComputeInstance:
-		event.SetComputeInstance(object)
-	case *privatev1.NetworkClass:
-		event.SetNetworkClass(object)
-	case *privatev1.VirtualNetwork:
-		event.SetVirtualNetwork(object)
-	case *privatev1.Subnet:
-		event.SetSubnet(object)
-	case *privatev1.SecurityGroup:
-		event.SetSecurityGroup(object)
-	case *privatev1.PublicIPPool:
-		event.SetPublicIpPool(object)
-	case *privatev1.PublicIP:
-		event.SetPublicIp(object)
-	case *privatev1.PublicIPAttachment:
-		event.SetPublicIpAttachment(object)
-	case *privatev1.ExternalIPPool:
-		event.SetExternalIpPool(object)
-	case *privatev1.ExternalIP:
-		event.SetExternalIp(object)
-	case *privatev1.ExternalIPAttachment:
-		event.SetExternalIpAttachment(object)
-	case *privatev1.Tenant:
-		event.SetTenant(object)
-	case *privatev1.User:
-		event.SetUser(object)
-	case *privatev1.Role:
-		event.SetRole(object)
-	case *privatev1.RoleBinding:
-		event.SetRoleBinding(object)
-	case *privatev1.Project:
-		event.SetProject(object)
-	case *privatev1.ProjectMembership:
-		event.SetProjectMembership(object)
-	case *privatev1.ClusterCatalogItem:
-		event.SetClusterCatalogItem(object)
-	case *privatev1.ComputeInstanceCatalogItem:
-		event.SetComputeInstanceCatalogItem(object)
-	case *privatev1.BareMetalInstance:
-		event.SetBareMetalInstance(object)
-	case *privatev1.BareMetalInstanceTemplate:
-		event.SetBareMetalInstanceTemplate(object)
-	case *privatev1.BareMetalInstanceCatalogItem:
-		event.SetBareMetalInstanceCatalogItem(object)
-	case *privatev1.StorageBackend:
-		object = proto.Clone(object).(*privatev1.StorageBackend)
-		if object.GetSpec().GetCredentials() != nil {
-			object.GetSpec().GetCredentials().SetPassword("")
-		}
-		event.SetStorageBackend(object)
-	case *privatev1.IdentityProvider:
-		// Redact sensitive fields before publishing - controller will fetch them separately via API
-		object = proto.Clone(object).(*privatev1.IdentityProvider)
-		spec := object.GetSpec()
-		if spec != nil {
-			if oidc := spec.GetOidc(); oidc != nil {
-				oidc.SetClientSecret("")
-			}
-			if ldap := spec.GetLdap(); ldap != nil {
-				ldap.SetBindCredential("")
-			}
-		}
-		event.SetIdentityProvider(object)
-	default:
-		return fmt.Errorf("unknown object type '%T'", object)
+// setPayload sets the payload of the event message. If the payload field is not found the event is left unchanged. If a
+// redact function has been configured, the object is cloned and redacted before being set.
+func (s *GenericServer[O]) setPayload(event *privatev1.Event, object proto.Message) error {
+	if s.payloadField == nil {
+		return nil
 	}
+	if s.redactFunc != nil {
+		object = s.redactFunc(proto.Clone(object).(O))
+	}
+	event.ProtoReflect().Set(s.payloadField, protoreflect.ValueOfMessage(object.ProtoReflect()))
 	return nil
 }
 
@@ -1409,3 +1363,18 @@ func (s *GenericServer[O]) equivalentMetadata(x, y protoreflect.Message) bool {
 	}
 	return true
 }
+
+// Names of gRPC methods:
+const (
+	listMethod   = "List"
+	getMethod    = "Get"
+	createMethod = "Create"
+	updateMethod = "Update"
+	deleteMethod = "Delete"
+	signalMethod = "Signal"
+)
+
+// Names of fields:
+const (
+	eventPayloadField = "payload"
+)

--- a/internal/servers/generic_server_test.go
+++ b/internal/servers/generic_server_test.go
@@ -1,0 +1,136 @@
+/*
+Copyright (c) 2026 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package servers
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"go.uber.org/mock/gomock"
+	"google.golang.org/protobuf/proto"
+
+	privatev1 "github.com/osac-project/fulfillment-service/internal/api/osac/private/v1"
+	"github.com/osac-project/fulfillment-service/internal/events"
+)
+
+var _ = Describe("Generic server", func() {
+	var ctrl *gomock.Controller
+
+	BeforeEach(func() {
+		ctrl = gomock.NewController(GinkgoT())
+		DeferCleanup(ctrl.Finish)
+	})
+
+	It("Sets the payload via reflection for a simple object type", func() {
+		// Create a mock notifier that captures the event:
+		var event *privatev1.Event
+		notifier := events.NewMockNotifier(ctrl)
+		notifier.EXPECT().
+			Notify(gomock.Any(), gomock.Any()).
+			DoAndReturn(
+				func(ctx context.Context, payload proto.Message) error {
+					event = payload.(*privatev1.Event)
+					return nil
+				},
+			)
+
+		// Create the server:
+		server, err := NewGenericServer[*privatev1.HostType]().
+			SetLogger(logger).
+			SetService(privatev1.HostTypes_ServiceDesc.ServiceName).
+			SetAttributionLogic(attribution).
+			SetTenancyLogic(tenancy).
+			SetNotifier(notifier).
+			Build()
+		Expect(err).ToNot(HaveOccurred())
+
+		// Create the object:
+		response := &privatev1.HostTypesCreateResponse{}
+		err = server.Create(
+			ctx,
+			privatev1.HostTypesCreateRequest_builder{
+				Object: privatev1.HostType_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name: "my-object",
+					}.Build(),
+				}.Build(),
+			}.Build(),
+			&response,
+		)
+		Expect(err).ToNot(HaveOccurred())
+
+		// Verify the event:
+		Expect(event).ToNot(BeNil())
+		Expect(event.GetType()).To(Equal(privatev1.EventType_EVENT_TYPE_OBJECT_CREATED))
+		object := event.GetHostType()
+		Expect(object).ToNot(BeNil())
+		metadata := object.GetMetadata()
+		Expect(metadata).ToNot(BeNil())
+		Expect(metadata.GetName()).To(Equal("my-object"))
+	})
+
+	It("Redacts the payload", func() {
+		// Create a mock notifier that captures the event:
+		var event *privatev1.Event
+		notifier := events.NewMockNotifier(ctrl)
+		notifier.EXPECT().
+			Notify(gomock.Any(), gomock.Any()).
+			DoAndReturn(
+				func(ctx context.Context, payload proto.Message) error {
+					event = payload.(*privatev1.Event)
+					return nil
+				},
+			)
+
+		// Create the server with a redact function that clears some field from the object:
+		server, err := NewGenericServer[*privatev1.HostType]().
+			SetLogger(logger).
+			SetService(privatev1.HostTypes_ServiceDesc.ServiceName).
+			SetAttributionLogic(attribution).
+			SetTenancyLogic(tenancy).
+			SetNotifier(notifier).
+			SetRedactFunc(
+				func(object *privatev1.HostType) *privatev1.HostType {
+					object.SetDescription("***")
+					return object
+				},
+			).
+			Build()
+		Expect(err).ToNot(HaveOccurred())
+
+		// Create the object:
+		object := privatev1.HostType_builder{
+			Metadata: privatev1.Metadata_builder{
+				Name: "my-object",
+			}.Build(),
+			Description: "My description.",
+		}.Build()
+		request := privatev1.HostTypesCreateRequest_builder{
+			Object: object,
+		}.Build()
+		response := &privatev1.HostTypesCreateResponse{}
+		err = server.Create(ctx, request, &response)
+		Expect(err).ToNot(HaveOccurred())
+
+		// Verify the the payload has been redacted:
+		Expect(event).ToNot(BeNil())
+		Expect(event.GetType()).To(Equal(privatev1.EventType_EVENT_TYPE_OBJECT_CREATED))
+		Expect(event.GetHostType()).ToNot(BeNil())
+		Expect(event.GetHostType().GetDescription()).To(Equal("***"))
+
+		// Verify that the original object has not been modified:
+		Expect(object.GetDescription()).To(Equal("My description."))
+	})
+})

--- a/internal/servers/private_hubs_server.go
+++ b/internal/servers/private_hubs_server.go
@@ -84,11 +84,17 @@ func (b *PrivateHubsServerBuilder) Build() (result *PrivateHubsServer, err error
 		return
 	}
 
+	// Create the server early so that we can use its functions to set up other objects:
+	s := &PrivateHubsServer{
+		logger: b.logger,
+	}
+
 	// Create the generic server:
-	generic, err := NewGenericServer[*privatev1.Hub]().
+	s.generic, err = NewGenericServer[*privatev1.Hub]().
 		SetLogger(b.logger).
 		SetService(privatev1.Hubs_ServiceDesc.ServiceName).
 		SetNotifier(b.notifier).
+		SetRedactFunc(s.redact).
 		SetAttributionLogic(b.attributionLogic).
 		SetTenancyLogic(b.tenancyLogic).
 		SetMetricsRegisterer(b.metricsRegisterer).
@@ -97,12 +103,18 @@ func (b *PrivateHubsServerBuilder) Build() (result *PrivateHubsServer, err error
 		return
 	}
 
-	// Create and populate the object:
-	result = &PrivateHubsServer{
-		logger:  b.logger,
-		generic: generic,
-	}
+	// Return the server:
+	result = s
 	return
+}
+
+// redact clears sensitive fields from the hub before it is included in event notification payloads.
+func (s *PrivateHubsServer) redact(object *privatev1.Hub) *privatev1.Hub {
+	spec := object.GetSpec()
+	if spec != nil {
+		spec.SetKubeconfig(nil)
+	}
+	return object
 }
 
 func (s *PrivateHubsServer) List(ctx context.Context,

--- a/internal/servers/private_hubs_server_test.go
+++ b/internal/servers/private_hubs_server_test.go
@@ -14,13 +14,16 @@ language governing permissions and limitations under the License.
 package servers
 
 import (
+	"context"
 	"fmt"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"go.uber.org/mock/gomock"
 	"google.golang.org/protobuf/proto"
 
 	privatev1 "github.com/osac-project/fulfillment-service/internal/api/osac/private/v1"
+	"github.com/osac-project/fulfillment-service/internal/events"
 )
 
 var _ = Describe("Private hubs server", func() {
@@ -277,5 +280,48 @@ var _ = Describe("Private hubs server", func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(getResponse.GetObject().GetMetadata().GetDeletionTimestamp()).ToNot(BeNil())
 		})
+	})
+
+	It("Redacts event payload", func() {
+		// Create a mock notifier that captures the event:
+		var event *privatev1.Event
+		notifier := events.NewMockNotifier(ctrl)
+		notifier.EXPECT().
+			Notify(gomock.Any(), gomock.Any()).
+			DoAndReturn(
+				func(ctx context.Context, payload proto.Message) error {
+					event = payload.(*privatev1.Event)
+					return nil
+				},
+			)
+
+		// Create the server configured with the mock notifier:
+		server, err := NewPrivateHubsServer().
+			SetLogger(logger).
+			SetAttributionLogic(attribution).
+			SetTenancyLogic(tenancy).
+			SetNotifier(notifier).
+			Build()
+		Expect(err).ToNot(HaveOccurred())
+
+		// Create the object:
+		response, err := server.Create(
+			ctx, privatev1.HubsCreateRequest_builder{
+				Object: privatev1.Hub_builder{
+					Spec: privatev1.HubSpec_builder{
+						Kubeconfig: []byte("my_config"),
+					}.Build(),
+				}.Build(),
+			}.Build(),
+		)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(response).ToNot(BeNil())
+
+		// Verify the event:
+		Expect(event).ToNot(BeNil())
+		Expect(event.GetType()).To(Equal(privatev1.EventType_EVENT_TYPE_OBJECT_CREATED))
+		object := event.GetHub()
+		Expect(object).ToNot(BeNil())
+		Expect(object.GetSpec().GetKubeconfig()).To(BeEmpty())
 	})
 })

--- a/internal/servers/private_identity_providers_server.go
+++ b/internal/servers/private_identity_providers_server.go
@@ -85,11 +85,17 @@ func (b *PrivateIdentityProvidersServerBuilder) Build() (result *PrivateIdentity
 		return
 	}
 
+	// Create the server early so that we can use its functions to set up other objects:
+	s := &PrivateIdentityProvidersServer{
+		logger: b.logger,
+	}
+
 	// Create the generic server:
-	generic, err := NewGenericServer[*privatev1.IdentityProvider]().
+	s.generic, err = NewGenericServer[*privatev1.IdentityProvider]().
 		SetLogger(b.logger).
 		SetService(privatev1.IdentityProviders_ServiceDesc.ServiceName).
 		SetNotifier(b.notifier).
+		SetRedactFunc(s.redact).
 		SetAttributionLogic(b.attributionLogic).
 		SetTenancyLogic(b.tenancyLogic).
 		SetMetricsRegisterer(b.metricsRegisterer).
@@ -99,7 +105,7 @@ func (b *PrivateIdentityProvidersServerBuilder) Build() (result *PrivateIdentity
 	}
 
 	// Create the DAO:
-	dao, err := dao.NewGenericDAO[*privatev1.IdentityProvider]().
+	s.dao, err = dao.NewGenericDAO[*privatev1.IdentityProvider]().
 		SetLogger(b.logger).
 		SetTenancyLogic(b.tenancyLogic).
 		SetMetricsRegisterer(b.metricsRegisterer).
@@ -108,13 +114,26 @@ func (b *PrivateIdentityProvidersServerBuilder) Build() (result *PrivateIdentity
 		return
 	}
 
-	// Create and populate the object:
-	result = &PrivateIdentityProvidersServer{
-		logger:  b.logger,
-		generic: generic,
-		dao:     dao,
-	}
+	// Return the server:
+	result = s
 	return
+}
+
+// redact clears sensitive fields from the identity provider before it is included in event notification payloads.
+func (s *PrivateIdentityProvidersServer) redact(
+	object *privatev1.IdentityProvider) *privatev1.IdentityProvider {
+	spec := object.GetSpec()
+	if spec != nil {
+		oidc := spec.GetOidc()
+		if oidc != nil {
+			oidc.SetClientSecret("")
+		}
+		ldap := spec.GetLdap()
+		if ldap != nil {
+			ldap.SetBindCredential("")
+		}
+	}
+	return object
 }
 
 func (s *PrivateIdentityProvidersServer) Create(ctx context.Context,

--- a/internal/servers/private_identity_providers_server_test.go
+++ b/internal/servers/private_identity_providers_server_test.go
@@ -14,406 +14,201 @@ language governing permissions and limitations under the License.
 package servers
 
 import (
+	"context"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"go.uber.org/mock/gomock"
 	grpccodes "google.golang.org/grpc/codes"
 	grpcstatus "google.golang.org/grpc/status"
+	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/fieldmaskpb"
 
 	privatev1 "github.com/osac-project/fulfillment-service/internal/api/osac/private/v1"
-	"github.com/osac-project/fulfillment-service/internal/database"
-)
-
-const (
-	// Test fixture values for credentials (not real secrets)
-	testLdapBindCredential = "test-bind-credential-fixture"
-	testOidcClientSecret   = "test-client-secret-fixture"
+	"github.com/osac-project/fulfillment-service/internal/database/dao"
+	"github.com/osac-project/fulfillment-service/internal/events"
 )
 
 var _ = Describe("Private identity providers server", func() {
-	var privateServer *PrivateIdentityProvidersServer
+	const (
+		// Test fixture values for credentials (not real secrets)
+		testLdapBindCredential = "test-bind-credential-fixture"
+		testOidcClientSecret   = "test-client-secret-fixture"
+	)
 
 	BeforeEach(func() {
-		var err error
-
-		// Create server (without notifier for testing):
-		// Note: The default tenant mock returns "system", which is invalid for identity providers.
-		// Each test must explicitly set a valid tenant in the request.
-		privateServer, err = NewPrivateIdentityProvidersServer().
+		// The default tenant mock returns 'system', which is invalid for identity providers, so we need to
+		// create a valid tenant, and use it explicitly in the tests.
+		tenantsDao, err := dao.NewGenericDAO[*privatev1.Tenant]().
 			SetLogger(logger).
-			SetAttributionLogic(attribution).
 			SetTenancyLogic(tenancy).
 			Build()
 		Expect(err).ToNot(HaveOccurred())
-
-		// Create a tenant for identity providers
-		// This is required because of the foreign key constraint
-		tx, err := database.TxFromContext(ctx)
-		Expect(err).ToNot(HaveOccurred())
-		_, err = tx.Exec(ctx,
-			`insert into tenants (id, name, tenant, creator, data)
-			 values ($1, $2, $3, $4, $5) on conflict do nothing`,
-			"test-tenant", "test-tenant", "test-tenant", "system", "{}")
+		_, err = tenantsDao.Create().
+			SetObject(
+				privatev1.Tenant_builder{
+					Id: "my-tenant",
+					Metadata: privatev1.Metadata_builder{
+						Name:   "my-tenant",
+						Tenant: "my-tenant",
+					}.Build(),
+				}.Build(),
+			).Do(ctx)
 		Expect(err).ToNot(HaveOccurred())
 	})
 
-	It("Creates an identity provider", func() {
-		// Create request:
-		request := privatev1.IdentityProvidersCreateRequest_builder{
-			Object: privatev1.IdentityProvider_builder{
-				Metadata: privatev1.Metadata_builder{
-					Name:   "test-ldap",
-					Tenant: "test-tenant", // Must specify tenant explicitly
-				}.Build(),
-				Spec: privatev1.IdentityProviderSpec_builder{
-					Title:   "Test LDAP",
-					Enabled: true,
-					Ldap: privatev1.LdapConfig_builder{
-						ConnectionUrl:  "ldap://ldap.example.com:389",
-						BindDn:         "cn=admin,dc=example,dc=com",
-						BindCredential: testLdapBindCredential,
-						UsersDn:        "ou=users,dc=example,dc=com",
-					}.Build(),
-				}.Build(),
-			}.Build(),
-		}.Build()
+	Describe("Behaviour", func() {
+		var server *PrivateIdentityProvidersServer
 
-		// Create identity provider:
-		response, err := privateServer.Create(ctx, request)
-		Expect(err).ToNot(HaveOccurred())
-		Expect(response).ToNot(BeNil())
-		Expect(response.Object).ToNot(BeNil())
-		Expect(response.Object.Id).ToNot(BeEmpty())
-		Expect(response.Object.Metadata.Name).To(Equal("test-ldap"))
-		Expect(response.Object.Spec.Title).To(Equal("Test LDAP"))
-		Expect(response.Object.Spec.Enabled).To(BeTrue())
-		Expect(response.Object.Spec.GetLdap()).ToNot(BeNil())
-		Expect(response.Object.Spec.GetLdap().ConnectionUrl).To(Equal("ldap://ldap.example.com:389"))
-	})
+		BeforeEach(func() {
+			var err error
 
-	It("Sets tenant from the request context for identity providers", func() {
-		// Create request with explicit tenant (required for identity providers):
-		request := privatev1.IdentityProvidersCreateRequest_builder{
-			Object: privatev1.IdentityProvider_builder{
-				Metadata: privatev1.Metadata_builder{
-					Name:   "test-oidc",
-					Tenant: "test-tenant", // Must specify tenant explicitly
-				}.Build(),
-				Spec: privatev1.IdentityProviderSpec_builder{
-					Title:   "Test OIDC",
-					Enabled: true,
-					Oidc: privatev1.OidcConfig_builder{
-						AuthorizationUrl: "https://example.com/auth",
-						TokenUrl:         "https://example.com/token",
-						ClientId:         "client-id",
-						ClientSecret:     testOidcClientSecret,
-						Issuer:           "https://example.com",
-					}.Build(),
-				}.Build(),
-			}.Build(),
-		}.Build()
-
-		// Create identity provider:
-		response, err := privateServer.Create(ctx, request)
-		Expect(err).ToNot(HaveOccurred())
-		Expect(response).ToNot(BeNil())
-		Expect(response.Object).ToNot(BeNil())
-		// Tenant should be preserved from the request
-		Expect(response.Object.Metadata.Tenant).To(Equal("test-tenant"))
-	})
-
-	It("Lists identity providers", func() {
-		// Create an identity provider first:
-		createReq := privatev1.IdentityProvidersCreateRequest_builder{
-			Object: privatev1.IdentityProvider_builder{
-				Metadata: privatev1.Metadata_builder{
-					Name:   "test-ldap",
-					Tenant: "test-tenant", // Must specify tenant explicitly
-				}.Build(),
-				Spec: privatev1.IdentityProviderSpec_builder{
-					Title:   "Test LDAP",
-					Enabled: true,
-					Ldap: privatev1.LdapConfig_builder{
-						ConnectionUrl:  "ldap://ldap.example.com:389",
-						BindDn:         "cn=admin,dc=example,dc=com",
-						BindCredential: testLdapBindCredential,
-						UsersDn:        "ou=users,dc=example,dc=com",
-					}.Build(),
-				}.Build(),
-			}.Build(),
-		}.Build()
-		_, err := privateServer.Create(ctx, createReq)
-		Expect(err).ToNot(HaveOccurred())
-
-		// List identity providers:
-		listResp, err := privateServer.List(ctx, &privatev1.IdentityProvidersListRequest{
-			Filter: new("this.metadata.name == 'test-ldap'"),
+			// Create server:
+			server, err = NewPrivateIdentityProvidersServer().
+				SetLogger(logger).
+				SetAttributionLogic(attribution).
+				SetTenancyLogic(tenancy).
+				Build()
+			Expect(err).ToNot(HaveOccurred())
 		})
-		Expect(err).ToNot(HaveOccurred())
-		Expect(listResp.Size).To(Equal(int32(1)))
-		Expect(listResp.Items).To(HaveLen(1))
-		Expect(listResp.Items[0].Metadata.Name).To(Equal("test-ldap"))
-	})
 
-	It("Gets an identity provider by ID", func() {
-		// Create an identity provider:
-		createReq := privatev1.IdentityProvidersCreateRequest_builder{
-			Object: privatev1.IdentityProvider_builder{
-				Metadata: privatev1.Metadata_builder{
-					Name:   "test-ldap",
-					Tenant: "test-tenant", // Must specify tenant explicitly
-				}.Build(),
-				Spec: privatev1.IdentityProviderSpec_builder{
-					Title:   "Test LDAP",
-					Enabled: true,
-					Ldap: privatev1.LdapConfig_builder{
-						ConnectionUrl:  "ldap://ldap.example.com:389",
-						BindDn:         "cn=admin,dc=example,dc=com",
-						BindCredential: testLdapBindCredential,
-						UsersDn:        "ou=users,dc=example,dc=com",
+		It("Creates an identity provider", func() {
+			// Create request:
+			request := privatev1.IdentityProvidersCreateRequest_builder{
+				Object: privatev1.IdentityProvider_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name:   "test-ldap",
+						Tenant: "my-tenant",
+					}.Build(),
+					Spec: privatev1.IdentityProviderSpec_builder{
+						Title:   "Test LDAP",
+						Enabled: true,
+						Ldap: privatev1.LdapConfig_builder{
+							ConnectionUrl:  "ldap://ldap.example.com:389",
+							BindDn:         "cn=admin,dc=example,dc=com",
+							BindCredential: testLdapBindCredential,
+							UsersDn:        "ou=users,dc=example,dc=com",
+						}.Build(),
 					}.Build(),
 				}.Build(),
-			}.Build(),
-		}.Build()
-		createResp, err := privateServer.Create(ctx, createReq)
-		Expect(err).ToNot(HaveOccurred())
+			}.Build()
 
-		// Get the identity provider:
-		getResp, err := privateServer.Get(ctx, privatev1.IdentityProvidersGetRequest_builder{
-			Id: createResp.Object.Id,
-		}.Build())
-		Expect(err).ToNot(HaveOccurred())
-		Expect(getResp.Object.Id).To(Equal(createResp.Object.Id))
-		Expect(getResp.Object.Metadata.Name).To(Equal("test-ldap"))
-	})
+			// Create identity provider:
+			response, err := server.Create(ctx, request)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(response).ToNot(BeNil())
+			Expect(response.Object).ToNot(BeNil())
+			Expect(response.Object.Id).ToNot(BeEmpty())
+			Expect(response.Object.Metadata.Name).To(Equal("test-ldap"))
+			Expect(response.Object.Spec.Title).To(Equal("Test LDAP"))
+			Expect(response.Object.Spec.Enabled).To(BeTrue())
+			Expect(response.Object.Spec.GetLdap()).ToNot(BeNil())
+			Expect(response.Object.Spec.GetLdap().ConnectionUrl).To(Equal("ldap://ldap.example.com:389"))
+		})
 
-	It("Deletes an identity provider", func() {
-		// Create an identity provider:
-		createReq := privatev1.IdentityProvidersCreateRequest_builder{
-			Object: privatev1.IdentityProvider_builder{
-				Metadata: privatev1.Metadata_builder{
-					Name:   "test-ldap",
-					Tenant: "test-tenant", // Must specify tenant explicitly
-				}.Build(),
-				Spec: privatev1.IdentityProviderSpec_builder{
-					Title:   "Test LDAP",
-					Enabled: true,
-					Ldap: privatev1.LdapConfig_builder{
-						ConnectionUrl:  "ldap://ldap.example.com:389",
-						BindDn:         "cn=admin,dc=example,dc=com",
-						BindCredential: testLdapBindCredential,
-						UsersDn:        "ou=users,dc=example,dc=com",
+		It("Sets tenant from the request context for identity providers", func() {
+			// Create request with explicit tenant (required for identity providers):
+			request := privatev1.IdentityProvidersCreateRequest_builder{
+				Object: privatev1.IdentityProvider_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name:   "test-oidc",
+						Tenant: "my-tenant",
+					}.Build(),
+					Spec: privatev1.IdentityProviderSpec_builder{
+						Title:   "Test OIDC",
+						Enabled: true,
+						Oidc: privatev1.OidcConfig_builder{
+							AuthorizationUrl: "https://example.com/auth",
+							TokenUrl:         "https://example.com/token",
+							ClientId:         "client-id",
+							ClientSecret:     testOidcClientSecret,
+							Issuer:           "https://example.com",
+						}.Build(),
 					}.Build(),
 				}.Build(),
-			}.Build(),
-		}.Build()
-		createResp, err := privateServer.Create(ctx, createReq)
-		Expect(err).ToNot(HaveOccurred())
+			}.Build()
 
-		// Delete the identity provider:
-		_, err = privateServer.Delete(ctx, privatev1.IdentityProvidersDeleteRequest_builder{
-			Id: createResp.Object.Id,
-		}.Build())
-		Expect(err).ToNot(HaveOccurred())
-	})
+			// Create identity provider:
+			response, err := server.Create(ctx, request)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(response).ToNot(BeNil())
+			Expect(response.Object).ToNot(BeNil())
+			// Tenant should be preserved from the request
+			Expect(response.Object.Metadata.Tenant).To(Equal("my-tenant"))
+		})
 
-	It("Updates an identity provider", func() {
-		// Create an identity provider:
-		createReq := privatev1.IdentityProvidersCreateRequest_builder{
-			Object: privatev1.IdentityProvider_builder{
-				Metadata: privatev1.Metadata_builder{
-					Name:   "test-ldap",
-					Tenant: "test-tenant", // Must specify tenant explicitly
-				}.Build(),
-				Spec: privatev1.IdentityProviderSpec_builder{
-					Title:   "Test LDAP",
-					Enabled: true,
-					Ldap: privatev1.LdapConfig_builder{
-						ConnectionUrl:  "ldap://ldap.example.com:389",
-						BindDn:         "cn=admin,dc=example,dc=com",
-						BindCredential: testLdapBindCredential,
-						UsersDn:        "ou=users,dc=example,dc=com",
+		It("Lists identity providers", func() {
+			// Create an identity provider first:
+			createReq := privatev1.IdentityProvidersCreateRequest_builder{
+				Object: privatev1.IdentityProvider_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name:   "test-ldap",
+						Tenant: "my-tenant",
+					}.Build(),
+					Spec: privatev1.IdentityProviderSpec_builder{
+						Title:   "Test LDAP",
+						Enabled: true,
+						Ldap: privatev1.LdapConfig_builder{
+							ConnectionUrl:  "ldap://ldap.example.com:389",
+							BindDn:         "cn=admin,dc=example,dc=com",
+							BindCredential: testLdapBindCredential,
+							UsersDn:        "ou=users,dc=example,dc=com",
+						}.Build(),
 					}.Build(),
 				}.Build(),
-			}.Build(),
-		}.Build()
-		createResp, err := privateServer.Create(ctx, createReq)
-		Expect(err).ToNot(HaveOccurred())
+			}.Build()
+			_, err := server.Create(ctx, createReq)
+			Expect(err).ToNot(HaveOccurred())
 
-		// Update the identity provider:
-		updateReq := privatev1.IdentityProvidersUpdateRequest_builder{
-			Object: privatev1.IdentityProvider_builder{
+			// List identity providers:
+			listResp, err := server.List(ctx, &privatev1.IdentityProvidersListRequest{
+				Filter: new("this.metadata.name == 'test-ldap'"),
+			})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(listResp.Size).To(Equal(int32(1)))
+			Expect(listResp.Items).To(HaveLen(1))
+			Expect(listResp.Items[0].Metadata.Name).To(Equal("test-ldap"))
+		})
+
+		It("Gets an identity provider by ID", func() {
+			// Create an identity provider:
+			createReq := privatev1.IdentityProvidersCreateRequest_builder{
+				Object: privatev1.IdentityProvider_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name:   "test-ldap",
+						Tenant: "my-tenant",
+					}.Build(),
+					Spec: privatev1.IdentityProviderSpec_builder{
+						Title:   "Test LDAP",
+						Enabled: true,
+						Ldap: privatev1.LdapConfig_builder{
+							ConnectionUrl:  "ldap://ldap.example.com:389",
+							BindDn:         "cn=admin,dc=example,dc=com",
+							BindCredential: testLdapBindCredential,
+							UsersDn:        "ou=users,dc=example,dc=com",
+						}.Build(),
+					}.Build(),
+				}.Build(),
+			}.Build()
+			createResp, err := server.Create(ctx, createReq)
+			Expect(err).ToNot(HaveOccurred())
+
+			// Get the identity provider:
+			getResp, err := server.Get(ctx, privatev1.IdentityProvidersGetRequest_builder{
 				Id: createResp.Object.Id,
-				Spec: privatev1.IdentityProviderSpec_builder{
-					Title: "Updated LDAP Title",
-				}.Build(),
-			}.Build(),
-			UpdateMask: &fieldmaskpb.FieldMask{
-				Paths: []string{
-					"spec.title",
-				},
-			},
-		}.Build()
-		updateResp, err := privateServer.Update(ctx, updateReq)
-		Expect(err).ToNot(HaveOccurred())
-		Expect(updateResp.Object.Spec.Title).To(Equal("Updated LDAP Title"))
-	})
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+			Expect(getResp.Object.Id).To(Equal(createResp.Object.Id))
+			Expect(getResp.Object.Metadata.Name).To(Equal("test-ldap"))
+		})
 
-	It("Accepts creation of an identity provider without a name", func() {
-		// Identity providers can have empty names (name is not mandatory)
-		response, err := privateServer.Create(ctx, privatev1.IdentityProvidersCreateRequest_builder{
-			Object: privatev1.IdentityProvider_builder{
-				Metadata: privatev1.Metadata_builder{
-					Tenant: "test-tenant", // Must specify tenant explicitly
-				}.Build(),
-				Spec: privatev1.IdentityProviderSpec_builder{
-					Title:   "Test LDAP",
-					Enabled: true,
-					Ldap: privatev1.LdapConfig_builder{
-						ConnectionUrl:  "ldap://ldap.example.com:389",
-						BindDn:         "cn=admin,dc=example,dc=com",
-						BindCredential: testLdapBindCredential,
-						UsersDn:        "ou=users,dc=example,dc=com",
-					}.Build(),
-				}.Build(),
-			}.Build(),
-		}.Build())
-		Expect(err).ToNot(HaveOccurred())
-		Expect(response).ToNot(BeNil())
-		// Tenant should be preserved from the request
-		Expect(response.Object.Metadata.Tenant).To(Equal("test-tenant"))
-	})
-
-	It("Rejects update of the name of an identity provider", func() {
-		createResponse, err := privateServer.Create(ctx, privatev1.IdentityProvidersCreateRequest_builder{
-			Object: privatev1.IdentityProvider_builder{
-				Metadata: privatev1.Metadata_builder{
-					Name:   "test-ldap",
-					Tenant: "test-tenant", // Must specify tenant explicitly
-				}.Build(),
-				Spec: privatev1.IdentityProviderSpec_builder{
-					Title:   "Test LDAP",
-					Enabled: true,
-					Ldap: privatev1.LdapConfig_builder{
-						ConnectionUrl:  "ldap://ldap.example.com:389",
-						BindDn:         "cn=admin,dc=example,dc=com",
-						BindCredential: testLdapBindCredential,
-						UsersDn:        "ou=users,dc=example,dc=com",
-					}.Build(),
-				}.Build(),
-			}.Build(),
-		}.Build())
-		Expect(err).ToNot(HaveOccurred())
-		object := createResponse.GetObject()
-		id := object.GetId()
-		updateResponse, err := privateServer.Update(ctx, privatev1.IdentityProvidersUpdateRequest_builder{
-			Object: privatev1.IdentityProvider_builder{
-				Id: id,
-				Metadata: privatev1.Metadata_builder{
-					Name: "new-name",
-				}.Build(),
-			}.Build(),
-			UpdateMask: &fieldmaskpb.FieldMask{
-				Paths: []string{
-					"metadata.name",
-				},
-			},
-		}.Build())
-		Expect(err).To(HaveOccurred())
-		Expect(updateResponse).To(BeNil())
-		status, ok := grpcstatus.FromError(err)
-		Expect(ok).To(BeTrue())
-		Expect(status.Code()).To(Equal(grpccodes.InvalidArgument))
-		Expect(status.Message()).To(Equal(
-			"field 'metadata.name' is immutable",
-		))
-	})
-
-	It("Rejects update of the tenant of an identity provider", func() {
-		createResponse, err := privateServer.Create(ctx, privatev1.IdentityProvidersCreateRequest_builder{
-			Object: privatev1.IdentityProvider_builder{
-				Metadata: privatev1.Metadata_builder{
-					Name:   "test-ldap",
-					Tenant: "test-tenant", // Must specify tenant explicitly
-				}.Build(),
-				Spec: privatev1.IdentityProviderSpec_builder{
-					Title:   "Test LDAP",
-					Enabled: true,
-					Ldap: privatev1.LdapConfig_builder{
-						ConnectionUrl:  "ldap://ldap.example.com:389",
-						BindDn:         "cn=admin,dc=example,dc=com",
-						BindCredential: testLdapBindCredential,
-						UsersDn:        "ou=users,dc=example,dc=com",
-					}.Build(),
-				}.Build(),
-			}.Build(),
-		}.Build())
-		Expect(err).ToNot(HaveOccurred())
-		object := createResponse.GetObject()
-		id := object.GetId()
-		updateResponse, err := privateServer.Update(ctx, privatev1.IdentityProvidersUpdateRequest_builder{
-			Object: privatev1.IdentityProvider_builder{
-				Id: id,
-				Metadata: privatev1.Metadata_builder{
-					Tenant: "other-tenant",
-				}.Build(),
-			}.Build(),
-			UpdateMask: &fieldmaskpb.FieldMask{
-				Paths: []string{
-					"metadata.tenant",
-				},
-			},
-		}.Build())
-		Expect(err).To(HaveOccurred())
-		Expect(updateResponse).To(BeNil())
-		status, ok := grpcstatus.FromError(err)
-		Expect(ok).To(BeTrue())
-		Expect(status.Code()).To(Equal(grpccodes.InvalidArgument))
-		Expect(status.Message()).To(Equal(
-			"field 'metadata.tenant' is immutable",
-		))
-	})
-
-	It("Creates an OIDC identity provider", func() {
-		// Create request:
-		request := privatev1.IdentityProvidersCreateRequest_builder{
-			Object: privatev1.IdentityProvider_builder{
-				Metadata: privatev1.Metadata_builder{
-					Name:   "test-oidc",
-					Tenant: "test-tenant", // Must specify tenant explicitly
-				}.Build(),
-				Spec: privatev1.IdentityProviderSpec_builder{
-					Title:   "Test OIDC",
-					Enabled: true,
-					Oidc: privatev1.OidcConfig_builder{
-						AuthorizationUrl: "https://accounts.google.com/o/oauth2/v2/auth",
-						TokenUrl:         "https://oauth2.googleapis.com/token",
-						ClientId:         "my-client-id",
-						ClientSecret:     testOidcClientSecret,
-						Issuer:           "https://accounts.google.com",
-					}.Build(),
-				}.Build(),
-			}.Build(),
-		}.Build()
-
-		// Create identity provider:
-		response, err := privateServer.Create(ctx, request)
-		Expect(err).ToNot(HaveOccurred())
-		Expect(response).ToNot(BeNil())
-		Expect(response.Object).ToNot(BeNil())
-		Expect(response.Object.Id).ToNot(BeEmpty())
-		Expect(response.Object.Metadata.Name).To(Equal("test-oidc"))
-		Expect(response.Object.Spec.GetOidc()).ToNot(BeNil())
-		Expect(response.Object.Spec.GetOidc().Issuer).To(Equal("https://accounts.google.com"))
-	})
-
-	Describe("Tenant Validation", func() {
-		It("Rejects creation when tenant is explicitly set to 'shared'", func() {
-			request := privatev1.IdentityProvidersCreateRequest_builder{
+		It("Deletes an identity provider", func() {
+			// Create an identity provider:
+			createReq := privatev1.IdentityProvidersCreateRequest_builder{
 				Object: privatev1.IdentityProvider_builder{
 					Metadata: privatev1.Metadata_builder{
 						Name:   "test-ldap",
-						Tenant: "shared",
+						Tenant: "my-tenant",
 					}.Build(),
 					Spec: privatev1.IdentityProviderSpec_builder{
 						Title:   "Test LDAP",
@@ -427,21 +222,23 @@ var _ = Describe("Private identity providers server", func() {
 					}.Build(),
 				}.Build(),
 			}.Build()
+			createResp, err := server.Create(ctx, createReq)
+			Expect(err).ToNot(HaveOccurred())
 
-			_, err := privateServer.Create(ctx, request)
-			Expect(err).To(HaveOccurred())
-			status, ok := grpcstatus.FromError(err)
-			Expect(ok).To(BeTrue())
-			Expect(status.Code()).To(Equal(grpccodes.InvalidArgument))
-			Expect(status.Message()).To(ContainSubstring("cannot belong to 'shared' tenant"))
+			// Delete the identity provider:
+			_, err = server.Delete(ctx, privatev1.IdentityProvidersDeleteRequest_builder{
+				Id: createResp.Object.Id,
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
 		})
 
-		It("Rejects creation when tenant is explicitly set to 'system'", func() {
-			request := privatev1.IdentityProvidersCreateRequest_builder{
+		It("Updates an identity provider", func() {
+			// Create an identity provider:
+			createReq := privatev1.IdentityProvidersCreateRequest_builder{
 				Object: privatev1.IdentityProvider_builder{
 					Metadata: privatev1.Metadata_builder{
 						Name:   "test-ldap",
-						Tenant: "system",
+						Tenant: "my-tenant",
 					}.Build(),
 					Spec: privatev1.IdentityProviderSpec_builder{
 						Title:   "Test LDAP",
@@ -455,37 +252,355 @@ var _ = Describe("Private identity providers server", func() {
 					}.Build(),
 				}.Build(),
 			}.Build()
+			createResp, err := server.Create(ctx, createReq)
+			Expect(err).ToNot(HaveOccurred())
 
-			_, err := privateServer.Create(ctx, request)
+			// Update the identity provider:
+			updateReq := privatev1.IdentityProvidersUpdateRequest_builder{
+				Object: privatev1.IdentityProvider_builder{
+					Id: createResp.Object.Id,
+					Spec: privatev1.IdentityProviderSpec_builder{
+						Title: "Updated LDAP Title",
+					}.Build(),
+				}.Build(),
+				UpdateMask: &fieldmaskpb.FieldMask{
+					Paths: []string{
+						"spec.title",
+					},
+				},
+			}.Build()
+			updateResp, err := server.Update(ctx, updateReq)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(updateResp.Object.Spec.Title).To(Equal("Updated LDAP Title"))
+		})
+
+		It("Accepts creation of an identity provider without a name", func() {
+			// Identity providers can have empty names (name is not mandatory)
+			response, err := server.Create(ctx, privatev1.IdentityProvidersCreateRequest_builder{
+				Object: privatev1.IdentityProvider_builder{
+					Metadata: privatev1.Metadata_builder{
+						Tenant: "my-tenant",
+					}.Build(),
+					Spec: privatev1.IdentityProviderSpec_builder{
+						Title:   "Test LDAP",
+						Enabled: true,
+						Ldap: privatev1.LdapConfig_builder{
+							ConnectionUrl:  "ldap://ldap.example.com:389",
+							BindDn:         "cn=admin,dc=example,dc=com",
+							BindCredential: testLdapBindCredential,
+							UsersDn:        "ou=users,dc=example,dc=com",
+						}.Build(),
+					}.Build(),
+				}.Build(),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+			Expect(response).ToNot(BeNil())
+			// Tenant should be preserved from the request
+			Expect(response.Object.Metadata.Tenant).To(Equal("my-tenant"))
+		})
+
+		It("Rejects update of the name of an identity provider", func() {
+			createResponse, err := server.Create(ctx, privatev1.IdentityProvidersCreateRequest_builder{
+				Object: privatev1.IdentityProvider_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name:   "test-ldap",
+						Tenant: "my-tenant",
+					}.Build(),
+					Spec: privatev1.IdentityProviderSpec_builder{
+						Title:   "Test LDAP",
+						Enabled: true,
+						Ldap: privatev1.LdapConfig_builder{
+							ConnectionUrl:  "ldap://ldap.example.com:389",
+							BindDn:         "cn=admin,dc=example,dc=com",
+							BindCredential: testLdapBindCredential,
+							UsersDn:        "ou=users,dc=example,dc=com",
+						}.Build(),
+					}.Build(),
+				}.Build(),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+			object := createResponse.GetObject()
+			id := object.GetId()
+			updateResponse, err := server.Update(ctx, privatev1.IdentityProvidersUpdateRequest_builder{
+				Object: privatev1.IdentityProvider_builder{
+					Id: id,
+					Metadata: privatev1.Metadata_builder{
+						Name: "new-name",
+					}.Build(),
+				}.Build(),
+				UpdateMask: &fieldmaskpb.FieldMask{
+					Paths: []string{
+						"metadata.name",
+					},
+				},
+			}.Build())
 			Expect(err).To(HaveOccurred())
+			Expect(updateResponse).To(BeNil())
 			status, ok := grpcstatus.FromError(err)
 			Expect(ok).To(BeTrue())
 			Expect(status.Code()).To(Equal(grpccodes.InvalidArgument))
-			Expect(status.Message()).To(ContainSubstring("cannot belong to 'system' tenant"))
+			Expect(status.Message()).To(Equal(
+				"field 'metadata.name' is immutable",
+			))
+		})
+
+		It("Rejects update of the tenant of an identity provider", func() {
+			createResponse, err := server.Create(ctx, privatev1.IdentityProvidersCreateRequest_builder{
+				Object: privatev1.IdentityProvider_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name:   "test-ldap",
+						Tenant: "my-tenant",
+					}.Build(),
+					Spec: privatev1.IdentityProviderSpec_builder{
+						Title:   "Test LDAP",
+						Enabled: true,
+						Ldap: privatev1.LdapConfig_builder{
+							ConnectionUrl:  "ldap://ldap.example.com:389",
+							BindDn:         "cn=admin,dc=example,dc=com",
+							BindCredential: testLdapBindCredential,
+							UsersDn:        "ou=users,dc=example,dc=com",
+						}.Build(),
+					}.Build(),
+				}.Build(),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+			object := createResponse.GetObject()
+			id := object.GetId()
+			updateResponse, err := server.Update(ctx, privatev1.IdentityProvidersUpdateRequest_builder{
+				Object: privatev1.IdentityProvider_builder{
+					Id: id,
+					Metadata: privatev1.Metadata_builder{
+						Tenant: "other-tenant",
+					}.Build(),
+				}.Build(),
+				UpdateMask: &fieldmaskpb.FieldMask{
+					Paths: []string{
+						"metadata.tenant",
+					},
+				},
+			}.Build())
+			Expect(err).To(HaveOccurred())
+			Expect(updateResponse).To(BeNil())
+			status, ok := grpcstatus.FromError(err)
+			Expect(ok).To(BeTrue())
+			Expect(status.Code()).To(Equal(grpccodes.InvalidArgument))
+			Expect(status.Message()).To(Equal(
+				"field 'metadata.tenant' is immutable",
+			))
+		})
+
+		It("Creates an OIDC identity provider", func() {
+			// Create request:
+			request := privatev1.IdentityProvidersCreateRequest_builder{
+				Object: privatev1.IdentityProvider_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name:   "test-oidc",
+						Tenant: "my-tenant",
+					}.Build(),
+					Spec: privatev1.IdentityProviderSpec_builder{
+						Title:   "Test OIDC",
+						Enabled: true,
+						Oidc: privatev1.OidcConfig_builder{
+							AuthorizationUrl: "https://accounts.google.com/o/oauth2/v2/auth",
+							TokenUrl:         "https://oauth2.googleapis.com/token",
+							ClientId:         "my-client-id",
+							ClientSecret:     testOidcClientSecret,
+							Issuer:           "https://accounts.google.com",
+						}.Build(),
+					}.Build(),
+				}.Build(),
+			}.Build()
+
+			// Create identity provider:
+			response, err := server.Create(ctx, request)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(response).ToNot(BeNil())
+			Expect(response.Object).ToNot(BeNil())
+			Expect(response.Object.Id).ToNot(BeEmpty())
+			Expect(response.Object.Metadata.Name).To(Equal("test-oidc"))
+			Expect(response.Object.Spec.GetOidc()).ToNot(BeNil())
+			Expect(response.Object.Spec.GetOidc().Issuer).To(Equal("https://accounts.google.com"))
+		})
+
+		Describe("Tenant Validation", func() {
+			It("Rejects creation when tenant is explicitly set to 'shared'", func() {
+				request := privatev1.IdentityProvidersCreateRequest_builder{
+					Object: privatev1.IdentityProvider_builder{
+						Metadata: privatev1.Metadata_builder{
+							Name:   "test-ldap",
+							Tenant: "shared",
+						}.Build(),
+						Spec: privatev1.IdentityProviderSpec_builder{
+							Title:   "Test LDAP",
+							Enabled: true,
+							Ldap: privatev1.LdapConfig_builder{
+								ConnectionUrl:  "ldap://ldap.example.com:389",
+								BindDn:         "cn=admin,dc=example,dc=com",
+								BindCredential: testLdapBindCredential,
+								UsersDn:        "ou=users,dc=example,dc=com",
+							}.Build(),
+						}.Build(),
+					}.Build(),
+				}.Build()
+
+				_, err := server.Create(ctx, request)
+				Expect(err).To(HaveOccurred())
+				status, ok := grpcstatus.FromError(err)
+				Expect(ok).To(BeTrue())
+				Expect(status.Code()).To(Equal(grpccodes.InvalidArgument))
+				Expect(status.Message()).To(ContainSubstring("cannot belong to 'shared' tenant"))
+			})
+
+			It("Rejects creation when tenant is explicitly set to 'system'", func() {
+				request := privatev1.IdentityProvidersCreateRequest_builder{
+					Object: privatev1.IdentityProvider_builder{
+						Metadata: privatev1.Metadata_builder{
+							Name:   "test-ldap",
+							Tenant: "system",
+						}.Build(),
+						Spec: privatev1.IdentityProviderSpec_builder{
+							Title:   "Test LDAP",
+							Enabled: true,
+							Ldap: privatev1.LdapConfig_builder{
+								ConnectionUrl:  "ldap://ldap.example.com:389",
+								BindDn:         "cn=admin,dc=example,dc=com",
+								BindCredential: testLdapBindCredential,
+								UsersDn:        "ou=users,dc=example,dc=com",
+							}.Build(),
+						}.Build(),
+					}.Build(),
+				}.Build()
+
+				_, err := server.Create(ctx, request)
+				Expect(err).To(HaveOccurred())
+				status, ok := grpcstatus.FromError(err)
+				Expect(ok).To(BeTrue())
+				Expect(status.Code()).To(Equal(grpccodes.InvalidArgument))
+				Expect(status.Message()).To(ContainSubstring("cannot belong to 'system' tenant"))
+			})
+		})
+
+		Describe("Assign and Unassign", func() {
+			It("Returns not implemented for Assign", func() {
+				_, err := server.Assign(ctx, &privatev1.IdentityProvidersAssignRequest{
+					Name:       "test-ldap",
+					TenantName: "my-tenant",
+				})
+				Expect(err).To(HaveOccurred())
+				status, ok := grpcstatus.FromError(err)
+				Expect(ok).To(BeTrue())
+				Expect(status.Code()).To(Equal(grpccodes.Unimplemented))
+			})
+
+			It("Returns not implemented for Unassign", func() {
+				_, err := server.Unassign(ctx, &privatev1.IdentityProvidersUnassignRequest{
+					Name:       "test-ldap",
+					TenantName: "my-tenant",
+				})
+				Expect(err).To(HaveOccurred())
+				status, ok := grpcstatus.FromError(err)
+				Expect(ok).To(BeTrue())
+				Expect(status.Code()).To(Equal(grpccodes.Unimplemented))
+			})
 		})
 	})
 
-	Describe("Assign and Unassign", func() {
-		It("Returns not implemented for Assign", func() {
-			_, err := privateServer.Assign(ctx, &privatev1.IdentityProvidersAssignRequest{
-				Name:       "test-ldap",
-				TenantName: "my-tenant",
-			})
-			Expect(err).To(HaveOccurred())
-			status, ok := grpcstatus.FromError(err)
-			Expect(ok).To(BeTrue())
-			Expect(status.Code()).To(Equal(grpccodes.Unimplemented))
+	Describe("Redacts event payload", func() {
+		var (
+			event  *privatev1.Event
+			server *PrivateIdentityProvidersServer
+		)
+
+		BeforeEach(func() {
+			var err error
+
+			// Create a mock notifier that captures the event:
+			notifier := events.NewMockNotifier(ctrl)
+			notifier.EXPECT().
+				Notify(gomock.Any(), gomock.Any()).
+				DoAndReturn(
+					func(ctx context.Context, payload proto.Message) error {
+						event = payload.(*privatev1.Event)
+						return nil
+					},
+				)
+
+			// Create the server configured with the mock notifier:
+			server, err = NewPrivateIdentityProvidersServer().
+				SetLogger(logger).
+				SetAttributionLogic(attribution).
+				SetTenancyLogic(tenancy).
+				SetNotifier(notifier).
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+
 		})
 
-		It("Returns not implemented for Unassign", func() {
-			_, err := privateServer.Unassign(ctx, &privatev1.IdentityProvidersUnassignRequest{
-				Name:       "test-ldap",
-				TenantName: "my-tenant",
-			})
-			Expect(err).To(HaveOccurred())
-			status, ok := grpcstatus.FromError(err)
-			Expect(ok).To(BeTrue())
-			Expect(status.Code()).To(Equal(grpccodes.Unimplemented))
+		It("OIDC", func() {
+			// Create the object:
+			_, err := server.Create(
+				ctx,
+				privatev1.IdentityProvidersCreateRequest_builder{
+					Object: privatev1.IdentityProvider_builder{
+						Metadata: privatev1.Metadata_builder{
+							Tenant: "my-tenant",
+							Name:   "my-oidc",
+						}.Build(),
+						Spec: privatev1.IdentityProviderSpec_builder{
+							Title:   "My OIDC",
+							Enabled: true,
+							Oidc: privatev1.OidcConfig_builder{
+								AuthorizationUrl: "https://accounts.google.com/o/oauth2/v2/auth",
+								TokenUrl:         "https://oauth2.googleapis.com/token",
+								ClientId:         "my-client-id",
+								ClientSecret:     testOidcClientSecret,
+								Issuer:           "https://accounts.google.com",
+							}.Build(),
+						}.Build(),
+					}.Build(),
+				}.Build(),
+			)
+			Expect(err).ToNot(HaveOccurred())
+
+			// Verify the event:
+			Expect(event).ToNot(BeNil())
+			Expect(event.GetType()).To(Equal(privatev1.EventType_EVENT_TYPE_OBJECT_CREATED))
+			object := event.GetIdentityProvider()
+			Expect(object).ToNot(BeNil())
+			Expect(object.GetSpec().GetOidc().GetClientSecret()).To(BeEmpty())
+		})
+
+		It("LDAP", func() {
+			// Create the object:
+			_, err := server.Create(
+				ctx,
+				privatev1.IdentityProvidersCreateRequest_builder{
+					Object: privatev1.IdentityProvider_builder{
+						Metadata: privatev1.Metadata_builder{
+							Tenant: "my-tenant",
+							Name:   "my-ldap",
+						}.Build(),
+						Spec: privatev1.IdentityProviderSpec_builder{
+							Title:   "My LDAP",
+							Enabled: true,
+							Ldap: privatev1.LdapConfig_builder{
+								ConnectionUrl:  "ldap://ldap.example.com:389",
+								BindDn:         "cn=admin,dc=example,dc=com",
+								BindCredential: testLdapBindCredential,
+								UsersDn:        "ou=users,dc=example,dc=com",
+							}.Build(),
+						}.Build(),
+					}.Build(),
+				}.Build(),
+			)
+			Expect(err).ToNot(HaveOccurred())
+
+			// Verify the event:
+			Expect(event).ToNot(BeNil())
+			Expect(event.GetType()).To(Equal(privatev1.EventType_EVENT_TYPE_OBJECT_CREATED))
+			object := event.GetIdentityProvider()
+			Expect(object).ToNot(BeNil())
+			Expect(object.GetSpec().GetLdap().GetBindCredential()).To(BeEmpty())
 		})
 	})
 })

--- a/internal/servers/private_storage_backends_server.go
+++ b/internal/servers/private_storage_backends_server.go
@@ -74,6 +74,7 @@ func (b *PrivateStorageBackendsServerBuilder) SetMetricsRegisterer(value prometh
 }
 
 func (b *PrivateStorageBackendsServerBuilder) Build() (result *PrivateStorageBackendsServer, err error) {
+	// Check parameters:
 	if b.logger == nil {
 		err = errors.New("logger is mandatory")
 		return
@@ -83,10 +84,17 @@ func (b *PrivateStorageBackendsServerBuilder) Build() (result *PrivateStorageBac
 		return
 	}
 
-	generic, err := NewGenericServer[*privatev1.StorageBackend]().
+	// Create the server early so that we can use its functions to set up other objects:
+	s := &PrivateStorageBackendsServer{
+		logger: b.logger,
+	}
+
+	// Create the generic server:
+	s.generic, err = NewGenericServer[*privatev1.StorageBackend]().
 		SetLogger(b.logger).
 		SetService(privatev1.StorageBackends_ServiceDesc.ServiceName).
 		SetNotifier(b.notifier).
+		SetRedactFunc(s.redact).
 		SetAttributionLogic(b.attributionLogic).
 		SetTenancyLogic(b.tenancyLogic).
 		SetMetricsRegisterer(b.metricsRegisterer).
@@ -95,11 +103,23 @@ func (b *PrivateStorageBackendsServerBuilder) Build() (result *PrivateStorageBac
 		return
 	}
 
-	result = &PrivateStorageBackendsServer{
-		logger:  b.logger,
-		generic: generic,
-	}
+	// Return the server:
+	result = s
 	return
+}
+
+// redact clears sensitive fields from the storage backend before it is included in event notification payloads.
+func (s *PrivateStorageBackendsServer) redact(object *privatev1.StorageBackend) *privatev1.StorageBackend {
+	spec := object.GetSpec()
+	if spec == nil {
+		return object
+	}
+	credentials := spec.GetCredentials()
+	if credentials == nil {
+		return object
+	}
+	credentials.SetPassword("")
+	return object
 }
 
 func (s *PrivateStorageBackendsServer) List(ctx context.Context,

--- a/internal/servers/private_storage_backends_server_test.go
+++ b/internal/servers/private_storage_backends_server_test.go
@@ -14,17 +14,21 @@ language governing permissions and limitations under the License.
 package servers
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/google/uuid"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"go.uber.org/mock/gomock"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/fieldmaskpb"
 
 	privatev1 "github.com/osac-project/fulfillment-service/internal/api/osac/private/v1"
 	"github.com/osac-project/fulfillment-service/internal/auth"
+	"github.com/osac-project/fulfillment-service/internal/events"
 )
 
 var _ = Describe("Private storage backends server", func() {
@@ -606,5 +610,56 @@ var _ = Describe("Private storage backends server", func() {
 			Expect(st.Code()).To(Equal(codes.InvalidArgument))
 			Expect(st.Message()).To(ContainSubstring("identifier"))
 		})
+	})
+
+	It("Redacts event payload", func() {
+		// Create a mock notifier that captures the event:
+		var event *privatev1.Event
+		notifier := events.NewMockNotifier(ctrl)
+		notifier.EXPECT().
+			Notify(gomock.Any(), gomock.Any()).
+			DoAndReturn(
+				func(ctx context.Context, payload proto.Message) error {
+					event = payload.(*privatev1.Event)
+					return nil
+				},
+			)
+
+		// Create the server configured with the mock notifier:
+		server, err := NewPrivateStorageBackendsServer().
+			SetLogger(logger).
+			SetAttributionLogic(attribution).
+			SetTenancyLogic(tenancy).
+			SetNotifier(notifier).
+			Build()
+		Expect(err).ToNot(HaveOccurred())
+
+		// Create the object:
+		_, err = server.Create(
+			ctx,
+			privatev1.StorageBackendsCreateRequest_builder{
+				Object: privatev1.StorageBackend_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name: "my-backend",
+					}.Build(),
+					Spec: privatev1.StorageBackendSpec_builder{
+						Provider: "ceph",
+						Endpoint: "https://other.example.com:8443",
+						Credentials: privatev1.StorageBackendCredentials_builder{
+							Username: "admin",
+							Password: "secret",
+						}.Build(),
+					}.Build(),
+				}.Build(),
+			}.Build(),
+		)
+		Expect(err).ToNot(HaveOccurred())
+
+		// Verify the event:
+		Expect(event).ToNot(BeNil())
+		Expect(event.GetType()).To(Equal(privatev1.EventType_EVENT_TYPE_OBJECT_CREATED))
+		object := event.GetStorageBackend()
+		Expect(object).ToNot(BeNil())
+		Expect(object.GetSpec().GetCredentials().GetPassword()).To(BeEmpty())
 	})
 })


### PR DESCRIPTION
## Summary

- Replace the hard-coded type switch in `setPayload` with protobuf reflection so that adding
  a new object type to the API no longer requires updating the generic server.
- Move sensitive field redaction out of the generic server into the private servers that own
  each type (`Hub`, `StorageBackend`, `IdentityProvider`) via a new `SetRedactFunc` builder
  option.
- Add tests for payload setting and redaction in the new `generic_server_test.go` file.

## Test plan

- [x] `ginkgo run internal/servers` passes all 1272 specs.
- [x] Verify that the event payload is correctly set for each object type.
- [x] Verify that sensitive fields are redacted in hub, storage backend, and identity provider
  event payloads.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Sensitive fields in event notification payloads are now automatically redacted (for example kubeconfig and credential secrets) before events are delivered.
  * Event payload handling is more generic and consistent across object types, improving how payload metadata is extracted and surfaced.

* **Bug Fixes**
  * Improved event payload/metadata extraction to reliably emit object creation events while hiding secrets (credentials, kubeconfig, and other sensitive fields).
  * Enhanced event handling so metadata for filtering and visibility works across varying payload shapes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->