### PR TITLE
OSAC-1972: add image defaults, validation, and immutability for BareMetalInstance

### DIFF
--- a/internal/servers/private_baremetal_instances_server.go
+++ b/internal/servers/private_baremetal_instances_server.go
@@ -18,6 +18,7 @@ import (
 	"errors"
 	"log/slog"
 	"maps"
+	"strings"
 
 	"github.com/prometheus/client_golang/prometheus"
 
@@ -208,6 +209,12 @@ func (s *PrivateBareMetalInstancesServer) validateSpec(bmi *privatev1.BareMetalI
 		}
 	}
 
+	if spec.HasImage() {
+		if err := s.validateBareMetalInstanceImage(spec.GetImage()); err != nil {
+			return err
+		}
+	}
+
 	return nil
 }
 
@@ -280,6 +287,8 @@ func (s *PrivateBareMetalInstancesServer) validateAndApplyTemplateParameters(ctx
 	}
 	template := getResponse.GetObject()
 
+	s.applyBareMetalInstanceSpecDefaults(bmi.GetSpec(), template.GetSpecDefaults())
+
 	if len(template.GetParameters()) == 0 && len(providedParams) == 0 {
 		return nil
 	}
@@ -297,8 +306,8 @@ func (s *PrivateBareMetalInstancesServer) validateAndApplyTemplateParameters(ctx
 	return nil
 }
 
-// validateImmutability ensures catalog_item, ssh_public_key, user_data, and template_parameters
-// cannot be changed after creation.
+// validateImmutability ensures catalog_item, ssh_public_key, user_data, template_parameters,
+// and image cannot be changed after creation.
 func (s *PrivateBareMetalInstancesServer) validateImmutability(ctx context.Context,
 	request *privatev1.BareMetalInstancesUpdateRequest) error {
 	mask := request.GetUpdateMask()
@@ -306,13 +315,14 @@ func (s *PrivateBareMetalInstancesServer) validateImmutability(ctx context.Conte
 	updatingSshKey := updateIncludesField(mask, "spec.ssh_public_key")
 	updatingUserData := updateIncludesField(mask, "spec.user_data")
 	updatingTemplateParams := updateIncludesField(mask, "spec.template_parameters")
+	updatingImage := updateIncludesField(mask, "spec.image")
 
 	bmi := request.GetObject()
 	if bmi == nil {
 		return grpcstatus.Errorf(grpccodes.InvalidArgument, "bare metal instance is mandatory")
 	}
 	newSpec := bmi.GetSpec()
-	if newSpec == nil && (updatingCatalogItem || updatingSshKey || updatingUserData || updatingTemplateParams) {
+	if newSpec == nil && (updatingCatalogItem || updatingSshKey || updatingUserData || updatingTemplateParams || updatingImage) {
 		return grpcstatus.Errorf(grpccodes.InvalidArgument, "bare metal instance spec is mandatory")
 	}
 	id := bmi.GetId()
@@ -362,5 +372,52 @@ func (s *PrivateBareMetalInstancesServer) validateImmutability(ctx context.Conte
 		}
 	}
 
+	if updatingImage && !proto.Equal(existingSpec.GetImage(), newSpec.GetImage()) {
+		return grpcstatus.Errorf(grpccodes.InvalidArgument,
+			"cannot change spec.image: image is immutable after creation")
+	}
+
+	return nil
+}
+
+func (s *PrivateBareMetalInstancesServer) applyBareMetalInstanceSpecDefaults(spec *privatev1.BareMetalInstanceSpec, defaults *privatev1.BareMetalInstanceTemplateSpecDefaults) {
+	if spec == nil || defaults == nil {
+		return
+	}
+	if !defaults.HasImage() {
+		return
+	}
+	if !spec.HasImage() {
+		spec.SetImage(proto.Clone(defaults.GetImage()).(*privatev1.BareMetalInstanceImage))
+		return
+	}
+	img := spec.GetImage()
+	defImg := defaults.GetImage()
+	if img.GetSourceType() == "" && defImg.GetSourceType() != "" {
+		img.SetSourceType(defImg.GetSourceType())
+	}
+	if img.GetSourceRef() == "" && defImg.GetSourceRef() != "" {
+		img.SetSourceRef(defImg.GetSourceRef())
+	}
+}
+
+func (s *PrivateBareMetalInstancesServer) validateBareMetalInstanceImage(image *privatev1.BareMetalInstanceImage) error {
+	if image == nil {
+		return nil
+	}
+	var missing []string
+	if image.GetSourceType() == "" {
+		missing = append(missing, "image.source_type")
+	}
+	if image.GetSourceRef() == "" {
+		missing = append(missing, "image.source_ref")
+	}
+	if len(missing) > 0 {
+		return grpcstatus.Errorf(
+			grpccodes.InvalidArgument,
+			"the following required image fields are missing: %s",
+			strings.Join(missing, ", "),
+		)
+	}
 	return nil
 }

--- a/internal/servers/private_baremetal_instances_server_test.go
+++ b/internal/servers/private_baremetal_instances_server_test.go
@@ -398,6 +398,289 @@ var _ = Describe("Private bare metal instances server", func() {
 			Expect(status.Message()).To(ContainSubstring("user_data is immutable"))
 		})
 
+		It("Rejects PATCH that changes image", func() {
+			createResponse, err := server.Create(ctx, privatev1.BareMetalInstancesCreateRequest_builder{
+				Object: privatev1.BareMetalInstance_builder{
+					Spec: privatev1.BareMetalInstanceSpec_builder{
+						CatalogItem: catalogItemID,
+						Image: privatev1.BareMetalInstanceImage_builder{
+							SourceType: "registry",
+							SourceRef:  "quay.io/test:latest",
+						}.Build(),
+					}.Build(),
+				}.Build(),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+			object := createResponse.GetObject()
+
+			_, err = server.Update(ctx, privatev1.BareMetalInstancesUpdateRequest_builder{
+				Object: privatev1.BareMetalInstance_builder{
+					Id: object.GetId(),
+					Spec: privatev1.BareMetalInstanceSpec_builder{
+						CatalogItem: catalogItemID,
+						Image: privatev1.BareMetalInstanceImage_builder{
+							SourceType: "registry",
+							SourceRef:  "quay.io/other:latest",
+						}.Build(),
+					}.Build(),
+				}.Build(),
+				UpdateMask: &fieldmaskpb.FieldMask{
+					Paths: []string{"spec.image"},
+				},
+			}.Build())
+			Expect(err).To(HaveOccurred())
+			status, ok := grpcstatus.FromError(err)
+			Expect(ok).To(BeTrue())
+			Expect(status.Code()).To(Equal(grpccodes.InvalidArgument))
+			Expect(status.Message()).To(ContainSubstring("image is immutable"))
+		})
+
+		It("Creates object with image and persists it", func() {
+			createResponse, err := server.Create(ctx, privatev1.BareMetalInstancesCreateRequest_builder{
+				Object: privatev1.BareMetalInstance_builder{
+					Spec: privatev1.BareMetalInstanceSpec_builder{
+						CatalogItem: catalogItemID,
+						Image: privatev1.BareMetalInstanceImage_builder{
+							SourceType: "registry",
+							SourceRef:  "quay.io/test:latest",
+						}.Build(),
+					}.Build(),
+				}.Build(),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+			object := createResponse.GetObject()
+			Expect(object.GetSpec().GetImage().GetSourceType()).To(Equal("registry"))
+			Expect(object.GetSpec().GetImage().GetSourceRef()).To(Equal("quay.io/test:latest"))
+
+			getResponse, err := server.Get(ctx, privatev1.BareMetalInstancesGetRequest_builder{
+				Id: object.GetId(),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+			fetched := getResponse.GetObject()
+			Expect(fetched.GetSpec().GetImage().GetSourceType()).To(Equal("registry"))
+			Expect(fetched.GetSpec().GetImage().GetSourceRef()).To(Equal("quay.io/test:latest"))
+		})
+
+		It("Rejects image with missing source_type", func() {
+			_, err := server.Create(ctx, privatev1.BareMetalInstancesCreateRequest_builder{
+				Object: privatev1.BareMetalInstance_builder{
+					Spec: privatev1.BareMetalInstanceSpec_builder{
+						CatalogItem: catalogItemID,
+						Image: privatev1.BareMetalInstanceImage_builder{
+							SourceRef: "quay.io/test:latest",
+						}.Build(),
+					}.Build(),
+				}.Build(),
+			}.Build())
+			Expect(err).To(HaveOccurred())
+			status, ok := grpcstatus.FromError(err)
+			Expect(ok).To(BeTrue())
+			Expect(status.Code()).To(Equal(grpccodes.InvalidArgument))
+			Expect(status.Message()).To(ContainSubstring("image.source_type"))
+		})
+
+		It("Rejects image with missing source_ref", func() {
+			_, err := server.Create(ctx, privatev1.BareMetalInstancesCreateRequest_builder{
+				Object: privatev1.BareMetalInstance_builder{
+					Spec: privatev1.BareMetalInstanceSpec_builder{
+						CatalogItem: catalogItemID,
+						Image: privatev1.BareMetalInstanceImage_builder{
+							SourceType: "registry",
+						}.Build(),
+					}.Build(),
+				}.Build(),
+			}.Build())
+			Expect(err).To(HaveOccurred())
+			status, ok := grpcstatus.FromError(err)
+			Expect(ok).To(BeTrue())
+			Expect(status.Code()).To(Equal(grpccodes.InvalidArgument))
+			Expect(status.Message()).To(ContainSubstring("image.source_ref"))
+		})
+
+		It("Applies image defaults from template spec_defaults", func() {
+			templatesDao, err := dao.NewGenericDAO[*privatev1.BareMetalInstanceTemplate]().
+				SetLogger(logger).
+				SetTenancyLogic(tenancy).
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+
+			template := privatev1.BareMetalInstanceTemplate_builder{
+				Id:          "image-default-template",
+				Title:       "Template with image default",
+				Description: "Has default image in spec_defaults",
+				Metadata: privatev1.Metadata_builder{
+					Tenant: auth.SharedTenant,
+				}.Build(),
+				SpecDefaults: privatev1.BareMetalInstanceTemplateSpecDefaults_builder{
+					Image: privatev1.BareMetalInstanceImage_builder{
+						SourceType: "registry",
+						SourceRef:  "quay.io/default:latest",
+					}.Build(),
+				}.Build(),
+			}.Build()
+
+			_, err = templatesDao.Create().SetObject(template).Do(ctx)
+			Expect(err).ToNot(HaveOccurred())
+
+			catResp, err := catalogServer.Create(ctx, privatev1.BareMetalInstanceCatalogItemsCreateRequest_builder{
+				Object: privatev1.BareMetalInstanceCatalogItem_builder{
+					Title:     "Catalog with image default",
+					Template:  "image-default-template",
+					Published: true,
+				}.Build(),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+			catID := catResp.GetObject().GetId()
+
+			createResponse, err := server.Create(ctx, privatev1.BareMetalInstancesCreateRequest_builder{
+				Object: privatev1.BareMetalInstance_builder{
+					Spec: privatev1.BareMetalInstanceSpec_builder{
+						CatalogItem: catID,
+					}.Build(),
+				}.Build(),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+			spec := createResponse.GetObject().GetSpec()
+			Expect(spec.GetImage().GetSourceType()).To(Equal("registry"))
+			Expect(spec.GetImage().GetSourceRef()).To(Equal("quay.io/default:latest"))
+		})
+
+		It("User-provided image overrides template default", func() {
+			templatesDao, err := dao.NewGenericDAO[*privatev1.BareMetalInstanceTemplate]().
+				SetLogger(logger).
+				SetTenancyLogic(tenancy).
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+
+			template := privatev1.BareMetalInstanceTemplate_builder{
+				Id:          "image-override-template",
+				Title:       "Template with image default",
+				Description: "Has default image in spec_defaults",
+				Metadata: privatev1.Metadata_builder{
+					Tenant: auth.SharedTenant,
+				}.Build(),
+				SpecDefaults: privatev1.BareMetalInstanceTemplateSpecDefaults_builder{
+					Image: privatev1.BareMetalInstanceImage_builder{
+						SourceType: "registry",
+						SourceRef:  "quay.io/default:latest",
+					}.Build(),
+				}.Build(),
+			}.Build()
+
+			_, err = templatesDao.Create().SetObject(template).Do(ctx)
+			Expect(err).ToNot(HaveOccurred())
+
+			catResp, err := catalogServer.Create(ctx, privatev1.BareMetalInstanceCatalogItemsCreateRequest_builder{
+				Object: privatev1.BareMetalInstanceCatalogItem_builder{
+					Title:     "Catalog with image default override",
+					Template:  "image-override-template",
+					Published: true,
+				}.Build(),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+			catID := catResp.GetObject().GetId()
+
+			createResponse, err := server.Create(ctx, privatev1.BareMetalInstancesCreateRequest_builder{
+				Object: privatev1.BareMetalInstance_builder{
+					Spec: privatev1.BareMetalInstanceSpec_builder{
+						CatalogItem: catID,
+						Image: privatev1.BareMetalInstanceImage_builder{
+							SourceType: "registry",
+							SourceRef:  "quay.io/user-chosen:v2",
+						}.Build(),
+					}.Build(),
+				}.Build(),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+			spec := createResponse.GetObject().GetSpec()
+			Expect(spec.GetImage().GetSourceType()).To(Equal("registry"))
+			Expect(spec.GetImage().GetSourceRef()).To(Equal("quay.io/user-chosen:v2"))
+		})
+
+		It("Merges user-provided source_type with template default source_ref", func() {
+			templatesDao, err := dao.NewGenericDAO[*privatev1.BareMetalInstanceTemplate]().
+				SetLogger(logger).
+				SetTenancyLogic(tenancy).
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+
+			template := privatev1.BareMetalInstanceTemplate_builder{
+				Id:          "image-partial-merge-template",
+				Title:       "Template with image default",
+				Description: "Has default image in spec_defaults",
+				Metadata: privatev1.Metadata_builder{
+					Tenant: auth.SharedTenant,
+				}.Build(),
+				SpecDefaults: privatev1.BareMetalInstanceTemplateSpecDefaults_builder{
+					Image: privatev1.BareMetalInstanceImage_builder{
+						SourceType: "registry",
+						SourceRef:  "quay.io/default:latest",
+					}.Build(),
+				}.Build(),
+			}.Build()
+
+			_, err = templatesDao.Create().SetObject(template).Do(ctx)
+			Expect(err).ToNot(HaveOccurred())
+
+			catResp, err := catalogServer.Create(ctx, privatev1.BareMetalInstanceCatalogItemsCreateRequest_builder{
+				Object: privatev1.BareMetalInstanceCatalogItem_builder{
+					Title:     "Catalog with partial merge",
+					Template:  "image-partial-merge-template",
+					Published: true,
+				}.Build(),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+			catID := catResp.GetObject().GetId()
+
+			createResponse, err := server.Create(ctx, privatev1.BareMetalInstancesCreateRequest_builder{
+				Object: privatev1.BareMetalInstance_builder{
+					Spec: privatev1.BareMetalInstanceSpec_builder{
+						CatalogItem: catID,
+						Image: privatev1.BareMetalInstanceImage_builder{
+							SourceType: "custom-source",
+						}.Build(),
+					}.Build(),
+				}.Build(),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+			spec := createResponse.GetObject().GetSpec()
+			Expect(spec.GetImage().GetSourceType()).To(Equal("custom-source"))
+			Expect(spec.GetImage().GetSourceRef()).To(Equal("quay.io/default:latest"))
+		})
+
+		It("Allows PATCH with same image value", func() {
+			createResponse, err := server.Create(ctx, privatev1.BareMetalInstancesCreateRequest_builder{
+				Object: privatev1.BareMetalInstance_builder{
+					Spec: privatev1.BareMetalInstanceSpec_builder{
+						CatalogItem: catalogItemID,
+						Image: privatev1.BareMetalInstanceImage_builder{
+							SourceType: "registry",
+							SourceRef:  "quay.io/test:latest",
+						}.Build(),
+					}.Build(),
+				}.Build(),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+			object := createResponse.GetObject()
+
+			_, err = server.Update(ctx, privatev1.BareMetalInstancesUpdateRequest_builder{
+				Object: privatev1.BareMetalInstance_builder{
+					Id: object.GetId(),
+					Spec: privatev1.BareMetalInstanceSpec_builder{
+						CatalogItem: catalogItemID,
+						Image: privatev1.BareMetalInstanceImage_builder{
+							SourceType: "registry",
+							SourceRef:  "quay.io/test:latest",
+						}.Build(),
+					}.Build(),
+				}.Build(),
+				UpdateMask: &fieldmaskpb.FieldMask{
+					Paths: []string{"spec.image"},
+				},
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+		})
+
 		It("Allows PATCH that does not touch immutable fields", func() {
 			createResponse, err := server.Create(ctx, privatev1.BareMetalInstancesCreateRequest_builder{
 				Object: privatev1.BareMetalInstance_builder{


### PR DESCRIPTION
## Summary

Add server logic for the BareMetalInstance `image` field (proto added in #831):

- **Spec defaults**: `ApplyBareMetalInstanceSpecDefaults()` merges template `spec_defaults.image` into the spec when the user doesn't provide one. Supports partial merge (user provides `source_ref`, template provides `source_type`). Pattern follows `mergeImageDefaults()` from ComputeInstance.
- **Validation**: `ValidateBareMetalInstanceImage()` validates `source_type` and `source_ref` are present when an image is provided. Called from `validateSpec()` during Create.
- **Immutability**: Rejects PATCH requests that change `spec.image` after creation. Follows the same pattern as `ssh_public_key`, `user_data`, `template_parameters`.

Safe to merge independently — the image field is optional, so existing Create/Update calls without an image continue to work.

## Files changed

- `internal/utils/baremetal_spec_defaults.go` (new) — spec defaults and validation
- `internal/servers/private_baremetal_instances_server.go` — wire defaults, validation, immutability
- `internal/servers/private_baremetal_instances_server_test.go` — 6 new tests

## Test coverage

| Test | What it verifies |
|------|-----------------|
| Creates object with image and persists it | Image stored and returned on Get |
| Rejects image with missing source_type | Validation catches incomplete image |
| Rejects image with missing source_ref | Validation catches incomplete image |
| Applies image defaults from template spec_defaults | Template default fills in when user omits image |
| User-provided image overrides template default | User value takes precedence |
| Rejects PATCH that changes image | Immutability enforced |

## Test plan

- [x] `go build ./...` passes
- [x] `ginkgo run internal/servers` — 1292 tests pass (6 new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added stricter validation for bare metal instance `image` during creation, ensuring required image details are provided.
  * Enforced `image` immutability on update when `spec.image` is targeted, rejecting mismatched changes.
  * Improved template behavior so `spec.image` defaults are applied when omitted, with user-provided values overriding or completing missing fields.
  * Enhanced error messaging for cases where required image fields are missing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->