### PR TITLE
OSAC-1284: Fix Project sub-group naming and lookup and register ProjectMembership controllers

### DIFF
--- a/internal/cmd/service/start/controller/start_controller_cmd.go
+++ b/internal/cmd/service/start/controller/start_controller_cmd.go
@@ -50,6 +50,7 @@ import (
 	"github.com/osac-project/fulfillment-service/internal/controllers/identityprovider"
 	"github.com/osac-project/fulfillment-service/internal/controllers/onboarding"
 	"github.com/osac-project/fulfillment-service/internal/controllers/project"
+	"github.com/osac-project/fulfillment-service/internal/controllers/projectmembership"
 	"github.com/osac-project/fulfillment-service/internal/controllers/publicip"
 	"github.com/osac-project/fulfillment-service/internal/controllers/publicipattachment"
 	"github.com/osac-project/fulfillment-service/internal/controllers/publicippool"
@@ -1004,6 +1005,43 @@ func (r *runnerContext) run(cmd *cobra.Command, argv []string) error { //nolint:
 			r.logger.InfoContext(
 				ctx,
 				"Project reconciler failed",
+				slog.Any("error", err),
+			)
+		}
+	}()
+
+	// Create the project membership reconciler:
+	r.logger.InfoContext(ctx, "Creating project membership reconciler")
+	projectMembershipReconcilerFunction, err := projectmembership.NewFunction().
+		SetLogger(r.logger).
+		SetConnection(r.client).
+		SetIdpClient(idpClient).
+		Build()
+	if err != nil {
+		return fmt.Errorf("failed to build project membership reconciler function: %w", err)
+	}
+	projectMembershipReconciler, err := controllers.NewReconciler[*privatev1.ProjectMembership]().
+		SetLogger(r.logger).
+		SetName("project_membership").
+		SetClient(r.client).
+		SetFunction(projectMembershipReconcilerFunction.Run).
+		SetEventFilter("has(event.project_membership)").
+		SetHealthReporter(healthAggregator).
+		Build()
+	if err != nil {
+		return fmt.Errorf("failed to build project membership reconciler: %w", err)
+	}
+
+	// Start the project membership reconciler:
+	r.logger.InfoContext(ctx, "Starting project membership reconciler")
+	go func() {
+		err := projectMembershipReconciler.Start(ctx)
+		if err == nil || errors.Is(err, context.Canceled) {
+			r.logger.InfoContext(ctx, "Project membership reconciler finished")
+		} else {
+			r.logger.InfoContext(
+				ctx,
+				"Project membership reconciler failed",
 				slog.Any("error", err),
 			)
 		}

--- a/internal/controllers/projectmembership/project_membership_reconciler_function.go
+++ b/internal/controllers/projectmembership/project_membership_reconciler_function.go
@@ -318,9 +318,9 @@ func (t *task) syncProjectMembership(ctx context.Context) error {
 func (t *task) mapRoleToGroupSuffix(role privatev1.ProjectMembershipRole) string {
 	switch role {
 	case privatev1.ProjectMembershipRole_PROJECT_MEMBERSHIP_ROLE_VIEWER:
-		return "viewers"
+		return "system:viewers"
 	case privatev1.ProjectMembershipRole_PROJECT_MEMBERSHIP_ROLE_MANAGER:
-		return "managers"
+		return "system:managers"
 	default:
 		return ""
 	}
@@ -472,7 +472,8 @@ func (t *task) cleanupProjectMembership(ctx context.Context) error {
 	groupID, err := t.r.idpClient.GetGroupIDByPath(ctx, organizationName, groupPath)
 	if err != nil {
 		// Only ignore NotFound - propagate transient errors for retry
-		if status.Code(err) == codes.NotFound {
+		// Check both gRPC status code and error message since IDP client wraps errors
+		if status.Code(err) == codes.NotFound || strings.Contains(err.Error(), "not found") {
 			t.r.logger.DebugContext(ctx, "Authorization group not found during cleanup, skipping",
 				slog.String("group_path", groupPath))
 			return nil

--- a/internal/controllers/projectmembership/project_membership_reconciler_function_test.go
+++ b/internal/controllers/projectmembership/project_membership_reconciler_function_test.go
@@ -15,6 +15,7 @@ package projectmembership
 
 import (
 	"context"
+	"fmt"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -109,16 +110,16 @@ var _ = Describe("Default Values", func() {
 })
 
 var _ = Describe("Role to Group Suffix Mapping", func() {
-	It("should map VIEWER role to viewers suffix", func() {
+	It("should map VIEWER role to system:viewers suffix", func() {
 		t := &task{}
 		suffix := t.mapRoleToGroupSuffix(privatev1.ProjectMembershipRole_PROJECT_MEMBERSHIP_ROLE_VIEWER)
-		Expect(suffix).To(Equal("viewers"))
+		Expect(suffix).To(Equal("system:viewers"))
 	})
 
-	It("should map MANAGER role to managers suffix", func() {
+	It("should map MANAGER role to system:managers suffix", func() {
 		t := &task{}
 		suffix := t.mapRoleToGroupSuffix(privatev1.ProjectMembershipRole_PROJECT_MEMBERSHIP_ROLE_MANAGER)
-		Expect(suffix).To(Equal("managers"))
+		Expect(suffix).To(Equal("system:managers"))
 	})
 
 	It("should return empty string for unspecified role", func() {
@@ -173,9 +174,9 @@ var _ = Describe("Project Group Path Building", func() {
 				r: functionObj,
 			}
 
-			path, err := task.buildProjectGroupPath(ctx, project, "managers")
+			path, err := task.buildProjectGroupPath(ctx, project, "system:managers")
 			Expect(err).ToNot(HaveOccurred())
-			Expect(path).To(Equal("/my-project/managers"))
+			Expect(path).To(Equal("/my-project/system:managers"))
 		})
 
 		It("should build path with viewers suffix", func() {
@@ -190,9 +191,9 @@ var _ = Describe("Project Group Path Building", func() {
 				r: functionObj,
 			}
 
-			path, err := task.buildProjectGroupPath(ctx, project, "viewers")
+			path, err := task.buildProjectGroupPath(ctx, project, "system:viewers")
 			Expect(err).ToNot(HaveOccurred())
-			Expect(path).To(Equal("/my-project/viewers"))
+			Expect(path).To(Equal("/my-project/system:viewers"))
 		})
 	})
 
@@ -221,9 +222,9 @@ var _ = Describe("Project Group Path Building", func() {
 				r: functionObj,
 			}
 
-			path, err := task.buildProjectGroupPath(ctx, childProject, "managers")
+			path, err := task.buildProjectGroupPath(ctx, childProject, "system:managers")
 			Expect(err).ToNot(HaveOccurred())
-			Expect(path).To(Equal("/parent/child/managers"))
+			Expect(path).To(Equal("/parent/child/system:managers"))
 		})
 
 		It("should build hierarchical path for two-level nesting", func() {
@@ -264,9 +265,9 @@ var _ = Describe("Project Group Path Building", func() {
 				r: functionObj,
 			}
 
-			path, err := task.buildProjectGroupPath(ctx, childProject, "viewers")
+			path, err := task.buildProjectGroupPath(ctx, childProject, "system:viewers")
 			Expect(err).ToNot(HaveOccurred())
-			Expect(path).To(Equal("/root/parent/child/viewers"))
+			Expect(path).To(Equal("/root/parent/child/system:viewers"))
 		})
 
 		It("should build hierarchical path for three-level nesting", func() {
@@ -320,9 +321,9 @@ var _ = Describe("Project Group Path Building", func() {
 				r: functionObj,
 			}
 
-			path, err := task.buildProjectGroupPath(ctx, componentProject, "managers")
+			path, err := task.buildProjectGroupPath(ctx, componentProject, "system:managers")
 			Expect(err).ToNot(HaveOccurred())
-			Expect(path).To(Equal("/org/team/product/component/managers"))
+			Expect(path).To(Equal("/org/team/product/component/system:managers"))
 		})
 	})
 
@@ -377,7 +378,7 @@ var _ = Describe("Project Group Path Building", func() {
 				r: functionObj,
 			}
 
-			path, err := task.buildProjectGroupPath(ctx, deepProject, "managers")
+			path, err := task.buildProjectGroupPath(ctx, deepProject, "system:managers")
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("exceeded maximum depth"))
 			Expect(err.Error()).To(ContainSubstring("circular reference"))
@@ -457,7 +458,7 @@ var _ = Describe("Synchronization", func() {
 				Return(&privatev1.ProjectsGetResponse{Object: project}, nil)
 
 			mockIdpClient.EXPECT().
-				GetGroupIDByPath(gomock.Any(), "acme", "/my-project/managers").
+				GetGroupIDByPath(gomock.Any(), "acme", "/my-project/system:managers").
 				Return("group-id", nil)
 
 			mockIdpClient.EXPECT().
@@ -528,7 +529,7 @@ var _ = Describe("Synchronization", func() {
 				Return(&privatev1.ProjectsGetResponse{Object: parentProject}, nil)
 
 			mockIdpClient.EXPECT().
-				GetGroupIDByPath(gomock.Any(), "acme", "/parent/child/viewers").
+				GetGroupIDByPath(gomock.Any(), "acme", "/parent/child/system:viewers").
 				Return("group-id", nil)
 
 			mockIdpClient.EXPECT().
@@ -657,7 +658,7 @@ var _ = Describe("Synchronization", func() {
 				Return(&privatev1.ProjectsGetResponse{Object: project}, nil)
 
 			mockIdpClient.EXPECT().
-				GetGroupIDByPath(gomock.Any(), "acme", "/my-project/managers").
+				GetGroupIDByPath(gomock.Any(), "acme", "/my-project/system:managers").
 				Return("", status.Error(codes.NotFound, "group not found"))
 
 			task := &task{
@@ -743,7 +744,7 @@ var _ = Describe("Deletion Cleanup", func() {
 			Return(&privatev1.ProjectsGetResponse{Object: project}, nil)
 
 		mockIdpClient.EXPECT().
-			GetGroupIDByPath(gomock.Any(), "acme", "/my-project/managers").
+			GetGroupIDByPath(gomock.Any(), "acme", "/my-project/system:managers").
 			Return("group-id", nil)
 
 		mockIdpClient.EXPECT().
@@ -811,7 +812,7 @@ var _ = Describe("Deletion Cleanup", func() {
 			Return(&privatev1.ProjectsGetResponse{Object: parentProject}, nil)
 
 		mockIdpClient.EXPECT().
-			GetGroupIDByPath(gomock.Any(), "acme", "/parent/child/viewers").
+			GetGroupIDByPath(gomock.Any(), "acme", "/parent/child/system:viewers").
 			Return("group-id", nil)
 
 		mockIdpClient.EXPECT().
@@ -843,6 +844,109 @@ var _ = Describe("Deletion Cleanup", func() {
 		mockUsersClient.EXPECT().
 			Get(gomock.Any(), gomock.Any()).
 			Return(nil, status.Error(codes.NotFound, "user not found"))
+
+		task := &task{
+			r:          functionObj,
+			membership: membership,
+		}
+
+		err := task.delete(ctx)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(membership.GetMetadata().GetFinalizers()).ToNot(ContainElement(finalizers.ProjectMembershipFinalizer))
+	})
+
+	It("should handle group not found during cleanup with gRPC status code", func() {
+		user := privatev1.User_builder{
+			Spec: privatev1.UserSpec_builder{
+				Username: "alice",
+			}.Build(),
+			Status: privatev1.UserStatus_builder{
+				KeycloakUserId: "keycloak-alice-id",
+			}.Build(),
+		}.Build()
+
+		project := privatev1.Project_builder{
+			Metadata: privatev1.Metadata_builder{
+				Name:   "my-project",
+				Tenant: "acme",
+			}.Build(),
+			Spec: privatev1.ProjectSpec_builder{}.Build(),
+		}.Build()
+
+		membership := privatev1.ProjectMembership_builder{
+			Metadata: privatev1.Metadata_builder{
+				Finalizers: []string{finalizers.ProjectMembershipFinalizer},
+			}.Build(),
+			Spec: privatev1.ProjectMembershipSpec_builder{
+				User:    new("user-id"),
+				Project: "project-id",
+				Role:    privatev1.ProjectMembershipRole_PROJECT_MEMBERSHIP_ROLE_MANAGER,
+			}.Build(),
+		}.Build()
+
+		mockUsersClient.EXPECT().
+			Get(gomock.Any(), gomock.Any()).
+			Return(&privatev1.UsersGetResponse{Object: user}, nil)
+
+		mockProjectsClient.EXPECT().
+			Get(gomock.Any(), gomock.Any()).
+			Return(&privatev1.ProjectsGetResponse{Object: project}, nil)
+
+		mockIdpClient.EXPECT().
+			GetGroupIDByPath(gomock.Any(), "acme", "/my-project/system:managers").
+			Return("", status.Error(codes.NotFound, "group not found"))
+
+		task := &task{
+			r:          functionObj,
+			membership: membership,
+		}
+
+		err := task.delete(ctx)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(membership.GetMetadata().GetFinalizers()).ToNot(ContainElement(finalizers.ProjectMembershipFinalizer))
+	})
+
+	It("should handle group not found during cleanup with wrapped error message", func() {
+		user := privatev1.User_builder{
+			Spec: privatev1.UserSpec_builder{
+				Username: "alice",
+			}.Build(),
+			Status: privatev1.UserStatus_builder{
+				KeycloakUserId: "keycloak-alice-id",
+			}.Build(),
+		}.Build()
+
+		project := privatev1.Project_builder{
+			Metadata: privatev1.Metadata_builder{
+				Name:   "my-project",
+				Tenant: "acme",
+			}.Build(),
+			Spec: privatev1.ProjectSpec_builder{}.Build(),
+		}.Build()
+
+		membership := privatev1.ProjectMembership_builder{
+			Metadata: privatev1.Metadata_builder{
+				Finalizers: []string{finalizers.ProjectMembershipFinalizer},
+			}.Build(),
+			Spec: privatev1.ProjectMembershipSpec_builder{
+				User:    new("user-id"),
+				Project: "project-id",
+				Role:    privatev1.ProjectMembershipRole_PROJECT_MEMBERSHIP_ROLE_VIEWER,
+			}.Build(),
+		}.Build()
+
+		mockUsersClient.EXPECT().
+			Get(gomock.Any(), gomock.Any()).
+			Return(&privatev1.UsersGetResponse{Object: user}, nil)
+
+		mockProjectsClient.EXPECT().
+			Get(gomock.Any(), gomock.Any()).
+			Return(&privatev1.ProjectsGetResponse{Object: project}, nil)
+
+		// Simulate a wrapped error that doesn't have gRPC status code but contains "not found" in message
+		mockIdpClient.EXPECT().
+			GetGroupIDByPath(gomock.Any(), "acme", "/my-project/system:viewers").
+			Return("", fmt.Errorf("wrapped error: group not found in keycloak"))
 
 		task := &task{
 			r:          functionObj,

--- a/internal/idp/keycloak/authz_groups.go
+++ b/internal/idp/keycloak/authz_groups.go
@@ -268,35 +268,32 @@ type groupNode struct {
 // getGroupIDByPathWithOrgID returns the group ID for a path using orgID directly (not organization name).
 // This is used internally when we already have the orgID to avoid an extra lookup.
 func (c *Client) getGroupIDByPathWithOrgID(ctx context.Context, orgID, groupPath string) (result string, err error) {
-	// Send the request to list all groups in the organization:
-	path := fmt.Sprintf(
-		"/admin/realms/%s/organizations/%s/groups",
-		url.PathEscape(c.realmName), url.PathEscape(orgID),
-	)
-	var response *http.Response
-	response, err = c.httpClient.DoRequest(ctx, http.MethodGet, path, nil)
-	if err != nil {
-		err = fmt.Errorf("failed to list organization groups: %w", err)
-		return
-	}
-	defer response.Body.Close()
-	var groups []groupNode
-	err = json.NewDecoder(response.Body).Decode(&groups)
-	if err != nil {
-		err = fmt.Errorf("failed to decode organization groups: %w", err)
-		return
-	}
+	// The Keycloak organization groups list API does not populate subgroups, sowe manually traverse the hierarchy by splitting the path and fetching each level.
 
-	// Search recursively through the group hierarchy:
-	for _, group := range groups {
-		result = searchGroupRecursively(group, groupPath)
-		if result != "" {
+	// Normalize and split the path: "/bens-project/system:managers" -> ["bens-project", "system:managers"]
+	normalizedPath := strings.Trim(groupPath, "/")
+	if normalizedPath == "" {
+		err = fmt.Errorf("empty group path")
+		return
+	}
+	segments := strings.Split(normalizedPath, "/")
+
+	// Start at the top level and traverse down
+	var currentParentID string // empty for top level
+	for i, segment := range segments {
+		// Get the group ID for this segment
+		groupID, lookupErr := c.getGroupIDByName(ctx, orgID, currentParentID, segment)
+		if lookupErr != nil {
+			err = fmt.Errorf("failed to find group segment %d '%s' (parent: %s): %w", i, segment, currentParentID, lookupErr)
 			return
 		}
+
+		// This segment becomes the parent for the next iteration
+		currentParentID = groupID
 	}
 
-	// We didn't find the group:
-	err = fmt.Errorf("organization group not found: %s", groupPath)
+	// The last segment's ID is the final group ID
+	result = currentParentID
 	return
 }
 

--- a/internal/idp/keycloak/authz_groups_test.go
+++ b/internal/idp/keycloak/authz_groups_test.go
@@ -14,87 +14,9 @@ language governing permissions and limitations under the License.
 package keycloak
 
 import (
-	"strings"
-
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
-
-var _ = Describe("ensureGroupHierarchyWithCache path normalization", func() {
-	It("should normalize path with double leading slashes", func() {
-		// When a project path is empty, we might get "//system:viewers"
-		// This should be normalized to "/system:viewers"
-		groupPath := "//system:viewers"
-
-		// The normalization should:
-		// 1. Trim leading/trailing slashes: "system:viewers"
-		// 2. Replace double slashes: (already done after trim)
-		// 3. Split into segments: ["system:viewers"]
-		// 4. Build path as "/system:viewers"
-
-		// We expect the normalized path to be stored in cache as "/system:viewers"
-		expectedNormalizedPath := "/system:viewers"
-
-		// Verify the normalization logic matches what we expect
-		normalizedPath := strings.Trim(groupPath, "/")
-		normalizedPath = strings.ReplaceAll(normalizedPath, "//", "/")
-		Expect(normalizedPath).To(Equal("system:viewers"))
-
-		// After building the path, it should be stored with leading slash
-		segments := strings.Split(normalizedPath, "/")
-		Expect(segments).To(Equal([]string{"system:viewers"}))
-
-		builtPath := "/" + segments[0]
-		Expect(builtPath).To(Equal(expectedNormalizedPath))
-	})
-
-	It("should normalize path with double slashes", func() {
-		// The main use case is handling empty project paths that result in "//system:viewers"
-		groupPath := "/web-app//system:viewers"
-
-		normalizedPath := strings.Trim(groupPath, "/")
-		normalizedPath = strings.ReplaceAll(normalizedPath, "//", "/")
-
-		// After trimming: "web-app//system:viewers"
-		// After replacing "//": "web-app/system:viewers"
-		Expect(normalizedPath).To(Equal("web-app/system:viewers"))
-	})
-
-	It("should handle normal path without modification", func() {
-		groupPath := "/web-app/system:viewers"
-
-		normalizedPath := strings.Trim(groupPath, "/")
-		normalizedPath = strings.ReplaceAll(normalizedPath, "//", "/")
-
-		Expect(normalizedPath).To(Equal("web-app/system:viewers"))
-	})
-
-	It("should handle single segment path", func() {
-		groupPath := "/system:viewers"
-
-		normalizedPath := strings.Trim(groupPath, "/")
-		normalizedPath = strings.ReplaceAll(normalizedPath, "//", "/")
-
-		segments := strings.Split(normalizedPath, "/")
-		Expect(segments).To(Equal([]string{"system:viewers"}))
-	})
-
-	It("should detect empty path as invalid", func() {
-		groupPath := "/"
-
-		normalizedPath := strings.Trim(groupPath, "/")
-		segments := strings.Split(normalizedPath, "/")
-
-		// Empty string splits into one segment with empty string
-		Expect(segments).To(HaveLen(1))
-		Expect(segments[0]).To(Equal(""))
-
-		// This should trigger the error condition:
-		// len(segments) == 1 && segments[0] == ""
-		isInvalid := len(segments) == 0 || (len(segments) == 1 && segments[0] == "")
-		Expect(isInvalid).To(BeTrue())
-	})
-})
 
 var _ = Describe("searchGroupRecursively", func() {
 	It("should find a top-level group", func() {

--- a/internal/idp/keycloak/client_test.go
+++ b/internal/idp/keycloak/client_test.go
@@ -2728,15 +2728,30 @@ var _ = Describe("Keycloak Client", func() {
 						}
 						return
 					}
-					// Second request: list organization groups (no search parameter - returns all groups)
+					// Second request: list top-level organization groups to find "web-app"
 					if r.Method == http.MethodGet && r.URL.Path == "/admin/realms/osac/organizations/org-123/groups" {
-						// Return all groups - implementation searches recursively through the list
 						groups := []struct {
 							ID   string `json:"id"`
-							Path string `json:"path"`
+							Name string `json:"name"`
 						}{
-							{ID: "group-123", Path: "/web-app/system:viewers"},
-							{ID: "group-456", Path: "/web-app/system:managers"},
+							{ID: "group-parent", Name: "web-app"},
+						}
+						w.Header().Set("Content-Type", "application/json")
+						w.WriteHeader(http.StatusOK)
+						if err := json.NewEncoder(w).Encode(groups); err != nil {
+							http.Error(w, err.Error(), http.StatusInternalServerError)
+							return
+						}
+						return
+					}
+					// Third request: list children of "web-app" group to find "system:viewers"
+					if r.Method == http.MethodGet && r.URL.Path == "/admin/realms/osac/organizations/org-123/groups/group-parent/children" {
+						groups := []struct {
+							ID   string `json:"id"`
+							Name string `json:"name"`
+						}{
+							{ID: "group-123", Name: "system:viewers"},
+							{ID: "group-456", Name: "system:managers"},
 						}
 						w.Header().Set("Content-Type", "application/json")
 						w.WriteHeader(http.StatusOK)
@@ -2792,11 +2807,11 @@ var _ = Describe("Keycloak Client", func() {
 						}
 						return
 					}
-					// Second request: search returns empty
+					// Second request: list top-level groups returns empty (group not found)
 					if r.Method == http.MethodGet && r.URL.Path == "/admin/realms/osac/organizations/org-123/groups" {
 						groups := []struct {
 							ID   string `json:"id"`
-							Path string `json:"path"`
+							Name string `json:"name"`
 						}{}
 						w.Header().Set("Content-Type", "application/json")
 						w.WriteHeader(http.StatusOK)
@@ -2813,7 +2828,7 @@ var _ = Describe("Keycloak Client", func() {
 
 				_, err := client.GetGroupIDByPath(ctx, "acme-corp", "/nonexistent-group")
 				Expect(err).To(HaveOccurred())
-				Expect(err.Error()).To(ContainSubstring("organization group not found"))
+				Expect(err.Error()).To(ContainSubstring("not found"))
 			})
 
 			It("should return error when list fails", func() {
@@ -2831,7 +2846,7 @@ var _ = Describe("Keycloak Client", func() {
 						}
 						return
 					}
-					// Second request: list fails
+					// Second request: list groups fails
 					if r.Method == http.MethodGet && r.URL.Path == "/admin/realms/osac/organizations/org-123/groups" {
 						w.WriteHeader(http.StatusInternalServerError)
 						return
@@ -2843,7 +2858,187 @@ var _ = Describe("Keycloak Client", func() {
 
 				_, err := client.GetGroupIDByPath(ctx, "acme-corp", "/web-app/system:viewers")
 				Expect(err).To(HaveOccurred())
-				Expect(err.Error()).To(ContainSubstring("failed to list organization groups"))
+				Expect(err.Error()).To(ContainSubstring("failed to list groups"))
+			})
+
+			It("should find a deeply nested group with three levels", func() {
+				server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					// First request: get organization
+					if r.Method == http.MethodGet && r.URL.Path == "/admin/realms/osac/organizations" && r.URL.RawQuery == "exact=true&search=acme-corp" {
+						orgs := []keycloakOrganization{
+							{ID: "org-123", Name: "acme-corp"},
+						}
+						w.Header().Set("Content-Type", "application/json")
+						w.WriteHeader(http.StatusOK)
+						if err := json.NewEncoder(w).Encode(orgs); err != nil {
+							http.Error(w, err.Error(), http.StatusInternalServerError)
+							return
+						}
+						return
+					}
+					// Second request: list top-level groups to find "parent"
+					if r.Method == http.MethodGet && r.URL.Path == "/admin/realms/osac/organizations/org-123/groups" {
+						groups := []struct {
+							ID   string `json:"id"`
+							Name string `json:"name"`
+						}{
+							{ID: "group-parent", Name: "parent"},
+						}
+						w.Header().Set("Content-Type", "application/json")
+						w.WriteHeader(http.StatusOK)
+						if err := json.NewEncoder(w).Encode(groups); err != nil {
+							http.Error(w, err.Error(), http.StatusInternalServerError)
+							return
+						}
+						return
+					}
+					// Third request: list children of "parent" to find "child"
+					if r.Method == http.MethodGet && r.URL.Path == "/admin/realms/osac/organizations/org-123/groups/group-parent/children" {
+						groups := []struct {
+							ID   string `json:"id"`
+							Name string `json:"name"`
+						}{
+							{ID: "group-child", Name: "child"},
+						}
+						w.Header().Set("Content-Type", "application/json")
+						w.WriteHeader(http.StatusOK)
+						if err := json.NewEncoder(w).Encode(groups); err != nil {
+							http.Error(w, err.Error(), http.StatusInternalServerError)
+							return
+						}
+						return
+					}
+					// Fourth request: list children of "child" to find "system:managers"
+					if r.Method == http.MethodGet && r.URL.Path == "/admin/realms/osac/organizations/org-123/groups/group-child/children" {
+						groups := []struct {
+							ID   string `json:"id"`
+							Name string `json:"name"`
+						}{
+							{ID: "group-managers", Name: "system:managers"},
+							{ID: "group-viewers", Name: "system:viewers"},
+						}
+						w.Header().Set("Content-Type", "application/json")
+						w.WriteHeader(http.StatusOK)
+						if err := json.NewEncoder(w).Encode(groups); err != nil {
+							http.Error(w, err.Error(), http.StatusInternalServerError)
+							return
+						}
+						return
+					}
+					w.WriteHeader(http.StatusNotFound)
+				}))
+
+				client = createTestClient(server.URL)
+
+				groupID, err := client.GetGroupIDByPath(ctx, "acme-corp", "/parent/child/system:managers")
+				Expect(err).ToNot(HaveOccurred())
+				Expect(groupID).To(Equal("group-managers"))
+			})
+
+			It("should return error when intermediate segment is not found", func() {
+				server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					// First request: get organization
+					if r.Method == http.MethodGet && r.URL.Path == "/admin/realms/osac/organizations" && r.URL.RawQuery == "exact=true&search=acme-corp" {
+						orgs := []keycloakOrganization{
+							{ID: "org-123", Name: "acme-corp"},
+						}
+						w.Header().Set("Content-Type", "application/json")
+						w.WriteHeader(http.StatusOK)
+						if err := json.NewEncoder(w).Encode(orgs); err != nil {
+							http.Error(w, err.Error(), http.StatusInternalServerError)
+							return
+						}
+						return
+					}
+					// Second request: list top-level groups - "parent" exists
+					if r.Method == http.MethodGet && r.URL.Path == "/admin/realms/osac/organizations/org-123/groups" {
+						groups := []struct {
+							ID   string `json:"id"`
+							Name string `json:"name"`
+						}{
+							{ID: "group-parent", Name: "parent"},
+						}
+						w.Header().Set("Content-Type", "application/json")
+						w.WriteHeader(http.StatusOK)
+						if err := json.NewEncoder(w).Encode(groups); err != nil {
+							http.Error(w, err.Error(), http.StatusInternalServerError)
+							return
+						}
+						return
+					}
+					// Third request: list children of "parent" - "missing-child" not found
+					if r.Method == http.MethodGet && r.URL.Path == "/admin/realms/osac/organizations/org-123/groups/group-parent/children" {
+						groups := []struct {
+							ID   string `json:"id"`
+							Name string `json:"name"`
+						}{}
+						w.Header().Set("Content-Type", "application/json")
+						w.WriteHeader(http.StatusOK)
+						if err := json.NewEncoder(w).Encode(groups); err != nil {
+							http.Error(w, err.Error(), http.StatusInternalServerError)
+							return
+						}
+						return
+					}
+					w.WriteHeader(http.StatusNotFound)
+				}))
+
+				client = createTestClient(server.URL)
+
+				_, err := client.GetGroupIDByPath(ctx, "acme-corp", "/parent/missing-child/system:viewers")
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("failed to find group segment 1"))
+				Expect(err.Error()).To(ContainSubstring("missing-child"))
+			})
+
+			It("should handle empty path error", func() {
+				server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					// First request: get organization
+					if r.Method == http.MethodGet && r.URL.Path == "/admin/realms/osac/organizations" && r.URL.RawQuery == "exact=true&search=acme-corp" {
+						orgs := []keycloakOrganization{
+							{ID: "org-123", Name: "acme-corp"},
+						}
+						w.Header().Set("Content-Type", "application/json")
+						w.WriteHeader(http.StatusOK)
+						if err := json.NewEncoder(w).Encode(orgs); err != nil {
+							http.Error(w, err.Error(), http.StatusInternalServerError)
+							return
+						}
+						return
+					}
+					w.WriteHeader(http.StatusNotFound)
+				}))
+
+				client = createTestClient(server.URL)
+
+				_, err := client.GetGroupIDByPath(ctx, "acme-corp", "")
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("empty group path"))
+			})
+
+			It("should handle path with only slashes as empty", func() {
+				server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					// First request: get organization
+					if r.Method == http.MethodGet && r.URL.Path == "/admin/realms/osac/organizations" && r.URL.RawQuery == "exact=true&search=acme-corp" {
+						orgs := []keycloakOrganization{
+							{ID: "org-123", Name: "acme-corp"},
+						}
+						w.Header().Set("Content-Type", "application/json")
+						w.WriteHeader(http.StatusOK)
+						if err := json.NewEncoder(w).Encode(orgs); err != nil {
+							http.Error(w, err.Error(), http.StatusInternalServerError)
+							return
+						}
+						return
+					}
+					w.WriteHeader(http.StatusNotFound)
+				}))
+
+				client = createTestClient(server.URL)
+
+				_, err := client.GetGroupIDByPath(ctx, "acme-corp", "/")
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("empty group path"))
 			})
 		})
 	})


### PR DESCRIPTION
# Description

Relevant changes:
- Updated project role constants from `managers` and `viewers` group to match updated name `system:managers` and `system:viewers`
- Fixed Keycloak group lookup so that sub-groups like `/<project name>/system:managers` can be found
- Registered the ProjectMembership controllers


# Testing

- [x] go build passes
- [x] go unit test passes
- [x] deployed integration environment, created tenant, connected idp
    - created project as idp user and verified user was auto added to `system:managers` group of project in keycloak
    - added another tenant user to project as `system:viewer` and verified they appeared on keycloak as a member of the project's `system:viewers` group 


/cc @jhernand 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Project membership synchronization is now supported during controller startup.

* **Bug Fixes**
  * Authorization groups now use `system:viewers` and `system:managers` for relevant roles.
  * Group lookup is more reliable for nested paths and paths with leading/trailing slashes.
  * Cleanup now handles “not found” errors even when they are wrapped by the identity provider.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->