### PR TITLE
Extract Integration Tests and Unit Tests from Check pull request

### DIFF
--- a/.github/workflows/check-pull-request.yaml
+++ b/.github/workflows/check-pull-request.yaml
@@ -73,17 +73,6 @@ jobs:
         buf generate
         git diff --exit-code
 
-  run-unit-tests:
-    name: Run unit tests
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
-      with:
-        persist-credentials: false
-    - uses: ./.github/actions/setup-go
-    - run: |
-        ginkgo run --timeout 1h -r internal
-
   build-binaries:
     name: Build binaries
     runs-on: ubuntu-latest
@@ -95,43 +84,3 @@ jobs:
     - uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94  # v7
       with:
         args: build --snapshot --clean
-
-  run-integration-tests-helm:
-    name: Run integration tests - Helm
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
-      with:
-        persist-credentials: false
-    - uses: ./.github/actions/setup-go
-    - run: |
-        echo '127.0.0.1 fulfillment-api.osac.svc.cluster.local' | sudo tee -a /etc/hosts
-        echo '127.0.0.1 fulfillment-internal-api.osac.svc.cluster.local' | sudo tee -a /etc/hosts
-        echo '127.0.0.1 keycloak.keycloak.svc.cluster.local' | sudo tee -a /etc/hosts
-        IT_DEPLOY_MODE=helm ginkgo run --timeout 1h -v it
-    - if: always()
-      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
-      with:
-        name: logs-helm
-        path: logs
-        retention-days: 7
-
-  run-integration-tests-kustomize:
-    name: Run integration tests - Kustomize
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
-      with:
-        persist-credentials: false
-    - uses: ./.github/actions/setup-go
-    - run: |
-        echo '127.0.0.1 fulfillment-api.osac.svc.cluster.local' | sudo tee -a /etc/hosts
-        echo '127.0.0.1 fulfillment-internal-api.osac.svc.cluster.local' | sudo tee -a /etc/hosts
-        echo '127.0.0.1 keycloak.keycloak.svc.cluster.local' | sudo tee -a /etc/hosts
-        IT_DEPLOY_MODE=kustomize ginkgo run --timeout 1h -v it
-    - if: always()
-      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
-      with:
-        name: logs-kustomize
-        path: logs
-        retention-days: 7

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -1,0 +1,68 @@
+#
+# Copyright (c) 2025 Red Hat Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License. You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License
+# is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+# or implied. See the License for the specific language governing permissions and limitations under
+# the License.
+#
+
+name: Integration Tests
+
+on:
+  pull_request:
+    branches:
+    - main
+  workflow_dispatch:
+  schedule:
+    - cron: '0 0 * * *'
+
+permissions:
+  contents: read
+
+jobs:
+
+  run-integration-tests-helm:
+    name: Run integration tests - Helm
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+      with:
+        persist-credentials: false
+    - uses: ./.github/actions/setup-go
+    - run: |
+        echo '127.0.0.1 fulfillment-api.osac.svc.cluster.local' | sudo tee -a /etc/hosts
+        echo '127.0.0.1 fulfillment-internal-api.osac.svc.cluster.local' | sudo tee -a /etc/hosts
+        echo '127.0.0.1 keycloak.keycloak.svc.cluster.local' | sudo tee -a /etc/hosts
+        IT_DEPLOY_MODE=helm ginkgo run --timeout 1h -v it
+    - if: always()
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
+      with:
+        name: logs-helm
+        path: logs
+        retention-days: 7
+
+  run-integration-tests-kustomize:
+    name: Run integration tests - Kustomize
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+      with:
+        persist-credentials: false
+    - uses: ./.github/actions/setup-go
+    - run: |
+        echo '127.0.0.1 fulfillment-api.osac.svc.cluster.local' | sudo tee -a /etc/hosts
+        echo '127.0.0.1 fulfillment-internal-api.osac.svc.cluster.local' | sudo tee -a /etc/hosts
+        echo '127.0.0.1 keycloak.keycloak.svc.cluster.local' | sudo tee -a /etc/hosts
+        IT_DEPLOY_MODE=kustomize ginkgo run --timeout 1h -v it
+    - if: always()
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
+      with:
+        name: logs-kustomize
+        path: logs
+        retention-days: 7

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,0 +1,39 @@
+#
+# Copyright (c) 2025 Red Hat Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License. You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License
+# is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+# or implied. See the License for the specific language governing permissions and limitations under
+# the License.
+#
+
+name: Unit Tests
+
+on:
+  pull_request:
+    branches:
+    - main
+  workflow_dispatch:
+  schedule:
+    - cron: '0 0 * * *'
+
+permissions:
+  contents: read
+
+jobs:
+
+  run-unit-tests:
+    name: Run unit tests
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+      with:
+        persist-credentials: false
+    - uses: ./.github/actions/setup-go
+    - run: |
+        ginkgo run --timeout 1h -r internal


### PR DESCRIPTION
## What

`check-pull-request.yaml` bundled 7 jobs (3 lint jobs, generated-code check, unit tests, build, and 2 integration-test variants) under one workflow named `Check pull request`. Extracts:

- `run-integration-tests-helm` + `run-integration-tests-kustomize` -> new `integration-tests.yml` (`Integration Tests`)
- `run-unit-tests` -> new `unit-tests.yml` (`Unit Tests`)

Both new workflows also get a daily `schedule` trigger (in addition to the existing `pull_request`/new `workflow_dispatch`), so they run periodically like the equivalent workflows in other OSAC repos.

`check-pull-request.yaml` keeps its remaining 4 jobs (`check-pre-commit`, `check-python-code`, `check-go-code`, `check-generated-code`, `build-binaries`) and its current name — no logic changes there.

## Why

Since the GitHub Actions runs API only exposes one pass/fail result per workflow (not per job), the CI monitoring dashboard couldn't distinguish a lint failure from an integration-test failure in this repo. Part of [OSAC-2377](https://redhat.atlassian.net/browse/OSAC-2377): aligning integration/unit-test workflow naming across OSAC repos so the dashboard's cross-repo merge groups them correctly.

Confirmed this repo's branch protection required status checks (`e2e-vmaas-full-install / e2e`, `ci/prow/unit`) don't reference any of the job/workflow names touched here — `ci/prow/unit` is a legacy Prow-era name unrelated to `run-unit-tests`.

## Verification

Confirmed via YAML diff that all 8 original jobs are accounted for and byte-identical to before — this is a pure extraction/rename plus the added schedule trigger, no other logic changes.