### PR TITLE
OSAC-2187: Document that published OpenAPI docs track main only

### DIFF
--- a/.github/workflows/publish-openapi.yaml
+++ b/.github/workflows/publish-openapi.yaml
@@ -12,6 +12,8 @@
 #
 
 # This workflow generates the OpenAPI specification and uploads it to the GitHub pages of the project.
+# The published docs reflect the latest successfully deployed output from 'main' and are NOT release-versioned.
+# See docs/OPENAPI.md for details on why tag-triggered publishing is intentionally excluded.
 
 name: Publish OpenAPI
 

--- a/docs/OPENAPI.md
+++ b/docs/OPENAPI.md
@@ -1,0 +1,35 @@
+# OpenAPI Documentation Publishing
+
+The hosted OpenAPI docs (GitHub Pages) reflect the latest successfully
+deployed output generated from the tip of `main`. They are **not**
+release-versioned — each deployment replaces the entire site artifact, so no
+per-version snapshot is retained across runs.
+
+## Why no tag trigger?
+
+Unlike sibling workflows (`publish-charts`, `publish-proto`, `publish-image`),
+`publish-openapi.yaml` intentionally does **not** trigger on `v*` tag pushes:
+
+1. **Redundant in the common case** — releases are cut from the tip of `main`,
+   so by the time a tag is pushed the preceding `main` push has already
+   published that exact content.
+
+2. **Harmful in edge cases** — if a tag is ever cut from a commit that is not
+   the current tip of `main` (release lag, hotfix), a tag-triggered run would
+   republish older docs and overwrite newer content already live on the site
+   until the next `main` push corrects it.
+
+3. **Versioned publishing is not feasible** with the current GitHub Pages
+   Actions-based deployment model, which replaces the whole site artifact on
+   every run with no built-in mechanism to retain prior versions.
+
+## Implications for consumers
+
+Do not assume the hosted OpenAPI spec matches any specific tagged release.
+To inspect the API surface for a particular version, check out that tag
+locally and run:
+
+```bash
+go build ./cmd/osac-dev
+./osac-dev generate openapi --project-dir . --output-dir pages/openapi
+```


### PR DESCRIPTION
## Summary

Document that the Pages-hosted OpenAPI docs track `main` only and are not release-versioned.

- Add `docs/OPENAPI.md` explaining the publishing model, rationale for excluding tag triggers, and how consumers can generate docs for a specific version locally.
- Add a brief workflow comment pointing to the docs file.

## Test plan

- [ ] Confirm workflow YAML still parses correctly
- [ ] Confirm the job runs correctly on a `main` push (no functional change to the trigger)
- [ ] Verify `docs/OPENAPI.md` renders correctly on GitHub

Fixes [OSAC-2187](https://redhat.atlassian.net/browse/OSAC-2187).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that hosted OpenAPI documentation reflects the latest successful deployment from `main` rather than release-specific versions.
  * Documented why tag-triggered publishing is excluded.
  * Added instructions for generating version-specific OpenAPI documentation locally from a release tag.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->