### PR TITLE
OSAC-1972: inject imageURL into templateParameters in reconciler

### DIFF
--- a/internal/controllers/baremetalinstance/baremetalinstance_reconciler_function.go
+++ b/internal/controllers/baremetalinstance/baremetalinstance_reconciler_function.go
@@ -591,6 +591,9 @@ func (t *task) mutateBMI(ctx context.Context, object *bmfov1alpha1.BareMetalInst
 	if t.userDataSecretName != "" {
 		params["userDataSecret"] = t.userDataSecretName
 	}
+	if t.bareMetalInstance.GetSpec().HasImage() {
+		params["imageURL"] = t.bareMetalInstance.GetSpec().GetImage().GetSourceRef()
+	}
 	if len(params) > 0 {
 		paramsJSON, err := json.Marshal(params)
 		if err != nil {

--- a/internal/controllers/baremetalinstance/baremetalinstance_reconciler_function_test.go
+++ b/internal/controllers/baremetalinstance/baremetalinstance_reconciler_function_test.go
@@ -395,6 +395,128 @@ var _ = Describe("mutateBMI", func() {
 		Expect(err.Error()).To(ContainSubstring("failed to get catalog item"))
 		Expect(err.Error()).To(ContainSubstring("missing-catalog"))
 	})
+
+	It("should include imageURL in templateParameters when image is set", func() {
+		catalogItemsClient := defaultFakeCatalogItemsClient()
+
+		t := &task{
+			r: &function{
+				logger:                              logger,
+				bareMetalInstanceCatalogItemsClient: catalogItemsClient,
+			},
+			bareMetalInstance: privatev1.BareMetalInstance_builder{
+				Id: "bmi-test",
+				Spec: privatev1.BareMetalInstanceSpec_builder{
+					CatalogItem: "catalog-1",
+					Image: privatev1.BareMetalInstanceImage_builder{
+						SourceType: "registry",
+						SourceRef:  "quay.io/org/rhel9:latest",
+					}.Build(),
+				}.Build(),
+			}.Build(),
+		}
+
+		var obj bmfov1alpha1.BareMetalInstance
+		err := t.mutateBMI(ctx, &obj)
+		Expect(err).ToNot(HaveOccurred())
+
+		var params map[string]string
+		Expect(json.Unmarshal([]byte(obj.Spec.TemplateParameters), &params)).To(Succeed())
+		Expect(params["imageURL"]).To(Equal("quay.io/org/rhel9:latest"))
+	})
+
+	It("should not include imageURL in templateParameters when image is not set", func() {
+		catalogItemsClient := defaultFakeCatalogItemsClient()
+
+		t := &task{
+			r: &function{
+				logger:                              logger,
+				bareMetalInstanceCatalogItemsClient: catalogItemsClient,
+			},
+			bareMetalInstance: privatev1.BareMetalInstance_builder{
+				Id: "bmi-test",
+				Spec: privatev1.BareMetalInstanceSpec_builder{
+					CatalogItem:  "catalog-1",
+					SshPublicKey: new("ssh-ed25519 AAAA... test@example.com"),
+				}.Build(),
+			}.Build(),
+		}
+
+		var obj bmfov1alpha1.BareMetalInstance
+		err := t.mutateBMI(ctx, &obj)
+		Expect(err).ToNot(HaveOccurred())
+
+		var params map[string]string
+		Expect(json.Unmarshal([]byte(obj.Spec.TemplateParameters), &params)).To(Succeed())
+		Expect(params).ToNot(HaveKey("imageURL"))
+	})
+
+	It("should let system imageURL override user-provided template_parameters value", func() {
+		catalogItemsClient := defaultFakeCatalogItemsClient()
+
+		userImageParam, err := anypb.New(wrapperspb.String("user-provided-image"))
+		Expect(err).ToNot(HaveOccurred())
+
+		t := &task{
+			r: &function{
+				logger:                              logger,
+				bareMetalInstanceCatalogItemsClient: catalogItemsClient,
+			},
+			bareMetalInstance: privatev1.BareMetalInstance_builder{
+				Id: "bmi-test",
+				Spec: privatev1.BareMetalInstanceSpec_builder{
+					CatalogItem:        "catalog-1",
+					TemplateParameters: map[string]*anypb.Any{"imageURL": userImageParam},
+					Image: privatev1.BareMetalInstanceImage_builder{
+						SourceType: "registry",
+						SourceRef:  "quay.io/org/rhel9:latest",
+					}.Build(),
+				}.Build(),
+			}.Build(),
+		}
+
+		var obj bmfov1alpha1.BareMetalInstance
+		err = t.mutateBMI(ctx, &obj)
+		Expect(err).ToNot(HaveOccurred())
+
+		var params map[string]any
+		Expect(json.Unmarshal([]byte(obj.Spec.TemplateParameters), &params)).To(Succeed())
+		Expect(params["imageURL"]).To(Equal("quay.io/org/rhel9:latest"),
+			"system imageURL must override user-provided template_parameters value")
+	})
+
+	It("should include imageURL alongside sshPublicKey in templateParameters", func() {
+		catalogItemsClient := defaultFakeCatalogItemsClient()
+
+		t := &task{
+			r: &function{
+				logger:                              logger,
+				bareMetalInstanceCatalogItemsClient: catalogItemsClient,
+			},
+			bareMetalInstance: privatev1.BareMetalInstance_builder{
+				Id: "bmi-test",
+				Spec: privatev1.BareMetalInstanceSpec_builder{
+					CatalogItem:  "catalog-1",
+					SshPublicKey: new("ssh-ed25519 AAAA... test@example.com"),
+					Image: privatev1.BareMetalInstanceImage_builder{
+						SourceType: "registry",
+						SourceRef:  "quay.io/org/fedora:latest",
+					}.Build(),
+				}.Build(),
+			}.Build(),
+			userDataSecretName: "bmi-test-user-data",
+		}
+
+		var obj bmfov1alpha1.BareMetalInstance
+		err := t.mutateBMI(ctx, &obj)
+		Expect(err).ToNot(HaveOccurred())
+
+		var params map[string]string
+		Expect(json.Unmarshal([]byte(obj.Spec.TemplateParameters), &params)).To(Succeed())
+		Expect(params["imageURL"]).To(Equal("quay.io/org/fedora:latest"))
+		Expect(params["sshPublicKey"]).To(Equal("ssh-ed25519 AAAA... test@example.com"))
+		Expect(params["userDataSecret"]).To(Equal("bmi-test-user-data"))
+	})
 })
 
 var _ = Describe("update", func() {


### PR DESCRIPTION
## Summary

Map `spec.image.source_ref` to `imageURL` in the `templateParameters` JSON when creating the BareMetalInstance CRD on the hub cluster. This is a 3-line change in `mutateBMI()` following the existing pattern for `sshPublicKey` and `userDataSecret`.

The osac-aap Ansible role `bm_host_metal3_provisioning` already reads `imageURL` from `templateParameters` and passes it to the Metal3 BareMetalHost CR — no downstream changes needed in bare-metal-fulfillment-operator or osac-aap.

Safe to merge independently — if no image is set on the BareMetalInstance, the `imageURL` key is simply not added to templateParameters (existing behavior unchanged).

## Files changed

- `internal/controllers/baremetalinstance/baremetalinstance_reconciler_function.go` — 3 lines added
- `internal/controllers/baremetalinstance/baremetalinstance_reconciler_function_test.go` — 3 new tests

## Tests

| Test | What it verifies |
|------|-----------------|
| should include imageURL in templateParameters when image is set | imageURL = source_ref |
| should not include imageURL when image is not set | No imageURL key present |
| should include imageURL alongside sshPublicKey | All system params coexist |

## Test plan

- [x] `go build ./...` passes
- [x] `ginkgo run internal/controllers/baremetalinstance` — 66 tests pass (3 new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved instance configuration so image-based deployments now include the correct image URL automatically.
  * Preserved existing setup values (such as SSH keys and user data secrets) while adding the image URL when an image is provided.
  * Confirmed the configuration omits the image URL when no image is set, avoiding unexpected parameters.
* **Tests**
  * Added coverage for template parameter behavior around `imageURL`, including override and combined parameter scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->