### PR TITLE
OSAC-953: Add missing org groups to keycloak realm.json

### DIFF
--- a/internal/auth/policies/authz.rego
+++ b/internal/auth/policies/authz.rego
@@ -328,8 +328,8 @@ allow if {
   input.auth.identity.authnMethod == "jwt"
   some group in subject_org_groups[tenant].groups
   group in {
-    sprintf("/%s/viewers", [name]),
-    sprintf("/%s/managers", [name]),
+    sprintf("/%s/system:viewers", [name]),
+    sprintf("/%s/system:managers", [name]),
   }
 }
 
@@ -343,7 +343,7 @@ allow if {
   name := input.context.context_extensions.name
   input.auth.identity.authnMethod == "jwt"
   some group in subject_org_groups[tenant].groups
-  group == sprintf("/%s/managers", [name])
+  group == sprintf("/%s/system:managers", [name])
 }
 
 # Subject construction:

--- a/it/charts/keycloak/files/realm.json
+++ b/it/charts/keycloak/files/realm.json
@@ -859,6 +859,18 @@
         "claim.name" : "organization",
         "jsonType.label" : "String"
       }
+    }, {
+      "id" : "c4d5e6f7-8901-2345-6789-0123456789ab",
+      "name" : "organization groups",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-organization-group-membership-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "introspection.token.claim" : "true",
+        "userinfo.token.claim" : "true",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true"
+      }
     } ]
   }, {
     "id" : "ced65214-50b1-4c1b-9775-18fcbf5c27a6",


### PR DESCRIPTION
Org groups were previously not added to the JWT claim. Also updates authz.rego to use the correct group
naming after the changes in
https://github.com/osac-project/fulfillment-service/pull/817

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated organization-scoped access rules so project viewing now recognizes the revised viewer and manager group names.
  * Updated project editing and deletion access checks to use the revised manager group name.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->