### PR TITLE
OSAC-2822: skip CI for docs-only and metadata-only PRs

### DIFF
--- a/.github/workflows/check-pull-request.yaml
+++ b/.github/workflows/check-pull-request.yaml
@@ -18,6 +18,11 @@ on:
   pull_request:
     branches:
     - main
+    paths-ignore:
+      - 'OWNERS'
+      - 'LICENSE'
+      - '*.md'
+      - 'docs/**'
 
 permissions:
   contents: read

--- a/.github/workflows/e2e-vmaas-full-install.yml
+++ b/.github/workflows/e2e-vmaas-full-install.yml
@@ -30,7 +30,28 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    outputs:
+      should-run: ${{ github.event_name != 'pull_request' || steps.filter.outputs.docs-only != 'true' }}
+    steps:
+      - uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706  # v4.0.2
+        if: github.event_name == 'pull_request'
+        id: filter
+        with:
+          predicate-quantifier: 'every'
+          filters: |
+            docs-only:
+              - 'OWNERS'
+              - 'LICENSE'
+              - '*.md'
+              - 'docs/**'
+
   e2e-vmaas-full-install:
+    needs: changes
+    if: needs.changes.outputs.should-run == 'true'
     uses: osac-project/osac-test-infra/.github/workflows/e2e-vmaas-full-install.yml@main
     with:
       test-suite: ${{ inputs.test-suite || 'vmaas' }}
@@ -46,3 +67,11 @@ jobs:
       # Checkout osac-test-infra for tests/Containerfile (not the caller repo)
       test-infra-repository: osac-project/osac-test-infra
       test-infra-ref: ${{ inputs.test-infra-ref || 'main' }}
+
+  e2e:
+    if: always()
+    needs: [changes, e2e-vmaas-full-install]
+    runs-on: ubuntu-latest
+    steps:
+      - if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
+        run: exit 1

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -18,6 +18,11 @@ on:
   pull_request:
     branches:
     - main
+    paths-ignore:
+      - 'OWNERS'
+      - 'LICENSE'
+      - '*.md'
+      - 'docs/**'
   workflow_dispatch:
   schedule:
     - cron: '0 0 * * *'

--- a/.github/workflows/publish-image.yaml
+++ b/.github/workflows/publish-image.yaml
@@ -2,6 +2,11 @@ name: Container image
 
 on:
   pull_request:
+    paths-ignore:
+      - 'OWNERS'
+      - 'LICENSE'
+      - '*.md'
+      - 'docs/**'
   push:
     branches:
       - main

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -18,6 +18,11 @@ on:
   pull_request:
     branches:
     - main
+    paths-ignore:
+      - 'OWNERS'
+      - 'LICENSE'
+      - '*.md'
+      - 'docs/**'
   workflow_dispatch:
   schedule:
     - cron: '0 0 * * *'


### PR DESCRIPTION
## Summary

- Add `paths-ignore` filters to all PR-triggered workflows so they don't run when only non-code files change (OWNERS, LICENSE, `*.md`, `docs/**`).
- Affected workflows: check-pull-request, publish-image, e2e-vmaas-full-install, unit-tests, integration-tests.
- Scheduled and workflow_dispatch triggers are unaffected.

## Branch protection

Requires switching any required status checks from classic branch protection to a GitHub Ruleset with "Do not require status checks on creation" enabled, so the check is enforced on code PRs but doesn't block docs-only PRs.

## Test plan

- [ ] Verify a code-changing PR still triggers all workflows normally
- [ ] Confirm docs-only PRs can merge without waiting for skipped checks

Assisted-by: Claude Code <noreply@anthropic.com>