### PR TITLE
OSAC-1978: add integration test for restart_trigger propagation

### DIFF
--- a/it/crds/osac.openshift.io_baremetalinstances.yaml
+++ b/it/crds/osac.openshift.io_baremetalinstances.yaml
@@ -101,6 +101,13 @@ spec:
                 description: NetworkClass is the network class for this host (e.g.
                   openstack).
                 type: string
+              restartTrigger:
+                description: |-
+                  RestartTrigger is used to trigger a restart of the physical machine.
+                  Change it to any value to trigger the restart.
+                  The value itself is not important; only the change matters.
+                format: int64
+                type: integer
               runStrategy:
                 allOf:
                 - enum:
@@ -278,6 +285,11 @@ spec:
                 - Failed
                 - Deleting
                 type: string
+              restartTrigger:
+                description: RestartTrigger is the observed restart version of the
+                  instance
+                format: int64
+                type: integer
               runStrategy:
                 allOf:
                 - enum:

--- a/it/it_baremetal_instance_lifecycle_test.go
+++ b/it/it_baremetal_instance_lifecycle_test.go
@@ -527,4 +527,89 @@ var _ = Describe("BareMetalInstance lifecycle", func() {
 		Expect(status.Code()).To(Equal(grpccodes.InvalidArgument))
 		Expect(status.Message()).To(ContainSubstring("image is immutable"))
 	})
+
+	It("Propagates restart_trigger to BMFO CR spec", func(ctx context.Context) {
+		createResp, err := bareMetalInstancesClient.Create(ctx, publicv1.BareMetalInstancesCreateRequest_builder{
+			Object: publicv1.BareMetalInstance_builder{
+				Spec: publicv1.BareMetalInstanceSpec_builder{
+					CatalogItem: catalogItemId,
+				}.Build(),
+			}.Build(),
+		}.Build())
+		Expect(err).ToNot(HaveOccurred())
+		bareMetalInstanceId := createResp.GetObject().GetId()
+		DeferCleanup(func(ctx context.Context) {
+			_, err := privateBareMetalInstancesClient.Delete(ctx, privatev1.BareMetalInstancesDeleteRequest_builder{
+				Id: bareMetalInstanceId,
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+			Eventually(func(g Gomega) {
+				_, err := privateBareMetalInstancesClient.Get(ctx, privatev1.BareMetalInstancesGetRequest_builder{
+					Id: bareMetalInstanceId,
+				}.Build())
+				g.Expect(err).To(HaveOccurred())
+				status, ok := grpcstatus.FromError(err)
+				g.Expect(ok).To(BeTrue())
+				g.Expect(status.Code()).To(Equal(grpccodes.NotFound))
+			}, 2*time.Minute, time.Second).Should(Succeed())
+		})
+
+		// Wait for the controller to reconcile (state moves from UNSPECIFIED)
+		Eventually(func(g Gomega) {
+			resp, err := privateBareMetalInstancesClient.Get(ctx, privatev1.BareMetalInstancesGetRequest_builder{
+				Id: bareMetalInstanceId,
+			}.Build())
+			g.Expect(err).ToNot(HaveOccurred())
+			state := resp.GetObject().GetStatus().GetState()
+			fmt.Fprintf(GinkgoWriter, "[DEBUG] BMI id=%s state=%s\n", bareMetalInstanceId, state)
+			g.Expect(state).ToNot(
+				Equal(privatev1.BareMetalInstanceState_BARE_METAL_INSTANCE_STATE_UNSPECIFIED),
+				"controller should reconcile the BMI and set state")
+		}, time.Minute, time.Second).Should(Succeed())
+
+		// Verify the BMFO CR was created with restart_trigger=0
+		kubeClient := tool.KubeClient()
+		var kubeObject *bmfov1alpha1.BareMetalInstance
+		Eventually(func(g Gomega) {
+			bmiList := &bmfov1alpha1.BareMetalInstanceList{}
+			err := kubeClient.List(ctx, bmiList, crclient.MatchingLabels{
+				labels.BareMetalInstanceUuid: bareMetalInstanceId,
+			})
+			g.Expect(err).ToNot(HaveOccurred())
+			fmt.Fprintf(GinkgoWriter, "[DEBUG] BMFO CR count=%d\n", len(bmiList.Items))
+			g.Expect(bmiList.Items).To(HaveLen(1))
+			kubeObject = &bmiList.Items[0]
+		}, time.Minute, time.Second).Should(Succeed())
+
+		Expect(kubeObject.Spec.RestartTrigger).To(Equal(int64(0)),
+			"newly created BareMetalInstance CR should have RestartTrigger=0")
+
+		// Update restart_trigger via public API
+		_, err = bareMetalInstancesClient.Update(ctx, publicv1.BareMetalInstancesUpdateRequest_builder{
+			Object: publicv1.BareMetalInstance_builder{
+				Id: bareMetalInstanceId,
+				Spec: publicv1.BareMetalInstanceSpec_builder{
+					RestartTrigger: 1,
+				}.Build(),
+			}.Build(),
+			UpdateMask: &fieldmaskpb.FieldMask{
+				Paths: []string{"spec.restart_trigger"},
+			},
+		}.Build())
+		Expect(err).ToNot(HaveOccurred())
+
+		// Wait for the controller to propagate restart_trigger=1 onto the CR
+		Eventually(func(g Gomega) {
+			bmiList := &bmfov1alpha1.BareMetalInstanceList{}
+			err := kubeClient.List(ctx, bmiList, crclient.MatchingLabels{
+				labels.BareMetalInstanceUuid: bareMetalInstanceId,
+			})
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(bmiList.Items).To(HaveLen(1))
+			trigger := bmiList.Items[0].Spec.RestartTrigger
+			fmt.Fprintf(GinkgoWriter, "[DEBUG] BMFO CR RestartTrigger=%d\n", trigger)
+			g.Expect(trigger).To(Equal(int64(1)),
+				"controller should propagate restart_trigger=1 to CR spec")
+		}, time.Minute, time.Second).Should(Succeed())
+	})
 })


### PR DESCRIPTION
## Summary

- Validates that `spec.restart_trigger` set via the public API is propagated onto the BMFO BareMetalInstance CR by the reconciler
- Includes the [OSAC-2258](https://redhat.atlassian.net/browse/OSAC-2258) fix (`mutateBMI` was missing `RestartTrigger` propagation) and its unit tests
- Adds an IT test to `it_baremetal_instance_lifecycle_test.go` covering the restart_trigger flow

## Changes

**Bug fix ([OSAC-2258](https://redhat.atlassian.net/browse/OSAC-2258)):** `mutateBMI()` now copies `restart_trigger` from the proto spec onto the CR, alongside the other direct spec assignments (HostType, TemplateID, etc.)

**Unit tests:** Two new `mutateBMI` test cases — trigger set to 42 and trigger at zero default.

**Integration test:** Creates a BMI, waits for controller reconciliation, verifies `RestartTrigger=0` on the CR, updates to `restart_trigger=1` via public API with field mask, waits for reconciliation, verifies `RestartTrigger=1` on the CR.

## Test Plan

- [x] Unit tests pass (69/69 in baremetalinstance controller)
- [x] IT test compiles
- [ ] IT test passes on kind cluster (`ginkgo run it`)

Depends on: [OSAC-2258](https://redhat.atlassian.net/browse/OSAC-2258) (PR #884) — included in this PR
Closes: [OSAC-1978](https://redhat.atlassian.net/browse/OSAC-1978)

Assisted-by: Claude Code <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a restart trigger to BareMetalInstance resources, allowing a value change to request a physical machine restart.
  - Exposed the observed restart version in resource status.

- **Tests**
  - Added integration coverage verifying that restart trigger updates are propagated and reconciled correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->