### PR TITLE
feat: register ocp_4_20_ai_maas cluster template

### DIFF
--- a/internal/database/migrations/74_add_ocp_4_20_ai_maas_cluster_template.up.sql
+++ b/internal/database/migrations/74_add_ocp_4_20_ai_maas_cluster_template.up.sql
@@ -1,0 +1,73 @@
+--
+-- Copyright (c) 2025 Red Hat Inc.
+--
+-- Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+-- the License. You may obtain a copy of the License at
+--
+--   http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+-- an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+-- specific language governing permissions and limitations under the License.
+--
+
+insert into cluster_templates (id, tenant, data) values
+(
+  'ocp_4_20_ai_maas',
+  'shared',
+  '{
+    "id": "ocp_4_20_ai_maas",
+    "title": "OpenShift AI 4.20 Cluster with MaaS",
+    "description": "Builds an OpenShift 4.20 cluster with RHOAI 3.4, Models-as-a-Service (GA), Keycloak SSO, and observability.",
+    "parameters": [
+      {
+        "type": "type.googleapis.com/google.protobuf.BoolValue",
+        "name": "enable_maas",
+        "default": {
+          "@type": "type.googleapis.com/google.protobuf.BoolValue",
+          "value": true
+        }
+      },
+      {
+        "type": "type.googleapis.com/google.protobuf.BoolValue",
+        "name": "enable_keycloak",
+        "default": {
+          "@type": "type.googleapis.com/google.protobuf.BoolValue",
+          "value": true
+        }
+      },
+      {
+        "type": "type.googleapis.com/google.protobuf.StringValue",
+        "name": "oidc_issuer",
+        "default": {
+          "@type": "type.googleapis.com/google.protobuf.StringValue",
+          "value": ""
+        }
+      },
+      {
+        "type": "type.googleapis.com/google.protobuf.StringValue",
+        "name": "oidc_client_id",
+        "default": {
+          "@type": "type.googleapis.com/google.protobuf.StringValue",
+          "value": ""
+        }
+      },
+      {
+        "type": "type.googleapis.com/google.protobuf.BoolValue",
+        "name": "enable_observability",
+        "default": {
+          "@type": "type.googleapis.com/google.protobuf.BoolValue",
+          "value": true
+        }
+      },
+      {
+        "type": "type.googleapis.com/google.protobuf.BoolValue",
+        "name": "enable_dashboard",
+        "default": {
+          "@type": "type.googleapis.com/google.protobuf.BoolValue",
+          "value": true
+        }
+      }
+    ]
+  }'
+) on conflict (id) do nothing;


### PR DESCRIPTION
## Summary
- Adds database migration 74 to register the `ocp_4_20_ai_maas` cluster template in the fulfillment-service
- Enables users to create ClusterOrders for MaaS (Models as a Service) inference clusters with RHOAI 3.4, Keycloak SSO, and observability
- Template is seeded in the `shared` tenant, matching the pattern of the existing `ocp_4_17_small` template

## Jira
N/A

## Test plan
- [x] `go build ./...` passes
- [x] `gofmt` passes
- [ ] Integration tests (migration runs cleanly on fresh DB)

## Related
Companion to osac-aap PR #351 which adds the `ocp_4_20_ai_maas` Ansible role

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new “OpenShift AI 4.20 Cluster with MaaS” template.
  * Includes configurable defaults for MaaS, Keycloak, observability, dashboards, and OIDC issuer/client ID settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->