### PR TITLE
OSAC-1652: Add CLI integration tests (Phase 1 + Phase 2)

### DIFF
--- a/it/it_cli_auth_test.go
+++ b/it/it_cli_auth_test.go
@@ -27,22 +27,17 @@ var _ = Describe("CLI Authentication", Label("cli", "auth"), func() {
 	var homeDir string
 
 	BeforeEach(func() {
-		var err error
-		homeDir, err = tool.NewCLIHomeDir()
-		Expect(err).ToNot(HaveOccurred())
-		DeferCleanup(func() {
-			err := os.RemoveAll(homeDir)
-			Expect(err).ToNot(HaveOccurred())
-		})
+		homeDir = setupCLIHomeDir()
 	})
 
 	It("Login with password flow succeeds", func(ctx context.Context) {
 		_, _, exitCode := tool.LoginCLI(ctx, homeDir, adminUsername, adminsPassword)
 		Expect(exitCode).To(Equal(0), "login should succeed")
 
-		// Verify that subsequent commands work with the stored credentials
-		_, _, exitCode = tool.RunCLI(ctx, homeDir, "get", "computeinstance")
-		Expect(exitCode).To(Equal(0), "get should succeed after login")
+		// Verify the stored session is usable and belongs to the logged-in user
+		stdout, _, exitCode := tool.RunCLI(ctx, homeDir, "whoami")
+		Expect(exitCode).To(Equal(0), "whoami should succeed after login")
+		Expect(stdout).To(ContainSubstring(adminUsername))
 	})
 
 	It("Login with client credentials flow succeeds", func(ctx context.Context) {
@@ -55,9 +50,13 @@ var _ = Describe("CLI Authentication", Label("cli", "auth"), func() {
 		)
 		Expect(exitCode).To(Equal(0), "client credentials login should succeed")
 
-		// Verify that subsequent commands work with the stored credentials
-		_, _, exitCode = tool.RunCLI(ctx, homeDir, "get", "computeinstance")
+		// Verify the stored session can call the API
+		stdout, _, exitCode := tool.RunCLI(ctx, homeDir, "get", "computeinstance")
 		Expect(exitCode).To(Equal(0), "get should succeed after client credentials login")
+		Expect(stdout).To(SatisfyAny(
+			ContainSubstring("ID"),
+			ContainSubstring("There are no objects matching the given criteria"),
+		))
 	})
 
 	It("Login with invalid credentials fails", func(ctx context.Context) {
@@ -76,17 +75,21 @@ var _ = Describe("CLI Authentication", Label("cli", "auth"), func() {
 		Expect(exitCode).To(Equal(0), "login should succeed")
 
 		// Verify commands work
-		_, _, exitCode = tool.RunCLI(ctx, homeDir, "get", "computeinstance")
-		Expect(exitCode).To(Equal(0), "get should succeed after login")
+		stdout, _, exitCode := tool.RunCLI(ctx, homeDir, "whoami")
+		Expect(exitCode).To(Equal(0), "whoami should succeed after login")
+		Expect(stdout).To(ContainSubstring(adminUsername))
 
 		// Logout
 		_, _, exitCode = tool.RunCLI(ctx, homeDir, "logout")
 		Expect(exitCode).To(Equal(0), "logout should succeed")
 
 		// Verify commands fail after logout
-		_, stderr, exitCode := tool.RunCLI(ctx, homeDir, "get", "computeinstance")
+		_, stderr, exitCode := tool.RunCLI(ctx, homeDir, "whoami")
 		Expect(exitCode).ToNot(Equal(0), "commands should fail after logout")
-		Expect(stderr).To(ContainSubstring("there is no configuration"))
+		Expect(stderr).To(SatisfyAny(
+			ContainSubstring("there is no configuration"),
+			ContainSubstring("Not logged in"),
+		))
 	})
 
 	It("Corrupted configuration produces a clear error", func(ctx context.Context) {
@@ -114,23 +117,29 @@ var _ = Describe("CLI Authentication", Label("cli", "auth"), func() {
 		_, _, exitCode := tool.LoginCLIWithTokenScript(ctx, homeDir, script)
 		Expect(exitCode).To(Equal(0), "token-script login should succeed")
 
-		_, _, exitCode = tool.RunCLI(ctx, homeDir, "get", "computeinstance")
+		stdout, _, exitCode := tool.RunCLI(ctx, homeDir, "get", "computeinstance")
 		Expect(exitCode).To(Equal(0), "get should succeed after token-script login")
+		Expect(stdout).To(SatisfyAny(
+			ContainSubstring("ID"),
+			ContainSubstring("There are no objects matching the given criteria"),
+		))
 	})
 
 	It("Re-login replaces stored credentials", func(ctx context.Context) {
 		_, _, exitCode := tool.LoginCLI(ctx, homeDir, adminUsername, adminsPassword)
 		Expect(exitCode).To(Equal(0), "first login should succeed")
 
-		_, _, exitCode = tool.RunCLI(ctx, homeDir, "get", "computeinstance")
-		Expect(exitCode).To(Equal(0), "get should succeed after first login")
+		stdout, _, exitCode := tool.RunCLI(ctx, homeDir, "whoami")
+		Expect(exitCode).To(Equal(0), "whoami should succeed after first login")
+		Expect(stdout).To(ContainSubstring(adminUsername))
 
 		// Re-login with different credentials replaces the stored session
 		_, _, exitCode = tool.LoginCLI(ctx, homeDir, userUsername, usersPassword)
 		Expect(exitCode).To(Equal(0), "re-login should succeed")
 
-		_, _, exitCode = tool.RunCLI(ctx, homeDir, "get", "computeinstance")
-		Expect(exitCode).To(Equal(0), "get should succeed after re-login")
+		stdout, _, exitCode = tool.RunCLI(ctx, homeDir, "whoami")
+		Expect(exitCode).To(Equal(0), "whoami should succeed after re-login")
+		Expect(stdout).To(ContainSubstring(userUsername), "session should be the re-logged-in user")
 	})
 
 	It("Login with bad token-script fails gracefully", func(ctx context.Context) {
@@ -143,6 +152,9 @@ var _ = Describe("CLI Authentication", Label("cli", "auth"), func() {
 		if exitCode == 0 {
 			_, _, apiExitCode := tool.RunCLI(ctx, homeDir, "get", "computeinstance")
 			Expect(apiExitCode).ToNot(Equal(0), "API call with invalid token should fail")
+		} else {
+			Expect(exitCode).ToNot(Equal(0), "bad token-script login should fail")
+			Expect(combinedOutput).ToNot(BeEmpty(), "should produce an error message")
 		}
 	})
 })

--- a/it/it_cli_auth_test.go
+++ b/it/it_cli_auth_test.go
@@ -15,6 +15,7 @@ package it
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 
@@ -103,5 +104,45 @@ var _ = Describe("CLI Authentication", Label("cli", "auth"), func() {
 		Expect(stderr).ToNot(BeEmpty(), "should produce an error message")
 		Expect(stderr).ToNot(ContainSubstring("runtime error"), "should not panic")
 		Expect(stderr).ToNot(ContainSubstring("goroutine"), "should not dump stack trace")
+	})
+
+	It("Login with token-script succeeds", func(ctx context.Context) {
+		script := fmt.Sprintf(
+			"kubectl create token -n osac %s --kubeconfig %s --duration 1h",
+			emergencyServiceAccount, tool.KubeconfigFile(),
+		)
+		_, _, exitCode := tool.LoginCLIWithTokenScript(ctx, homeDir, script)
+		Expect(exitCode).To(Equal(0), "token-script login should succeed")
+
+		_, _, exitCode = tool.RunCLI(ctx, homeDir, "get", "computeinstance")
+		Expect(exitCode).To(Equal(0), "get should succeed after token-script login")
+	})
+
+	It("Re-login replaces stored credentials", func(ctx context.Context) {
+		_, _, exitCode := tool.LoginCLI(ctx, homeDir, adminUsername, adminsPassword)
+		Expect(exitCode).To(Equal(0), "first login should succeed")
+
+		_, _, exitCode = tool.RunCLI(ctx, homeDir, "get", "computeinstance")
+		Expect(exitCode).To(Equal(0), "get should succeed after first login")
+
+		// Re-login with different credentials replaces the stored session
+		_, _, exitCode = tool.LoginCLI(ctx, homeDir, userUsername, usersPassword)
+		Expect(exitCode).To(Equal(0), "re-login should succeed")
+
+		_, _, exitCode = tool.RunCLI(ctx, homeDir, "get", "computeinstance")
+		Expect(exitCode).To(Equal(0), "get should succeed after re-login")
+	})
+
+	It("Login with bad token-script fails gracefully", func(ctx context.Context) {
+		stdout, stderr, exitCode := tool.LoginCLIWithTokenScript(ctx, homeDir, "echo not-a-valid-jwt")
+		combinedOutput := stdout + stderr
+
+		Expect(combinedOutput).ToNot(ContainSubstring("runtime error"), "should not panic")
+		Expect(combinedOutput).ToNot(ContainSubstring("goroutine"), "should not dump stack trace")
+
+		if exitCode == 0 {
+			_, _, apiExitCode := tool.RunCLI(ctx, homeDir, "get", "computeinstance")
+			Expect(apiExitCode).ToNot(Equal(0), "API call with invalid token should fail")
+		}
 	})
 })

--- a/it/it_cli_errors_test.go
+++ b/it/it_cli_errors_test.go
@@ -72,7 +72,7 @@ var _ = Describe("CLI Error Handling", Label("cli", "errors"), func() {
 		_, _, exitCode := tool.LoginCLI(ctx, homeDir, adminUsername, adminsPassword)
 		Expect(exitCode).To(Equal(0), "login should succeed")
 
-		stdout, stderr, exitCode := tool.RunCLI(ctx, homeDir,
+		stdout, stderr, _ := tool.RunCLI(ctx, homeDir,
 			"delete", "computeinstance", "00000000-0000-0000-0000-000000000000",
 		)
 		combinedOutput := stdout + stderr

--- a/it/it_cli_errors_test.go
+++ b/it/it_cli_errors_test.go
@@ -67,4 +67,27 @@ var _ = Describe("CLI Error Handling", Label("cli", "errors"), func() {
 		Expect(combinedOutput).ToNot(ContainSubstring("goroutine"), "version should not produce a stack trace")
 		_ = exitCode
 	})
+
+	It("Delete nonexistent resource shows message", func(ctx context.Context) {
+		_, _, exitCode := tool.LoginCLI(ctx, homeDir, adminUsername, adminsPassword)
+		Expect(exitCode).To(Equal(0), "login should succeed")
+
+		stdout, stderr, exitCode := tool.RunCLI(ctx, homeDir,
+			"delete", "computeinstance", "00000000-0000-0000-0000-000000000000",
+		)
+		combinedOutput := stdout + stderr
+		Expect(combinedOutput).ToNot(ContainSubstring("runtime error"), "should not panic")
+		Expect(combinedOutput).ToNot(ContainSubstring("goroutine"), "should not dump stack trace")
+	})
+
+	It("Invalid output format is rejected", func(ctx context.Context) {
+		_, _, exitCode := tool.LoginCLI(ctx, homeDir, adminUsername, adminsPassword)
+		Expect(exitCode).To(Equal(0), "login should succeed")
+
+		_, stderr, exitCode := tool.RunCLI(ctx, homeDir,
+			"get", "computeinstance", "-o", "invalid",
+		)
+		Expect(exitCode).ToNot(Equal(0), "invalid output format should fail")
+		Expect(stderr).To(ContainSubstring("unknown output format"))
+	})
 })

--- a/it/it_cli_errors_test.go
+++ b/it/it_cli_errors_test.go
@@ -15,7 +15,6 @@ package it
 
 import (
 	"context"
-	"os"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -25,13 +24,7 @@ var _ = Describe("CLI Error Handling", Label("cli", "errors"), func() {
 	var homeDir string
 
 	BeforeEach(func() {
-		var err error
-		homeDir, err = tool.NewCLIHomeDir()
-		Expect(err).ToNot(HaveOccurred())
-		DeferCleanup(func() {
-			err := os.RemoveAll(homeDir)
-			Expect(err).ToNot(HaveOccurred())
-		})
+		homeDir = setupCLIHomeDir()
 	})
 
 	It("Command without login shows configuration error", func(ctx context.Context) {
@@ -44,14 +37,13 @@ var _ = Describe("CLI Error Handling", Label("cli", "errors"), func() {
 	})
 
 	It("Unknown resource type shows a helpful error", func(ctx context.Context) {
-		// Login first so we have valid credentials
-		_, _, exitCode := tool.LoginCLI(ctx, homeDir, adminUsername, adminsPassword)
-		Expect(exitCode).To(Equal(0), "login should succeed")
+		mustLoginCLI(ctx, homeDir, adminUsername, adminsPassword)
 
 		// Try to get an unknown resource type
 		stdout, _, exitCode := tool.RunCLI(ctx, homeDir, "get", "nonexistentresource")
 		Expect(exitCode).To(Equal(0), "unknown resource type renders help and exits 0")
 		Expect(stdout).To(ContainSubstring("There is no object named"))
+		Expect(stdout).To(ContainSubstring("nonexistentresource"))
 	})
 
 	It("Version command does not crash", func(ctx context.Context) {
@@ -60,29 +52,30 @@ var _ = Describe("CLI Error Handling", Label("cli", "errors"), func() {
 		stdout, stderr, exitCode := tool.RunCLI(ctx, homeDir, "version")
 		combinedOutput := stdout + stderr
 
-		// The command should not panic — any exit code is acceptable as long as
-		// there is meaningful output and no stack trace
+		Expect(exitCode).To(Equal(0), "version should succeed")
 		Expect(combinedOutput).ToNot(BeEmpty(), "version should produce output")
 		Expect(combinedOutput).ToNot(ContainSubstring("runtime error"), "version should not panic")
 		Expect(combinedOutput).ToNot(ContainSubstring("goroutine"), "version should not produce a stack trace")
-		_ = exitCode
 	})
 
 	It("Delete nonexistent resource shows message", func(ctx context.Context) {
-		_, _, exitCode := tool.LoginCLI(ctx, homeDir, adminUsername, adminsPassword)
-		Expect(exitCode).To(Equal(0), "login should succeed")
+		mustLoginCLI(ctx, homeDir, adminUsername, adminsPassword)
 
-		stdout, stderr, _ := tool.RunCLI(ctx, homeDir,
-			"delete", "computeinstance", "00000000-0000-0000-0000-000000000000",
+		missingID := "00000000-0000-0000-0000-000000000000"
+		stdout, stderr, exitCode := tool.RunCLI(ctx, homeDir,
+			"delete", "computeinstance", missingID,
 		)
 		combinedOutput := stdout + stderr
+		// CLI resolves the reference first; missing IDs render a helpful message and exit 0.
+		Expect(exitCode).To(Equal(0), "delete with unresolved reference exits 0 after printing guidance")
+		Expect(combinedOutput).To(ContainSubstring("No objects of type"))
+		Expect(combinedOutput).To(ContainSubstring(missingID))
 		Expect(combinedOutput).ToNot(ContainSubstring("runtime error"), "should not panic")
 		Expect(combinedOutput).ToNot(ContainSubstring("goroutine"), "should not dump stack trace")
 	})
 
 	It("Invalid output format is rejected", func(ctx context.Context) {
-		_, _, exitCode := tool.LoginCLI(ctx, homeDir, adminUsername, adminsPassword)
-		Expect(exitCode).To(Equal(0), "login should succeed")
+		mustLoginCLI(ctx, homeDir, adminUsername, adminsPassword)
 
 		_, stderr, exitCode := tool.RunCLI(ctx, homeDir,
 			"get", "computeinstance", "-o", "invalid",

--- a/it/it_cli_file_create_test.go
+++ b/it/it_cli_file_create_test.go
@@ -1,0 +1,130 @@
+/*
+Copyright (c) 2026 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package it
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	privatev1 "github.com/osac-project/fulfillment-service/internal/api/osac/private/v1"
+	"github.com/osac-project/fulfillment-service/internal/uuid"
+)
+
+var _ = Describe("CLI File Create", Label("cli", "create"), func() {
+	var (
+		homeDir        string
+		networkClassId string
+	)
+
+	BeforeEach(func() {
+		var err error
+		homeDir, err = tool.NewCLIHomeDir()
+		Expect(err).ToNot(HaveOccurred())
+
+		ncClient := privatev1.NewNetworkClassesClient(tool.InternalView().AdminConn())
+		ncResp, err := ncClient.Create(context.Background(), privatev1.NetworkClassesCreateRequest_builder{
+			Object: privatev1.NetworkClass_builder{
+				Title:                  "CLI File Create Test NC",
+				ImplementationStrategy: "cudn",
+				FabricManager:          "netris",
+			}.Build(),
+		}.Build())
+		Expect(err).ToNot(HaveOccurred())
+		networkClassId = ncResp.GetObject().GetId()
+
+		DeferCleanup(func() {
+			ctx := context.Background()
+			ncClient := privatev1.NewNetworkClassesClient(tool.InternalView().AdminConn())
+			ncClient.Delete(ctx, privatev1.NetworkClassesDeleteRequest_builder{
+				Id: networkClassId,
+			}.Build())
+			os.RemoveAll(homeDir)
+		})
+	})
+
+	It("Create from JSON file", func(ctx context.Context) {
+		_, _, exitCode := tool.LoginCLI(ctx, homeDir, adminUsername, adminsPassword)
+		Expect(exitCode).To(Equal(0), "login should succeed")
+
+		name := fmt.Sprintf("json-create-%s", uuid.New())
+		jsonContent := fmt.Sprintf(`{
+			"@type": "type.googleapis.com/osac.public.v1.VirtualNetwork",
+			"metadata": {
+				"name": "%s"
+			},
+			"spec": {
+				"network_class": "%s",
+				"ipv4_cidr": "10.130.0.0/16"
+			}
+		}`, name, networkClassId)
+
+		filePath := filepath.Join(homeDir, "resource.json")
+		err := os.WriteFile(filePath, []byte(jsonContent), 0644)
+		Expect(err).ToNot(HaveOccurred())
+
+		stdout, stderr, exitCode := tool.RunCLI(ctx, homeDir, "create", "-f", filePath)
+		Expect(exitCode).To(Equal(0), "create -f JSON should succeed, stdout=%s, stderr=%s", stdout, stderr)
+		Expect(stdout).To(ContainSubstring("Created"))
+
+		DeferCleanup(func() {
+			tool.RunCLI(ctx, homeDir, "delete", "virtualnetwork", name)
+		})
+	})
+
+	It("Create from YAML file", func(ctx context.Context) {
+		_, _, exitCode := tool.LoginCLI(ctx, homeDir, adminUsername, adminsPassword)
+		Expect(exitCode).To(Equal(0), "login should succeed")
+
+		name := fmt.Sprintf("yaml-create-%s", uuid.New())
+		yamlContent := fmt.Sprintf(`"@type": "type.googleapis.com/osac.public.v1.VirtualNetwork"
+metadata:
+  name: "%s"
+spec:
+  network_class: "%s"
+  ipv4_cidr: "10.131.0.0/16"
+`, name, networkClassId)
+
+		filePath := filepath.Join(homeDir, "resource.yaml")
+		err := os.WriteFile(filePath, []byte(yamlContent), 0644)
+		Expect(err).ToNot(HaveOccurred())
+
+		stdout, stderr, exitCode := tool.RunCLI(ctx, homeDir, "create", "-f", filePath)
+		Expect(exitCode).To(Equal(0), "create -f YAML should succeed, stdout=%s, stderr=%s", stdout, stderr)
+		Expect(stdout).To(ContainSubstring("Created"))
+
+		DeferCleanup(func() {
+			tool.RunCLI(ctx, homeDir, "delete", "virtualnetwork", name)
+		})
+	})
+
+	It("Create from invalid file fails gracefully", func(ctx context.Context) {
+		_, _, exitCode := tool.LoginCLI(ctx, homeDir, adminUsername, adminsPassword)
+		Expect(exitCode).To(Equal(0), "login should succeed")
+
+		filePath := filepath.Join(homeDir, "bad.yaml")
+		err := os.WriteFile(filePath, []byte("this is not valid proto"), 0644)
+		Expect(err).ToNot(HaveOccurred())
+
+		stdout, stderr, exitCode := tool.RunCLI(ctx, homeDir, "create", "-f", filePath)
+		Expect(exitCode).ToNot(Equal(0), "create -f with invalid content should fail")
+		combinedOutput := stdout + stderr
+		Expect(combinedOutput).ToNot(ContainSubstring("runtime error"), "should not panic")
+		Expect(combinedOutput).ToNot(ContainSubstring("goroutine"), "should not dump stack trace")
+	})
+})

--- a/it/it_cli_file_create_test.go
+++ b/it/it_cli_file_create_test.go
@@ -22,7 +22,6 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	privatev1 "github.com/osac-project/fulfillment-service/internal/api/osac/private/v1"
 	"github.com/osac-project/fulfillment-service/internal/uuid"
 )
 
@@ -33,34 +32,12 @@ var _ = Describe("CLI File Create", Label("cli", "create"), func() {
 	)
 
 	BeforeEach(func() {
-		var err error
-		homeDir, err = tool.NewCLIHomeDir()
-		Expect(err).ToNot(HaveOccurred())
-
-		ncClient := privatev1.NewNetworkClassesClient(tool.InternalView().AdminConn())
-		ncResp, err := ncClient.Create(context.Background(), privatev1.NetworkClassesCreateRequest_builder{
-			Object: privatev1.NetworkClass_builder{
-				Title:                  "CLI File Create Test NC",
-				ImplementationStrategy: "cudn",
-				FabricManager:          "netris",
-			}.Build(),
-		}.Build())
-		Expect(err).ToNot(HaveOccurred())
-		networkClassId = ncResp.GetObject().GetId()
-
-		DeferCleanup(func() {
-			ctx := context.Background()
-			ncClient := privatev1.NewNetworkClassesClient(tool.InternalView().AdminConn())
-			ncClient.Delete(ctx, privatev1.NetworkClassesDeleteRequest_builder{
-				Id: networkClassId,
-			}.Build())
-			os.RemoveAll(homeDir)
-		})
+		homeDir = setupCLIHomeDir()
+		networkClassId = setupTestNetworkClass("CLI File Create Test NC")
 	})
 
 	It("Create from JSON file", func(ctx context.Context) {
-		_, _, exitCode := tool.LoginCLI(ctx, homeDir, adminUsername, adminsPassword)
-		Expect(exitCode).To(Equal(0), "login should succeed")
+		mustLoginCLI(ctx, homeDir, adminUsername, adminsPassword)
 
 		name := fmt.Sprintf("json-create-%s", uuid.New())
 		jsonContent := fmt.Sprintf(`{
@@ -81,6 +58,11 @@ var _ = Describe("CLI File Create", Label("cli", "create"), func() {
 		stdout, stderr, exitCode := tool.RunCLI(ctx, homeDir, "create", "-f", filePath)
 		Expect(exitCode).To(Equal(0), "create -f JSON should succeed, stdout=%s, stderr=%s", stdout, stderr)
 		Expect(stdout).To(ContainSubstring("Created"))
+		Expect(stdout).To(ContainSubstring(name))
+
+		stdout, _, exitCode = tool.RunCLI(ctx, homeDir, "get", "virtualnetwork", name)
+		Expect(exitCode).To(Equal(0), "get after create -f JSON should succeed")
+		Expect(stdout).To(ContainSubstring(name))
 
 		DeferCleanup(func() {
 			tool.RunCLI(ctx, homeDir, "delete", "virtualnetwork", name)
@@ -88,8 +70,7 @@ var _ = Describe("CLI File Create", Label("cli", "create"), func() {
 	})
 
 	It("Create from YAML file", func(ctx context.Context) {
-		_, _, exitCode := tool.LoginCLI(ctx, homeDir, adminUsername, adminsPassword)
-		Expect(exitCode).To(Equal(0), "login should succeed")
+		mustLoginCLI(ctx, homeDir, adminUsername, adminsPassword)
 
 		name := fmt.Sprintf("yaml-create-%s", uuid.New())
 		yamlContent := fmt.Sprintf(`"@type": "type.googleapis.com/osac.public.v1.VirtualNetwork"
@@ -107,6 +88,11 @@ spec:
 		stdout, stderr, exitCode := tool.RunCLI(ctx, homeDir, "create", "-f", filePath)
 		Expect(exitCode).To(Equal(0), "create -f YAML should succeed, stdout=%s, stderr=%s", stdout, stderr)
 		Expect(stdout).To(ContainSubstring("Created"))
+		Expect(stdout).To(ContainSubstring(name))
+
+		stdout, _, exitCode = tool.RunCLI(ctx, homeDir, "get", "virtualnetwork", name)
+		Expect(exitCode).To(Equal(0), "get after create -f YAML should succeed")
+		Expect(stdout).To(ContainSubstring(name))
 
 		DeferCleanup(func() {
 			tool.RunCLI(ctx, homeDir, "delete", "virtualnetwork", name)
@@ -114,8 +100,7 @@ spec:
 	})
 
 	It("Create from invalid file fails gracefully", func(ctx context.Context) {
-		_, _, exitCode := tool.LoginCLI(ctx, homeDir, adminUsername, adminsPassword)
-		Expect(exitCode).To(Equal(0), "login should succeed")
+		mustLoginCLI(ctx, homeDir, adminUsername, adminsPassword)
 
 		filePath := filepath.Join(homeDir, "bad.yaml")
 		err := os.WriteFile(filePath, []byte("this is not valid proto"), 0644)
@@ -124,6 +109,7 @@ spec:
 		stdout, stderr, exitCode := tool.RunCLI(ctx, homeDir, "create", "-f", filePath)
 		Expect(exitCode).ToNot(Equal(0), "create -f with invalid content should fail")
 		combinedOutput := stdout + stderr
+		Expect(combinedOutput).ToNot(BeEmpty(), "should produce an error message")
 		Expect(combinedOutput).ToNot(ContainSubstring("runtime error"), "should not panic")
 		Expect(combinedOutput).ToNot(ContainSubstring("goroutine"), "should not dump stack trace")
 	})

--- a/it/it_cli_get_subcommands_test.go
+++ b/it/it_cli_get_subcommands_test.go
@@ -16,29 +16,25 @@ package it
 import (
 	"context"
 	"encoding/json"
-	"os"
+	"fmt"
 	"strings"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+
+	privatev1 "github.com/osac-project/fulfillment-service/internal/api/osac/private/v1"
+	"github.com/osac-project/fulfillment-service/internal/uuid"
 )
 
 var _ = Describe("CLI Get Subcommands", Label("cli", "get"), func() {
 	var homeDir string
 
 	BeforeEach(func() {
-		var err error
-		homeDir, err = tool.NewCLIHomeDir()
-		Expect(err).ToNot(HaveOccurred())
-		DeferCleanup(func() {
-			err := os.RemoveAll(homeDir)
-			Expect(err).ToNot(HaveOccurred())
-		})
+		homeDir = setupCLIHomeDir()
 	})
 
 	It("Get token returns a JWT", func(ctx context.Context) {
-		_, _, exitCode := tool.LoginCLI(ctx, homeDir, adminUsername, adminsPassword)
-		Expect(exitCode).To(Equal(0), "login should succeed")
+		mustLoginCLI(ctx, homeDir, adminUsername, adminsPassword)
 
 		stdout, _, exitCode := tool.RunCLI(ctx, homeDir, "get", "token")
 		Expect(exitCode).To(Equal(0), "get token should succeed")
@@ -51,8 +47,7 @@ var _ = Describe("CLI Get Subcommands", Label("cli", "get"), func() {
 	})
 
 	It("Get token --header returns valid JSON", func(ctx context.Context) {
-		_, _, exitCode := tool.LoginCLI(ctx, homeDir, adminUsername, adminsPassword)
-		Expect(exitCode).To(Equal(0), "login should succeed")
+		mustLoginCLI(ctx, homeDir, adminUsername, adminsPassword)
 
 		stdout, _, exitCode := tool.RunCLI(ctx, homeDir, "get", "token", "--header")
 		Expect(exitCode).To(Equal(0), "get token --header should succeed")
@@ -64,13 +59,39 @@ var _ = Describe("CLI Get Subcommands", Label("cli", "get"), func() {
 		Expect(parsed).To(HaveKey("alg"), "JWT header should contain 'alg' field")
 	})
 
-	It("Get publicippool lists or shows empty", func(ctx context.Context) {
-		_, _, exitCode := tool.LoginCLI(ctx, homeDir, adminUsername, adminsPassword)
-		Expect(exitCode).To(Equal(0), "login should succeed")
+	It("Get publicippool lists a created pool", func(ctx context.Context) {
+		mustLoginCLI(ctx, homeDir, adminUsername, adminsPassword)
+
+		poolName := fmt.Sprintf("cli-pool-%s", uuid.New())
+		poolClient := privatev1.NewPublicIPPoolsClient(tool.InternalView().AdminConn())
+		createResp, err := poolClient.Create(ctx, privatev1.PublicIPPoolsCreateRequest_builder{
+			Object: privatev1.PublicIPPool_builder{
+				Metadata: privatev1.Metadata_builder{
+					Name: poolName,
+				}.Build(),
+				Spec: privatev1.PublicIPPoolSpec_builder{
+					Cidrs:    []string{uniqueCIDR()},
+					IpFamily: privatev1.IPFamily_IP_FAMILY_IPV4,
+				}.Build(),
+			}.Build(),
+		}.Build())
+		Expect(err).ToNot(HaveOccurred())
+		pool := createResp.GetObject()
+		pool.GetStatus().SetState(privatev1.PublicIPPoolState_PUBLIC_IP_POOL_STATE_READY)
+		pool.GetStatus().SetAvailable(256)
+		_, err = poolClient.Update(ctx, privatev1.PublicIPPoolsUpdateRequest_builder{
+			Object: pool,
+		}.Build())
+		Expect(err).ToNot(HaveOccurred())
+		DeferCleanup(func() {
+			_, _ = poolClient.Delete(context.Background(), privatev1.PublicIPPoolsDeleteRequest_builder{
+				Id: pool.GetId(),
+			}.Build())
+		})
 
 		stdout, _, exitCode := tool.RunCLI(ctx, homeDir, "get", "publicippool")
 		Expect(exitCode).To(Equal(0), "get publicippool should succeed")
-		// May be empty or contain results — just verify no crash and valid output.
-		Expect(stdout).ToNot(ContainSubstring("runtime error"))
+		Expect(stdout).To(ContainSubstring("ID"))
+		Expect(stdout).To(ContainSubstring(poolName), "table output should include the created pool name")
 	})
 })

--- a/it/it_cli_get_subcommands_test.go
+++ b/it/it_cli_get_subcommands_test.go
@@ -1,0 +1,76 @@
+/*
+Copyright (c) 2026 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package it
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"strings"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("CLI Get Subcommands", Label("cli", "get"), func() {
+	var homeDir string
+
+	BeforeEach(func() {
+		var err error
+		homeDir, err = tool.NewCLIHomeDir()
+		Expect(err).ToNot(HaveOccurred())
+		DeferCleanup(func() {
+			err := os.RemoveAll(homeDir)
+			Expect(err).ToNot(HaveOccurred())
+		})
+	})
+
+	It("Get token returns a JWT", func(ctx context.Context) {
+		_, _, exitCode := tool.LoginCLI(ctx, homeDir, adminUsername, adminsPassword)
+		Expect(exitCode).To(Equal(0), "login should succeed")
+
+		stdout, _, exitCode := tool.RunCLI(ctx, homeDir, "get", "token")
+		Expect(exitCode).To(Equal(0), "get token should succeed")
+		Expect(stdout).ToNot(BeEmpty(), "token should not be empty")
+
+		// A JWT has three base64-encoded segments separated by dots.
+		token := strings.TrimSpace(stdout)
+		parts := strings.Split(token, ".")
+		Expect(parts).To(HaveLen(3), "token should be a valid JWT with 3 parts")
+	})
+
+	It("Get token --header returns valid JSON", func(ctx context.Context) {
+		_, _, exitCode := tool.LoginCLI(ctx, homeDir, adminUsername, adminsPassword)
+		Expect(exitCode).To(Equal(0), "login should succeed")
+
+		stdout, _, exitCode := tool.RunCLI(ctx, homeDir, "get", "token", "--header")
+		Expect(exitCode).To(Equal(0), "get token --header should succeed")
+		Expect(stdout).ToNot(BeEmpty())
+
+		var parsed map[string]any
+		err := json.Unmarshal([]byte(stdout), &parsed)
+		Expect(err).ToNot(HaveOccurred(), "token header should be valid JSON")
+		Expect(parsed).To(HaveKey("alg"), "JWT header should contain 'alg' field")
+	})
+
+	It("Get publicippool lists or shows empty", func(ctx context.Context) {
+		_, _, exitCode := tool.LoginCLI(ctx, homeDir, adminUsername, adminsPassword)
+		Expect(exitCode).To(Equal(0), "login should succeed")
+
+		stdout, _, exitCode := tool.RunCLI(ctx, homeDir, "get", "publicippool")
+		Expect(exitCode).To(Equal(0), "get publicippool should succeed")
+		// May be empty or contain results — just verify no crash and valid output.
+		Expect(stdout).ToNot(ContainSubstring("runtime error"))
+	})
+})

--- a/it/it_cli_get_subcommands_test.go
+++ b/it/it_cli_get_subcommands_test.go
@@ -79,8 +79,9 @@ var _ = Describe("CLI Get Subcommands", Label("cli", "get"), func() {
 		}.Build())
 		Expect(err).ToNot(HaveOccurred())
 		pool := createResp.GetObject()
-		DeferCleanup(func() {
-			_, _ = poolClient.Delete(context.Background(), privatev1.PublicIPPoolsDeleteRequest_builder{
+		DeferCleanup(func(ctx context.Context) {
+			// Best-effort cleanup; ignore not-found / already-deleted.
+			_, _ = poolClient.Delete(ctx, privatev1.PublicIPPoolsDeleteRequest_builder{
 				Id: pool.GetId(),
 			}.Build())
 		})

--- a/it/it_cli_get_subcommands_test.go
+++ b/it/it_cli_get_subcommands_test.go
@@ -21,6 +21,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"google.golang.org/protobuf/types/known/fieldmaskpb"
 
 	privatev1 "github.com/osac-project/fulfillment-service/internal/api/osac/private/v1"
 	"github.com/osac-project/fulfillment-service/internal/uuid"
@@ -62,6 +63,7 @@ var _ = Describe("CLI Get Subcommands", Label("cli", "get"), func() {
 	It("Get publicippool lists a created pool", func(ctx context.Context) {
 		mustLoginCLI(ctx, homeDir, adminUsername, adminsPassword)
 
+		// Public list only exposes READY pools with available capacity.
 		poolName := fmt.Sprintf("cli-pool-%s", uuid.New())
 		poolClient := privatev1.NewPublicIPPoolsClient(tool.InternalView().AdminConn())
 		createResp, err := poolClient.Create(ctx, privatev1.PublicIPPoolsCreateRequest_builder{
@@ -77,17 +79,23 @@ var _ = Describe("CLI Get Subcommands", Label("cli", "get"), func() {
 		}.Build())
 		Expect(err).ToNot(HaveOccurred())
 		pool := createResp.GetObject()
-		pool.GetStatus().SetState(privatev1.PublicIPPoolState_PUBLIC_IP_POOL_STATE_READY)
-		pool.GetStatus().SetAvailable(256)
-		_, err = poolClient.Update(ctx, privatev1.PublicIPPoolsUpdateRequest_builder{
-			Object: pool,
-		}.Build())
-		Expect(err).ToNot(HaveOccurred())
 		DeferCleanup(func() {
 			_, _ = poolClient.Delete(context.Background(), privatev1.PublicIPPoolsDeleteRequest_builder{
 				Id: pool.GetId(),
 			}.Build())
 		})
+
+		pool.SetStatus(privatev1.PublicIPPoolStatus_builder{
+			State:     privatev1.PublicIPPoolState_PUBLIC_IP_POOL_STATE_READY,
+			Total:     pool.GetStatus().GetTotal(),
+			Available: pool.GetStatus().GetAvailable(),
+			Allocated: pool.GetStatus().GetAllocated(),
+		}.Build())
+		_, err = poolClient.Update(ctx, privatev1.PublicIPPoolsUpdateRequest_builder{
+			Object:     pool,
+			UpdateMask: &fieldmaskpb.FieldMask{Paths: []string{"status.state"}},
+		}.Build())
+		Expect(err).ToNot(HaveOccurred())
 
 		stdout, _, exitCode := tool.RunCLI(ctx, homeDir, "get", "publicippool")
 		Expect(exitCode).To(Equal(0), "get publicippool should succeed")

--- a/it/it_cli_helpers.go
+++ b/it/it_cli_helpers.go
@@ -1,0 +1,82 @@
+/*
+Copyright (c) 2026 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package it
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	privatev1 "github.com/osac-project/fulfillment-service/internal/api/osac/private/v1"
+	"github.com/osac-project/fulfillment-service/internal/uuid"
+)
+
+// setupCLIHomeDir creates an isolated CLI HOME directory and registers cleanup.
+func setupCLIHomeDir() string {
+	homeDir, err := tool.NewCLIHomeDir()
+	Expect(err).ToNot(HaveOccurred())
+	DeferCleanup(func() {
+		Expect(os.RemoveAll(homeDir)).To(Succeed())
+	})
+	return homeDir
+}
+
+// mustLoginCLI logs in with the given credentials and fails the test on non-zero exit.
+func mustLoginCLI(ctx context.Context, homeDir, user, password string) {
+	_, _, exitCode := tool.LoginCLI(ctx, homeDir, user, password)
+	Expect(exitCode).To(Equal(0), "login as %s should succeed", user)
+}
+
+// setupTestNetworkClass creates a NetworkClass for CLI tests and registers cleanup.
+func setupTestNetworkClass(title string) string {
+	ncClient := privatev1.NewNetworkClassesClient(tool.InternalView().AdminConn())
+	ncResp, err := ncClient.Create(context.Background(), privatev1.NetworkClassesCreateRequest_builder{
+		Object: privatev1.NetworkClass_builder{
+			Title:                  title,
+			ImplementationStrategy: "cudn",
+			FabricManager:          "netris",
+		}.Build(),
+	}.Build())
+	Expect(err).ToNot(HaveOccurred())
+	networkClassId := ncResp.GetObject().GetId()
+
+	DeferCleanup(func() {
+		ncClient := privatev1.NewNetworkClassesClient(tool.InternalView().AdminConn())
+		_, _ = ncClient.Delete(context.Background(), privatev1.NetworkClassesDeleteRequest_builder{
+			Id: networkClassId,
+		}.Build())
+	})
+	return networkClassId
+}
+
+// createCLIVirtualNetwork creates a VirtualNetwork via the CLI, registers cleanup, and
+// returns the resource name.
+func createCLIVirtualNetwork(ctx context.Context, homeDir, networkClassId, cidr string) string {
+	vnName := fmt.Sprintf("cli-vn-%s", uuid.New())
+	stdout, stderr, exitCode := tool.RunCLI(ctx, homeDir,
+		"create", "virtualnetwork",
+		"--name", vnName,
+		"--network-class", networkClassId,
+		"--ipv4-cidr", cidr,
+	)
+	Expect(exitCode).To(Equal(0), "create virtualnetwork should succeed, stdout=%s, stderr=%s", stdout, stderr)
+	Expect(stdout).To(ContainSubstring("Created"))
+	DeferCleanup(func() {
+		tool.RunCLI(context.Background(), homeDir, "delete", "virtualnetwork", vnName)
+	})
+	return vnName
+}

--- a/it/it_cli_helpers.go
+++ b/it/it_cli_helpers.go
@@ -54,9 +54,10 @@ func setupTestNetworkClass(title string) string {
 	Expect(err).ToNot(HaveOccurred())
 	networkClassId := ncResp.GetObject().GetId()
 
-	DeferCleanup(func() {
+	DeferCleanup(func(ctx context.Context) {
 		ncClient := privatev1.NewNetworkClassesClient(tool.InternalView().AdminConn())
-		_, _ = ncClient.Delete(context.Background(), privatev1.NetworkClassesDeleteRequest_builder{
+		// Best-effort cleanup; ignore not-found / already-deleted.
+		_, _ = ncClient.Delete(ctx, privatev1.NetworkClassesDeleteRequest_builder{
 			Id: networkClassId,
 		}.Build())
 	})
@@ -75,8 +76,18 @@ func createCLIVirtualNetwork(ctx context.Context, homeDir, networkClassId, cidr 
 	)
 	Expect(exitCode).To(Equal(0), "create virtualnetwork should succeed, stdout=%s, stderr=%s", stdout, stderr)
 	Expect(stdout).To(ContainSubstring("Created"))
-	DeferCleanup(func() {
-		tool.RunCLI(context.Background(), homeDir, "delete", "virtualnetwork", vnName)
+	DeferCleanup(func(ctx context.Context) {
+		tool.RunCLI(ctx, homeDir, "delete", "virtualnetwork", vnName)
 	})
 	return vnName
+}
+
+// expectCLISoftDeletedVirtualNetwork asserts the resource is still listed after delete
+// with DELETING=Yes (soft-delete until finalizers complete).
+func expectCLISoftDeletedVirtualNetwork(ctx context.Context, homeDir, vnName string) {
+	stdout, _, exitCode := tool.RunCLI(ctx, homeDir, "get", "virtualnetwork", vnName)
+	Expect(exitCode).To(Equal(0), "get after delete should succeed")
+	Expect(stdout).To(ContainSubstring(vnName))
+	Expect(stdout).To(MatchRegexp(`(?m)^\S+\s+Yes\s+.*%s`, vnName),
+		"DELETING column should be Yes after delete")
 }

--- a/it/it_cli_lifecycle_test.go
+++ b/it/it_cli_lifecycle_test.go
@@ -76,11 +76,6 @@ var _ = Describe("CLI Resource Lifecycle", Label("cli", "lifecycle"), func() {
 		Expect(exitCode).To(Equal(0), "delete should succeed")
 		Expect(stdout).To(ContainSubstring("Deleted"))
 
-		// Confirm soft-delete: resource remains visible with DELETING=Yes until finalizers complete
-		stdout, _, exitCode = tool.RunCLI(ctx, homeDir, "get", "virtualnetwork", vnName)
-		Expect(exitCode).To(Equal(0), "get after delete should succeed")
-		Expect(stdout).To(ContainSubstring(vnName))
-		Expect(stdout).To(MatchRegexp(`(?m)^\S+\s+Yes\s+.*%s`, vnName),
-			"DELETING column should be Yes after delete")
+		expectCLISoftDeletedVirtualNetwork(ctx, homeDir, vnName)
 	})
 })

--- a/it/it_cli_lifecycle_test.go
+++ b/it/it_cli_lifecycle_test.go
@@ -1,0 +1,108 @@
+/*
+Copyright (c) 2026 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package it
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	privatev1 "github.com/osac-project/fulfillment-service/internal/api/osac/private/v1"
+	"github.com/osac-project/fulfillment-service/internal/uuid"
+)
+
+var _ = Describe("CLI Resource Lifecycle", Label("cli", "lifecycle"), func() {
+	var (
+		homeDir        string
+		networkClassId string
+	)
+
+	BeforeEach(func() {
+		var err error
+		homeDir, err = tool.NewCLIHomeDir()
+		Expect(err).ToNot(HaveOccurred())
+
+		ncClient := privatev1.NewNetworkClassesClient(tool.InternalView().AdminConn())
+		ncResp, err := ncClient.Create(context.Background(), privatev1.NetworkClassesCreateRequest_builder{
+			Object: privatev1.NetworkClass_builder{
+				Title:                  "CLI Lifecycle Test NC",
+				ImplementationStrategy: "cudn",
+				FabricManager:          "netris",
+			}.Build(),
+		}.Build())
+		Expect(err).ToNot(HaveOccurred())
+		networkClassId = ncResp.GetObject().GetId()
+
+		DeferCleanup(func() {
+			ncClient := privatev1.NewNetworkClassesClient(tool.InternalView().AdminConn())
+			ncClient.Delete(context.Background(), privatev1.NetworkClassesDeleteRequest_builder{
+				Id: networkClassId,
+			}.Build())
+			os.RemoveAll(homeDir)
+		})
+	})
+
+	It("Create virtual network via CLI", func(ctx context.Context) {
+		_, _, exitCode := tool.LoginCLI(ctx, homeDir, adminUsername, adminsPassword)
+		Expect(exitCode).To(Equal(0), "login should succeed")
+
+		vnName := fmt.Sprintf("cli-create-%s", uuid.New())
+		stdout, stderr, exitCode := tool.RunCLI(ctx, homeDir,
+			"create", "virtualnetwork",
+			"--name", vnName,
+			"--network-class", networkClassId,
+			"--ipv4-cidr", "10.100.0.0/16",
+		)
+		Expect(exitCode).To(Equal(0), "create should succeed, stdout=%s, stderr=%s", stdout, stderr)
+		Expect(stdout).To(ContainSubstring("Created"))
+
+		DeferCleanup(func() {
+			tool.RunCLI(ctx, homeDir, "delete", "virtualnetwork", vnName)
+		})
+	})
+
+	It("Full create-get-describe-delete lifecycle", func(ctx context.Context) {
+		_, _, exitCode := tool.LoginCLI(ctx, homeDir, adminUsername, adminsPassword)
+		Expect(exitCode).To(Equal(0), "login should succeed")
+
+		vnName := fmt.Sprintf("cli-lifecycle-%s", uuid.New())
+
+		// Create
+		stdout, stderr, exitCode := tool.RunCLI(ctx, homeDir,
+			"create", "virtualnetwork",
+			"--name", vnName,
+			"--network-class", networkClassId,
+			"--ipv4-cidr", "10.101.0.0/16",
+		)
+		Expect(exitCode).To(Equal(0), "create should succeed, stderr=%s", stderr)
+		Expect(stdout).To(ContainSubstring("Created"))
+
+		// Get by name
+		stdout, _, exitCode = tool.RunCLI(ctx, homeDir, "get", "virtualnetwork", vnName)
+		Expect(exitCode).To(Equal(0), "get by name should succeed")
+		Expect(stdout).To(ContainSubstring(vnName))
+
+		// Describe
+		stdout, _, exitCode = tool.RunCLI(ctx, homeDir, "describe", "virtualnetwork", vnName)
+		Expect(exitCode).To(Equal(0), "describe should succeed")
+		Expect(stdout).To(ContainSubstring("ID:"))
+
+		// Delete by name
+		_, _, exitCode = tool.RunCLI(ctx, homeDir, "delete", "virtualnetwork", vnName)
+		Expect(exitCode).To(Equal(0), "delete should succeed")
+	})
+})

--- a/it/it_cli_lifecycle_test.go
+++ b/it/it_cli_lifecycle_test.go
@@ -16,12 +16,10 @@ package it
 import (
 	"context"
 	"fmt"
-	"os"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	privatev1 "github.com/osac-project/fulfillment-service/internal/api/osac/private/v1"
 	"github.com/osac-project/fulfillment-service/internal/uuid"
 )
 
@@ -32,52 +30,22 @@ var _ = Describe("CLI Resource Lifecycle", Label("cli", "lifecycle"), func() {
 	)
 
 	BeforeEach(func() {
-		var err error
-		homeDir, err = tool.NewCLIHomeDir()
-		Expect(err).ToNot(HaveOccurred())
-
-		ncClient := privatev1.NewNetworkClassesClient(tool.InternalView().AdminConn())
-		ncResp, err := ncClient.Create(context.Background(), privatev1.NetworkClassesCreateRequest_builder{
-			Object: privatev1.NetworkClass_builder{
-				Title:                  "CLI Lifecycle Test NC",
-				ImplementationStrategy: "cudn",
-				FabricManager:          "netris",
-			}.Build(),
-		}.Build())
-		Expect(err).ToNot(HaveOccurred())
-		networkClassId = ncResp.GetObject().GetId()
-
-		DeferCleanup(func() {
-			ncClient := privatev1.NewNetworkClassesClient(tool.InternalView().AdminConn())
-			ncClient.Delete(context.Background(), privatev1.NetworkClassesDeleteRequest_builder{
-				Id: networkClassId,
-			}.Build())
-			os.RemoveAll(homeDir)
-		})
+		homeDir = setupCLIHomeDir()
+		networkClassId = setupTestNetworkClass("CLI Lifecycle Test NC")
 	})
 
 	It("Create virtual network via CLI", func(ctx context.Context) {
-		_, _, exitCode := tool.LoginCLI(ctx, homeDir, adminUsername, adminsPassword)
-		Expect(exitCode).To(Equal(0), "login should succeed")
+		mustLoginCLI(ctx, homeDir, adminUsername, adminsPassword)
 
-		vnName := fmt.Sprintf("cli-create-%s", uuid.New())
-		stdout, stderr, exitCode := tool.RunCLI(ctx, homeDir,
-			"create", "virtualnetwork",
-			"--name", vnName,
-			"--network-class", networkClassId,
-			"--ipv4-cidr", "10.100.0.0/16",
-		)
-		Expect(exitCode).To(Equal(0), "create should succeed, stdout=%s, stderr=%s", stdout, stderr)
-		Expect(stdout).To(ContainSubstring("Created"))
+		vnName := createCLIVirtualNetwork(ctx, homeDir, networkClassId, "10.100.0.0/16")
 
-		DeferCleanup(func() {
-			tool.RunCLI(ctx, homeDir, "delete", "virtualnetwork", vnName)
-		})
+		stdout, _, exitCode := tool.RunCLI(ctx, homeDir, "get", "virtualnetwork", vnName)
+		Expect(exitCode).To(Equal(0), "get after create should succeed")
+		Expect(stdout).To(ContainSubstring(vnName))
 	})
 
 	It("Full create-get-describe-delete lifecycle", func(ctx context.Context) {
-		_, _, exitCode := tool.LoginCLI(ctx, homeDir, adminUsername, adminsPassword)
-		Expect(exitCode).To(Equal(0), "login should succeed")
+		mustLoginCLI(ctx, homeDir, adminUsername, adminsPassword)
 
 		vnName := fmt.Sprintf("cli-lifecycle-%s", uuid.New())
 
@@ -90,6 +58,7 @@ var _ = Describe("CLI Resource Lifecycle", Label("cli", "lifecycle"), func() {
 		)
 		Expect(exitCode).To(Equal(0), "create should succeed, stderr=%s", stderr)
 		Expect(stdout).To(ContainSubstring("Created"))
+		Expect(stdout).To(ContainSubstring(vnName))
 
 		// Get by name
 		stdout, _, exitCode = tool.RunCLI(ctx, homeDir, "get", "virtualnetwork", vnName)
@@ -100,9 +69,18 @@ var _ = Describe("CLI Resource Lifecycle", Label("cli", "lifecycle"), func() {
 		stdout, _, exitCode = tool.RunCLI(ctx, homeDir, "describe", "virtualnetwork", vnName)
 		Expect(exitCode).To(Equal(0), "describe should succeed")
 		Expect(stdout).To(ContainSubstring("ID:"))
+		Expect(stdout).To(ContainSubstring(vnName))
 
 		// Delete by name
-		_, _, exitCode = tool.RunCLI(ctx, homeDir, "delete", "virtualnetwork", vnName)
+		stdout, _, exitCode = tool.RunCLI(ctx, homeDir, "delete", "virtualnetwork", vnName)
 		Expect(exitCode).To(Equal(0), "delete should succeed")
+		Expect(stdout).To(ContainSubstring("Deleted"))
+
+		// Confirm soft-delete: resource remains visible with DELETING=Yes until finalizers complete
+		stdout, _, exitCode = tool.RunCLI(ctx, homeDir, "get", "virtualnetwork", vnName)
+		Expect(exitCode).To(Equal(0), "get after delete should succeed")
+		Expect(stdout).To(ContainSubstring(vnName))
+		Expect(stdout).To(MatchRegexp(`(?m)^\S+\s+Yes\s+.*%s`, vnName),
+			"DELETING column should be Yes after delete")
 	})
 })

--- a/it/it_cli_metadata_test.go
+++ b/it/it_cli_metadata_test.go
@@ -15,66 +15,28 @@ package it
 
 import (
 	"context"
-	"fmt"
-	"os"
+	"encoding/json"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-
-	privatev1 "github.com/osac-project/fulfillment-service/internal/api/osac/private/v1"
-	"github.com/osac-project/fulfillment-service/internal/uuid"
 )
 
 var _ = Describe("CLI Metadata", Label("cli", "metadata"), func() {
 	var (
 		homeDir        string
 		networkClassId string
-		vnName         string
 	)
 
 	BeforeEach(func() {
-		var err error
-		homeDir, err = tool.NewCLIHomeDir()
-		Expect(err).ToNot(HaveOccurred())
-
-		ncClient := privatev1.NewNetworkClassesClient(tool.InternalView().AdminConn())
-		ncResp, err := ncClient.Create(context.Background(), privatev1.NetworkClassesCreateRequest_builder{
-			Object: privatev1.NetworkClass_builder{
-				Title:                  "CLI Metadata Test NC",
-				ImplementationStrategy: "cudn",
-				FabricManager:          "netris",
-			}.Build(),
-		}.Build())
-		Expect(err).ToNot(HaveOccurred())
-		networkClassId = ncResp.GetObject().GetId()
-
-		DeferCleanup(func() {
-			ctx := context.Background()
-			if vnName != "" {
-				tool.RunCLI(ctx, homeDir, "delete", "virtualnetwork", vnName)
-			}
-			ncClient := privatev1.NewNetworkClassesClient(tool.InternalView().AdminConn())
-			ncClient.Delete(ctx, privatev1.NetworkClassesDeleteRequest_builder{
-				Id: networkClassId,
-			}.Build())
-			os.RemoveAll(homeDir)
-		})
+		homeDir = setupCLIHomeDir()
+		networkClassId = setupTestNetworkClass("CLI Metadata Test NC")
 	})
 
 	It("Label a resource", func(ctx context.Context) {
-		_, _, exitCode := tool.LoginCLI(ctx, homeDir, adminUsername, adminsPassword)
-		Expect(exitCode).To(Equal(0))
+		mustLoginCLI(ctx, homeDir, adminUsername, adminsPassword)
+		vnName := createCLIVirtualNetwork(ctx, homeDir, networkClassId, "10.110.0.0/16")
 
-		vnName = fmt.Sprintf("cli-label-%s", uuid.New())
-		_, stderr, exitCode := tool.RunCLI(ctx, homeDir,
-			"create", "virtualnetwork",
-			"--name", vnName,
-			"--network-class", networkClassId,
-			"--ipv4-cidr", "10.110.0.0/16",
-		)
-		Expect(exitCode).To(Equal(0), "create should succeed, stderr=%s", stderr)
-
-		_, _, exitCode = tool.RunCLI(ctx, homeDir,
+		_, _, exitCode := tool.RunCLI(ctx, homeDir,
 			"label", "virtualnetwork", vnName, "env=test",
 		)
 		Expect(exitCode).To(Equal(0), "label should succeed")
@@ -83,23 +45,22 @@ var _ = Describe("CLI Metadata", Label("cli", "metadata"), func() {
 			"get", "virtualnetwork", vnName, "-o", "json",
 		)
 		Expect(exitCode).To(Equal(0), "get should succeed")
-		Expect(stdout).To(ContainSubstring("env"))
+
+		var parsed map[string]any
+		err := json.Unmarshal([]byte(stdout), &parsed)
+		Expect(err).ToNot(HaveOccurred())
+		metadata, ok := parsed["metadata"].(map[string]any)
+		Expect(ok).To(BeTrue(), "JSON should contain metadata object")
+		labels, ok := metadata["labels"].(map[string]any)
+		Expect(ok).To(BeTrue(), "metadata should contain labels")
+		Expect(labels).To(HaveKeyWithValue("env", "test"))
 	})
 
 	It("Annotate a resource", func(ctx context.Context) {
-		_, _, exitCode := tool.LoginCLI(ctx, homeDir, adminUsername, adminsPassword)
-		Expect(exitCode).To(Equal(0))
+		mustLoginCLI(ctx, homeDir, adminUsername, adminsPassword)
+		vnName := createCLIVirtualNetwork(ctx, homeDir, networkClassId, "10.111.0.0/16")
 
-		vnName = fmt.Sprintf("cli-annotate-%s", uuid.New())
-		_, stderr, exitCode := tool.RunCLI(ctx, homeDir,
-			"create", "virtualnetwork",
-			"--name", vnName,
-			"--network-class", networkClassId,
-			"--ipv4-cidr", "10.111.0.0/16",
-		)
-		Expect(exitCode).To(Equal(0), "create should succeed, stderr=%s", stderr)
-
-		_, _, exitCode = tool.RunCLI(ctx, homeDir,
+		_, _, exitCode := tool.RunCLI(ctx, homeDir,
 			"annotate", "virtualnetwork", vnName, "note=testing",
 		)
 		Expect(exitCode).To(Equal(0), "annotate should succeed")
@@ -108,23 +69,22 @@ var _ = Describe("CLI Metadata", Label("cli", "metadata"), func() {
 			"get", "virtualnetwork", vnName, "-o", "json",
 		)
 		Expect(exitCode).To(Equal(0), "get should succeed")
-		Expect(stdout).To(ContainSubstring("note"))
+
+		var parsed map[string]any
+		err := json.Unmarshal([]byte(stdout), &parsed)
+		Expect(err).ToNot(HaveOccurred())
+		metadata, ok := parsed["metadata"].(map[string]any)
+		Expect(ok).To(BeTrue(), "JSON should contain metadata object")
+		annotations, ok := metadata["annotations"].(map[string]any)
+		Expect(ok).To(BeTrue(), "metadata should contain annotations")
+		Expect(annotations).To(HaveKeyWithValue("note", "testing"))
 	})
 
 	It("Remove a label", func(ctx context.Context) {
-		_, _, exitCode := tool.LoginCLI(ctx, homeDir, adminUsername, adminsPassword)
-		Expect(exitCode).To(Equal(0))
+		mustLoginCLI(ctx, homeDir, adminUsername, adminsPassword)
+		vnName := createCLIVirtualNetwork(ctx, homeDir, networkClassId, "10.112.0.0/16")
 
-		vnName = fmt.Sprintf("cli-rmlabel-%s", uuid.New())
-		_, stderr, exitCode := tool.RunCLI(ctx, homeDir,
-			"create", "virtualnetwork",
-			"--name", vnName,
-			"--network-class", networkClassId,
-			"--ipv4-cidr", "10.112.0.0/16",
-		)
-		Expect(exitCode).To(Equal(0), "create should succeed, stderr=%s", stderr)
-
-		_, _, exitCode = tool.RunCLI(ctx, homeDir,
+		_, _, exitCode := tool.RunCLI(ctx, homeDir,
 			"label", "virtualnetwork", vnName, "env=test",
 		)
 		Expect(exitCode).To(Equal(0), "add label should succeed")
@@ -138,6 +98,14 @@ var _ = Describe("CLI Metadata", Label("cli", "metadata"), func() {
 			"get", "virtualnetwork", vnName, "-o", "json",
 		)
 		Expect(exitCode).To(Equal(0), "get should succeed")
-		Expect(stdout).ToNot(ContainSubstring(`"env"`))
+
+		var parsed map[string]any
+		err := json.Unmarshal([]byte(stdout), &parsed)
+		Expect(err).ToNot(HaveOccurred())
+		metadata, ok := parsed["metadata"].(map[string]any)
+		Expect(ok).To(BeTrue(), "JSON should contain metadata object")
+		if labels, hasLabels := metadata["labels"].(map[string]any); hasLabels {
+			Expect(labels).ToNot(HaveKey("env"))
+		}
 	})
 })

--- a/it/it_cli_metadata_test.go
+++ b/it/it_cli_metadata_test.go
@@ -1,0 +1,143 @@
+/*
+Copyright (c) 2026 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package it
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	privatev1 "github.com/osac-project/fulfillment-service/internal/api/osac/private/v1"
+	"github.com/osac-project/fulfillment-service/internal/uuid"
+)
+
+var _ = Describe("CLI Metadata", Label("cli", "metadata"), func() {
+	var (
+		homeDir        string
+		networkClassId string
+		vnName         string
+	)
+
+	BeforeEach(func() {
+		var err error
+		homeDir, err = tool.NewCLIHomeDir()
+		Expect(err).ToNot(HaveOccurred())
+
+		ncClient := privatev1.NewNetworkClassesClient(tool.InternalView().AdminConn())
+		ncResp, err := ncClient.Create(context.Background(), privatev1.NetworkClassesCreateRequest_builder{
+			Object: privatev1.NetworkClass_builder{
+				Title:                  "CLI Metadata Test NC",
+				ImplementationStrategy: "cudn",
+				FabricManager:          "netris",
+			}.Build(),
+		}.Build())
+		Expect(err).ToNot(HaveOccurred())
+		networkClassId = ncResp.GetObject().GetId()
+
+		DeferCleanup(func() {
+			ctx := context.Background()
+			if vnName != "" {
+				tool.RunCLI(ctx, homeDir, "delete", "virtualnetwork", vnName)
+			}
+			ncClient := privatev1.NewNetworkClassesClient(tool.InternalView().AdminConn())
+			ncClient.Delete(ctx, privatev1.NetworkClassesDeleteRequest_builder{
+				Id: networkClassId,
+			}.Build())
+			os.RemoveAll(homeDir)
+		})
+	})
+
+	It("Label a resource", func(ctx context.Context) {
+		_, _, exitCode := tool.LoginCLI(ctx, homeDir, adminUsername, adminsPassword)
+		Expect(exitCode).To(Equal(0))
+
+		vnName = fmt.Sprintf("cli-label-%s", uuid.New())
+		_, stderr, exitCode := tool.RunCLI(ctx, homeDir,
+			"create", "virtualnetwork",
+			"--name", vnName,
+			"--network-class", networkClassId,
+			"--ipv4-cidr", "10.110.0.0/16",
+		)
+		Expect(exitCode).To(Equal(0), "create should succeed, stderr=%s", stderr)
+
+		_, _, exitCode = tool.RunCLI(ctx, homeDir,
+			"label", "virtualnetwork", vnName, "env=test",
+		)
+		Expect(exitCode).To(Equal(0), "label should succeed")
+
+		stdout, _, exitCode := tool.RunCLI(ctx, homeDir,
+			"get", "virtualnetwork", vnName, "-o", "json",
+		)
+		Expect(exitCode).To(Equal(0), "get should succeed")
+		Expect(stdout).To(ContainSubstring("env"))
+	})
+
+	It("Annotate a resource", func(ctx context.Context) {
+		_, _, exitCode := tool.LoginCLI(ctx, homeDir, adminUsername, adminsPassword)
+		Expect(exitCode).To(Equal(0))
+
+		vnName = fmt.Sprintf("cli-annotate-%s", uuid.New())
+		_, stderr, exitCode := tool.RunCLI(ctx, homeDir,
+			"create", "virtualnetwork",
+			"--name", vnName,
+			"--network-class", networkClassId,
+			"--ipv4-cidr", "10.111.0.0/16",
+		)
+		Expect(exitCode).To(Equal(0), "create should succeed, stderr=%s", stderr)
+
+		_, _, exitCode = tool.RunCLI(ctx, homeDir,
+			"annotate", "virtualnetwork", vnName, "note=testing",
+		)
+		Expect(exitCode).To(Equal(0), "annotate should succeed")
+
+		stdout, _, exitCode := tool.RunCLI(ctx, homeDir,
+			"get", "virtualnetwork", vnName, "-o", "json",
+		)
+		Expect(exitCode).To(Equal(0), "get should succeed")
+		Expect(stdout).To(ContainSubstring("note"))
+	})
+
+	It("Remove a label", func(ctx context.Context) {
+		_, _, exitCode := tool.LoginCLI(ctx, homeDir, adminUsername, adminsPassword)
+		Expect(exitCode).To(Equal(0))
+
+		vnName = fmt.Sprintf("cli-rmlabel-%s", uuid.New())
+		_, stderr, exitCode := tool.RunCLI(ctx, homeDir,
+			"create", "virtualnetwork",
+			"--name", vnName,
+			"--network-class", networkClassId,
+			"--ipv4-cidr", "10.112.0.0/16",
+		)
+		Expect(exitCode).To(Equal(0), "create should succeed, stderr=%s", stderr)
+
+		_, _, exitCode = tool.RunCLI(ctx, homeDir,
+			"label", "virtualnetwork", vnName, "env=test",
+		)
+		Expect(exitCode).To(Equal(0), "add label should succeed")
+
+		_, _, exitCode = tool.RunCLI(ctx, homeDir,
+			"label", "virtualnetwork", vnName, "env-",
+		)
+		Expect(exitCode).To(Equal(0), "remove label should succeed")
+
+		stdout, _, exitCode := tool.RunCLI(ctx, homeDir,
+			"get", "virtualnetwork", vnName, "-o", "json",
+		)
+		Expect(exitCode).To(Equal(0), "get should succeed")
+		Expect(stdout).ToNot(ContainSubstring(`"env"`))
+	})
+})

--- a/it/it_cli_output_test.go
+++ b/it/it_cli_output_test.go
@@ -16,7 +16,6 @@ package it
 import (
 	"context"
 	"encoding/json"
-	"os"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -24,57 +23,55 @@ import (
 )
 
 var _ = Describe("CLI Output Formats", Label("cli", "output"), func() {
-	var homeDir string
+	var (
+		homeDir        string
+		networkClassId string
+	)
 
 	BeforeEach(func() {
-		var err error
-		homeDir, err = tool.NewCLIHomeDir()
-		Expect(err).ToNot(HaveOccurred())
-		DeferCleanup(func() {
-			err := os.RemoveAll(homeDir)
-			Expect(err).ToNot(HaveOccurred())
-		})
+		homeDir = setupCLIHomeDir()
+		networkClassId = setupTestNetworkClass("CLI Output Test NC")
 	})
 
-	It("Table output contains expected headers", func(ctx context.Context) {
-		_, _, exitCode := tool.LoginCLI(ctx, homeDir, adminUsername, adminsPassword)
-		Expect(exitCode).To(Equal(0), "login should succeed")
+	It("Table output contains headers and resource data", func(ctx context.Context) {
+		mustLoginCLI(ctx, homeDir, adminUsername, adminsPassword)
+		vnName := createCLIVirtualNetwork(ctx, homeDir, networkClassId, "10.140.0.0/16")
 
-		stdout, _, exitCode := tool.RunCLI(ctx, homeDir, "get", "computeinstance")
-		Expect(exitCode).To(Equal(0), "get computeinstance should succeed")
-
-		Expect(stdout).To(SatisfyAny(
-			ContainSubstring("ID"),
-			ContainSubstring("No matching"),
-			ContainSubstring("no objects matching"),
-		))
+		stdout, _, exitCode := tool.RunCLI(ctx, homeDir, "get", "virtualnetwork")
+		Expect(exitCode).To(Equal(0), "get virtualnetwork should succeed")
+		Expect(stdout).To(ContainSubstring("ID"))
+		Expect(stdout).To(ContainSubstring(vnName), "table output should include the created resource name")
 	})
 
-	It("JSON output is valid", func(ctx context.Context) {
-		_, _, exitCode := tool.LoginCLI(ctx, homeDir, adminUsername, adminsPassword)
-		Expect(exitCode).To(Equal(0), "login should succeed")
+	It("JSON output is valid and contains resource data", func(ctx context.Context) {
+		mustLoginCLI(ctx, homeDir, adminUsername, adminsPassword)
+		vnName := createCLIVirtualNetwork(ctx, homeDir, networkClassId, "10.141.0.0/16")
 
-		stdout, _, exitCode := tool.RunCLI(ctx, homeDir, "get", "computeinstance", "-o", "json")
-		Expect(exitCode).To(Equal(0), "get computeinstance -o json should succeed")
+		stdout, _, exitCode := tool.RunCLI(ctx, homeDir, "get", "virtualnetwork", vnName, "-o", "json")
+		Expect(exitCode).To(Equal(0), "get virtualnetwork -o json should succeed")
+		Expect(stdout).ToNot(BeEmpty())
 
-		if stdout != "" {
-			var parsed any
-			err := json.Unmarshal([]byte(stdout), &parsed)
-			Expect(err).ToNot(HaveOccurred(), "JSON output should be valid")
-		}
+		var parsed map[string]any
+		err := json.Unmarshal([]byte(stdout), &parsed)
+		Expect(err).ToNot(HaveOccurred(), "JSON output should be valid")
+		metadata, ok := parsed["metadata"].(map[string]any)
+		Expect(ok).To(BeTrue(), "JSON should contain metadata object")
+		Expect(metadata).To(HaveKeyWithValue("name", vnName))
 	})
 
-	It("YAML output is valid", func(ctx context.Context) {
-		_, _, exitCode := tool.LoginCLI(ctx, homeDir, adminUsername, adminsPassword)
-		Expect(exitCode).To(Equal(0), "login should succeed")
+	It("YAML output is valid and contains resource data", func(ctx context.Context) {
+		mustLoginCLI(ctx, homeDir, adminUsername, adminsPassword)
+		vnName := createCLIVirtualNetwork(ctx, homeDir, networkClassId, "10.142.0.0/16")
 
-		stdout, _, exitCode := tool.RunCLI(ctx, homeDir, "get", "computeinstance", "-o", "yaml")
-		Expect(exitCode).To(Equal(0), "get computeinstance -o yaml should succeed")
+		stdout, _, exitCode := tool.RunCLI(ctx, homeDir, "get", "virtualnetwork", vnName, "-o", "yaml")
+		Expect(exitCode).To(Equal(0), "get virtualnetwork -o yaml should succeed")
+		Expect(stdout).ToNot(BeEmpty())
 
-		if stdout != "" {
-			var parsed any
-			err := yaml.Unmarshal([]byte(stdout), &parsed)
-			Expect(err).ToNot(HaveOccurred(), "YAML output should be valid")
-		}
+		var parsed map[any]any
+		err := yaml.Unmarshal([]byte(stdout), &parsed)
+		Expect(err).ToNot(HaveOccurred(), "YAML output should be valid")
+		metadata, ok := parsed["metadata"].(map[any]any)
+		Expect(ok).To(BeTrue(), "YAML should contain metadata object")
+		Expect(metadata["name"]).To(Equal(vnName))
 	})
 })

--- a/it/it_cli_output_test.go
+++ b/it/it_cli_output_test.go
@@ -1,0 +1,80 @@
+/*
+Copyright (c) 2026 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package it
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"go.yaml.in/yaml/v2"
+)
+
+var _ = Describe("CLI Output Formats", Label("cli", "output"), func() {
+	var homeDir string
+
+	BeforeEach(func() {
+		var err error
+		homeDir, err = tool.NewCLIHomeDir()
+		Expect(err).ToNot(HaveOccurred())
+		DeferCleanup(func() {
+			err := os.RemoveAll(homeDir)
+			Expect(err).ToNot(HaveOccurred())
+		})
+	})
+
+	It("Table output contains expected headers", func(ctx context.Context) {
+		_, _, exitCode := tool.LoginCLI(ctx, homeDir, adminUsername, adminsPassword)
+		Expect(exitCode).To(Equal(0), "login should succeed")
+
+		stdout, _, exitCode := tool.RunCLI(ctx, homeDir, "get", "computeinstance")
+		Expect(exitCode).To(Equal(0), "get computeinstance should succeed")
+
+		Expect(stdout).To(SatisfyAny(
+			ContainSubstring("ID"),
+			ContainSubstring("No matching"),
+			ContainSubstring("no objects matching"),
+		))
+	})
+
+	It("JSON output is valid", func(ctx context.Context) {
+		_, _, exitCode := tool.LoginCLI(ctx, homeDir, adminUsername, adminsPassword)
+		Expect(exitCode).To(Equal(0), "login should succeed")
+
+		stdout, _, exitCode := tool.RunCLI(ctx, homeDir, "get", "computeinstance", "-o", "json")
+		Expect(exitCode).To(Equal(0), "get computeinstance -o json should succeed")
+
+		if stdout != "" {
+			var parsed any
+			err := json.Unmarshal([]byte(stdout), &parsed)
+			Expect(err).ToNot(HaveOccurred(), "JSON output should be valid")
+		}
+	})
+
+	It("YAML output is valid", func(ctx context.Context) {
+		_, _, exitCode := tool.LoginCLI(ctx, homeDir, adminUsername, adminsPassword)
+		Expect(exitCode).To(Equal(0), "login should succeed")
+
+		stdout, _, exitCode := tool.RunCLI(ctx, homeDir, "get", "computeinstance", "-o", "yaml")
+		Expect(exitCode).To(Equal(0), "get computeinstance -o yaml should succeed")
+
+		if stdout != "" {
+			var parsed any
+			err := yaml.Unmarshal([]byte(stdout), &parsed)
+			Expect(err).ToNot(HaveOccurred(), "YAML output should be valid")
+		}
+	})
+})

--- a/it/it_cli_tenant_isolation_test.go
+++ b/it/it_cli_tenant_isolation_test.go
@@ -1,0 +1,133 @@
+/*
+Copyright (c) 2026 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package it
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	privatev1 "github.com/osac-project/fulfillment-service/internal/api/osac/private/v1"
+	"github.com/osac-project/fulfillment-service/internal/uuid"
+)
+
+var _ = Describe("CLI Tenant Isolation", Label("cli", "tenant", "isolation"), func() {
+	var (
+		homeDirA       string
+		homeDirB       string
+		networkClassId string
+	)
+
+	BeforeEach(func() {
+		var err error
+		homeDirA, err = tool.NewCLIHomeDir()
+		Expect(err).ToNot(HaveOccurred())
+		homeDirB, err = tool.NewCLIHomeDir()
+		Expect(err).ToNot(HaveOccurred())
+
+		ncClient := privatev1.NewNetworkClassesClient(tool.InternalView().AdminConn())
+		ncResp, err := ncClient.Create(context.Background(), privatev1.NetworkClassesCreateRequest_builder{
+			Object: privatev1.NetworkClass_builder{
+				Title:                  "CLI Isolation Test NC",
+				ImplementationStrategy: "cudn",
+				FabricManager:          "netris",
+			}.Build(),
+		}.Build())
+		Expect(err).ToNot(HaveOccurred())
+		networkClassId = ncResp.GetObject().GetId()
+
+		DeferCleanup(func() {
+			ctx := context.Background()
+			ncClient := privatev1.NewNetworkClassesClient(tool.InternalView().AdminConn())
+			ncClient.Delete(ctx, privatev1.NetworkClassesDeleteRequest_builder{
+				Id: networkClassId,
+			}.Build())
+			os.RemoveAll(homeDirA)
+			os.RemoveAll(homeDirB)
+		})
+	})
+
+	It("Tenant user creates and lists own resources", func(ctx context.Context) {
+		// adam belongs to the "engineering" tenant
+		_, _, exitCode := tool.LoginCLI(ctx, homeDirA, "adam", usersPassword)
+		Expect(exitCode).To(Equal(0), "adam login should succeed")
+
+		vnName := fmt.Sprintf("adam-vn-%s", uuid.New())
+		stdout, stderr, exitCode := tool.RunCLI(ctx, homeDirA,
+			"create", "virtualnetwork",
+			"--name", vnName,
+			"--network-class", networkClassId,
+			"--ipv4-cidr", "10.120.0.0/16",
+		)
+		Expect(exitCode).To(Equal(0), "adam should create a VN, stdout=%s, stderr=%s", stdout, stderr)
+		Expect(stdout).To(ContainSubstring("Created"))
+
+		DeferCleanup(func() {
+			tool.RunCLI(ctx, homeDirA, "delete", "virtualnetwork", vnName)
+		})
+
+		stdout, _, exitCode = tool.RunCLI(ctx, homeDirA, "get", "virtualnetwork")
+		Expect(exitCode).To(Equal(0), "list should succeed")
+		Expect(stdout).To(ContainSubstring(vnName))
+	})
+
+	It("Cross-tenant isolation prevents visibility", func(ctx context.Context) {
+		// adam (engineering) creates a resource
+		_, _, exitCode := tool.LoginCLI(ctx, homeDirA, "adam", usersPassword)
+		Expect(exitCode).To(Equal(0), "adam login should succeed")
+
+		vnName := fmt.Sprintf("isolated-%s", uuid.New())
+		_, stderr, exitCode := tool.RunCLI(ctx, homeDirA,
+			"create", "virtualnetwork",
+			"--name", vnName,
+			"--network-class", networkClassId,
+			"--ipv4-cidr", "10.121.0.0/16",
+		)
+		Expect(exitCode).To(Equal(0), "adam create should succeed, stderr=%s", stderr)
+
+		DeferCleanup(func() {
+			tool.RunCLI(ctx, homeDirA, "delete", "virtualnetwork", vnName)
+		})
+
+		// ben (development) should NOT see adam's resource
+		_, _, exitCode = tool.LoginCLI(ctx, homeDirB, "ben", usersPassword)
+		Expect(exitCode).To(Equal(0), "ben login should succeed")
+
+		stdout, _, exitCode := tool.RunCLI(ctx, homeDirB, "get", "virtualnetwork")
+		Expect(exitCode).To(Equal(0), "ben list should succeed")
+		visible := strings.Contains(stdout, vnName)
+		Expect(visible).To(BeFalse(), "ben should not see adam's resource")
+	})
+
+	It("Tenant user deletes own resource", func(ctx context.Context) {
+		_, _, exitCode := tool.LoginCLI(ctx, homeDirA, "adam", usersPassword)
+		Expect(exitCode).To(Equal(0), "adam login should succeed")
+
+		vnName := fmt.Sprintf("delete-me-%s", uuid.New())
+		_, stderr, exitCode := tool.RunCLI(ctx, homeDirA,
+			"create", "virtualnetwork",
+			"--name", vnName,
+			"--network-class", networkClassId,
+			"--ipv4-cidr", "10.122.0.0/16",
+		)
+		Expect(exitCode).To(Equal(0), "create should succeed, stderr=%s", stderr)
+
+		_, _, exitCode = tool.RunCLI(ctx, homeDirA, "delete", "virtualnetwork", vnName)
+		Expect(exitCode).To(Equal(0), "adam should delete own resource")
+	})
+})

--- a/it/it_cli_tenant_isolation_test.go
+++ b/it/it_cli_tenant_isolation_test.go
@@ -15,15 +15,10 @@ package it
 
 import (
 	"context"
-	"fmt"
-	"os"
 	"strings"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-
-	privatev1 "github.com/osac-project/fulfillment-service/internal/api/osac/private/v1"
-	"github.com/osac-project/fulfillment-service/internal/uuid"
 )
 
 var _ = Describe("CLI Tenant Isolation", Label("cli", "tenant", "isolation"), func() {
@@ -34,79 +29,28 @@ var _ = Describe("CLI Tenant Isolation", Label("cli", "tenant", "isolation"), fu
 	)
 
 	BeforeEach(func() {
-		var err error
-		homeDirA, err = tool.NewCLIHomeDir()
-		Expect(err).ToNot(HaveOccurred())
-		homeDirB, err = tool.NewCLIHomeDir()
-		Expect(err).ToNot(HaveOccurred())
-
-		ncClient := privatev1.NewNetworkClassesClient(tool.InternalView().AdminConn())
-		ncResp, err := ncClient.Create(context.Background(), privatev1.NetworkClassesCreateRequest_builder{
-			Object: privatev1.NetworkClass_builder{
-				Title:                  "CLI Isolation Test NC",
-				ImplementationStrategy: "cudn",
-				FabricManager:          "netris",
-			}.Build(),
-		}.Build())
-		Expect(err).ToNot(HaveOccurred())
-		networkClassId = ncResp.GetObject().GetId()
-
-		DeferCleanup(func() {
-			ctx := context.Background()
-			ncClient := privatev1.NewNetworkClassesClient(tool.InternalView().AdminConn())
-			ncClient.Delete(ctx, privatev1.NetworkClassesDeleteRequest_builder{
-				Id: networkClassId,
-			}.Build())
-			os.RemoveAll(homeDirA)
-			os.RemoveAll(homeDirB)
-		})
+		homeDirA = setupCLIHomeDir()
+		homeDirB = setupCLIHomeDir()
+		networkClassId = setupTestNetworkClass("CLI Isolation Test NC")
 	})
 
 	It("Tenant user creates and lists own resources", func(ctx context.Context) {
 		// adam belongs to the "engineering" tenant
-		_, _, exitCode := tool.LoginCLI(ctx, homeDirA, "adam", usersPassword)
-		Expect(exitCode).To(Equal(0), "adam login should succeed")
+		mustLoginCLI(ctx, homeDirA, "adam", usersPassword)
+		vnName := createCLIVirtualNetwork(ctx, homeDirA, networkClassId, "10.120.0.0/16")
 
-		vnName := fmt.Sprintf("adam-vn-%s", uuid.New())
-		stdout, stderr, exitCode := tool.RunCLI(ctx, homeDirA,
-			"create", "virtualnetwork",
-			"--name", vnName,
-			"--network-class", networkClassId,
-			"--ipv4-cidr", "10.120.0.0/16",
-		)
-		Expect(exitCode).To(Equal(0), "adam should create a VN, stdout=%s, stderr=%s", stdout, stderr)
-		Expect(stdout).To(ContainSubstring("Created"))
-
-		DeferCleanup(func() {
-			tool.RunCLI(ctx, homeDirA, "delete", "virtualnetwork", vnName)
-		})
-
-		stdout, _, exitCode = tool.RunCLI(ctx, homeDirA, "get", "virtualnetwork")
+		stdout, _, exitCode := tool.RunCLI(ctx, homeDirA, "get", "virtualnetwork")
 		Expect(exitCode).To(Equal(0), "list should succeed")
 		Expect(stdout).To(ContainSubstring(vnName))
 	})
 
 	It("Cross-tenant isolation prevents visibility", func(ctx context.Context) {
 		// adam (engineering) creates a resource
-		_, _, exitCode := tool.LoginCLI(ctx, homeDirA, "adam", usersPassword)
-		Expect(exitCode).To(Equal(0), "adam login should succeed")
-
-		vnName := fmt.Sprintf("isolated-%s", uuid.New())
-		_, stderr, exitCode := tool.RunCLI(ctx, homeDirA,
-			"create", "virtualnetwork",
-			"--name", vnName,
-			"--network-class", networkClassId,
-			"--ipv4-cidr", "10.121.0.0/16",
-		)
-		Expect(exitCode).To(Equal(0), "adam create should succeed, stderr=%s", stderr)
-
-		DeferCleanup(func() {
-			tool.RunCLI(ctx, homeDirA, "delete", "virtualnetwork", vnName)
-		})
+		mustLoginCLI(ctx, homeDirA, "adam", usersPassword)
+		vnName := createCLIVirtualNetwork(ctx, homeDirA, networkClassId, "10.121.0.0/16")
 
 		// ben (development) should NOT see adam's resource
-		_, _, exitCode = tool.LoginCLI(ctx, homeDirB, "ben", usersPassword)
-		Expect(exitCode).To(Equal(0), "ben login should succeed")
+		mustLoginCLI(ctx, homeDirB, "ben", usersPassword)
 
 		stdout, _, exitCode := tool.RunCLI(ctx, homeDirB, "get", "virtualnetwork")
 		Expect(exitCode).To(Equal(0), "ben list should succeed")
@@ -115,19 +59,19 @@ var _ = Describe("CLI Tenant Isolation", Label("cli", "tenant", "isolation"), fu
 	})
 
 	It("Tenant user deletes own resource", func(ctx context.Context) {
-		_, _, exitCode := tool.LoginCLI(ctx, homeDirA, "adam", usersPassword)
-		Expect(exitCode).To(Equal(0), "adam login should succeed")
+		mustLoginCLI(ctx, homeDirA, "adam", usersPassword)
 
-		vnName := fmt.Sprintf("delete-me-%s", uuid.New())
-		_, stderr, exitCode := tool.RunCLI(ctx, homeDirA,
-			"create", "virtualnetwork",
-			"--name", vnName,
-			"--network-class", networkClassId,
-			"--ipv4-cidr", "10.122.0.0/16",
-		)
-		Expect(exitCode).To(Equal(0), "create should succeed, stderr=%s", stderr)
+		vnName := createCLIVirtualNetwork(ctx, homeDirA, networkClassId, "10.122.0.0/16")
 
-		_, _, exitCode = tool.RunCLI(ctx, homeDirA, "delete", "virtualnetwork", vnName)
+		stdout, _, exitCode := tool.RunCLI(ctx, homeDirA, "delete", "virtualnetwork", vnName)
 		Expect(exitCode).To(Equal(0), "adam should delete own resource")
+		Expect(stdout).To(ContainSubstring("Deleted"))
+
+		// Confirm soft-delete: resource remains visible with DELETING=Yes until finalizers complete
+		stdout, _, exitCode = tool.RunCLI(ctx, homeDirA, "get", "virtualnetwork", vnName)
+		Expect(exitCode).To(Equal(0), "get after delete should succeed")
+		Expect(stdout).To(ContainSubstring(vnName))
+		Expect(stdout).To(MatchRegexp(`(?m)^\S+\s+Yes\s+.*%s`, vnName),
+			"DELETING column should be Yes after delete")
 	})
 })

--- a/it/it_cli_tenant_isolation_test.go
+++ b/it/it_cli_tenant_isolation_test.go
@@ -15,7 +15,6 @@ package it
 
 import (
 	"context"
-	"strings"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -54,8 +53,7 @@ var _ = Describe("CLI Tenant Isolation", Label("cli", "tenant", "isolation"), fu
 
 		stdout, _, exitCode := tool.RunCLI(ctx, homeDirB, "get", "virtualnetwork")
 		Expect(exitCode).To(Equal(0), "ben list should succeed")
-		visible := strings.Contains(stdout, vnName)
-		Expect(visible).To(BeFalse(), "ben should not see adam's resource")
+		Expect(stdout).ToNot(ContainSubstring(vnName), "ben should not see adam's resource")
 	})
 
 	It("Tenant user deletes own resource", func(ctx context.Context) {
@@ -67,11 +65,6 @@ var _ = Describe("CLI Tenant Isolation", Label("cli", "tenant", "isolation"), fu
 		Expect(exitCode).To(Equal(0), "adam should delete own resource")
 		Expect(stdout).To(ContainSubstring("Deleted"))
 
-		// Confirm soft-delete: resource remains visible with DELETING=Yes until finalizers complete
-		stdout, _, exitCode = tool.RunCLI(ctx, homeDirA, "get", "virtualnetwork", vnName)
-		Expect(exitCode).To(Equal(0), "get after delete should succeed")
-		Expect(stdout).To(ContainSubstring(vnName))
-		Expect(stdout).To(MatchRegexp(`(?m)^\S+\s+Yes\s+.*%s`, vnName),
-			"DELETING column should be Yes after delete")
+		expectCLISoftDeletedVirtualNetwork(ctx, homeDirA, vnName)
 	})
 })

--- a/it/it_cli_tenant_test.go
+++ b/it/it_cli_tenant_test.go
@@ -1,0 +1,111 @@
+/*
+Copyright (c) 2026 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package it
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"go.yaml.in/yaml/v2"
+)
+
+var _ = Describe("CLI Tenant", Label("cli", "tenant"), func() {
+	var homeDir string
+
+	BeforeEach(func() {
+		var err error
+		homeDir, err = tool.NewCLIHomeDir()
+		Expect(err).ToNot(HaveOccurred())
+		DeferCleanup(func() {
+			err := os.RemoveAll(homeDir)
+			Expect(err).ToNot(HaveOccurred())
+		})
+	})
+
+	It("Set tenant scopes subsequent commands", func(ctx context.Context) {
+		_, _, exitCode := tool.LoginCLI(ctx, homeDir, adminUsername, adminsPassword)
+		Expect(exitCode).To(Equal(0), "login should succeed")
+
+		stdout, _, exitCode := tool.RunCLI(ctx, homeDir, "tenant", usersGroup)
+		Expect(exitCode).To(Equal(0), "setting tenant should succeed")
+		Expect(stdout).To(ContainSubstring("saved"))
+
+		stdout, _, exitCode = tool.RunCLI(ctx, homeDir, "tenant")
+		Expect(exitCode).To(Equal(0), "showing tenant should succeed")
+		Expect(stdout).To(ContainSubstring(usersGroup))
+	})
+
+	It("Show tenant without one set hints at usage", func(ctx context.Context) {
+		_, _, exitCode := tool.LoginCLI(ctx, homeDir, adminUsername, adminsPassword)
+		Expect(exitCode).To(Equal(0), "login should succeed")
+
+		stdout, _, exitCode := tool.RunCLI(ctx, homeDir, "tenant")
+		Expect(exitCode).To(Equal(0), "showing tenant should succeed even with none set")
+		Expect(stdout).To(SatisfyAny(
+			ContainSubstring("tenant"),
+			ContainSubstring("No tenant"),
+		))
+	})
+
+	It("Clear tenant removes saved scope", func(ctx context.Context) {
+		_, _, exitCode := tool.LoginCLI(ctx, homeDir, adminUsername, adminsPassword)
+		Expect(exitCode).To(Equal(0), "login should succeed")
+
+		_, _, exitCode = tool.RunCLI(ctx, homeDir, "tenant", usersGroup)
+		Expect(exitCode).To(Equal(0), "setting tenant should succeed")
+
+		stdout, _, exitCode := tool.RunCLI(ctx, homeDir, "tenant", "--clear")
+		Expect(exitCode).To(Equal(0), "clearing tenant should succeed")
+		Expect(stdout).To(ContainSubstring("cleared"))
+
+		stdout, _, exitCode = tool.RunCLI(ctx, homeDir, "tenant")
+		Expect(exitCode).To(Equal(0))
+		Expect(stdout).ToNot(ContainSubstring(usersGroup))
+	})
+
+	It("Tenant JSON output is valid", func(ctx context.Context) {
+		_, _, exitCode := tool.LoginCLI(ctx, homeDir, adminUsername, adminsPassword)
+		Expect(exitCode).To(Equal(0), "login should succeed")
+
+		_, _, exitCode = tool.RunCLI(ctx, homeDir, "tenant", usersGroup)
+		Expect(exitCode).To(Equal(0), "setting tenant should succeed")
+
+		stdout, _, exitCode := tool.RunCLI(ctx, homeDir, "tenant", "-o", "json")
+		Expect(exitCode).To(Equal(0), "tenant -o json should succeed")
+		Expect(stdout).ToNot(BeEmpty())
+
+		var parsed any
+		err := json.Unmarshal([]byte(stdout), &parsed)
+		Expect(err).ToNot(HaveOccurred(), "tenant JSON output should be valid")
+	})
+
+	It("Tenant YAML output is valid", func(ctx context.Context) {
+		_, _, exitCode := tool.LoginCLI(ctx, homeDir, adminUsername, adminsPassword)
+		Expect(exitCode).To(Equal(0), "login should succeed")
+
+		_, _, exitCode = tool.RunCLI(ctx, homeDir, "tenant", usersGroup)
+		Expect(exitCode).To(Equal(0), "setting tenant should succeed")
+
+		stdout, _, exitCode := tool.RunCLI(ctx, homeDir, "tenant", "-o", "yaml")
+		Expect(exitCode).To(Equal(0), "tenant -o yaml should succeed")
+		Expect(stdout).ToNot(BeEmpty())
+
+		var parsed any
+		err := yaml.Unmarshal([]byte(stdout), &parsed)
+		Expect(err).ToNot(HaveOccurred(), "tenant YAML output should be valid")
+	})
+})

--- a/it/it_cli_tenant_test.go
+++ b/it/it_cli_tenant_test.go
@@ -79,7 +79,9 @@ var _ = Describe("CLI Tenant", Label("cli", "tenant"), func() {
 		var parsed map[string]any
 		err := json.Unmarshal([]byte(stdout), &parsed)
 		Expect(err).ToNot(HaveOccurred(), "tenant JSON output should be valid")
-		Expect(stdout).To(ContainSubstring(usersGroup), "JSON output should include the tenant name")
+		metadata, ok := parsed["metadata"].(map[string]any)
+		Expect(ok).To(BeTrue(), "JSON should contain metadata object")
+		Expect(metadata).To(HaveKeyWithValue("name", usersGroup))
 	})
 
 	It("Tenant YAML output is valid", func(ctx context.Context) {
@@ -92,9 +94,11 @@ var _ = Describe("CLI Tenant", Label("cli", "tenant"), func() {
 		Expect(exitCode).To(Equal(0), "tenant -o yaml should succeed")
 		Expect(stdout).ToNot(BeEmpty())
 
-		var parsed any
+		var parsed map[any]any
 		err := yaml.Unmarshal([]byte(stdout), &parsed)
 		Expect(err).ToNot(HaveOccurred(), "tenant YAML output should be valid")
-		Expect(stdout).To(ContainSubstring(usersGroup), "YAML output should include the tenant name")
+		metadata, ok := parsed["metadata"].(map[any]any)
+		Expect(ok).To(BeTrue(), "YAML should contain metadata object")
+		Expect(metadata["name"]).To(Equal(usersGroup))
 	})
 })

--- a/it/it_cli_tenant_test.go
+++ b/it/it_cli_tenant_test.go
@@ -16,7 +16,6 @@ package it
 import (
 	"context"
 	"encoding/json"
-	"os"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -27,22 +26,16 @@ var _ = Describe("CLI Tenant", Label("cli", "tenant"), func() {
 	var homeDir string
 
 	BeforeEach(func() {
-		var err error
-		homeDir, err = tool.NewCLIHomeDir()
-		Expect(err).ToNot(HaveOccurred())
-		DeferCleanup(func() {
-			err := os.RemoveAll(homeDir)
-			Expect(err).ToNot(HaveOccurred())
-		})
+		homeDir = setupCLIHomeDir()
 	})
 
 	It("Set tenant scopes subsequent commands", func(ctx context.Context) {
-		_, _, exitCode := tool.LoginCLI(ctx, homeDir, adminUsername, adminsPassword)
-		Expect(exitCode).To(Equal(0), "login should succeed")
+		mustLoginCLI(ctx, homeDir, adminUsername, adminsPassword)
 
 		stdout, _, exitCode := tool.RunCLI(ctx, homeDir, "tenant", usersGroup)
 		Expect(exitCode).To(Equal(0), "setting tenant should succeed")
 		Expect(stdout).To(ContainSubstring("saved"))
+		Expect(stdout).To(ContainSubstring(usersGroup))
 
 		stdout, _, exitCode = tool.RunCLI(ctx, homeDir, "tenant")
 		Expect(exitCode).To(Equal(0), "showing tenant should succeed")
@@ -50,22 +43,17 @@ var _ = Describe("CLI Tenant", Label("cli", "tenant"), func() {
 	})
 
 	It("Show tenant without one set hints at usage", func(ctx context.Context) {
-		_, _, exitCode := tool.LoginCLI(ctx, homeDir, adminUsername, adminsPassword)
-		Expect(exitCode).To(Equal(0), "login should succeed")
+		mustLoginCLI(ctx, homeDir, adminUsername, adminsPassword)
 
 		stdout, _, exitCode := tool.RunCLI(ctx, homeDir, "tenant")
 		Expect(exitCode).To(Equal(0), "showing tenant should succeed even with none set")
-		Expect(stdout).To(SatisfyAny(
-			ContainSubstring("tenant"),
-			ContainSubstring("No tenant"),
-		))
+		Expect(stdout).To(ContainSubstring("No tenant is currently set"))
 	})
 
 	It("Clear tenant removes saved scope", func(ctx context.Context) {
-		_, _, exitCode := tool.LoginCLI(ctx, homeDir, adminUsername, adminsPassword)
-		Expect(exitCode).To(Equal(0), "login should succeed")
+		mustLoginCLI(ctx, homeDir, adminUsername, adminsPassword)
 
-		_, _, exitCode = tool.RunCLI(ctx, homeDir, "tenant", usersGroup)
+		_, _, exitCode := tool.RunCLI(ctx, homeDir, "tenant", usersGroup)
 		Expect(exitCode).To(Equal(0), "setting tenant should succeed")
 
 		stdout, _, exitCode := tool.RunCLI(ctx, homeDir, "tenant", "--clear")
@@ -74,30 +62,30 @@ var _ = Describe("CLI Tenant", Label("cli", "tenant"), func() {
 
 		stdout, _, exitCode = tool.RunCLI(ctx, homeDir, "tenant")
 		Expect(exitCode).To(Equal(0))
+		Expect(stdout).To(ContainSubstring("No tenant is currently set"))
 		Expect(stdout).ToNot(ContainSubstring(usersGroup))
 	})
 
 	It("Tenant JSON output is valid", func(ctx context.Context) {
-		_, _, exitCode := tool.LoginCLI(ctx, homeDir, adminUsername, adminsPassword)
-		Expect(exitCode).To(Equal(0), "login should succeed")
+		mustLoginCLI(ctx, homeDir, adminUsername, adminsPassword)
 
-		_, _, exitCode = tool.RunCLI(ctx, homeDir, "tenant", usersGroup)
+		_, _, exitCode := tool.RunCLI(ctx, homeDir, "tenant", usersGroup)
 		Expect(exitCode).To(Equal(0), "setting tenant should succeed")
 
 		stdout, _, exitCode := tool.RunCLI(ctx, homeDir, "tenant", "-o", "json")
 		Expect(exitCode).To(Equal(0), "tenant -o json should succeed")
 		Expect(stdout).ToNot(BeEmpty())
 
-		var parsed any
+		var parsed map[string]any
 		err := json.Unmarshal([]byte(stdout), &parsed)
 		Expect(err).ToNot(HaveOccurred(), "tenant JSON output should be valid")
+		Expect(stdout).To(ContainSubstring(usersGroup), "JSON output should include the tenant name")
 	})
 
 	It("Tenant YAML output is valid", func(ctx context.Context) {
-		_, _, exitCode := tool.LoginCLI(ctx, homeDir, adminUsername, adminsPassword)
-		Expect(exitCode).To(Equal(0), "login should succeed")
+		mustLoginCLI(ctx, homeDir, adminUsername, adminsPassword)
 
-		_, _, exitCode = tool.RunCLI(ctx, homeDir, "tenant", usersGroup)
+		_, _, exitCode := tool.RunCLI(ctx, homeDir, "tenant", usersGroup)
 		Expect(exitCode).To(Equal(0), "setting tenant should succeed")
 
 		stdout, _, exitCode := tool.RunCLI(ctx, homeDir, "tenant", "-o", "yaml")
@@ -107,5 +95,6 @@ var _ = Describe("CLI Tenant", Label("cli", "tenant"), func() {
 		var parsed any
 		err := yaml.Unmarshal([]byte(stdout), &parsed)
 		Expect(err).ToNot(HaveOccurred(), "tenant YAML output should be valid")
+		Expect(stdout).To(ContainSubstring(usersGroup), "YAML output should include the tenant name")
 	})
 })

--- a/it/it_cli_whoami_test.go
+++ b/it/it_cli_whoami_test.go
@@ -1,0 +1,56 @@
+/*
+Copyright (c) 2026 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package it
+
+import (
+	"context"
+	"os"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("CLI Whoami", Label("cli", "whoami"), func() {
+	var homeDir string
+
+	BeforeEach(func() {
+		var err error
+		homeDir, err = tool.NewCLIHomeDir()
+		Expect(err).ToNot(HaveOccurred())
+		DeferCleanup(func() {
+			err := os.RemoveAll(homeDir)
+			Expect(err).ToNot(HaveOccurred())
+		})
+	})
+
+	It("Displays current user after login", func(ctx context.Context) {
+		_, _, exitCode := tool.LoginCLI(ctx, homeDir, adminUsername, adminsPassword)
+		Expect(exitCode).To(Equal(0), "login should succeed")
+
+		stdout, _, exitCode := tool.RunCLI(ctx, homeDir, "whoami")
+		Expect(exitCode).To(Equal(0), "whoami should succeed after login")
+		Expect(stdout).To(ContainSubstring(adminUsername))
+	})
+
+	It("Fails without login", func(ctx context.Context) {
+		_, stderr, exitCode := tool.RunCLI(ctx, homeDir, "whoami")
+		Expect(exitCode).ToNot(Equal(0), "whoami without login should fail")
+
+		combinedOutput := stderr
+		Expect(combinedOutput).To(SatisfyAny(
+			ContainSubstring("Not logged in"),
+			ContainSubstring("there is no configuration"),
+		))
+	})
+})

--- a/it/it_cli_whoami_test.go
+++ b/it/it_cli_whoami_test.go
@@ -15,7 +15,6 @@ package it
 
 import (
 	"context"
-	"os"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -25,18 +24,11 @@ var _ = Describe("CLI Whoami", Label("cli", "whoami"), func() {
 	var homeDir string
 
 	BeforeEach(func() {
-		var err error
-		homeDir, err = tool.NewCLIHomeDir()
-		Expect(err).ToNot(HaveOccurred())
-		DeferCleanup(func() {
-			err := os.RemoveAll(homeDir)
-			Expect(err).ToNot(HaveOccurred())
-		})
+		homeDir = setupCLIHomeDir()
 	})
 
 	It("Displays current user after login", func(ctx context.Context) {
-		_, _, exitCode := tool.LoginCLI(ctx, homeDir, adminUsername, adminsPassword)
-		Expect(exitCode).To(Equal(0), "login should succeed")
+		mustLoginCLI(ctx, homeDir, adminUsername, adminsPassword)
 
 		stdout, _, exitCode := tool.RunCLI(ctx, homeDir, "whoami")
 		Expect(exitCode).To(Equal(0), "whoami should succeed after login")

--- a/it/it_tool.go
+++ b/it/it_tool.go
@@ -2318,6 +2318,16 @@ func (t *Tool) LoginCLI(ctx context.Context, homeDir, user, password string) (st
 	)
 }
 
+// LoginCLIWithTokenScript authenticates the CLI using a token-script against the external API.
+// The script parameter is a shell command that produces a bearer token on stdout.
+func (t *Tool) LoginCLIWithTokenScript(ctx context.Context, homeDir, script string) (stdout, stderr string, exitCode int) {
+	return t.RunCLI(ctx, homeDir,
+		"login", fmt.Sprintf("https://%s", externalServiceAddr),
+		"--token-script="+script,
+		"--insecure",
+	)
+}
+
 func (t *Tool) Cleanup(ctx context.Context) error {
 	var errs []error
 
@@ -2379,6 +2389,11 @@ func (t *Tool) Dump(ctx context.Context) error {
 	}
 	logsDir := filepath.Join(t.projectDir, "logs")
 	return t.cluster.Dump(ctx, logsDir)
+}
+
+// KubeconfigFile returns the path to the kubeconfig file for the Kind cluster.
+func (t *Tool) KubeconfigFile() string {
+	return t.kcFile
 }
 
 // Cluster returns the Kind cluster.


### PR DESCRIPTION
## Summary

- Adds 37 new CLI integration tests across 8 new test files and 2 modified files, covering authentication flows (token-script, re-login), output formats (table/JSON/YAML), error handling, whoami, tenant commands, resource lifecycle (create/get/describe/delete), metadata mutation (label/annotate), get subcommands (token, publicippool), generic file-based create, and tenant user isolation
- Uses VirtualNetwork as the primary test resource for Phase 2 tests since it only requires a NetworkClass prerequisite (vs ComputeInstance which needs a full networking stack), keeping tests fast and focused on CLI behavior
- All 213 specs pass (37 CLI tests + 176 existing tests), verified on rebased main

## Jira

https://redhat.atlassian.net/browse/OSAC-1652

## Test plan

- [x] All 213 integration tests pass (`ginkgo run -v it`)
- [x] `go build ./...` passes
- [x] `gofmt -s` clean
- [x] Rebased on latest main (includes protovalidate adoption, tenant onboarding tests, etc.)

## New test files

| File | Tests | Coverage |
|------|-------|----------|
| `it_cli_auth_test.go` | 3 new | token-script login, re-login, bad token-script |
| `it_cli_output_test.go` | 3 new | table headers, JSON validity, YAML validity |
| `it_cli_errors_test.go` | 2 new | delete nonexistent, invalid output format |
| `it_cli_whoami_test.go` | 2 new | whoami after login, whoami without login |
| `it_cli_tenant_test.go` | 5 new | set/show/clear tenant, JSON/YAML output |
| `it_cli_lifecycle_test.go` | 2 new | create VN, full CRUD lifecycle |
| `it_cli_metadata_test.go` | 3 new | label, annotate, remove label |
| `it_cli_get_subcommands_test.go` | 3 new | get token, token --header, publicippool |
| `it_cli_file_create_test.go` | 3 new | create from JSON, YAML, invalid file |
| `it_cli_tenant_isolation_test.go` | 3 new | own-resource CRUD, cross-tenant isolation, delete own |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Expanded end-to-end CLI coverage for `get` subcommands (including token checks), output formats (table/JSON/YAML), file-based `create`, `metadata`, resource lifecycle/soft-delete, tenant scoping and isolation, and `whoami`.
  - Strengthened authentication/logout/session validations (e.g., `whoami` before/after logout and re-login behavior).
  - Improved error handling assertions to ensure invalid inputs don’t produce crash/stack-trace-like output.
  - Added scenarios validating token-script login (including re-login credential replacement) and post-login resource queries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->