### PR TITLE
OSAC-1503: add immutability validation for cluster network_attachment

### DIFF
--- a/internal/servers/private_clusters_server.go
+++ b/internal/servers/private_clusters_server.go
@@ -229,6 +229,10 @@ func (s *PrivateClustersServer) Update(ctx context.Context,
 	if err != nil {
 		return
 	}
+	err = s.validateNetworkAttachmentImmutability(ctx, request)
+	if err != nil {
+		return
+	}
 	if err = utils.ValidateClusterSpecFields(request.GetObject().GetSpec()); err != nil {
 		return
 	}
@@ -536,6 +540,47 @@ func (s *PrivateClustersServer) validateTemplateImmutability(ctx context.Context
 			"cannot change spec.catalog_item from '%s' to '%s': catalog item is immutable",
 			existingSpec.GetCatalogItem(),
 			newSpec.GetCatalogItem(),
+		)
+	}
+
+	return nil
+}
+
+// validateNetworkAttachmentImmutability ensures that the subnet field within
+// network_attachment cannot be changed after cluster creation.
+func (s *PrivateClustersServer) validateNetworkAttachmentImmutability(ctx context.Context,
+	request *privatev1.ClustersUpdateRequest) error {
+	updateMask := request.GetUpdateMask()
+
+	subnetMayChange := false
+	if updateMask != nil {
+		for _, path := range updateMask.GetPaths() {
+			if path == "spec.network_attachment" || path == "spec.network_attachment.subnet" {
+				subnetMayChange = true
+				break
+			}
+		}
+	}
+	if !subnetMayChange {
+		return nil
+	}
+
+	existingCluster, found, err := s.getExistingCluster(ctx, request)
+	if err != nil {
+		return err
+	}
+	if !found {
+		return nil
+	}
+
+	existingSubnet := existingCluster.GetSpec().GetNetworkAttachment().GetSubnet()
+	newSubnet := request.GetObject().GetSpec().GetNetworkAttachment().GetSubnet()
+
+	if existingSubnet != newSubnet {
+		return grpcstatus.Errorf(
+			grpccodes.InvalidArgument,
+			"cannot change spec.network_attachment.subnet from '%s' to '%s': subnet is immutable",
+			existingSubnet, newSubnet,
 		)
 	}
 

--- a/internal/servers/private_clusters_server_test.go
+++ b/internal/servers/private_clusters_server_test.go
@@ -1044,6 +1044,167 @@ var _ = Describe("Private clusters server", func() {
 			Expect(status.Message()).To(Equal("cannot change spec.template_parameters: template parameters are immutable"))
 		})
 
+		Describe("Network attachment immutability", func() {
+			createClusterWithNetworkAttachment := func(subnet string, securityGroups []string) *privatev1.Cluster {
+				createResponse, err := server.Create(ctx, privatev1.ClustersCreateRequest_builder{
+					Object: privatev1.Cluster_builder{
+						Spec: privatev1.ClusterSpec_builder{
+							Template: "my-template-id",
+							NetworkAttachment: privatev1.ClusterNetworkAttachment_builder{
+								Subnet:         subnet,
+								SecurityGroups: securityGroups,
+							}.Build(),
+						}.Build(),
+					}.Build(),
+				}.Build())
+				Expect(err).ToNot(HaveOccurred())
+				return createResponse.GetObject()
+			}
+
+			It("Rejects changing subnet via whole attachment replacement", func() {
+				object := createClusterWithNetworkAttachment("subnet-1", []string{"sg-1"})
+
+				_, err := server.Update(ctx, privatev1.ClustersUpdateRequest_builder{
+					Object: privatev1.Cluster_builder{
+						Id: object.GetId(),
+						Spec: privatev1.ClusterSpec_builder{
+							NetworkAttachment: privatev1.ClusterNetworkAttachment_builder{
+								Subnet:         "subnet-2",
+								SecurityGroups: []string{"sg-1"},
+							}.Build(),
+						}.Build(),
+					}.Build(),
+					UpdateMask: &fieldmaskpb.FieldMask{
+						Paths: []string{"spec.network_attachment"},
+					},
+				}.Build())
+				Expect(err).To(HaveOccurred())
+				status, ok := grpcstatus.FromError(err)
+				Expect(ok).To(BeTrue())
+				Expect(status.Code()).To(Equal(grpccodes.InvalidArgument))
+				Expect(status.Message()).To(Equal(
+					"cannot change spec.network_attachment.subnet from 'subnet-1' to 'subnet-2': subnet is immutable",
+				))
+			})
+
+			It("Rejects removing network_attachment when one exists", func() {
+				object := createClusterWithNetworkAttachment("subnet-1", []string{"sg-1"})
+
+				_, err := server.Update(ctx, privatev1.ClustersUpdateRequest_builder{
+					Object: privatev1.Cluster_builder{
+						Id:   object.GetId(),
+						Spec: privatev1.ClusterSpec_builder{}.Build(),
+					}.Build(),
+					UpdateMask: &fieldmaskpb.FieldMask{
+						Paths: []string{"spec.network_attachment"},
+					},
+				}.Build())
+				Expect(err).To(HaveOccurred())
+				status, ok := grpcstatus.FromError(err)
+				Expect(ok).To(BeTrue())
+				Expect(status.Code()).To(Equal(grpccodes.InvalidArgument))
+				Expect(status.Message()).To(Equal(
+					"cannot change spec.network_attachment.subnet from 'subnet-1' to '': subnet is immutable",
+				))
+			})
+
+			It("Rejects adding network_attachment when none existed", func() {
+				createResponse, err := server.Create(ctx, privatev1.ClustersCreateRequest_builder{
+					Object: privatev1.Cluster_builder{
+						Spec: privatev1.ClusterSpec_builder{
+							Template: "my-template-id",
+						}.Build(),
+					}.Build(),
+				}.Build())
+				Expect(err).ToNot(HaveOccurred())
+				object := createResponse.GetObject()
+
+				_, err = server.Update(ctx, privatev1.ClustersUpdateRequest_builder{
+					Object: privatev1.Cluster_builder{
+						Id: object.GetId(),
+						Spec: privatev1.ClusterSpec_builder{
+							NetworkAttachment: privatev1.ClusterNetworkAttachment_builder{
+								Subnet: "subnet-1",
+							}.Build(),
+						}.Build(),
+					}.Build(),
+					UpdateMask: &fieldmaskpb.FieldMask{
+						Paths: []string{"spec.network_attachment"},
+					},
+				}.Build())
+				Expect(err).To(HaveOccurred())
+				status, ok := grpcstatus.FromError(err)
+				Expect(ok).To(BeTrue())
+				Expect(status.Code()).To(Equal(grpccodes.InvalidArgument))
+				Expect(status.Message()).To(Equal(
+					"cannot change spec.network_attachment.subnet from '' to 'subnet-1': subnet is immutable",
+				))
+			})
+
+			It("Allows changing security_groups with same subnet", func() {
+				object := createClusterWithNetworkAttachment("subnet-1", []string{"sg-1"})
+
+				updateResponse, err := server.Update(ctx, privatev1.ClustersUpdateRequest_builder{
+					Object: privatev1.Cluster_builder{
+						Id: object.GetId(),
+						Spec: privatev1.ClusterSpec_builder{
+							NetworkAttachment: privatev1.ClusterNetworkAttachment_builder{
+								Subnet:         "subnet-1",
+								SecurityGroups: []string{"sg-1", "sg-2"},
+							}.Build(),
+						}.Build(),
+					}.Build(),
+					UpdateMask: &fieldmaskpb.FieldMask{
+						Paths: []string{"spec.network_attachment"},
+					},
+				}.Build())
+				Expect(err).ToNot(HaveOccurred())
+				updated := updateResponse.GetObject()
+				Expect(updated.GetSpec().GetNetworkAttachment().GetSubnet()).To(Equal("subnet-1"))
+				Expect(updated.GetSpec().GetNetworkAttachment().GetSecurityGroups()).To(Equal([]string{"sg-1", "sg-2"}))
+			})
+
+			It("Allows updating security_groups via sub-field mask", func() {
+				object := createClusterWithNetworkAttachment("subnet-1", []string{"sg-1"})
+
+				updateResponse, err := server.Update(ctx, privatev1.ClustersUpdateRequest_builder{
+					Object: privatev1.Cluster_builder{
+						Id: object.GetId(),
+						Spec: privatev1.ClusterSpec_builder{
+							NetworkAttachment: privatev1.ClusterNetworkAttachment_builder{
+								SecurityGroups: []string{"sg-2", "sg-3"},
+							}.Build(),
+						}.Build(),
+					}.Build(),
+					UpdateMask: &fieldmaskpb.FieldMask{
+						Paths: []string{"spec.network_attachment.security_groups"},
+					},
+				}.Build())
+				Expect(err).ToNot(HaveOccurred())
+				updated := updateResponse.GetObject()
+				Expect(updated.GetSpec().GetNetworkAttachment().GetSecurityGroups()).To(Equal([]string{"sg-2", "sg-3"}))
+			})
+
+			It("Passes through when mask does not include network_attachment", func() {
+				object := createClusterWithNetworkAttachment("subnet-1", []string{"sg-1"})
+
+				updateResponse, err := server.Update(ctx, privatev1.ClustersUpdateRequest_builder{
+					Object: privatev1.Cluster_builder{
+						Id: object.GetId(),
+						Status: privatev1.ClusterStatus_builder{
+							State: privatev1.ClusterState_CLUSTER_STATE_READY,
+						}.Build(),
+					}.Build(),
+					UpdateMask: &fieldmaskpb.FieldMask{
+						Paths: []string{"status.state"},
+					},
+				}.Build())
+				Expect(err).ToNot(HaveOccurred())
+				updated := updateResponse.GetObject()
+				Expect(updated.GetSpec().GetNetworkAttachment().GetSubnet()).To(Equal("subnet-1"))
+			})
+		})
+
 		Describe("Catalog item", func() {
 			var catalogItemsDao *dao.GenericDAO[*privatev1.ClusterCatalogItem]
 


### PR DESCRIPTION
## [OSAC-1503](https://redhat.atlassian.net/browse/OSAC-1503): Add immutability validation for cluster network_attachment

**Jira:** https://redhat.atlassian.net/browse/OSAC-1503

### Summary

Adds server-side validation to reject Update requests that modify the `subnet` field within `network_attachment` on Cluster. The subnet determines which V-Net cluster nodes are placed on and changing it requires recreating the cluster. Security groups remain mutable.

### Changes

- **`internal/servers/private_clusters_server.go`:**
  - Added `validateNetworkAttachmentImmutability()` method that checks whether the update mask could affect the subnet (`spec.network_attachment` or `spec.network_attachment.subnet`) and compares existing vs new subnet values
  - Called from `Update()` after `validateNodeSetsUpdate()`, following the existing `validateTemplateImmutability()` pattern

- **`internal/servers/private_clusters_server_test.go`:**
  - Added 6 test cases in a `"Network attachment immutability"` Describe block

### Testing

- **Unit tests:** 6 new tests covering all behavioral paths — reject subnet change, reject add/remove, allow security_groups change (whole attachment and sub-field mask), pass through unrelated updates
- **Integration tests:** N/A — pure server-side validation
- **Coverage:** All behavioral paths through the new function are exercised

### Acceptance Criteria

- [ ] Reject Update requests that modify `spec.network_attachment.subnet`
- [ ] Reject Update requests that add/remove `network_attachment` (set↔unset)
- [ ] Allow Update requests that modify `spec.network_attachment.security_groups`
- [ ] Pass through Update requests that don't include `spec.network_attachment` in the field mask


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented changes to a cluster’s network attachment subnet after creation.
  * Added validation for replacing, removing, or adding network attachments when the subnet would change.
  * Continued to allow updates to security groups without changing the subnet.
  * Preserved existing network attachment details when they are not included in an update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->