### PR TITLE
OSAC-1905: surface reconciliation errors in ComputeInstance status

### DIFF
--- a/internal/controllers/computeinstance/computeinstance_reconciler_function.go
+++ b/internal/controllers/computeinstance/computeinstance_reconciler_function.go
@@ -135,26 +135,29 @@ func (r *function) run(ctx context.Context, computeInstance *privatev1.ComputeIn
 		r:               r,
 		computeInstance: computeInstance,
 	}
-	var err error
+	var reconcileErr error
 	if computeInstance.HasMetadata() && computeInstance.GetMetadata().HasDeletionTimestamp() {
-		err = t.delete(ctx)
+		reconcileErr = t.delete(ctx)
 	} else {
-		err = t.update(ctx)
+		reconcileErr = t.update(ctx)
 	}
-	if err != nil {
-		return err
+	if reconcileErr != nil {
+		t.setReconciliationFailed(reconcileErr)
 	}
 	// Calculate which fields the reconciler actually modified and use a field mask
 	// to update only those fields. This prevents overwriting concurrent user changes.
 	updateMask := r.maskCalculator.Calculate(oldComputeInstance, computeInstance)
 
 	// Only send an update if there are actual changes
-	_, err = r.computeInstancesClient.Update(ctx, privatev1.ComputeInstancesUpdateRequest_builder{
+	_, updateErr := r.computeInstancesClient.Update(ctx, privatev1.ComputeInstancesUpdateRequest_builder{
 		Object:     computeInstance,
 		UpdateMask: updateMask,
 	}.Build())
 
-	return err
+	if reconcileErr != nil {
+		return reconcileErr
+	}
+	return updateErr
 }
 
 func (t *task) update(ctx context.Context) error {
@@ -522,6 +525,19 @@ func (t *task) updateCondition(conditionType privatev1.ComputeInstanceConditionT
 		}.Build())
 	}
 	t.computeInstance.GetStatus().SetConditions(conditions)
+}
+
+func (t *task) setReconciliationFailed(err error) {
+	if !t.computeInstance.HasStatus() {
+		t.computeInstance.SetStatus(&privatev1.ComputeInstanceStatus{})
+	}
+	t.computeInstance.GetStatus().SetState(privatev1.ComputeInstanceState_COMPUTE_INSTANCE_STATE_FAILED)
+	t.updateCondition(
+		privatev1.ComputeInstanceConditionType_COMPUTE_INSTANCE_CONDITION_TYPE_PROVISIONED,
+		privatev1.ConditionStatus_CONDITION_STATUS_FALSE,
+		"ReconciliationFailed",
+		err.Error(),
+	)
 }
 
 // buildSpec constructs the spec for the Kubernetes ComputeInstance object based on the

--- a/internal/controllers/computeinstance/computeinstance_reconciler_function_test.go
+++ b/internal/controllers/computeinstance/computeinstance_reconciler_function_test.go
@@ -1382,6 +1382,92 @@ var _ = Describe("ensureUserDataSecret", func() {
 	})
 })
 
+var _ = Describe("setReconciliationFailed", func() {
+	It("should set state to FAILED and update PROVISIONED condition", func() {
+		ci := privatev1.ComputeInstance_builder{
+			Id: "test-ci-fail",
+			Status: privatev1.ComputeInstanceStatus_builder{
+				State: privatev1.ComputeInstanceState_COMPUTE_INSTANCE_STATE_STARTING,
+			}.Build(),
+		}.Build()
+
+		t := &task{
+			r:               &function{logger: logger},
+			computeInstance: ci,
+		}
+
+		reconcileErr := errors.New("spec.runStrategy: Unsupported value: \"\": supported values: \"Always\", \"Halted\"")
+		t.setReconciliationFailed(reconcileErr)
+
+		Expect(ci.GetStatus().GetState()).To(Equal(privatev1.ComputeInstanceState_COMPUTE_INSTANCE_STATE_FAILED))
+
+		var provisionedCondition *privatev1.ComputeInstanceCondition
+		for _, c := range ci.GetStatus().GetConditions() {
+			if c.GetType() == privatev1.ComputeInstanceConditionType_COMPUTE_INSTANCE_CONDITION_TYPE_PROVISIONED {
+				provisionedCondition = c
+				break
+			}
+		}
+		Expect(provisionedCondition).ToNot(BeNil())
+		Expect(provisionedCondition.GetStatus()).To(Equal(privatev1.ConditionStatus_CONDITION_STATUS_FALSE))
+		Expect(provisionedCondition.GetReason()).To(Equal("ReconciliationFailed"))
+		Expect(provisionedCondition.GetMessage()).To(ContainSubstring("runStrategy"))
+	})
+
+	It("should create status if not present", func() {
+		ci := privatev1.ComputeInstance_builder{
+			Id: "test-ci-no-status",
+		}.Build()
+
+		t := &task{
+			r:               &function{logger: logger},
+			computeInstance: ci,
+		}
+
+		t.setReconciliationFailed(errors.New("hub not found"))
+
+		Expect(ci.HasStatus()).To(BeTrue())
+		Expect(ci.GetStatus().GetState()).To(Equal(privatev1.ComputeInstanceState_COMPUTE_INSTANCE_STATE_FAILED))
+	})
+
+	It("should update existing PROVISIONED condition rather than creating duplicate", func() {
+		reason := "WaitingForVM"
+		message := "initial state"
+		ci := privatev1.ComputeInstance_builder{
+			Id: "test-ci-existing-condition",
+			Status: privatev1.ComputeInstanceStatus_builder{
+				State: privatev1.ComputeInstanceState_COMPUTE_INSTANCE_STATE_STARTING,
+				Conditions: []*privatev1.ComputeInstanceCondition{
+					privatev1.ComputeInstanceCondition_builder{
+						Type:    privatev1.ComputeInstanceConditionType_COMPUTE_INSTANCE_CONDITION_TYPE_PROVISIONED,
+						Status:  privatev1.ConditionStatus_CONDITION_STATUS_FALSE,
+						Reason:  &reason,
+						Message: &message,
+					}.Build(),
+				},
+			}.Build(),
+		}.Build()
+
+		t := &task{
+			r:               &function{logger: logger},
+			computeInstance: ci,
+		}
+
+		t.setReconciliationFailed(errors.New("create failed"))
+
+		conditions := ci.GetStatus().GetConditions()
+		provisionedCount := 0
+		for _, c := range conditions {
+			if c.GetType() == privatev1.ComputeInstanceConditionType_COMPUTE_INSTANCE_CONDITION_TYPE_PROVISIONED {
+				provisionedCount++
+				Expect(c.GetReason()).To(Equal("ReconciliationFailed"))
+				Expect(c.GetMessage()).To(ContainSubstring("create failed"))
+			}
+		}
+		Expect(provisionedCount).To(Equal(1))
+	})
+})
+
 var _ = Describe("hub persistence", func() {
 	const (
 		computeInstanceID = "test-ci-hub"
@@ -1490,6 +1576,12 @@ var _ = Describe("hub persistence", func() {
 			}, nil)
 
 		computeInstancesClient := NewMockComputeInstancesClient(ctrl)
+		computeInstancesClient.EXPECT().
+			Update(gomock.Any(), gomock.Any(), gomock.Any()).
+			DoAndReturn(func(ctx context.Context, req *privatev1.ComputeInstancesUpdateRequest, opts ...grpc.CallOption) (*privatev1.ComputeInstancesUpdateResponse, error) {
+				return &privatev1.ComputeInstancesUpdateResponse{Object: req.GetObject()}, nil
+			}).
+			AnyTimes()
 
 		computeInstance := privatev1.ComputeInstance_builder{
 			Id: computeInstanceID,
@@ -1515,6 +1607,9 @@ var _ = Describe("hub persistence", func() {
 		err := f.run(ctx, computeInstance)
 		Expect(err).To(HaveOccurred())
 		Expect(err.Error()).To(ContainSubstring("there are no hubs"))
+
+		// Verify status was set to FAILED with error details
+		Expect(computeInstance.GetStatus().GetState()).To(Equal(privatev1.ComputeInstanceState_COMPUTE_INSTANCE_STATE_FAILED))
 
 		// Verify ComputeInstance was NOT created
 		list := &osacv1alpha1.ComputeInstanceList{}


### PR DESCRIPTION
## Summary

- When the ComputeInstance reconciler fails (e.g. due to missing `runStrategy`), set status to `FAILED` with error details in the `PROVISIONED` condition
- Previously, reconciliation errors were only returned to controller-runtime for retry, leaving the instance stuck in `STARTING` with no user-visible indication
- Now the FAILED status is persisted via Update before returning the error, so users can see why their instance failed

## Changes

- Modified `run()` to capture reconcile errors, call `setReconciliationFailed()` to update status, persist via Update, then return the original error for retry
- Added `setReconciliationFailed()` method that sets state to FAILED and records the error message in the PROVISIONED condition
- Updated existing "no hubs available" test to expect the new FAILED status behavior
- Added 3 new unit tests for `setReconciliationFailed`: basic failure, missing status creation, and no duplicate conditions

## Test plan

- [x] `go build ./...` — compiles cleanly
- [x] `ginkgo run internal/controllers/computeinstance/` — 38/38 specs pass (3 new)
- [x] `go vet` — clean
- [x] `gofmt` — clean
- [ ] Deploy and verify: create a ComputeInstance without `run_strategy`, confirm status shows FAILED with error message

Supersedes #856

Fixes: [OSAC-1905](https://redhat.atlassian.net/browse/OSAC-1905)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Compute instance reconciliation failures are now recorded in the instance status.
  * Failed reconciliations set the instance state to **FAILED** and mark provisioning as unsuccessful with an explanatory message.
  * Failure status is persisted even when errors occur during updates, deletion, or hub selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->