### PR TITLE
OSAC-1983: add --image flag and IMAGE column for BareMetalInstance CLI

### DIFF
--- a/internal/cmd/cli/create/baremetalinstance/create_bare_metal_instance_cmd.go
+++ b/internal/cmd/cli/create/baremetalinstance/create_bare_metal_instance_cmd.go
@@ -70,6 +70,18 @@ func Cmd() *cobra.Command {
 		"",
 		runStrategyFlagHelp,
 	)
+	flags.StringVar(
+		&runner.args.imageSourceRef,
+		"image",
+		"",
+		imageFlagHelp,
+	)
+	flags.StringVar(
+		&runner.args.imageSourceType,
+		"image-source-type",
+		"registry",
+		imageSourceTypeFlagHelp,
+	)
 
 	if err := result.MarkFlagRequired("catalog-item"); err != nil {
 		panic(fmt.Sprintf("failed to mark catalog-item flag as required: %v", err))
@@ -79,11 +91,13 @@ func Cmd() *cobra.Command {
 
 type runnerContext struct {
 	args struct {
-		name        string
-		catalogItem string
-		sshKey      string
-		userData    string
-		runStrategy string
+		name            string
+		catalogItem     string
+		sshKey          string
+		userData        string
+		runStrategy     string
+		imageSourceRef  string
+		imageSourceType string
 	}
 	logger *slog.Logger
 }
@@ -114,6 +128,12 @@ func (c *runnerContext) run(cmd *cobra.Command, _ []string) error {
 	if c.args.userData != "" {
 		userData := c.args.userData
 		spec.UserData = &userData
+	}
+	if c.args.imageSourceRef != "" {
+		spec.Image = publicv1.BareMetalInstanceImage_builder{
+			SourceType: c.args.imageSourceType,
+			SourceRef:  c.args.imageSourceRef,
+		}.Build()
 	}
 	if c.args.runStrategy != "" {
 		val, ok := publicv1.BareMetalInstanceRunStrategy_value["BARE_METAL_INSTANCE_RUN_STRATEGY_"+strings.ToUpper(c.args.runStrategy)]
@@ -174,4 +194,12 @@ const runStrategyFlagHelp = `
 _STRATEGY_ - Run strategy controlling the power state. Valid values are
 {{ bt }}Always{{ bt }} (keep powered on) and {{ bt }}Halted{{ bt }}
 (power off).
+`
+
+const imageFlagHelp = `
+_URL_ - Image reference, for example an OCI image URL.
+`
+
+const imageSourceTypeFlagHelp = `
+_TYPE_ - Image source type.
 `

--- a/internal/rendering/tables/osac.private.v1.BareMetalInstance.yaml
+++ b/internal/rendering/tables/osac.private.v1.BareMetalInstance.yaml
@@ -24,6 +24,9 @@ columns:
   type: osac.private.v1.BareMetalInstanceCatalogItem
   lookup: true
 
+- header: IMAGE
+  value: "has(this.spec.image) && has(this.spec.image.source_ref)? this.spec.image.source_ref: '-'"
+
 - header: STATE
   value: this.status.state
   type: osac.private.v1.BareMetalInstanceState

--- a/internal/rendering/tables/osac.public.v1.BareMetalInstance.yaml
+++ b/internal/rendering/tables/osac.public.v1.BareMetalInstance.yaml
@@ -24,6 +24,9 @@ columns:
   type: osac.public.v1.BareMetalInstanceCatalogItem
   lookup: true
 
+- header: IMAGE
+  value: "has(this.spec.image) && has(this.spec.image.source_ref)? this.spec.image.source_ref: '-'"
+
 - header: STATE
   value: this.status.state
   type: osac.public.v1.BareMetalInstanceState


### PR DESCRIPTION
## Summary

- Add `--image` and `--image-source-type` flags to `create bare-metal-instance` CLI command, following the same pattern as `create compute-instance`
- Default source type is `registry`; image is wired into `BareMetalInstanceSpec.Image` when `--image` is provided
- Add IMAGE column to both public and private BareMetalInstance table rendering (`osac get bare-metal-instances`), showing `spec.image.source_ref`

## Jira

https://redhat.atlassian.net/browse/OSAC-1983

## Test plan

- [x] `gofmt -s -w .` — no formatting changes
- [x] `buf generate` — no codegen drift
- [x] `go build ./...` — compiles cleanly
- [x] `ginkgo run -r internal` — 1286 tests pass
- [x] Pattern matches `create compute-instance` reference implementation (flag registration, struct fields, spec building, help text)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * You can now set an image when creating a bare metal instance using new command-line options.
  * Bare metal instance lists now show an **IMAGE** column when an image is available.

* **Improvements**
  * If no image is set, the table display now shows a clear placeholder instead of leaving the field blank.
  * Updated command help text to include the new image-related options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->