### PR TITLE
OSAC-2089: fix IDP re-creation when tenant was already synced

### DIFF
--- a/internal/controllers/tenant/tenant_reconciler_function.go
+++ b/internal/controllers/tenant/tenant_reconciler_function.go
@@ -164,6 +164,12 @@ func (t *task) update(ctx context.Context) error {
 
 // syncToIDP synchronizes the tenant to the identity provider.
 func (t *task) syncToIDP(ctx context.Context) error {
+	if t.tenant.GetStatus().GetIdpTenantName() != "" {
+		t.tenant.GetStatus().SetState(privatev1.TenantState_TENANT_STATE_SYNCED)
+		t.tenant.GetStatus().ClearMessage()
+		return nil
+	}
+
 	t.tenant.GetStatus().SetState(privatev1.TenantState_TENANT_STATE_PENDING)
 
 	tenantName := t.tenant.GetMetadata().GetName()

--- a/internal/controllers/tenant/tenant_reconciler_function_test.go
+++ b/internal/controllers/tenant/tenant_reconciler_function_test.go
@@ -419,6 +419,36 @@ var _ = Describe("IDP Sync", func() {
 		Expect(tenant.GetStatus().GetState()).To(Equal(privatev1.TenantState_TENANT_STATE_SYNCED))
 	})
 
+	It("should restore SYNCED without re-creating when IDP tenant already exists", func() {
+		tenant := privatev1.Tenant_builder{
+			Id: "org-123",
+			Metadata: privatev1.Metadata_builder{
+				Name:       "test-org",
+				Finalizers: []string{finalizers.Controller},
+				Tenant:     "tenant-1",
+			}.Build(),
+			Status: privatev1.TenantStatus_builder{
+				State:            privatev1.TenantState_TENANT_STATE_PENDING,
+				IdpTenantName:    "test-org",
+				BreakGlassUserId: "user-123",
+				Message:          new("previous hub sync failure"),
+			}.Build(),
+		}.Build()
+
+		task := &task{
+			r:      reconciler,
+			tenant: tenant,
+		}
+
+		err := task.update(ctx)
+		Expect(err).ToNot(HaveOccurred())
+
+		Expect(tenant.GetStatus().GetState()).To(Equal(privatev1.TenantState_TENANT_STATE_SYNCED))
+		Expect(tenant.GetStatus().HasMessage()).To(BeFalse())
+		Expect(tenant.GetStatus().GetIdpTenantName()).To(Equal("test-org"))
+		Expect(tenant.GetStatus().GetBreakGlassUserId()).To(Equal("user-123"))
+	})
+
 	It("should pass domains to IDP during initial sync", func() {
 		tenant := privatev1.Tenant_builder{
 			Id: "org-domains",


### PR DESCRIPTION
When a tenant's state is reset to PENDING but idp_tenant_name is already set, the IDP controller attempted to re-create the organization in Keycloak, hitting a 409 conflict.

Example flow that triggers the bug:

  1. Tenant "test-org-1" is created and reaches SYNCED (idp_tenant_name="test-org-1", break-glass credentials set)
  2. Hub goes down → onboarding controller sets FAILED
  3. Hub recovers → onboarding controller clears FAILED back to PENDING
  4. IDP controller sees PENDING → calls CreateTenant → 409 "organization already exists" → sets FAILED permanently

Fix: in syncToIDP, if idp_tenant_name is already populated, the tenant was previously synced to IDP. Restore to SYNCED directly instead of attempting re-creation.


Assisted-by: Claude Code <noreply@anthropic.com>