### PR TITLE
OSAC-2184: Restrict publish-binaries.yaml to v* release tags

### DIFF
--- a/.github/workflows/publish-binaries.yaml
+++ b/.github/workflows/publish-binaries.yaml
@@ -17,7 +17,7 @@ name: Publish binaries
 on:
   push:
     tags:
-    - '*'
+    - 'v*'
 
 jobs:
 


### PR DESCRIPTION
## Summary
- `publish-binaries.yaml` triggered on **every** pushed tag via an unscoped `tags: ['*']` filter, while its sibling release workflows (`publish-charts.yaml`, `publish-image.yaml`, `publish-proto.yaml`) all correctly scope to `tags: ['v*']`.
- This meant pushing an `api/v*` protobuf API version tag (which is intentionally excluded from release-version detection elsewhere via `grep -v '^api/'`) would spuriously trigger a binary release, creating a bogus GitHub Release with binaries stamped with a corrupted version string (e.g. `api/v0.0.6`), and wasting CI resources.
- Fix: change the trigger to `tags: ['v*']`, matching the rest of the release pipeline.

## Test plan
- [ ] Push an `api/v*` tag (e.g. `api/v0.0.7`) and confirm `publish-binaries.yaml` does **not** run.
- [ ] Push a normal `vX.Y.Z` release tag and confirm `publish-binaries.yaml` still runs as before.

Fixes [OSAC-2184](https://redhat.atlassian.net/browse/OSAC-2184)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the binary publishing workflow to run only for version tags, reducing unintended release runs on non-version tags.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->