### PR TITLE
OSAC-2258: propagate restart_trigger from API spec to BareMetalInstance CR

### DIFF
--- a/internal/controllers/baremetalinstance/baremetalinstance_reconciler_function.go
+++ b/internal/controllers/baremetalinstance/baremetalinstance_reconciler_function.go
@@ -572,6 +572,7 @@ func (t *task) mutateBMI(ctx context.Context, object *bmfov1alpha1.BareMetalInst
 	object.Spec.TemplateID = catalogItemResp.GetObject().GetTemplate()
 	object.Spec.TemplateParameters = ""
 	object.Spec.RunStrategy = bmfov1alpha1.RunStrategyUnspecified
+	object.Spec.RestartTrigger = t.bareMetalInstance.GetSpec().GetRestartTrigger()
 
 	params := map[string]any{}
 

--- a/internal/controllers/baremetalinstance/baremetalinstance_reconciler_function_test.go
+++ b/internal/controllers/baremetalinstance/baremetalinstance_reconciler_function_test.go
@@ -199,6 +199,51 @@ var _ = Describe("mutateBMI", func() {
 		Expect(obj.Spec.RunStrategy).To(Equal(bmfov1alpha1.RunStrategyUnspecified))
 	})
 
+	It("should propagate restart_trigger to CR spec", func() {
+		catalogItemsClient := defaultFakeCatalogItemsClient()
+
+		t := &task{
+			r: &function{
+				logger:                              logger,
+				bareMetalInstanceCatalogItemsClient: catalogItemsClient,
+			},
+			bareMetalInstance: privatev1.BareMetalInstance_builder{
+				Id: "bmi-test",
+				Spec: privatev1.BareMetalInstanceSpec_builder{
+					CatalogItem:    "catalog-1",
+					RestartTrigger: 42,
+				}.Build(),
+			}.Build(),
+		}
+
+		var obj bmfov1alpha1.BareMetalInstance
+		err := t.mutateBMI(ctx, &obj)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(obj.Spec.RestartTrigger).To(Equal(int64(42)))
+	})
+
+	It("should leave restart_trigger as zero when not set", func() {
+		catalogItemsClient := defaultFakeCatalogItemsClient()
+
+		t := &task{
+			r: &function{
+				logger:                              logger,
+				bareMetalInstanceCatalogItemsClient: catalogItemsClient,
+			},
+			bareMetalInstance: privatev1.BareMetalInstance_builder{
+				Id: "bmi-test",
+				Spec: privatev1.BareMetalInstanceSpec_builder{
+					CatalogItem: "catalog-1",
+				}.Build(),
+			}.Build(),
+		}
+
+		var obj bmfov1alpha1.BareMetalInstance
+		err := t.mutateBMI(ctx, &obj)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(obj.Spec.RestartTrigger).To(Equal(int64(0)))
+	})
+
 	It("should include sshPublicKey and userDataSecret in templateParameters", func() {
 		catalogItemsClient := defaultFakeCatalogItemsClient()
 


### PR DESCRIPTION
## Summary

- `mutateBMI()` was missing `restart_trigger` propagation — the field was never copied from the gRPC proto spec onto the BareMetalInstance CR, so `bare-metal-fulfillment-operator` never saw it and restarts silently did nothing
- Added `object.Spec.RestartTrigger` assignment alongside the other direct spec field assignments (HostType, TemplateID, etc.)
- Added two unit tests covering trigger propagation and zero-value default

## Root Cause

`mutateBMI()` in `baremetalinstance_reconciler_function.go` copies HostType, TemplateID, TemplateParameters, and RunStrategy from the proto spec onto `object.Spec`, but never set `RestartTrigger`. Downstream, `bare-metal-fulfillment-operator` correctly compares `Spec.RestartTrigger` vs `Status.RestartTrigger` to trigger power cycles ([OSAC-1716](https://redhat.atlassian.net/browse/OSAC-1716)), but the value never arrived on the CR.

## Test Plan

- [x] New test: `should propagate restart_trigger to CR spec` — sets trigger to 42, verifies it reaches the CR
- [x] New test: `should leave restart_trigger as zero when not set` — verifies default behavior
- [x] All 69 existing tests pass
- [x] Build compiles cleanly

Blocks: [OSAC-1978](https://redhat.atlassian.net/browse/OSAC-1978) (E2E restart validation)

Assisted-by: Claude Code <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved the configured restart trigger when syncing bare-metal instance specifications from the source to the hub-side resource.
  * When no restart trigger is configured, the hub-side restart trigger remains at its default value.
* **Tests**
  * Added unit tests validating restart trigger behavior for both explicitly set and unset/default scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->