### PR TITLE
OSAC-1852: Introduce osac whoami cli cmd

### DIFF
--- a/internal/cmd/cli/get/token/get_token_cmd.go
+++ b/internal/cmd/cli/get/token/get_token_cmd.go
@@ -14,17 +14,12 @@ language governing permissions and limitations under the License.
 package token
 
 import (
-	"context"
-	"log/slog"
-	"time"
-
 	"github.com/golang-jwt/jwt/v5"
-	"github.com/neilotoole/jsoncolor"
 	"github.com/spf13/cobra"
 
+	"github.com/osac-project/fulfillment-service/internal/cmd/cli/tokenutil"
 	"github.com/osac-project/fulfillment-service/internal/config"
 	"github.com/osac-project/fulfillment-service/internal/exit"
-	"github.com/osac-project/fulfillment-service/internal/logging"
 	"github.com/osac-project/fulfillment-service/internal/terminal"
 )
 
@@ -78,7 +73,6 @@ func Cmd() *cobra.Command {
 }
 
 type runnerContext struct {
-	logger  *slog.Logger
 	console *terminal.Console
 	refresh bool
 	header  bool
@@ -93,8 +87,7 @@ func (c *runnerContext) run(cmd *cobra.Command, args []string) error {
 	// Get the context:
 	ctx := cmd.Context()
 
-	// Get the logger, console and flags:
-	c.logger = logging.LoggerFromContext(ctx)
+	// Get the console:
 	c.console = terminal.ConsoleFromContext(ctx)
 
 	// Get the configuration:
@@ -147,47 +140,11 @@ func (c *runnerContext) run(cmd *cobra.Command, args []string) error {
 		c.console.RenderJson(ctx, parsed.Header)
 	case c.payload:
 		claims := *parsed.Claims.(*jwt.MapClaims)
-		claims = c.replaceTimeClaims(ctx, claims)
-		c.console.RenderJson(ctx, claims)
+		tokenutil.DisplayTokenClaims(ctx, c.console, claims, c.rfc3339, c.utc)
 	default:
 		c.console.Infof(ctx, "%s\n", selected)
 	}
 	return nil
-}
-
-func (c *runnerContext) replaceTimeClaims(ctx context.Context, claims jwt.MapClaims) jwt.MapClaims {
-	result := jwt.MapClaims{}
-	for name, value := range claims {
-		switch name {
-		case "iat", "exp", "nbf", "auth_time":
-			result[name] = c.replaceTimeClaim(ctx, name, value.(jsoncolor.Number))
-		default:
-			result[name] = value
-		}
-	}
-	return result
-}
-
-func (c *runnerContext) replaceTimeClaim(ctx context.Context, name string, value jsoncolor.Number) any {
-	if !c.rfc3339 {
-		return value
-	}
-	s, err := value.Int64()
-	if err != nil {
-		c.logger.ErrorContext(
-			ctx,
-			"Failed to parse claim as seconds",
-			slog.String("name", name),
-			slog.Any("value", value),
-			slog.Any("error", err),
-		)
-		return value
-	}
-	t := time.Unix(s, 0)
-	if c.utc {
-		t = t.UTC()
-	}
-	return t.Format(time.RFC3339)
 }
 
 const shortHelp = `Shows the authentication token, requesting a new one if necessary`

--- a/internal/cmd/cli/root_cmd.go
+++ b/internal/cmd/cli/root_cmd.go
@@ -34,6 +34,7 @@ import (
 	"github.com/osac-project/fulfillment-service/internal/cmd/cli/logout"
 	"github.com/osac-project/fulfillment-service/internal/cmd/cli/tenant"
 	"github.com/osac-project/fulfillment-service/internal/cmd/cli/version"
+	"github.com/osac-project/fulfillment-service/internal/cmd/cli/whoami"
 	"github.com/osac-project/fulfillment-service/internal/config"
 	"github.com/osac-project/fulfillment-service/internal/logging"
 	"github.com/osac-project/fulfillment-service/internal/terminal"
@@ -106,6 +107,7 @@ func Root() (result *cobra.Command, err error) {
 	result.AddCommand(logout.Cmd())
 	result.AddCommand(tenant.Cmd())
 	result.AddCommand(version.Cmd())
+	result.AddCommand(whoami.Cmd())
 
 	// Configure the root command, and therefore all its subcommands, to use Markdown for their help output:
 	help.Setup(result)

--- a/internal/cmd/cli/tokenutil/token_display.go
+++ b/internal/cmd/cli/tokenutil/token_display.go
@@ -1,0 +1,100 @@
+/*
+Copyright (c) 2026 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package tokenutil
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+
+	"github.com/osac-project/fulfillment-service/internal/logging"
+	"github.com/osac-project/fulfillment-service/internal/terminal"
+)
+
+// ParseTokenClaims parses a JWT token string and returns the claims without verification.
+// This is useful for displaying token information to the user.
+func ParseTokenClaims(tokenString string) (jwt.MapClaims, error) {
+	parser := jwt.NewParser(jwt.WithoutClaimsValidation())
+	parsedToken, _, err := parser.ParseUnverified(tokenString, jwt.MapClaims{})
+	if err != nil {
+		return nil, err
+	}
+
+	claims, ok := parsedToken.Claims.(jwt.MapClaims)
+	if !ok {
+		return nil, nil
+	}
+
+	return claims, nil
+}
+
+// DisplayTokenClaims displays decoded token claims to the console as JSON.
+// If rfc3339 is true, time claims (iat, exp, nbf, auth_time) are converted to RFC3339 format.
+// If utc is true, time claims are displayed in UTC timezone.
+func DisplayTokenClaims(ctx context.Context, console *terminal.Console, claims jwt.MapClaims, rfc3339, utc bool) {
+	if rfc3339 {
+		logger := logging.LoggerFromContext(ctx)
+		claims = replaceTimeClaims(ctx, logger, claims, utc)
+	}
+	console.RenderJson(ctx, claims)
+}
+
+// replaceTimeClaims converts time claims to RFC3339 format for better readability.
+func replaceTimeClaims(ctx context.Context, logger *slog.Logger, claims jwt.MapClaims, utc bool) jwt.MapClaims {
+	result := jwt.MapClaims{}
+	for name, value := range claims {
+		switch name {
+		case "iat", "exp", "nbf", "auth_time":
+			result[name] = replaceTimeClaim(ctx, logger, name, value, utc)
+		default:
+			result[name] = value
+		}
+	}
+	return result
+}
+
+// replaceTimeClaim converts a single time claim from Unix timestamp to RFC3339 format.
+func replaceTimeClaim(ctx context.Context, logger *slog.Logger, name string, value any, utc bool) any {
+	// Handle different numeric types
+	var seconds int64
+	switch v := value.(type) {
+	case json.Number:
+		var err error
+		seconds, err = v.Int64()
+		if err != nil {
+			logger.ErrorContext(
+				ctx,
+				"Failed to parse claim as seconds",
+				slog.String("name", name),
+				slog.Any("error", err),
+			)
+			return value
+		}
+	case float64:
+		seconds = int64(v)
+	case int64:
+		seconds = v
+	default:
+		return value
+	}
+
+	t := time.Unix(seconds, 0)
+	if utc {
+		t = t.UTC()
+	}
+	return t.Format(time.RFC3339)
+}

--- a/internal/cmd/cli/tokenutil/token_display_suite_test.go
+++ b/internal/cmd/cli/tokenutil/token_display_suite_test.go
@@ -1,0 +1,26 @@
+/*
+Copyright (c) 2026 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package tokenutil
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestTokenutil(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Tokenutil Suite")
+}

--- a/internal/cmd/cli/tokenutil/token_display_test.go
+++ b/internal/cmd/cli/tokenutil/token_display_test.go
@@ -1,0 +1,221 @@
+/*
+Copyright (c) 2026 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package tokenutil
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"log/slog"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+	. "github.com/onsi/ginkgo/v2/dsl/core"
+	. "github.com/onsi/gomega"
+
+	"github.com/osac-project/fulfillment-service/internal/logging"
+	"github.com/osac-project/fulfillment-service/internal/terminal"
+)
+
+var _ = Describe("ParseTokenClaims", func() {
+	It("Parses a valid JWT token", func() {
+		// Create a simple JWT token
+		token := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
+			"sub":      "1234567890",
+			"username": "testuser",
+			"iat":      float64(1516239022),
+		})
+		tokenString, err := token.SignedString([]byte("test-secret"))
+		Expect(err).ToNot(HaveOccurred())
+
+		// Parse the token
+		claims, err := ParseTokenClaims(tokenString)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(claims).ToNot(BeNil())
+		Expect(claims["sub"]).To(Equal("1234567890"))
+		Expect(claims["username"]).To(Equal("testuser"))
+		Expect(claims["iat"]).To(Equal(float64(1516239022)))
+	})
+
+	It("Returns error for invalid JWT token", func() {
+		claims, err := ParseTokenClaims("not-a-valid-token")
+		Expect(err).To(HaveOccurred())
+		Expect(claims).To(BeNil())
+	})
+
+	It("Returns error for malformed JWT token", func() {
+		claims, err := ParseTokenClaims("header.payload")
+		Expect(err).To(HaveOccurred())
+		Expect(claims).To(BeNil())
+	})
+
+	It("Returns empty claims for token with no claims", func() {
+		token := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{})
+		tokenString, err := token.SignedString([]byte("test-secret"))
+		Expect(err).ToNot(HaveOccurred())
+
+		claims, err := ParseTokenClaims(tokenString)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(claims).ToNot(BeNil())
+		Expect(claims).To(BeEmpty())
+	})
+})
+
+var _ = Describe("DisplayTokenClaims", func() {
+	var (
+		ctx     context.Context
+		console *terminal.Console
+		output  *bytes.Buffer
+	)
+
+	BeforeEach(func() {
+		ctx = logging.LoggerIntoContext(context.Background(), slog.Default())
+		output = &bytes.Buffer{}
+		var err error
+		console, err = terminal.NewConsole().
+			SetLogger(slog.Default()).
+			SetStdout(output).
+			Build()
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	parseOutput := func() jwt.MapClaims {
+		var result jwt.MapClaims
+		err := json.Unmarshal(output.Bytes(), &result)
+		Expect(err).ToNot(HaveOccurred())
+		return result
+	}
+
+	It("Displays claims without RFC3339 conversion by default", func() {
+		claims := jwt.MapClaims{
+			"iat":      float64(1609459200),
+			"username": "testuser",
+		}
+
+		DisplayTokenClaims(ctx, console, claims, false, false)
+
+		result := parseOutput()
+		Expect(result["iat"]).To(Equal(float64(1609459200)))
+		Expect(result["username"]).To(Equal("testuser"))
+	})
+
+	It("Converts iat claim to RFC3339 when rfc3339 is true", func() {
+		claims := jwt.MapClaims{
+			"iat":      float64(1609459200), // 2021-01-01 00:00:00 UTC
+			"username": "testuser",
+		}
+
+		DisplayTokenClaims(ctx, console, claims, true, true)
+
+		result := parseOutput()
+		Expect(result["iat"]).To(BeAssignableToTypeOf(""))
+		Expect(result["iat"]).To(ContainSubstring("2021-01-01"))
+		Expect(result["username"]).To(Equal("testuser"))
+	})
+
+	It("Converts multiple time claims to RFC3339", func() {
+		claims := jwt.MapClaims{
+			"iat":       float64(1609459200),
+			"exp":       float64(1609545600),
+			"nbf":       float64(1609459200),
+			"auth_time": float64(1609459200),
+			"username":  "testuser",
+		}
+
+		DisplayTokenClaims(ctx, console, claims, true, true)
+
+		result := parseOutput()
+		Expect(result["iat"]).To(ContainSubstring("2021-01-01"))
+		Expect(result["exp"]).To(ContainSubstring("2021-01-02"))
+		Expect(result["nbf"]).To(ContainSubstring("2021-01-01"))
+		Expect(result["auth_time"]).To(ContainSubstring("2021-01-01"))
+		Expect(result["username"]).To(Equal("testuser"))
+	})
+
+	It("Converts time to UTC when utc flag is true", func() {
+		claims := jwt.MapClaims{
+			"iat": float64(1609459200), // 2021-01-01 00:00:00 UTC
+		}
+
+		DisplayTokenClaims(ctx, console, claims, true, true)
+
+		result := parseOutput()
+		timestamp := result["iat"].(string)
+		parsedTime, err := time.Parse(time.RFC3339, timestamp)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(parsedTime.Location()).To(Equal(time.UTC))
+	})
+
+	It("Leaves non-time claims unchanged", func() {
+		claims := jwt.MapClaims{
+			"username": "testuser",
+			"sub":      "1234567890",
+			"roles":    []interface{}{"admin", "user"},
+		}
+
+		DisplayTokenClaims(ctx, console, claims, true, true)
+
+		result := parseOutput()
+		Expect(result["username"]).To(Equal("testuser"))
+		Expect(result["sub"]).To(Equal("1234567890"))
+		Expect(result["roles"]).To(HaveLen(2))
+	})
+
+	It("Handles non-numeric time claims gracefully", func() {
+		claims := jwt.MapClaims{
+			"iat":      "not-a-number",
+			"username": "testuser",
+		}
+
+		DisplayTokenClaims(ctx, console, claims, true, true)
+
+		result := parseOutput()
+		Expect(result["iat"]).To(Equal("not-a-number"))
+		Expect(result["username"]).To(Equal("testuser"))
+	})
+
+	It("Preserves all claims in the output", func() {
+		claims := jwt.MapClaims{
+			"iat":      float64(1609459200),
+			"exp":      float64(1609545600),
+			"username": "testuser",
+			"sub":      "1234567890",
+			"roles":    []interface{}{"admin"},
+		}
+
+		DisplayTokenClaims(ctx, console, claims, true, true)
+
+		result := parseOutput()
+		Expect(result).To(HaveLen(len(claims)))
+	})
+
+	It("Handles json.Number values for time claims with RFC3339 conversion", func() {
+		claims := jwt.MapClaims{
+			"iat":      json.Number("1609459200"), // 2021-01-01 00:00:00 UTC
+			"exp":      json.Number("1609545600"), // 2021-01-02 00:00:00 UTC
+			"username": "testuser",
+			"sub":      "1234567890",
+		}
+
+		DisplayTokenClaims(ctx, console, claims, true, true)
+
+		result := parseOutput()
+		Expect(result["iat"]).To(BeAssignableToTypeOf(""))
+		Expect(result["iat"]).To(ContainSubstring("2021-01-01"))
+		Expect(result["exp"]).To(BeAssignableToTypeOf(""))
+		Expect(result["exp"]).To(ContainSubstring("2021-01-02"))
+		Expect(result["username"]).To(Equal("testuser"))
+		Expect(result["sub"]).To(Equal("1234567890"))
+	})
+})

--- a/internal/cmd/cli/whoami/whoami_cmd.go
+++ b/internal/cmd/cli/whoami/whoami_cmd.go
@@ -1,0 +1,226 @@
+/*
+Copyright (c) 2026 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package whoami
+
+import (
+	"context"
+	"sort"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/osac-project/fulfillment-service/internal/auth"
+	"github.com/osac-project/fulfillment-service/internal/cmd/cli/tokenutil"
+	"github.com/osac-project/fulfillment-service/internal/config"
+	"github.com/osac-project/fulfillment-service/internal/exit"
+	"github.com/osac-project/fulfillment-service/internal/terminal"
+)
+
+func Cmd() *cobra.Command {
+	runner := &runnerContext{}
+	result := &cobra.Command{
+		Use:                   "whoami [FLAG...]",
+		Short:                 shortHelp,
+		Long:                  longHelp,
+		DisableFlagsInUseLine: true,
+		Args:                  cobra.NoArgs,
+		RunE:                  runner.run,
+	}
+
+	flags := result.Flags()
+	flags.BoolVarP(
+		&runner.args.showToken,
+		"show-token",
+		"t",
+		false,
+		showTokenFlagHelp,
+	)
+	flags.BoolVarP(
+		&runner.args.showTokenClaims,
+		"show-token-claims",
+		"c",
+		false,
+		showTokenClaimsFlagHelp,
+	)
+	flags.BoolVarP(
+		&runner.args.rfc3339,
+		"rfc-3339",
+		"R",
+		false,
+		rfc3339FlagHelp,
+	)
+	flags.BoolVarP(
+		&runner.args.utc,
+		"utc",
+		"U",
+		false,
+		utcFlagHelp,
+	)
+
+	return result
+}
+
+type runnerContext struct {
+	console *terminal.Console
+	args    struct {
+		showToken       bool
+		showTokenClaims bool
+		rfc3339         bool
+		utc             bool
+	}
+}
+
+func (c *runnerContext) run(cmd *cobra.Command, args []string) error {
+	ctx := cmd.Context()
+
+	c.console = terminal.ConsoleFromContext(ctx)
+	cfg := config.SettingsFromContext(ctx)
+
+	// Check if user is logged in
+	if !cfg.Armed() {
+		c.console.Errorf(ctx, "Not logged in. Use 'osac login' to authenticate.\n")
+		return exit.Error(1)
+	}
+
+	// Get the token source to extract user information
+	tokenSource, err := cfg.TokenSource(ctx)
+	if err != nil || tokenSource == nil {
+		c.console.Errorf(ctx, "Not logged in. Use 'osac login' to authenticate.\n")
+		return exit.Error(1)
+	}
+
+	// Get the current token
+	token, err := tokenSource.Token(ctx)
+	if err != nil {
+		c.console.Errorf(ctx, "Failed to retrieve authentication token: %v\n", err)
+		return exit.Error(1)
+	}
+	if token == nil {
+		c.console.Errorf(ctx, "Failed to retrieve authentication token. Please try logging in again with 'osac login'.\n")
+		return exit.Error(1)
+	}
+
+	// Display user information from the token
+	err = c.displayUserInfo(ctx, token)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (c *runnerContext) displayUserInfo(ctx context.Context, token *auth.Token) error {
+	// Parse the JWT token to extract claims
+	if token.Access == "" {
+		c.console.Errorf(ctx, "Not logged in. Use 'osac login' to authenticate.\n")
+		return exit.Error(1)
+	}
+
+	// Parse the JWT without verification since we just want to read claims
+	claims, err := tokenutil.ParseTokenClaims(token.Access)
+	if err != nil {
+		// If we can't parse the token, just show generic authentication message
+		c.console.Infof(ctx, "Logged in (unable to read token details)\n")
+		if c.args.showToken {
+			c.console.Infof(ctx, "\nAccess token:\n%s\n", token.Access)
+		}
+		return nil
+	}
+
+	if len(claims) == 0 {
+		c.console.Infof(ctx, "Logged in (unable to read token claims)\n")
+		if c.args.showToken {
+			c.console.Infof(ctx, "\nAccess token:\n%s\n", token.Access)
+		}
+		return nil
+	}
+
+	// Extract and display user information from claims
+	if username, ok := claims["username"].(string); ok && username != "" {
+		c.console.Infof(ctx, "Logged in as: %s\n", username)
+	}
+
+	// Show tenant
+	tenant := config.TenantFromContext(ctx)
+	if tenant != "" {
+		c.console.Infof(ctx, "Tenant: %s\n", tenant)
+	} else if orgMap, ok := claims["organization"].(map[string]interface{}); ok && len(orgMap) > 0 {
+		// Organization in JWT is a map where keys are org names
+		// Collect and sort to ensure deterministic selection
+		var orgNames []string
+		for orgName := range orgMap {
+			orgNames = append(orgNames, orgName)
+		}
+		if len(orgNames) > 0 {
+			sort.Strings(orgNames)
+			c.console.Infof(ctx, "Tenant: %s\n", orgNames[0])
+		}
+	}
+
+	// Show roles
+	if realmAccess, ok := claims["realm_access"].(map[string]interface{}); ok {
+		if rolesArray, ok := realmAccess["roles"].([]interface{}); ok && len(rolesArray) > 0 {
+			var roles []string
+			for _, role := range rolesArray {
+				if roleStr, ok := role.(string); ok {
+					roles = append(roles, roleStr)
+				}
+			}
+			if len(roles) > 0 {
+				c.console.Infof(ctx, "Roles: %s\n", strings.Join(roles, ", "))
+			}
+		}
+	}
+
+	// Show the access token if requested
+	if c.args.showToken {
+		c.console.Infof(ctx, "\nAccess token:\n%s\n", token.Access)
+	}
+
+	// Show token claims if requested
+	if c.args.showTokenClaims {
+		c.console.Infof(ctx, "\nToken claims:\n")
+		tokenutil.DisplayTokenClaims(ctx, c.console, claims, c.args.rfc3339, c.args.utc)
+	}
+
+	return nil
+}
+
+const shortHelp = `Display current user and connection information`
+
+const longHelp = `
+Display information about the current authenticated user session.
+
+Shows the authenticated username, configured tenant, and assigned roles.
+`
+
+const showTokenFlagHelp = `
+_[BOOLEAN]_ - Display the raw access token. Use with caution as this exposes sensitive
+authentication credentials.
+`
+
+const showTokenClaimsFlagHelp = `
+_[BOOLEAN]_ - Display the decoded token claims in JSON format.
+`
+
+const rfc3339FlagHelp = `
+_[BOOLEAN]_ - Display the time claims as RFC 3339 timestamps. By default the
+time claims are displayed as seconds since the Unix epoch, as that is the
+format used by JSON web tokens. Only applies when {{ bt }}--show-token-claims{{ bt }} is used.
+`
+
+const utcFlagHelp = `
+_[BOOLEAN]_ - Display the time claims using the UTC time zone. Only applies when
+{{ bt }}--rfc-3339{{ bt }} is used.
+`

--- a/internal/cmd/cli/whoami/whoami_cmd_test.go
+++ b/internal/cmd/cli/whoami/whoami_cmd_test.go
@@ -1,0 +1,501 @@
+/*
+Copyright (c) 2026 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package whoami
+
+import (
+	"bytes"
+	"context"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+	. "github.com/onsi/ginkgo/v2/dsl/core"
+	. "github.com/onsi/gomega"
+
+	"github.com/osac-project/fulfillment-service/internal/config"
+	"github.com/osac-project/fulfillment-service/internal/logging"
+	"github.com/osac-project/fulfillment-service/internal/terminal"
+)
+
+var _ = Describe("Whoami command flags", func() {
+	It("Has the expected use string", func() {
+		cmd := Cmd()
+		Expect(cmd.Use).To(Equal("whoami [FLAG...]"))
+	})
+
+	It("Has a --show-token flag", func() {
+		cmd := Cmd()
+		flag := cmd.Flags().Lookup("show-token")
+		Expect(flag).ToNot(BeNil())
+		Expect(flag.Shorthand).To(Equal("t"))
+		Expect(flag.DefValue).To(Equal("false"))
+	})
+
+	It("Has a --show-token-claims flag", func() {
+		cmd := Cmd()
+		flag := cmd.Flags().Lookup("show-token-claims")
+		Expect(flag).ToNot(BeNil())
+		Expect(flag.Shorthand).To(Equal("c"))
+		Expect(flag.DefValue).To(Equal("false"))
+	})
+
+	It("Has a --rfc-3339 flag", func() {
+		cmd := Cmd()
+		flag := cmd.Flags().Lookup("rfc-3339")
+		Expect(flag).ToNot(BeNil())
+		Expect(flag.Shorthand).To(Equal("R"))
+		Expect(flag.DefValue).To(Equal("false"))
+	})
+
+	It("Has a --utc flag", func() {
+		cmd := Cmd()
+		flag := cmd.Flags().Lookup("utc")
+		Expect(flag).ToNot(BeNil())
+		Expect(flag.Shorthand).To(Equal("U"))
+		Expect(flag.DefValue).To(Equal("false"))
+	})
+
+	It("Accepts no arguments", func() {
+		cmd := Cmd()
+		Expect(cmd.Args).ToNot(BeNil())
+	})
+})
+
+var _ = Describe("Whoami command execution", func() {
+	var (
+		ctx    context.Context
+		output *bytes.Buffer
+		stderr *bytes.Buffer
+	)
+
+	BeforeEach(func() {
+		ctx = context.Background()
+		ctx = logging.LoggerIntoContext(ctx, slog.Default())
+		output = &bytes.Buffer{}
+		stderr = &bytes.Buffer{}
+	})
+
+	createTestToken := func(username, organization string, roles []string) string {
+		claims := jwt.MapClaims{
+			"username": username,
+			"iat":      time.Now().Unix(),
+			"exp":      time.Now().Add(1 * time.Hour).Unix(),
+		}
+		if organization != "" {
+			claims["organization"] = map[string]interface{}{
+				organization: map[string]interface{}{},
+			}
+		}
+		if len(roles) > 0 {
+			claims["realm_access"] = map[string]interface{}{
+				"roles": roles,
+			}
+		}
+		token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
+		tokenString, _ := token.SignedString([]byte("test-secret"))
+		return tokenString
+	}
+
+	setupContext := func(tokenString string) context.Context {
+		console, err := terminal.NewConsole().
+			SetLogger(slog.Default()).
+			SetStdout(output).
+			SetStderr(stderr).
+			Build()
+		Expect(err).ToNot(HaveOccurred())
+		ctx = terminal.ConsoleIntoContext(ctx, console)
+
+		// Create a temporary directory for settings
+		tempDir, err := os.MkdirTemp("", "whoami-test-*")
+		Expect(err).ToNot(HaveOccurred())
+		DeferCleanup(func() {
+			os.RemoveAll(tempDir)
+		})
+
+		// Create settings with a valid token
+		settings, err := config.NewSettings().
+			SetLogger(slog.Default()).
+			SetDir(filepath.Join(tempDir, "settings")).
+			Build()
+		Expect(err).ToNot(HaveOccurred())
+
+		settings.SetAddress("localhost:8000")
+		settings.SetAccessToken(tokenString)
+		settings.SetRefreshToken("refresh-token")
+		settings.SetTokenExpiry(time.Now().Add(1 * time.Hour))
+
+		ctx = config.SettingsIntoContext(ctx, settings)
+		return ctx
+	}
+
+	It("Shows error when not logged in", func() {
+		console, err := terminal.NewConsole().
+			SetLogger(slog.Default()).
+			SetStdout(output).
+			SetStderr(stderr).
+			Build()
+		Expect(err).ToNot(HaveOccurred())
+		ctx = terminal.ConsoleIntoContext(ctx, console)
+
+		// Create a temporary directory for settings
+		tempDir, err := os.MkdirTemp("", "whoami-test-*")
+		Expect(err).ToNot(HaveOccurred())
+		DeferCleanup(func() {
+			os.RemoveAll(tempDir)
+		})
+
+		// Settings with no auth token
+		settings, err := config.NewSettings().
+			SetLogger(slog.Default()).
+			SetDir(filepath.Join(tempDir, "settings")).
+			Build()
+		Expect(err).ToNot(HaveOccurred())
+
+		ctx = config.SettingsIntoContext(ctx, settings)
+
+		cmd := Cmd()
+		cmd.SetOut(GinkgoWriter)
+		cmd.SetErr(GinkgoWriter)
+		cmd.SetContext(ctx)
+		cmd.SetArgs([]string{})
+
+		err = cmd.Execute()
+		Expect(err).To(HaveOccurred())
+		Expect(stderr.String()).To(ContainSubstring("Not logged in"))
+		Expect(stderr.String()).To(ContainSubstring("osac login"))
+	})
+
+	It("Shows username and tenant for logged in user", func() {
+		tokenString := createTestToken("testuser", "test-org", nil)
+		ctx = setupContext(tokenString)
+
+		cmd := Cmd()
+		cmd.SetOut(GinkgoWriter)
+		cmd.SetErr(GinkgoWriter)
+		cmd.SetContext(ctx)
+		cmd.SetArgs([]string{})
+
+		err := cmd.Execute()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(output.String()).To(ContainSubstring("Logged in as: testuser"))
+		Expect(output.String()).To(ContainSubstring("Tenant: test-org"))
+		Expect(output.String()).ToNot(ContainSubstring("Roles: "))
+		Expect(output.String()).ToNot(ContainSubstring("Token claims:"))
+		Expect(output.String()).ToNot(ContainSubstring("Access token:"))
+	})
+
+	It("Shows roles when present", func() {
+		tokenString := createTestToken("testuser", "test-org", []string{"admin", "developer"})
+		ctx = setupContext(tokenString)
+
+		cmd := Cmd()
+		cmd.SetOut(GinkgoWriter)
+		cmd.SetErr(GinkgoWriter)
+		cmd.SetContext(ctx)
+		cmd.SetArgs([]string{})
+
+		err := cmd.Execute()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(output.String()).To(ContainSubstring("Logged in as: testuser"))
+		Expect(output.String()).To(ContainSubstring("Roles: admin, developer"))
+	})
+
+	Context("--show-token flag behavior", func() {
+		It("Does not show token by default", func() {
+			tokenString := createTestToken("testuser", "test-org", nil)
+			ctx = setupContext(tokenString)
+
+			cmd := Cmd()
+			cmd.SetOut(GinkgoWriter)
+			cmd.SetErr(GinkgoWriter)
+			cmd.SetContext(ctx)
+			cmd.SetArgs([]string{})
+
+			err := cmd.Execute()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(output.String()).ToNot(ContainSubstring("Access token:"))
+			Expect(output.String()).ToNot(ContainSubstring(tokenString))
+		})
+
+		It("Shows token with --show-token flag", func() {
+			tokenString := createTestToken("testuser", "test-org", nil)
+			ctx = setupContext(tokenString)
+
+			cmd := Cmd()
+			cmd.SetOut(GinkgoWriter)
+			cmd.SetErr(GinkgoWriter)
+			cmd.SetContext(ctx)
+			cmd.SetArgs([]string{"--show-token"})
+
+			err := cmd.Execute()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(output.String()).To(ContainSubstring("Access token:"))
+			Expect(output.String()).To(ContainSubstring(tokenString))
+		})
+
+		It("Shows token with -t shorthand", func() {
+			tokenString := createTestToken("testuser", "test-org", nil)
+			ctx = setupContext(tokenString)
+
+			cmd := Cmd()
+			cmd.SetOut(GinkgoWriter)
+			cmd.SetErr(GinkgoWriter)
+			cmd.SetContext(ctx)
+			cmd.SetArgs([]string{"-t"})
+
+			err := cmd.Execute()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(output.String()).To(ContainSubstring("Access token:"))
+			Expect(output.String()).To(ContainSubstring(tokenString))
+		})
+	})
+
+	Context("--show-token-claims flag behavior", func() {
+		It("Does not show claims by default", func() {
+			tokenString := createTestToken("testuser", "test-org", nil)
+			ctx = setupContext(tokenString)
+
+			cmd := Cmd()
+			cmd.SetOut(GinkgoWriter)
+			cmd.SetErr(GinkgoWriter)
+			cmd.SetContext(ctx)
+			cmd.SetArgs([]string{})
+
+			err := cmd.Execute()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(output.String()).ToNot(ContainSubstring("Token claims:"))
+		})
+
+		It("Shows claims with --show-token-claims flag", func() {
+			tokenString := createTestToken("testuser", "test-org", nil)
+			ctx = setupContext(tokenString)
+
+			cmd := Cmd()
+			cmd.SetOut(GinkgoWriter)
+			cmd.SetErr(GinkgoWriter)
+			cmd.SetContext(ctx)
+			cmd.SetArgs([]string{"--show-token-claims"})
+
+			err := cmd.Execute()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(output.String()).To(ContainSubstring("Token claims:"))
+			Expect(output.String()).To(ContainSubstring("username"))
+			Expect(output.String()).To(ContainSubstring("testuser"))
+		})
+
+		It("Shows claims with -c shorthand", func() {
+			tokenString := createTestToken("testuser", "test-org", nil)
+			ctx = setupContext(tokenString)
+
+			cmd := Cmd()
+			cmd.SetOut(GinkgoWriter)
+			cmd.SetErr(GinkgoWriter)
+			cmd.SetContext(ctx)
+			cmd.SetArgs([]string{"-c"})
+
+			err := cmd.Execute()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(output.String()).To(ContainSubstring("Token claims:"))
+		})
+	})
+
+	Context("--rfc-3339 flag behavior", func() {
+		It("Shows Unix timestamps by default", func() {
+			tokenString := createTestToken("testuser", "test-org", nil)
+			ctx = setupContext(tokenString)
+
+			cmd := Cmd()
+			cmd.SetOut(GinkgoWriter)
+			cmd.SetErr(GinkgoWriter)
+			cmd.SetContext(ctx)
+			cmd.SetArgs([]string{"--show-token-claims"})
+
+			err := cmd.Execute()
+			Expect(err).ToNot(HaveOccurred())
+			// Should contain numeric Unix timestamp, not RFC3339 format
+			outputStr := output.String()
+			Expect(outputStr).To(ContainSubstring("iat"))
+			// RFC3339 has 'T' separator between date and time
+			Expect(outputStr).ToNot(MatchRegexp(`"iat":\s*"\d{4}-\d{2}-\d{2}T`))
+		})
+
+		It("Converts to RFC3339 with --rfc-3339 flag", func() {
+			tokenString := createTestToken("testuser", "test-org", nil)
+			ctx = setupContext(tokenString)
+
+			cmd := Cmd()
+			cmd.SetOut(GinkgoWriter)
+			cmd.SetErr(GinkgoWriter)
+			cmd.SetContext(ctx)
+			cmd.SetArgs([]string{"--show-token-claims", "--rfc-3339"})
+
+			err := cmd.Execute()
+			Expect(err).ToNot(HaveOccurred())
+			outputStr := output.String()
+			// Should contain RFC3339 formatted time (contains 'T' separator and timezone)
+			Expect(outputStr).To(MatchRegexp(`\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}`))
+		})
+
+		It("Converts to RFC3339 with -R shorthand", func() {
+			tokenString := createTestToken("testuser", "test-org", nil)
+			ctx = setupContext(tokenString)
+
+			cmd := Cmd()
+			cmd.SetOut(GinkgoWriter)
+			cmd.SetErr(GinkgoWriter)
+			cmd.SetContext(ctx)
+			cmd.SetArgs([]string{"-c", "-R"})
+
+			err := cmd.Execute()
+			Expect(err).ToNot(HaveOccurred())
+			outputStr := output.String()
+			Expect(outputStr).To(MatchRegexp(`\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}`))
+		})
+
+		It("Has no effect without --show-token-claims", func() {
+			tokenString := createTestToken("testuser", "test-org", nil)
+			ctx = setupContext(tokenString)
+
+			cmd := Cmd()
+			cmd.SetOut(GinkgoWriter)
+			cmd.SetErr(GinkgoWriter)
+			cmd.SetContext(ctx)
+			cmd.SetArgs([]string{"--rfc-3339"})
+
+			err := cmd.Execute()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(output.String()).ToNot(ContainSubstring("Token claims:"))
+		})
+	})
+
+	Context("--utc flag behavior", func() {
+		It("Uses local timezone by default", func() {
+			tokenString := createTestToken("testuser", "test-org", nil)
+			ctx = setupContext(tokenString)
+
+			cmd := Cmd()
+			cmd.SetOut(GinkgoWriter)
+			cmd.SetErr(GinkgoWriter)
+			cmd.SetContext(ctx)
+			cmd.SetArgs([]string{"--show-token-claims", "--rfc-3339"})
+
+			err := cmd.Execute()
+			Expect(err).ToNot(HaveOccurred())
+			// Just verify it produces RFC3339 output (timezone depends on system)
+			Expect(output.String()).To(MatchRegexp(`\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}`))
+		})
+
+		It("Uses UTC timezone with --utc flag", func() {
+			tokenString := createTestToken("testuser", "test-org", nil)
+			ctx = setupContext(tokenString)
+
+			cmd := Cmd()
+			cmd.SetOut(GinkgoWriter)
+			cmd.SetErr(GinkgoWriter)
+			cmd.SetContext(ctx)
+			cmd.SetArgs([]string{"--show-token-claims", "--rfc-3339", "--utc"})
+
+			err := cmd.Execute()
+			Expect(err).ToNot(HaveOccurred())
+			// UTC times end with 'Z' or '+00:00'
+			Expect(output.String()).To(MatchRegexp(`\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z`))
+		})
+
+		It("Uses UTC timezone with -U shorthand", func() {
+			tokenString := createTestToken("testuser", "test-org", nil)
+			ctx = setupContext(tokenString)
+
+			cmd := Cmd()
+			cmd.SetOut(GinkgoWriter)
+			cmd.SetErr(GinkgoWriter)
+			cmd.SetContext(ctx)
+			cmd.SetArgs([]string{"-c", "-R", "-U"})
+
+			err := cmd.Execute()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(output.String()).To(MatchRegexp(`\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z`))
+		})
+
+		It("Has no effect without --rfc-3339", func() {
+			tokenString := createTestToken("testuser", "test-org", nil)
+			ctx = setupContext(tokenString)
+
+			cmd := Cmd()
+			cmd.SetOut(GinkgoWriter)
+			cmd.SetErr(GinkgoWriter)
+			cmd.SetContext(ctx)
+			cmd.SetArgs([]string{"--show-token-claims", "--utc"})
+
+			err := cmd.Execute()
+			Expect(err).ToNot(HaveOccurred())
+			// Should still show Unix timestamps, not RFC3339
+			outputStr := output.String()
+			Expect(outputStr).To(ContainSubstring("iat"))
+			Expect(outputStr).ToNot(MatchRegexp(`"iat":\s*"\d{4}-\d{2}-\d{2}T`))
+		})
+	})
+
+	It("Prefers context tenant over token organization", func() {
+		tokenString := createTestToken("testuser", "token-org", nil)
+		ctx = setupContext(tokenString)
+		// Add context tenant which should take precedence
+		ctx = config.TenantIntoContext(ctx, "context-org")
+
+		cmd := Cmd()
+		cmd.SetOut(GinkgoWriter)
+		cmd.SetErr(GinkgoWriter)
+		cmd.SetContext(ctx)
+		cmd.SetArgs([]string{})
+
+		err := cmd.Execute()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(output.String()).To(ContainSubstring("Tenant: context-org"))
+		Expect(output.String()).ToNot(ContainSubstring("token-org"))
+	})
+
+	It("Combines multiple flags correctly", func() {
+		tokenString := createTestToken("testuser", "test-org", []string{"admin"})
+		ctx = setupContext(tokenString)
+
+		cmd := Cmd()
+		cmd.SetOut(GinkgoWriter)
+		cmd.SetErr(GinkgoWriter)
+		cmd.SetContext(ctx)
+		cmd.SetArgs([]string{"--show-token", "--show-token-claims"})
+
+		err := cmd.Execute()
+		Expect(err).ToNot(HaveOccurred())
+		outputStr := output.String()
+		Expect(outputStr).To(ContainSubstring("Logged in as: testuser"))
+		Expect(outputStr).To(ContainSubstring("Roles: admin"))
+		Expect(outputStr).To(ContainSubstring("Access token:"))
+		Expect(outputStr).To(ContainSubstring("Token claims:"))
+	})
+
+	It("Rejects arguments", func() {
+		cmd := Cmd()
+		cmd.SetOut(GinkgoWriter)
+		cmd.SetErr(GinkgoWriter)
+		cmd.SetArgs([]string{"extra-arg"})
+
+		err := cmd.Execute()
+		Expect(err).To(HaveOccurred())
+		// cobra's NoArgs validator returns this error
+		lines := strings.Split(err.Error(), "\n")
+		Expect(lines[0]).To(ContainSubstring("unknown command"))
+	})
+})

--- a/internal/cmd/cli/whoami/whoami_suite_test.go
+++ b/internal/cmd/cli/whoami/whoami_suite_test.go
@@ -1,0 +1,26 @@
+/*
+Copyright (c) 2026 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package whoami
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestWhoami(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Whoami Suite")
+}


### PR DESCRIPTION
# Description

Introduces the `osac whoami` command to display the current logged in user via the CLI. 

Combines the logic for displaying the user's token from `osac get payload --token` with `osac whoami --show-token-claims` 

# Testing 

While logged out, ran `osac whoami`
```sh
$ ./osac whoami
Not logged in. Use 'osac login' to authenticate.
```

Logged in as keycloak user
```sh
$ ./osac whoami
Logged in as: ben
Tenant: osac-demo
Roles: tenant-admin
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `whoami` command to show the currently authenticated user.
  * Added flags to optionally show the raw access token and decoded token claims.
  * Added options to render token timestamp claims in RFC 3339 and optionally force UTC.
* **Bug Fixes**
  * Improved consistent error messaging for unauthenticated sessions and token retrieval failures (“Not logged in… use `osac login`”).
* **Refactor**
  * Centralized JWT claim decoding and timestamp rendering for CLI token display.
* **Tests**
  * Added coverage for `whoami` and token claim display utilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->