### PR TITLE
NO-ISSUE: fix broken CI — replace removed Cores field in validation test

### DIFF
--- a/internal/servers/catalog_item_validation_test.go
+++ b/internal/servers/catalog_item_validation_test.go
@@ -301,10 +301,9 @@ var _ = Describe("applyFieldDefinitions rejects unlisted fields", func() {
 	})
 
 	It("rejects unlisted field on ComputeInstanceSpec", func() {
-		cores := int32(4)
-		spec := &privatev1.ComputeInstanceSpec{
-			Cores: &cores,
-		}
+		spec := privatev1.ComputeInstanceSpec_builder{
+			InstanceType: proto.String("m1.large"),
+		}.Build()
 		defaultVal, err := structpb.NewValue("ssh-ed25519 AAAA")
 		Expect(err).ToNot(HaveOccurred())
 		fieldDefs := []*privatev1.FieldDefinition{{
@@ -315,7 +314,7 @@ var _ = Describe("applyFieldDefinitions rejects unlisted fields", func() {
 		err = applyFieldDefinitions(spec, fieldDefs)
 		Expect(err).To(HaveOccurred())
 		Expect(status.Code(err)).To(Equal(codes.InvalidArgument))
-		Expect(err.Error()).To(ContainSubstring("cores"))
+		Expect(err.Error()).To(ContainSubstring("instance_type"))
 		Expect(err.Error()).To(ContainSubstring("not allowed"))
 	})
 })


### PR DESCRIPTION
## Summary
- PR #866 removed `cores`/`memory_gib` from `ComputeInstanceSpec` in favor of `instance_type`
- PR #783 added a test referencing the now-removed `Cores` field
- Both merged close together, leaving CI broken on every PR rebased on current main
- Replaces `Cores` with `InstanceType` in the "rejects unlisted field on ComputeInstanceSpec" test

## Test plan
- [x] `ginkgo run --focus="rejects unlisted field on ComputeInstanceSpec" internal/servers` passes
- [x] `go build ./internal/servers/` compiles cleanly

Assisted-by: Claude Code <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated validation coverage to confirm that unlisted `instance_type` fields are correctly rejected for compute instance specifications.
  * Refined the expected invalid-argument error message for this validation scenario.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->