### PR TITLE
OSAC-1826: Update logout cmd to end IdP user's session

### DIFF
--- a/internal/cmd/cli/logout/logout_cmd.go
+++ b/internal/cmd/cli/logout/logout_cmd.go
@@ -14,11 +14,21 @@ language governing permissions and limitations under the License.
 package logout
 
 import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/json"
 	"fmt"
+	"log/slog"
+	"net/http"
+	"net/url"
 
 	"github.com/spf13/cobra"
 
 	"github.com/osac-project/fulfillment-service/internal/config"
+	"github.com/osac-project/fulfillment-service/internal/logging"
+	"github.com/osac-project/fulfillment-service/internal/oauth"
+	"github.com/osac-project/fulfillment-service/internal/terminal"
 )
 
 func Cmd() *cobra.Command {
@@ -40,19 +50,161 @@ func (c *runnerContext) run(cmd *cobra.Command, args []string) error {
 	// Get the context:
 	ctx := cmd.Context()
 
-	// Get the configuration from the context:
+	// Get the configuration, console, and logger from the context:
 	cfg := config.SettingsFromContext(ctx)
+	console := terminal.ConsoleFromContext(ctx)
+	logger := logging.LoggerFromContext(ctx)
+
+	// Terminate the server-side session. If it fails, warn but continue — local credentials
+	// are always cleared regardless:
+	err := c.terminateSession(ctx, cfg, logger)
+	if err != nil {
+		console.Errorf(ctx, "Warning: Failed to terminate server session: %v\n", err)
+		console.Errorf(ctx, "Local credentials will be cleared, but the server session may remain active.\n")
+	}
 
 	// Clear all the details:
 	cfg.Reset()
 
 	// Save the configuration:
-	err := cfg.Save(ctx)
+	err = cfg.Save(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to save configuration: %w", err)
 	}
 
+	console.Infof(ctx, "Successfully logged out\n")
 	return nil
+}
+
+func (c *runnerContext) terminateSession(ctx context.Context, cfg *config.Settings,
+	logger *slog.Logger) error {
+	// Check that the issuer is configured:
+	issuer := cfg.Issuer()
+	if issuer == "" {
+		return nil
+	}
+
+	// Check that a token source is available:
+	tokenSource, err := cfg.TokenSource(ctx)
+	if err != nil || tokenSource == nil {
+		return nil
+	}
+
+	// Check that a refresh token is available:
+	token, err := tokenSource.Token(ctx)
+	if err != nil || token == nil || token.Refresh == "" {
+		return nil
+	}
+
+	// Get the CA pool:
+	caPool, err := cfg.CaPool(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to get CA pool: %w", err)
+	}
+
+	// Discover the OIDC endpoints from the issuer:
+	discoveryTool, err := oauth.NewDiscoveryTool().
+		SetLogger(logger).
+		SetIssuer(issuer).
+		SetInsecure(cfg.Insecure()).
+		SetCaPool(caPool).
+		Build()
+	if err != nil {
+		return fmt.Errorf("failed to create discovery tool: %w", err)
+	}
+
+	metadata, err := discoveryTool.Discover(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to discover OIDC endpoints: %w", err)
+	}
+
+	// Check that the end_session_endpoint is available:
+	if metadata.EndSessionEndpoint == "" {
+		return nil
+	}
+
+	// Create the HTTP client:
+	client := c.httpClient(caPool, cfg.Insecure())
+
+	// Obtain a fresh ID token via refresh grant. The ID token is not persisted locally, so we
+	// need to fetch one to use as id_token_hint for the end_session_endpoint:
+	idToken, err := c.refreshForIdToken(ctx, client, metadata.TokenEndpoint,
+		token.Refresh, cfg.ClientId(), cfg.ClientSecret())
+	if err != nil {
+		return fmt.Errorf("failed to obtain ID token for logout: %w", err)
+	}
+
+	// Send a back-channel request to the end_session_endpoint to terminate the server session:
+	params := url.Values{}
+	params.Set("id_token_hint", idToken)
+
+	logoutURL := fmt.Sprintf("%s?%s", metadata.EndSessionEndpoint, params.Encode())
+
+	resp, err := client.Get(logoutURL)
+	if err != nil {
+		return fmt.Errorf("failed to call end_session_endpoint: %w", err)
+	}
+	resp.Body.Close()
+
+	return nil
+}
+
+func (c *runnerContext) refreshForIdToken(ctx context.Context, client *http.Client,
+	tokenEndpoint, refreshToken, clientId, clientSecret string) (string, error) {
+	// Build the refresh grant form:
+	form := url.Values{}
+	form.Set("grant_type", "refresh_token")
+	form.Set("refresh_token", refreshToken)
+
+	// Add client credentials if configured:
+	if clientId != "" {
+		form.Set("client_id", clientId)
+	}
+	if clientSecret != "" {
+		form.Set("client_secret", clientSecret)
+	}
+
+	// Send the request to the token endpoint:
+	resp, err := client.PostForm(tokenEndpoint, form)
+	if err != nil {
+		return "", fmt.Errorf("failed to call token endpoint: %w", err)
+	}
+	defer resp.Body.Close()
+
+	// Check the response status:
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("token endpoint returned error status: %s", resp.Status)
+	}
+
+	// Extract the ID token from the response:
+	var tokenResponse struct {
+		IdToken string `json:"id_token"`
+	}
+	err = json.NewDecoder(resp.Body).Decode(&tokenResponse)
+	if err != nil {
+		return "", fmt.Errorf("failed to parse token response: %w", err)
+	}
+
+	// Check that the response contains an ID token:
+	if tokenResponse.IdToken == "" {
+		return "", fmt.Errorf("token endpoint did not return an ID token")
+	}
+
+	return tokenResponse.IdToken, nil
+}
+
+func (c *runnerContext) httpClient(caPool *x509.CertPool, insecure bool) *http.Client {
+	tlsConfig := &tls.Config{
+		RootCAs: caPool,
+	}
+	if insecure {
+		tlsConfig.InsecureSkipVerify = true
+	}
+	return &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: tlsConfig,
+		},
+	}
 }
 
 const shortHelp = `Discard connection and authentication details`

--- a/internal/cmd/cli/logout/logout_cmd_test.go
+++ b/internal/cmd/cli/logout/logout_cmd_test.go
@@ -1,0 +1,315 @@
+/*
+Copyright (c) 2026 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package logout
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"log/slog"
+
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2/dsl/core"
+	. "github.com/onsi/gomega"
+
+	"github.com/osac-project/fulfillment-service/internal/config"
+	"github.com/osac-project/fulfillment-service/internal/logging"
+	"github.com/osac-project/fulfillment-service/internal/terminal"
+)
+
+var _ = Describe("Logout command flags", func() {
+	It("Has the expected use string", func() {
+		cmd := Cmd()
+		Expect(cmd.Use).To(Equal("logout [FLAG...]"))
+	})
+
+	It("Has short help text", func() {
+		cmd := Cmd()
+		Expect(cmd.Short).ToNot(BeEmpty())
+	})
+
+	It("Has long help text", func() {
+		cmd := Cmd()
+		Expect(cmd.Long).ToNot(BeEmpty())
+	})
+})
+
+var _ = Describe("Logout command execution", func() {
+	var (
+		ctx    context.Context
+		output *bytes.Buffer
+		stderr *bytes.Buffer
+	)
+
+	BeforeEach(func() {
+		ctx = context.Background()
+		ctx = logging.LoggerIntoContext(ctx, slog.Default())
+		output = &bytes.Buffer{}
+		stderr = &bytes.Buffer{}
+	})
+
+	setupContext := func() (context.Context, *config.Settings) {
+		console, err := terminal.NewConsole().
+			SetLogger(slog.Default()).
+			SetStdout(output).
+			SetStderr(stderr).
+			Build()
+		Expect(err).ToNot(HaveOccurred())
+		ctx = terminal.ConsoleIntoContext(ctx, console)
+
+		tempDir, err := os.MkdirTemp("", "logout-test-*")
+		Expect(err).ToNot(HaveOccurred())
+		DeferCleanup(func() {
+			os.RemoveAll(tempDir)
+		})
+
+		settings, err := config.NewSettings().
+			SetLogger(slog.Default()).
+			SetDir(filepath.Join(tempDir, "settings")).
+			Build()
+		Expect(err).ToNot(HaveOccurred())
+
+		ctx = config.SettingsIntoContext(ctx, settings)
+		return ctx, settings
+	}
+
+	It("Clears credentials when no issuer is configured", func() {
+		ctx, settings := setupContext()
+
+		settings.SetAddress("localhost:8000")
+		settings.SetAccessToken("my-access-token")
+		settings.SetRefreshToken("my-refresh-token")
+
+		cmd := Cmd()
+		cmd.SetOut(GinkgoWriter)
+		cmd.SetErr(GinkgoWriter)
+		cmd.SetContext(ctx)
+		cmd.SetArgs([]string{})
+
+		err := cmd.Execute()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(output.String()).To(ContainSubstring("Successfully logged out"))
+		Expect(settings.Address()).To(BeEmpty())
+	})
+
+	It("Clears credentials when no token source is available", func() {
+		ctx, settings := setupContext()
+
+		settings.SetAddress("localhost:8000")
+		settings.SetIssuer("https://example.com/auth/realms/test")
+
+		cmd := Cmd()
+		cmd.SetOut(GinkgoWriter)
+		cmd.SetErr(GinkgoWriter)
+		cmd.SetContext(ctx)
+		cmd.SetArgs([]string{})
+
+		err := cmd.Execute()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(output.String()).To(ContainSubstring("Successfully logged out"))
+		Expect(settings.Address()).To(BeEmpty())
+		Expect(settings.Issuer()).To(BeEmpty())
+	})
+
+	It("Clears credentials when access token exists but no refresh token", func() {
+		ctx, settings := setupContext()
+
+		settings.SetAddress("localhost:8000")
+		settings.SetIssuer("https://example.com/auth/realms/test")
+		settings.SetAccessToken("my-access-token")
+		settings.SetTokenExpiry(time.Now().Add(1 * time.Hour))
+
+		cmd := Cmd()
+		cmd.SetOut(GinkgoWriter)
+		cmd.SetErr(GinkgoWriter)
+		cmd.SetContext(ctx)
+		cmd.SetArgs([]string{})
+
+		err := cmd.Execute()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(output.String()).To(ContainSubstring("Successfully logged out"))
+		Expect(settings.Address()).To(BeEmpty())
+	})
+
+	It("Shows warning and still clears credentials when session termination fails", func() {
+		discoveryServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			http.Error(w, "server error", http.StatusInternalServerError)
+		}))
+		DeferCleanup(discoveryServer.Close)
+
+		ctx, settings := setupContext()
+
+		settings.SetAddress("localhost:8000")
+		settings.SetIssuer(discoveryServer.URL)
+		settings.SetAccessToken("my-access-token")
+		settings.SetRefreshToken("my-refresh-token")
+		settings.SetTokenExpiry(time.Now().Add(1 * time.Hour))
+		settings.SetFlow("code")
+		settings.SetClientId("test-client")
+		settings.SetClientSecret("test-secret")
+		settings.SetScopes([]string{"openid"})
+
+		err := settings.Save(ctx)
+		Expect(err).ToNot(HaveOccurred())
+		err = settings.Load(ctx)
+		Expect(err).ToNot(HaveOccurred())
+
+		cmd := Cmd()
+		cmd.SetOut(GinkgoWriter)
+		cmd.SetErr(GinkgoWriter)
+		cmd.SetContext(ctx)
+		cmd.SetArgs([]string{})
+
+		err = cmd.Execute()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(stderr.String()).To(ContainSubstring("Warning: Failed to terminate server session"))
+		Expect(stderr.String()).To(ContainSubstring("Local credentials will be cleared"))
+		Expect(output.String()).To(ContainSubstring("Successfully logged out"))
+		Expect(settings.Address()).To(BeEmpty())
+	})
+})
+
+var _ = Describe("refreshForIdToken", func() {
+	var runner *runnerContext
+
+	BeforeEach(func() {
+		runner = &runnerContext{}
+	})
+
+	It("Returns the ID token on success", func() {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			Expect(r.Method).To(Equal(http.MethodPost))
+			Expect(r.FormValue("grant_type")).To(Equal("refresh_token"))
+			Expect(r.FormValue("refresh_token")).To(Equal("my-refresh-token"))
+			Expect(r.FormValue("client_id")).To(Equal("my-client"))
+			Expect(r.FormValue("client_secret")).To(Equal("my-secret"))
+
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(map[string]string{
+				"id_token": "the-id-token",
+			})
+		}))
+		DeferCleanup(server.Close)
+
+		idToken, err := runner.refreshForIdToken(
+			context.Background(), server.Client(), server.URL,
+			"my-refresh-token", "my-client", "my-secret",
+		)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(idToken).To(Equal("the-id-token"))
+	})
+
+	It("Omits client_id when empty", func() {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			Expect(r.FormValue("client_id")).To(BeEmpty())
+			Expect(r.FormValue("client_secret")).To(BeEmpty())
+
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(map[string]string{
+				"id_token": "token-no-client",
+			})
+		}))
+		DeferCleanup(server.Close)
+
+		idToken, err := runner.refreshForIdToken(
+			context.Background(), server.Client(), server.URL,
+			"my-refresh-token", "", "",
+		)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(idToken).To(Equal("token-no-client"))
+	})
+
+	It("Returns error when token endpoint returns non-200 status", func() {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			http.Error(w, "unauthorized", http.StatusUnauthorized)
+		}))
+		DeferCleanup(server.Close)
+
+		_, err := runner.refreshForIdToken(
+			context.Background(), server.Client(), server.URL,
+			"bad-token", "my-client", "my-secret",
+		)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("error status"))
+	})
+
+	It("Returns error when response does not contain id_token", func() {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(map[string]string{
+				"access_token": "some-access-token",
+			})
+		}))
+		DeferCleanup(server.Close)
+
+		_, err := runner.refreshForIdToken(
+			context.Background(), server.Client(), server.URL,
+			"my-refresh-token", "my-client", "my-secret",
+		)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("did not return an ID token"))
+	})
+
+	It("Returns error when response body is invalid JSON", func() {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.Write([]byte("not-json"))
+		}))
+		DeferCleanup(server.Close)
+
+		_, err := runner.refreshForIdToken(
+			context.Background(), server.Client(), server.URL,
+			"my-refresh-token", "my-client", "my-secret",
+		)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("failed to parse token response"))
+	})
+
+	It("Returns error when token endpoint is unreachable", func() {
+		_, err := runner.refreshForIdToken(
+			context.Background(), http.DefaultClient, "http://127.0.0.1:1",
+			"my-refresh-token", "my-client", "my-secret",
+		)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("failed to call token endpoint"))
+	})
+})
+
+var _ = Describe("httpClient", func() {
+	var runner *runnerContext
+
+	BeforeEach(func() {
+		runner = &runnerContext{}
+	})
+
+	It("Creates a client with default TLS config", func() {
+		client := runner.httpClient(nil, false)
+		Expect(client).ToNot(BeNil())
+		transport := client.Transport.(*http.Transport)
+		Expect(transport.TLSClientConfig).ToNot(BeNil())
+		Expect(transport.TLSClientConfig.InsecureSkipVerify).To(BeFalse())
+	})
+
+	It("Creates a client with insecure TLS config", func() {
+		client := runner.httpClient(nil, true)
+		Expect(client).ToNot(BeNil())
+		transport := client.Transport.(*http.Transport)
+		Expect(transport.TLSClientConfig.InsecureSkipVerify).To(BeTrue())
+	})
+})

--- a/internal/cmd/cli/logout/logout_suite_test.go
+++ b/internal/cmd/cli/logout/logout_suite_test.go
@@ -1,0 +1,26 @@
+/*
+Copyright (c) 2026 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package logout
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestLogout(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Logout Suite")
+}

--- a/internal/config/config_settings.go
+++ b/internal/config/config_settings.go
@@ -248,6 +248,16 @@ func (s *Settings) SetAccessToken(value string) {
 	s.secret.AccessToken = value
 }
 
+// ClientId returns the OAuth client identifier.
+func (s *Settings) ClientId() string {
+	return s.secret.ClientId
+}
+
+// ClientSecret returns the OAuth client secret.
+func (s *Settings) ClientSecret() string {
+	return s.secret.ClientSecret
+}
+
 // SetRefreshToken sets the refresh token.
 func (s *Settings) SetRefreshToken(value string) {
 	s.secret.RefreshToken = value

--- a/internal/oauth/oauth_discovery_tool.go
+++ b/internal/oauth/oauth_discovery_tool.go
@@ -35,6 +35,7 @@ import (
 type ServerMetadata struct {
 	AuthorizationEndpoint       string   `json:"authorization_endpoint,omitempty"`
 	DeviceAuthorizationEndpoint string   `json:"device_authorization_endpoint,omitempty"`
+	EndSessionEndpoint          string   `json:"end_session_endpoint,omitempty"`
 	Issuer                      string   `json:"issuer,omitempty"`
 	ScopesSupported             []string `json:"scopes_supported,omitempty"`
 	TokenEndpoint               string   `json:"token_endpoint,omitempty"`


### PR DESCRIPTION
# Description
When a user is logged into OSAC from an external IdP (OIDC) we previously didn't end their session, but only cleared the credentials locally. This is problematic since a new login would allow the next user to automatically authenticate into the session of the previous user.

This updates the command to actually log them out and end their session.

This command performs two operations:
1. Terminates the server-side session by calling the OIDC end_session_endpoint
   (if available). This ensures sessions with external identity providers are
   properly logged out.
2. Clears local authentication credentials and connection details.
If the server-side logout fails, local credentials are still cleared, but you
may need to manually log out from the identity provider.

# Testing

1. Ran integration test suite.
2. Built CLI locally
3. Created mock OIDC server with seeded users
4. Created tenant with cloud provider admin, associated keycloak user to tenant as tenant admin, logged in as tenant admin, and created IDP with mock OIDC server
5. Logged in using code flow on CLI and ran whoami to verify
6. Logged out via CLI
7. Logged back in using code flow on CLI and verified the user wasn't already authenticated and had to log in again

```yaml
"@type": "type.googleapis.com/osac.public.v1.IdentityProvider"
metadata:
  name: "osac-demo-oidc"
  tenant: "osac-demo"
spec:
  title: "OSAC Demo OIDC"
  enabled: true
  oidc:
    authorizationUrl: "$URL/oidc/authorize" # TODO: replace with actual URL
    tokenUrl: "$URL/oidc/token" # TODO: replace with actual URL
    clientId: "$CLIENT_ID" # TODO: replace withactual client ID - generated when OIDC server starts
    clientSecret: "$CLIENT_SECRET" # TODO: replace with actual client secret - generated when OIDC server starts
    issuer: "$URL/oidc" # TODO: replace with actual URL
```

```sh
$ ./osac login --ca-file testing/bundle.pem --flow code https://fulfillment-internal-api.osac.svc.cluster.local:8000
To complete authentication, please open the following URL in your browser:

  https://keycloak.keycloak.svc.cluster.local:8000/realms/osac/protocol/openid-connect/auth?client_id=osac-cli&code_challenge=36BkTgQFWo89dTrgdEuCL8PkOb2MLLUNIknVGNrVhc0&code_challenge_method=S256&redirect_uri=http%3A%2F%2Flocalhost%3A58485&response_type=code&scope=openid&state=efA1T7k-J6RDtY-Mh6RuVw

If the browser doesn't open automatically, open it manually and follow the instructions to
complete authentication.

Authentication succeeded.

$ ./osac whoami
Logged in as: aliceuser
Tenant: osac-demo
Roles: offline_access, uma_authorization, default-roles-my realm

$ ./osac logout
Successfully logged out

$ ./osac whoami
Not logged in. Use 'osac login' to authenticate.
```

Assisted-by: Claude Code <noreply@anthropic.com>

/cc @jhernand 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Logout now attempts to end the remote OIDC session before clearing local credentials.
  - Supports configured certificate authorities and optional insecure TLS connections during logout.
  - Logout still clears local credentials if remote session termination fails.

- **Bug Fixes**
  - Added warnings when remote logout cannot be completed, while allowing the command to finish successfully.

- **Tests**
  - Added coverage for logout behavior, token refresh, endpoint failures, and TLS configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->