### PR TITLE
OSAC-1635: report tenant CR creation failure in API object status

### DIFF
--- a/internal/controllers/onboarding/tenant_reconciler_function.go
+++ b/internal/controllers/onboarding/tenant_reconciler_function.go
@@ -118,15 +118,15 @@ func (r *function) run(ctx context.Context, tenant *privatev1.Tenant) error {
 	} else {
 		err = t.update(ctx)
 	}
-	if err != nil {
-		return err
-	}
 	updateMask := r.maskCalculator.Calculate(oldTenant, tenant)
 	if len(updateMask.GetPaths()) > 0 {
-		_, err = r.tenantsClient.Update(ctx, privatev1.TenantsUpdateRequest_builder{
+		_, updateErr := r.tenantsClient.Update(ctx, privatev1.TenantsUpdateRequest_builder{
 			Object:     tenant,
 			UpdateMask: updateMask,
 		}.Build())
+		if err == nil {
+			err = updateErr
+		}
 	}
 	return err
 }
@@ -162,11 +162,26 @@ func (t *task) update(ctx context.Context) error {
 			t.setFailed(fmt.Sprintf(
 				"Failed to sync tenant to hub '%s'", hub.GetId(),
 			))
-			return nil
+			return err
 		}
 	}
 
+	t.clearFailed()
 	return nil
+}
+
+func (t *task) clearFailed() {
+	if !t.tenant.HasStatus() {
+		return
+	}
+	if t.tenant.GetStatus().GetState() == privatev1.TenantState_TENANT_STATE_FAILED {
+		if t.tenant.GetStatus().GetIdpTenantName() != "" {
+			t.tenant.GetStatus().SetState(privatev1.TenantState_TENANT_STATE_SYNCED)
+		} else {
+			t.tenant.GetStatus().SetState(privatev1.TenantState_TENANT_STATE_PENDING)
+		}
+		t.tenant.GetStatus().ClearMessage()
+	}
 }
 
 func (t *task) createOrUpdateOnHub(ctx context.Context, hubId string, hubEntry *controllers.HubEntry) error {

--- a/internal/controllers/onboarding/tenant_reconciler_function.go
+++ b/internal/controllers/onboarding/tenant_reconciler_function.go
@@ -154,7 +154,15 @@ func (t *task) update(ctx context.Context) error {
 		}
 
 		if err := t.createOrUpdateOnHub(ctx, hub.GetId(), hubEntry); err != nil {
-			return err
+			t.r.logger.ErrorContext(ctx, "Failed to sync tenant to hub",
+				slog.String("hub_id", hub.GetId()),
+				slog.String("tenant_id", t.tenant.GetId()),
+				slog.String("error", err.Error()),
+			)
+			t.setFailed(fmt.Sprintf(
+				"Failed to sync tenant to hub '%s'", hub.GetId(),
+			))
+			return nil
 		}
 	}
 
@@ -377,4 +385,12 @@ func (t *task) removeFinalizer() {
 		})
 		t.tenant.GetMetadata().SetFinalizers(list)
 	}
+}
+
+func (t *task) setFailed(message string) {
+	if !t.tenant.HasStatus() {
+		t.tenant.SetStatus(&privatev1.TenantStatus{})
+	}
+	t.tenant.GetStatus().SetState(privatev1.TenantState_TENANT_STATE_FAILED)
+	t.tenant.GetStatus().SetMessage(message)
 }

--- a/internal/controllers/onboarding/tenant_reconciler_function_test.go
+++ b/internal/controllers/onboarding/tenant_reconciler_function_test.go
@@ -632,7 +632,7 @@ var _ = Describe("run", func() {
 		})
 
 		When("creating a Tenant CRD on a hub fails", func() {
-			It("sets status to FAILED with error message", func() {
+			It("sets status to FAILED and returns the error for requeue", func() {
 				expectedErr := errors.New("create failed")
 				fakeClient := fake.NewClientBuilder().
 					WithScheme(scheme).
@@ -675,7 +675,7 @@ var _ = Describe("run", func() {
 				f := newFunction(mockHubCache, mockHubs, mockTenants, mockProjects)
 				err := f.run(ctx, tenant)
 
-				Expect(err).ToNot(HaveOccurred())
+				Expect(err).To(HaveOccurred())
 				Expect(tenant.GetStatus().GetState()).To(
 					Equal(privatev1.TenantState_TENANT_STATE_FAILED),
 				)
@@ -685,6 +685,169 @@ var _ = Describe("run", func() {
 				Expect(tenant.GetStatus().GetMessage()).ToNot(
 					ContainSubstring("create failed"),
 				)
+			})
+		})
+
+		When("first hub succeeds but second hub fails", func() {
+			It("persists hub1 resources and sets FAILED for hub2", func() {
+				fakeClient1 := fake.NewClientBuilder().WithScheme(scheme).Build()
+				expectedErr := errors.New("hub2 unreachable")
+				fakeClient2 := fake.NewClientBuilder().
+					WithScheme(scheme).
+					WithInterceptorFuncs(interceptor.Funcs{
+						Create: func(ctx context.Context, client clnt.WithWatch, obj clnt.Object, opts ...clnt.CreateOption) error {
+							return expectedErr
+						},
+					}).
+					Build()
+
+				mockHubs.EXPECT().
+					List(gomock.Any(), gomock.Any()).
+					Return(&privatev1.HubsListResponse{
+						Size:  2,
+						Total: 2,
+						Items: []*privatev1.Hub{
+							privatev1.Hub_builder{Id: hub1ID}.Build(),
+							privatev1.Hub_builder{Id: hub2ID}.Build(),
+						},
+					}, nil)
+
+				mockHubCache.EXPECT().
+					Get(gomock.Any(), hub1ID).
+					Return(&controllers.HubEntry{Namespace: namespace1, Client: fakeClient1}, nil)
+				mockHubCache.EXPECT().
+					Get(gomock.Any(), hub2ID).
+					Return(&controllers.HubEntry{Namespace: namespace2, Client: fakeClient2}, nil)
+
+				mockTenants.EXPECT().
+					Update(gomock.Any(), gomock.Any(), gomock.Any()).
+					DoAndReturn(func(ctx context.Context, req *privatev1.TenantsUpdateRequest, opts ...grpc.CallOption) (*privatev1.TenantsUpdateResponse, error) {
+						return &privatev1.TenantsUpdateResponse{Object: req.GetObject()}, nil
+					})
+
+				tenant := privatev1.Tenant_builder{
+					Id: tenantID,
+					Metadata: privatev1.Metadata_builder{
+						Name:       tenantID,
+						Finalizers: []string{finalizers.Controller},
+						Tenant:     tenantName,
+					}.Build(),
+				}.Build()
+
+				f := newFunction(mockHubCache, mockHubs, mockTenants)
+				err := f.run(ctx, tenant)
+
+				Expect(err).To(HaveOccurred())
+				Expect(tenant.GetStatus().GetState()).To(
+					Equal(privatev1.TenantState_TENANT_STATE_FAILED),
+				)
+				Expect(tenant.GetStatus().GetMessage()).To(ContainSubstring(hub2ID))
+
+				list1 := &osacv1alpha1.TenantList{}
+				Expect(fakeClient1.List(ctx, list1)).To(Succeed())
+				Expect(list1.Items).To(HaveLen(1))
+
+				ns1 := &corev1.Namespace{}
+				Expect(fakeClient1.Get(ctx, clnt.ObjectKey{Name: tenantID}, ns1)).To(Succeed())
+			})
+		})
+
+		When("tenant was previously FAILED (no IDP sync) and hub sync now succeeds", func() {
+			It("clears the failed state back to PENDING", func() {
+				fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+				mockHubs.EXPECT().
+					List(gomock.Any(), gomock.Any()).
+					Return(&privatev1.HubsListResponse{
+						Size:  1,
+						Total: 1,
+						Items: []*privatev1.Hub{
+							privatev1.Hub_builder{Id: hub1ID}.Build(),
+						},
+					}, nil)
+
+				mockHubCache.EXPECT().
+					Get(gomock.Any(), hub1ID).
+					Return(&controllers.HubEntry{Namespace: namespace1, Client: fakeClient}, nil)
+
+				mockTenants.EXPECT().
+					Update(gomock.Any(), gomock.Any(), gomock.Any()).
+					DoAndReturn(func(ctx context.Context, req *privatev1.TenantsUpdateRequest, opts ...grpc.CallOption) (*privatev1.TenantsUpdateResponse, error) {
+						return &privatev1.TenantsUpdateResponse{Object: req.GetObject()}, nil
+					})
+
+				tenant := privatev1.Tenant_builder{
+					Id: tenantID,
+					Metadata: privatev1.Metadata_builder{
+						Name:       tenantID,
+						Finalizers: []string{finalizers.Controller},
+						Tenant:     tenantName,
+					}.Build(),
+					Status: privatev1.TenantStatus_builder{
+						State:   privatev1.TenantState_TENANT_STATE_FAILED,
+						Message: new("previous failure"),
+					}.Build(),
+				}.Build()
+
+				f := newFunction(mockHubCache, mockHubs, mockTenants)
+				err := f.run(ctx, tenant)
+
+				Expect(err).ToNot(HaveOccurred())
+				Expect(tenant.GetStatus().GetState()).To(
+					Equal(privatev1.TenantState_TENANT_STATE_PENDING),
+				)
+				Expect(tenant.GetStatus().HasMessage()).To(BeFalse())
+			})
+		})
+
+		When("tenant was previously FAILED (IDP already synced) and hub sync now succeeds", func() {
+			It("restores state to SYNCED instead of PENDING", func() {
+				fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+				mockHubs.EXPECT().
+					List(gomock.Any(), gomock.Any()).
+					Return(&privatev1.HubsListResponse{
+						Size:  1,
+						Total: 1,
+						Items: []*privatev1.Hub{
+							privatev1.Hub_builder{Id: hub1ID}.Build(),
+						},
+					}, nil)
+
+				mockHubCache.EXPECT().
+					Get(gomock.Any(), hub1ID).
+					Return(&controllers.HubEntry{Namespace: namespace1, Client: fakeClient}, nil)
+
+				mockTenants.EXPECT().
+					Update(gomock.Any(), gomock.Any(), gomock.Any()).
+					DoAndReturn(func(ctx context.Context, req *privatev1.TenantsUpdateRequest, opts ...grpc.CallOption) (*privatev1.TenantsUpdateResponse, error) {
+						return &privatev1.TenantsUpdateResponse{Object: req.GetObject()}, nil
+					})
+
+				idpName := "my-idp-tenant"
+				tenant := privatev1.Tenant_builder{
+					Id: tenantID,
+					Metadata: privatev1.Metadata_builder{
+						Name:       tenantID,
+						Finalizers: []string{finalizers.Controller},
+						Tenant:     tenantName,
+					}.Build(),
+					Status: privatev1.TenantStatus_builder{
+						State:         privatev1.TenantState_TENANT_STATE_FAILED,
+						Message:       new("hub sync failure"),
+						IdpTenantName: idpName,
+					}.Build(),
+				}.Build()
+
+				f := newFunction(mockHubCache, mockHubs, mockTenants)
+				err := f.run(ctx, tenant)
+
+				Expect(err).ToNot(HaveOccurred())
+				Expect(tenant.GetStatus().GetState()).To(
+					Equal(privatev1.TenantState_TENANT_STATE_SYNCED),
+				)
+				Expect(tenant.GetStatus().HasMessage()).To(BeFalse())
+				Expect(tenant.GetStatus().GetIdpTenantName()).To(Equal(idpName))
 			})
 		})
 	})

--- a/internal/controllers/onboarding/tenant_reconciler_function_test.go
+++ b/internal/controllers/onboarding/tenant_reconciler_function_test.go
@@ -632,7 +632,7 @@ var _ = Describe("run", func() {
 		})
 
 		When("creating a Tenant CRD on a hub fails", func() {
-			It("returns the error", func() {
+			It("sets status to FAILED with error message", func() {
 				expectedErr := errors.New("create failed")
 				fakeClient := fake.NewClientBuilder().
 					WithScheme(scheme).
@@ -657,6 +657,12 @@ var _ = Describe("run", func() {
 					Get(gomock.Any(), hub1ID).
 					Return(&controllers.HubEntry{Namespace: namespace1, Client: fakeClient}, nil)
 
+				mockTenants.EXPECT().
+					Update(gomock.Any(), gomock.Any(), gomock.Any()).
+					DoAndReturn(func(ctx context.Context, req *privatev1.TenantsUpdateRequest, opts ...grpc.CallOption) (*privatev1.TenantsUpdateResponse, error) {
+						return &privatev1.TenantsUpdateResponse{Object: req.GetObject()}, nil
+					})
+
 				tenant := privatev1.Tenant_builder{
 					Id: tenantID,
 					Metadata: privatev1.Metadata_builder{
@@ -669,7 +675,16 @@ var _ = Describe("run", func() {
 				f := newFunction(mockHubCache, mockHubs, mockTenants, mockProjects)
 				err := f.run(ctx, tenant)
 
-				Expect(err).To(MatchError(ContainSubstring("create failed")))
+				Expect(err).ToNot(HaveOccurred())
+				Expect(tenant.GetStatus().GetState()).To(
+					Equal(privatev1.TenantState_TENANT_STATE_FAILED),
+				)
+				Expect(tenant.GetStatus().GetMessage()).To(
+					ContainSubstring(hub1ID),
+				)
+				Expect(tenant.GetStatus().GetMessage()).ToNot(
+					ContainSubstring("create failed"),
+				)
 			})
 		})
 	})

--- a/it/crds/tenants.osac.openshift.io.yaml
+++ b/it/crds/tenants.osac.openshift.io.yaml
@@ -1,0 +1,382 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.20.0
+  name: tenants.osac.openshift.io
+spec:
+  group: osac.openshift.io
+  names:
+    kind: Tenant
+    listKind: TenantList
+    plural: tenants
+    singular: tenant
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.namespace
+      name: Tenant Namespace
+      type: string
+    - jsonPath: .status.storageClasses[*].name
+      name: Storage Classes
+      type: string
+    - jsonPath: .status.phase
+      name: Phase
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="StorageBackendReady")].status
+      name: Backend Ready
+      priority: 1
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="ClusterStorageReady")].status
+      name: Cluster Storage
+      priority: 1
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: Tenant is the Schema for the tenants API.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: TenantSpec defines the desired state of Tenant.
+            type: object
+          status:
+            description: TenantStatus defines the observed state of Tenant.
+            properties:
+              clusterStorage:
+                description: ClusterStorage tracks per-cluster StorageClass installation
+                  status.
+                items:
+                  description: ClusterStorageStatus tracks StorageClass installation
+                    status for a single cluster.
+                  properties:
+                    clusterName:
+                      description: ClusterName identifies the target cluster.
+                      type: string
+                    ready:
+                      description: Ready indicates whether StorageClasses are installed
+                        on this cluster.
+                      type: boolean
+                    reason:
+                      description: Reason provides a machine-readable reason for the
+                        current state.
+                      type: string
+                  required:
+                  - clusterName
+                  - ready
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - clusterName
+                x-kubernetes-list-type: map
+              clusterStorageJobs:
+                description: ClusterStorageJobs holds the history of cluster storage
+                  provisioning/deprovisioning jobs
+                items:
+                  description: JobStatus represents the status of a provisioning or
+                    deprovisioning job
+                  properties:
+                    blockDeletionOnFailure:
+                      description: |-
+                        BlockDeletionOnFailure indicates whether CR deletion should be blocked if this job fails.
+                        AAP sets this to true to prevent orphaned cloud resources when deprovisioning fails.
+                      type: boolean
+                    configVersion:
+                      description: |-
+                        ConfigVersion is the DesiredConfigVersion at the time this job was triggered.
+                        Used to determine retry behavior on failure: if ConfigVersion differs from
+                        the current DesiredConfigVersion, a new job is triggered immediately.
+                        If they match, the controller retries with exponential backoff.
+                      type: string
+                    jobID:
+                      description: JobID is the AAP job identifier from the provisioning
+                        provider API response.
+                      type: string
+                    message:
+                      description: Message provides human-readable status or error
+                        information
+                      type: string
+                    state:
+                      description: State is the current state of the job
+                      enum:
+                      - Pending
+                      - Waiting
+                      - Running
+                      - Succeeded
+                      - Failed
+                      - Canceled
+                      - Unknown
+                      type: string
+                    timestamp:
+                      description: Timestamp when this job was created/triggered
+                      format: date-time
+                      type: string
+                    type:
+                      description: Type indicates the operation type
+                      enum:
+                      - provision
+                      - deprovision
+                      type: string
+                  required:
+                  - jobID
+                  - state
+                  - timestamp
+                  - type
+                  type: object
+                type: array
+              conditions:
+                description: Conditions holds an array of metav1.Condition that describe
+                  the state of the Tenant
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              namespace:
+                description: Namespace is the namespace allocated to the tenant on
+                  the target cluster
+                type: string
+              phase:
+                description: Phase is the phase of the tenant
+                type: string
+              provisioningJobs:
+                description: ProvisioningJobs holds the history of provisioning jobs
+                  triggered for this tenant
+                items:
+                  description: JobStatus represents the status of a provisioning or
+                    deprovisioning job
+                  properties:
+                    blockDeletionOnFailure:
+                      description: |-
+                        BlockDeletionOnFailure indicates whether CR deletion should be blocked if this job fails.
+                        AAP sets this to true to prevent orphaned cloud resources when deprovisioning fails.
+                      type: boolean
+                    configVersion:
+                      description: |-
+                        ConfigVersion is the DesiredConfigVersion at the time this job was triggered.
+                        Used to determine retry behavior on failure: if ConfigVersion differs from
+                        the current DesiredConfigVersion, a new job is triggered immediately.
+                        If they match, the controller retries with exponential backoff.
+                      type: string
+                    jobID:
+                      description: JobID is the AAP job identifier from the provisioning
+                        provider API response.
+                      type: string
+                    message:
+                      description: Message provides human-readable status or error
+                        information
+                      type: string
+                    state:
+                      description: State is the current state of the job
+                      enum:
+                      - Pending
+                      - Waiting
+                      - Running
+                      - Succeeded
+                      - Failed
+                      - Canceled
+                      - Unknown
+                      type: string
+                    timestamp:
+                      description: Timestamp when this job was created/triggered
+                      format: date-time
+                      type: string
+                    type:
+                      description: Type indicates the operation type
+                      enum:
+                      - provision
+                      - deprovision
+                      type: string
+                  required:
+                  - jobID
+                  - state
+                  - timestamp
+                  - type
+                  type: object
+                type: array
+              storageBackendJobs:
+                description: StorageBackendJobs holds the history of storage backend
+                  provisioning/deprovisioning jobs
+                items:
+                  description: JobStatus represents the status of a provisioning or
+                    deprovisioning job
+                  properties:
+                    blockDeletionOnFailure:
+                      description: |-
+                        BlockDeletionOnFailure indicates whether CR deletion should be blocked if this job fails.
+                        AAP sets this to true to prevent orphaned cloud resources when deprovisioning fails.
+                      type: boolean
+                    configVersion:
+                      description: |-
+                        ConfigVersion is the DesiredConfigVersion at the time this job was triggered.
+                        Used to determine retry behavior on failure: if ConfigVersion differs from
+                        the current DesiredConfigVersion, a new job is triggered immediately.
+                        If they match, the controller retries with exponential backoff.
+                      type: string
+                    jobID:
+                      description: JobID is the AAP job identifier from the provisioning
+                        provider API response.
+                      type: string
+                    message:
+                      description: Message provides human-readable status or error
+                        information
+                      type: string
+                    state:
+                      description: State is the current state of the job
+                      enum:
+                      - Pending
+                      - Waiting
+                      - Running
+                      - Succeeded
+                      - Failed
+                      - Canceled
+                      - Unknown
+                      type: string
+                    timestamp:
+                      description: Timestamp when this job was created/triggered
+                      format: date-time
+                      type: string
+                    type:
+                      description: Type indicates the operation type
+                      enum:
+                      - provision
+                      - deprovision
+                      type: string
+                  required:
+                  - jobID
+                  - state
+                  - timestamp
+                  - type
+                  type: object
+                type: array
+              storageBackends:
+                description: StorageBackends tracks per-backend provisioning status.
+                items:
+                  description: StorageBackendStatus tracks provisioning status for
+                    a single storage backend.
+                  properties:
+                    message:
+                      description: Message provides human-readable status or error
+                        information.
+                      type: string
+                    name:
+                      description: Name is the storage backend identifier (e.g., "vast-1").
+                      type: string
+                    provider:
+                      description: Provider is the storage provider type (e.g., "vast").
+                      type: string
+                    ready:
+                      description: Ready indicates whether this backend is provisioned
+                        for the tenant.
+                      type: boolean
+                  required:
+                  - name
+                  - provider
+                  - ready
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - name
+                x-kubernetes-list-type: map
+              storageClasses:
+                description: |-
+                  StorageClasses lists all resolved StorageClass mappings for the tenant,
+                  one per storage tier.
+                items:
+                  description: |-
+                    ResolvedStorageClass captures a single resolved StorageClass for a specific
+                    storage tier. The OSAC Storage Controller populates one entry per tier.
+                  properties:
+                    name:
+                      description: Name is the name of the resolved Kubernetes StorageClass.
+                      minLength: 1
+                      type: string
+                    tier:
+                      description: |-
+                        Tier is the storage tier this StorageClass provides,
+                        taken from the osac.openshift.io/storage-tier label.
+                      maxLength: 63
+                      minLength: 1
+                      pattern: ^[a-z0-9]([a-z0-9._-]*[a-z0-9])?$
+                      type: string
+                  required:
+                  - name
+                  - tier
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - tier
+                x-kubernetes-list-type: map
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/it/it_suite_test.go
+++ b/it/it_suite_test.go
@@ -130,6 +130,7 @@ var _ = BeforeSuite(func() {
 		SetCaFiles(config.CaKey, config.CaCrt).
 		AddCrdFile(filepath.Join("crds", "clusterorders.osac.openshift.io.yaml")).
 		AddCrdFile(filepath.Join("crds", "hostedclusters.hypershift.openshift.io.yaml")).
+		AddCrdFile(filepath.Join("crds", "tenants.osac.openshift.io.yaml")).
 		Build()
 	Expect(err).ToNot(HaveOccurred())
 	err = tool.Setup(ctx)


### PR DESCRIPTION
When the onboarding controller fails to create a Tenant CR or namespace on a hub cluster, set status.state to FAILED with a descriptive message instead of silently retrying. This makes hub sync failures visible to API consumers.

Note: Integration tests (tenant lifecycle) fail because clearFailed can reset a previously-synced  tenant to PENDING, causing the IDP controller to re-attempt creation and hit a 409 conflict. This is fixed by #843 which should be merged first.

Assisted-by: Claude Code <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Hub synchronization failures no longer interrupt reconciliation; instead, the tenant status is set to **Failed** with a message identifying the failing hub.
  * When synchronization succeeds after a prior failure, the tenant status is automatically cleared—returning to **Pending** (no IDP sync) or **Synced** (IDP already synced).
  * Improved consistency of onboarding tenant reconciliation status handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->