### PR TITLE
OSAC-2156: Implement ClusterVersion server

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	buf.build/go/protovalidate v1.2.0
 	charm.land/glamour/v2 v2.0.1
 	charm.land/lipgloss/v2 v2.0.5
+	github.com/Masterminds/semver/v3 v3.4.0
 	github.com/alecthomas/chroma/v2 v2.27.0
 	github.com/cenkalti/backoff/v4 v4.3.0
 	github.com/coder/websocket v1.8.15
@@ -55,7 +56,6 @@ require (
 	buf.build/gen/go/pluginrpc/pluginrpc/protocolbuffers/go v1.36.11-20241007202033-cf42259fcbfc.1 // indirect
 	buf.build/go/spdx v0.2.0 // indirect
 	cel.dev/expr v0.25.1 // indirect
-	github.com/Masterminds/semver/v3 v3.4.0 // indirect
 	github.com/agnivade/levenshtein v1.2.1 // indirect
 	github.com/antlr4-go/antlr/v4 v4.13.1 // indirect
 	github.com/aymerick/douceur v0.2.0 // indirect

--- a/internal/api/osac/private/v1/cluster_version_type.pb.go
+++ b/internal/api/osac/private/v1/cluster_version_type.pb.go
@@ -49,7 +49,7 @@ const (
 	// The cluster version is fully available for new cluster creation.
 	//
 	// This is the default state assigned on creation. Returning to ACTIVE from DEPRECATED or OBSOLETE
-	// clears the corresponding deprecation timestamps.
+	// retains the corresponding deprecation timestamps as historical record.
 	ClusterVersionState_CLUSTER_VERSION_STATE_ACTIVE ClusterVersionState = 1
 	// The cluster version is available with warnings; migration to a newer version is recommended.
 	//
@@ -104,8 +104,8 @@ func (x ClusterVersionState) Number() protoreflect.EnumNumber {
 // Contains deprecation details for a cluster version.
 //
 // The timestamps are managed by the server during lifecycle state transitions. The deprecation_timestamp is set when
-// the version transitions to DEPRECATED, and the obsolescence_timestamp is set when it transitions to OBSOLETE. Both
-// are cleared if the version returns to ACTIVE.
+// the version transitions to DEPRECATED, and the obsolescence_timestamp is set when it transitions to OBSOLETE.
+// Timestamps are retained as historical record when the version returns to ACTIVE.
 type ClusterVersionDeprecation struct {
 	state protoimpl.MessageState `protogen:"hybrid.v1"`
 	// When deprecation was announced. Auto-set on transition to DEPRECATED.

--- a/internal/api/osac/private/v1/cluster_version_type_protoopaque.pb.go
+++ b/internal/api/osac/private/v1/cluster_version_type_protoopaque.pb.go
@@ -49,7 +49,7 @@ const (
 	// The cluster version is fully available for new cluster creation.
 	//
 	// This is the default state assigned on creation. Returning to ACTIVE from DEPRECATED or OBSOLETE
-	// clears the corresponding deprecation timestamps.
+	// retains the corresponding deprecation timestamps as historical record.
 	ClusterVersionState_CLUSTER_VERSION_STATE_ACTIVE ClusterVersionState = 1
 	// The cluster version is available with warnings; migration to a newer version is recommended.
 	//
@@ -104,8 +104,8 @@ func (x ClusterVersionState) Number() protoreflect.EnumNumber {
 // Contains deprecation details for a cluster version.
 //
 // The timestamps are managed by the server during lifecycle state transitions. The deprecation_timestamp is set when
-// the version transitions to DEPRECATED, and the obsolescence_timestamp is set when it transitions to OBSOLETE. Both
-// are cleared if the version returns to ACTIVE.
+// the version transitions to DEPRECATED, and the obsolescence_timestamp is set when it transitions to OBSOLETE.
+// Timestamps are retained as historical record when the version returns to ACTIVE.
 type ClusterVersionDeprecation struct {
 	state                            protoimpl.MessageState `protogen:"opaque.v1"`
 	xxx_hidden_DeprecationTimestamp  *timestamppb.Timestamp `protobuf:"bytes,1,opt,name=deprecation_timestamp,json=deprecationTimestamp,proto3"`

--- a/internal/api/osac/public/v1/cluster_version_type.pb.go
+++ b/internal/api/osac/public/v1/cluster_version_type.pb.go
@@ -49,7 +49,7 @@ const (
 	// The cluster version is fully available for new cluster creation.
 	//
 	// This is the default state assigned on creation. Returning to ACTIVE from DEPRECATED or OBSOLETE
-	// clears the corresponding deprecation timestamps.
+	// retains the corresponding deprecation timestamps as historical record.
 	ClusterVersionState_CLUSTER_VERSION_STATE_ACTIVE ClusterVersionState = 1
 	// The cluster version is available with warnings; migration to a newer version is recommended.
 	//
@@ -104,8 +104,8 @@ func (x ClusterVersionState) Number() protoreflect.EnumNumber {
 // Contains deprecation details for a cluster version.
 //
 // The timestamps are managed by the server during lifecycle state transitions. The deprecation_timestamp is set when
-// the version transitions to DEPRECATED, and the obsolescence_timestamp is set when it transitions to OBSOLETE. Both
-// are cleared if the version returns to ACTIVE.
+// the version transitions to DEPRECATED, and the obsolescence_timestamp is set when it transitions to OBSOLETE.
+// Timestamps are retained as historical record when the version returns to ACTIVE.
 type ClusterVersionDeprecation struct {
 	state protoimpl.MessageState `protogen:"hybrid.v1"`
 	// When deprecation was announced. Auto-set on transition to DEPRECATED.

--- a/internal/api/osac/public/v1/cluster_version_type_protoopaque.pb.go
+++ b/internal/api/osac/public/v1/cluster_version_type_protoopaque.pb.go
@@ -49,7 +49,7 @@ const (
 	// The cluster version is fully available for new cluster creation.
 	//
 	// This is the default state assigned on creation. Returning to ACTIVE from DEPRECATED or OBSOLETE
-	// clears the corresponding deprecation timestamps.
+	// retains the corresponding deprecation timestamps as historical record.
 	ClusterVersionState_CLUSTER_VERSION_STATE_ACTIVE ClusterVersionState = 1
 	// The cluster version is available with warnings; migration to a newer version is recommended.
 	//
@@ -104,8 +104,8 @@ func (x ClusterVersionState) Number() protoreflect.EnumNumber {
 // Contains deprecation details for a cluster version.
 //
 // The timestamps are managed by the server during lifecycle state transitions. The deprecation_timestamp is set when
-// the version transitions to DEPRECATED, and the obsolescence_timestamp is set when it transitions to OBSOLETE. Both
-// are cleared if the version returns to ACTIVE.
+// the version transitions to DEPRECATED, and the obsolescence_timestamp is set when it transitions to OBSOLETE.
+// Timestamps are retained as historical record when the version returns to ACTIVE.
 type ClusterVersionDeprecation struct {
 	state                            protoimpl.MessageState `protogen:"opaque.v1"`
 	xxx_hidden_DeprecationTimestamp  *timestamppb.Timestamp `protobuf:"bytes,1,opt,name=deprecation_timestamp,json=deprecationTimestamp,proto3"`

--- a/internal/auth/policies/authz.rego
+++ b/internal/auth/policies/authz.rego
@@ -188,6 +188,8 @@ allow if {
     "/osac.public.v1.ClusterCatalogItems/List",
     "/osac.public.v1.ClusterTemplates/Get",
     "/osac.public.v1.ClusterTemplates/List",
+    "/osac.public.v1.ClusterVersions/Get",
+    "/osac.public.v1.ClusterVersions/List",
     "/osac.public.v1.Clusters/Create",
     "/osac.public.v1.Clusters/Delete",
     "/osac.public.v1.Clusters/Get",

--- a/internal/cmd/service/start/grpcserver/start_grpc_server_cmd.go
+++ b/internal/cmd/service/start/grpcserver/start_grpc_server_cmd.go
@@ -993,6 +993,34 @@ func (c *runnerContext) run(cmd *cobra.Command, argv []string) error { //nolint:
 	}
 	privatev1.RegisterInstanceTypesServer(grpcServer, privateInstanceTypesServer)
 
+	// Create the cluster versions server:
+	c.logger.InfoContext(ctx, "Creating cluster versions server")
+	clusterVersionsServer, err := servers.NewClusterVersionsServer().
+		SetLogger(c.logger).
+		SetNotifier(notifier).
+		SetAttributionLogic(publicAttributionLogic).
+		SetTenancyLogic(tenancyLogic).
+		SetMetricsRegisterer(metricsRegisterer).
+		Build()
+	if err != nil {
+		return fmt.Errorf("failed to create cluster versions server: %w", err)
+	}
+	publicv1.RegisterClusterVersionsServer(grpcServer, clusterVersionsServer)
+
+	// Create the private cluster versions server:
+	c.logger.InfoContext(ctx, "Creating private cluster versions server")
+	privateClusterVersionsServer, err := servers.NewPrivateClusterVersionsServer().
+		SetLogger(c.logger).
+		SetNotifier(notifier).
+		SetAttributionLogic(privateAttributionLogic).
+		SetTenancyLogic(tenancyLogic).
+		SetMetricsRegisterer(metricsRegisterer).
+		Build()
+	if err != nil {
+		return fmt.Errorf("failed to create private cluster versions server: %w", err)
+	}
+	privatev1.RegisterClusterVersionsServer(grpcServer, privateClusterVersionsServer)
+
 	// Create the private storage backends server:
 	c.logger.InfoContext(ctx, "Creating private storage backends server")
 	privateStorageBackendsServer, err := servers.NewPrivateStorageBackendsServer().

--- a/internal/servers/catalog_item_validation.go
+++ b/internal/servers/catalog_item_validation.go
@@ -20,10 +20,8 @@ import (
 	"fmt"
 	"slices"
 	"strings"
-	"sync"
 	"time"
 
-	"github.com/google/cel-go/cel"
 	"github.com/santhosh-tekuri/jsonschema/v6"
 	grpccodes "google.golang.org/grpc/codes"
 	grpcstatus "google.golang.org/grpc/status"
@@ -34,29 +32,6 @@ import (
 	privatev1 "github.com/osac-project/fulfillment-service/internal/api/osac/private/v1"
 	"github.com/osac-project/fulfillment-service/internal/database/dao"
 )
-
-var (
-	celSyntaxEnv     *cel.Env
-	celSyntaxEnvOnce sync.Once
-	celSyntaxEnvErr  error
-)
-
-// validateCELSyntax checks that a filter string is a syntactically valid, complete CEL expression.
-// This prevents filter bypass attacks where a malicious filter like "true) || (true" could
-// break out of parenthesized composition and change operator precedence.
-func validateCELSyntax(filter string) error {
-	celSyntaxEnvOnce.Do(func() {
-		celSyntaxEnv, celSyntaxEnvErr = cel.NewEnv()
-	})
-	if celSyntaxEnvErr != nil {
-		return fmt.Errorf("failed to create CEL environment: %w", celSyntaxEnvErr)
-	}
-	_, issues := celSyntaxEnv.Parse(filter)
-	if issues != nil && issues.Err() != nil {
-		return fmt.Errorf("syntax error: %w", issues.Err())
-	}
-	return nil
-}
 
 // catalogItem is implemented by both ClusterCatalogItem and ComputeInstanceCatalogItem.
 type catalogItem interface {

--- a/internal/servers/catalog_item_validation_test.go
+++ b/internal/servers/catalog_item_validation_test.go
@@ -352,22 +352,4 @@ var _ = Describe("addPublishedFilter", func() {
 		Entry("unbalanced opening paren", `(true`),
 	)
 
-	DescribeTable("validateCELSyntax",
-		func(input string, shouldPass bool) {
-			err := validateCELSyntax(input)
-			if shouldPass {
-				Expect(err).ToNot(HaveOccurred())
-			} else {
-				Expect(err).To(HaveOccurred())
-			}
-		},
-		Entry("valid simple expression", "true", true),
-		Entry("valid field reference", "this.published", true),
-		Entry("valid comparison", "this.id == '123'", true),
-		Entry("valid compound", "this.a && this.b || this.c", true),
-		Entry("unbalanced closing paren", "true)", false),
-		Entry("unbalanced opening paren", "(true", false),
-		Entry("injection attempt", `true) || (true`, false),
-		Entry("empty string is not valid CEL", "", false),
-	)
 })

--- a/internal/servers/cel_filter.go
+++ b/internal/servers/cel_filter.go
@@ -1,0 +1,157 @@
+/*
+Copyright (c) 2025 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package servers
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/google/cel-go/cel"
+	"github.com/google/cel-go/common/ast"
+)
+
+var celSyntaxEnv = func() *cel.Env {
+	env, err := cel.NewEnv()
+	if err != nil {
+		panic(fmt.Sprintf("failed to create CEL environment: %v", err))
+	}
+	return env
+}()
+
+// validateCELSyntax checks that a filter string is a syntactically valid, complete CEL expression.
+// This prevents filter bypass attacks where a malicious filter like "true) || (true" could
+// break out of parenthesized composition and change operator precedence.
+func validateCELSyntax(filter string) error {
+	_, issues := celSyntaxEnv.Parse(filter)
+	if issues != nil && issues.Err() != nil {
+		return fmt.Errorf("syntax error: %w", issues.Err())
+	}
+	return nil
+}
+
+// filterReferencedFields parses a CEL filter and returns the set of all dotted field paths
+// referenced in the expression (e.g. "this.spec.state", "this.metadata.name"). Paths that do not
+// root at an identifier (e.g. function call results) are excluded.
+func filterReferencedFields(filter string) (map[string]bool, error) {
+	parsed, issues := celSyntaxEnv.Parse(filter)
+	if issues != nil && issues.Err() != nil {
+		return nil, fmt.Errorf("syntax error: %w", issues.Err())
+	}
+	fields := make(map[string]bool)
+	nav := ast.NavigateAST(parsed.NativeRep())
+	ast.MatchDescendants(nav, func(e ast.NavigableExpr) bool {
+		if e.Kind() != ast.SelectKind {
+			return false
+		}
+		path := resolveSelectPath(e.AsSelect())
+		if path != "" {
+			fields[path] = true
+		}
+		return false
+	})
+	return fields, nil
+}
+
+// fieldMatchesPrefix reports whether a dotted field path equals the prefix or is a direct child of
+// it (e.g. "this.spec.state" matches prefix "this.spec.state", and "this.spec.state.sub" matches
+// too, but "this.spec.state_machine" does not).
+func fieldMatchesPrefix(field, prefix string) bool {
+	return field == prefix || strings.HasPrefix(field, prefix+".")
+}
+
+// filterReferencesAnyField reports whether the CEL filter expression references a field whose dotted
+// path starts with any of the given prefixes (e.g. "this.spec.state"). Returns an error if
+// the filter has invalid syntax.
+func filterReferencesAnyField(filter string, prefixes ...string) (bool, error) {
+	fields, err := filterReferencedFields(filter)
+	if err != nil {
+		return false, err
+	}
+	for field := range fields {
+		for _, prefix := range prefixes {
+			if fieldMatchesPrefix(field, prefix) {
+				return true, nil
+			}
+		}
+	}
+	return false, nil
+}
+
+// filterDefault pairs a field prefix with the CEL predicate to apply when the user's filter does
+// not reference that field. Used with composeFilterDefaults for per-field default composition.
+type filterDefault struct {
+	field     string // field prefix to check, e.g. "this.spec.state"
+	predicate string // CEL predicate applied when field is absent, e.g. "this.spec.state == 1"
+}
+
+// composeFilterDefaults composes per-field default predicates with a user-provided filter. For each
+// default, the predicate is applied only if the user's filter does not reference that field. The
+// filter is parsed and walked once regardless of the number of defaults.
+func composeFilterDefaults(filter string, defaults []filterDefault) (string, error) {
+	if filter == "" {
+		clauses := make([]string, len(defaults))
+		for i, d := range defaults {
+			clauses[i] = d.predicate
+		}
+		return strings.Join(clauses, " && "), nil
+	}
+
+	fields, err := filterReferencedFields(filter)
+	if err != nil {
+		return "", fmt.Errorf("invalid filter: %w", err)
+	}
+
+	var missing []string
+	for _, d := range defaults {
+		referenced := false
+		for field := range fields {
+			if fieldMatchesPrefix(field, d.field) {
+				referenced = true
+				break
+			}
+		}
+		if !referenced {
+			missing = append(missing, d.predicate)
+		}
+	}
+
+	if len(missing) == 0 {
+		return filter, nil
+	}
+	return "(" + filter + ") && " + strings.Join(missing, " && "), nil
+}
+
+// resolveSelectPath reconstructs the full dotted field path from a chain of select expressions
+// rooted at an identifier. For example, this.spec.state becomes "this.spec.state".
+// Returns "" if the chain does not terminate at an identifier (e.g. a function call result).
+func resolveSelectPath(sel ast.SelectExpr) string {
+	var parts []string
+	for {
+		parts = append(parts, sel.FieldName())
+		operand := sel.Operand()
+		switch operand.Kind() {
+		case ast.SelectKind:
+			sel = operand.AsSelect()
+		case ast.IdentKind:
+			parts = append(parts, operand.AsIdent())
+			// Reverse to get root-to-leaf order:
+			for i, j := 0, len(parts)-1; i < j; i, j = i+1, j-1 {
+				parts[i], parts[j] = parts[j], parts[i]
+			}
+			return strings.Join(parts, ".")
+		default:
+			return ""
+		}
+	}
+}

--- a/internal/servers/cel_filter_test.go
+++ b/internal/servers/cel_filter_test.go
@@ -1,0 +1,162 @@
+/*
+Copyright (c) 2025 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package servers
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("CEL filter utilities", func() {
+	Describe("validateCELSyntax", func() {
+		DescribeTable("validates syntax",
+			func(input string, shouldPass bool) {
+				err := validateCELSyntax(input)
+				if shouldPass {
+					Expect(err).ToNot(HaveOccurred())
+				} else {
+					Expect(err).To(HaveOccurred())
+				}
+			},
+			Entry("valid simple expression", "true", true),
+			Entry("valid field reference", "this.published", true),
+			Entry("valid comparison", "this.id == '123'", true),
+			Entry("valid compound", "this.a && this.b || this.c", true),
+			Entry("unbalanced closing paren", "true)", false),
+			Entry("unbalanced opening paren", "(true", false),
+			Entry("injection attempt", `true) || (true`, false),
+			Entry("empty string is not valid CEL", "", false),
+		)
+	})
+
+	Describe("filterReferencedFields", func() {
+		It("returns all dotted field paths from a compound expression", func() {
+			fields, err := filterReferencedFields(
+				"this.metadata.name == 'x' && this.spec.state == 1 || this.spec.enabled")
+			Expect(err).ToNot(HaveOccurred())
+			// Intermediate selects (this.metadata, this.spec) are also returned because the
+			// AST walker visits every select node in the chain, not just leaves.
+			Expect(fields).To(Equal(map[string]bool{
+				"this.metadata.name": true,
+				"this.metadata":      true,
+				"this.spec.state":    true,
+				"this.spec.enabled":  true,
+				"this.spec":          true,
+			}))
+		})
+
+		It("returns empty map for expression with no field selects", func() {
+			fields, err := filterReferencedFields("true")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(fields).To(BeEmpty())
+		})
+
+		It("returns error for invalid syntax", func() {
+			_, err := filterReferencedFields("true) || (true")
+			Expect(err).To(HaveOccurred())
+		})
+	})
+
+	Describe("filterReferencesAnyField", func() {
+		DescribeTable("detects field references",
+			func(filter string, expected bool, prefixes ...string) {
+				found, err := filterReferencesAnyField(filter, prefixes...)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(found).To(Equal(expected))
+			},
+			Entry("exact field reference",
+				"this.spec.state == 1", true, "this.spec.state"),
+			Entry("child field via prefix",
+				"this.spec.allowed_upgrades.version_names.size() > 0", true, "this.spec.allowed_upgrades"),
+			Entry("sibling field with shared prefix does not match",
+				"this.spec.state_machine == true", false, "this.spec.state"),
+			Entry("unrelated field does not match",
+				"this.spec.enabled == false", false, "this.spec.state"),
+			Entry("one of multiple prefixes matches",
+				"this.spec.enabled == false", true, "this.spec.state", "this.spec.enabled", "this.spec.is_default"),
+			Entry("field in compound expression",
+				"this.metadata.name == 'test' && this.spec.state == 1", true, "this.spec.state"),
+			Entry("no prefix matches",
+				"this.metadata.name == 'test'", false, "this.spec.state"),
+			Entry("disjunction with repeated field",
+				"this.spec.state == 1 || this.spec.state == 2", true, "this.spec.state"),
+		)
+
+		It("returns error for invalid syntax", func() {
+			_, err := filterReferencesAnyField("true) || (true", "this.spec.state")
+			Expect(err).To(HaveOccurred())
+		})
+
+	})
+
+	Describe("composeFilterDefaults", func() {
+		defaults := []filterDefault{
+			{field: "this.spec.state", predicate: "(this.spec.state == 1 || this.spec.state == 2)"},
+			{field: "this.spec.enabled", predicate: "this.spec.enabled == true"},
+		}
+
+		It("applies all defaults when filter is empty", func() {
+			result, err := composeFilterDefaults("", defaults)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result).To(Equal(
+				"(this.spec.state == 1 || this.spec.state == 2) && this.spec.enabled == true"))
+		})
+
+		It("applies all defaults when filter references unrelated field", func() {
+			result, err := composeFilterDefaults("this.metadata.name == 'test'", defaults)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result).To(Equal(
+				"(this.metadata.name == 'test') && " +
+					"(this.spec.state == 1 || this.spec.state == 2) && " +
+					"this.spec.enabled == true"))
+		})
+
+		It("skips state default when filter references state", func() {
+			result, err := composeFilterDefaults("this.spec.state == 3", defaults)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result).To(Equal(
+				"(this.spec.state == 3) && this.spec.enabled == true"))
+		})
+
+		It("skips enabled default when filter references enabled", func() {
+			result, err := composeFilterDefaults("this.spec.enabled == false", defaults)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result).To(Equal(
+				"(this.spec.enabled == false) && (this.spec.state == 1 || this.spec.state == 2)"))
+		})
+
+		It("skips all defaults when filter references all fields", func() {
+			result, err := composeFilterDefaults(
+				"this.spec.state == 3 && this.spec.enabled == false", defaults)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result).To(Equal("this.spec.state == 3 && this.spec.enabled == false"))
+		})
+
+		It("returns error for invalid filter", func() {
+			_, err := composeFilterDefaults("true) || (true", defaults)
+			Expect(err).To(HaveOccurred())
+		})
+
+		It("skips default when child field is referenced", func() {
+			childDefaults := []filterDefault{
+				{field: "this.spec.upgrades", predicate: "this.spec.upgrades.enabled == true"},
+			}
+			result, err := composeFilterDefaults(
+				"this.spec.upgrades.count > 0", childDefaults)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result).To(Equal("this.spec.upgrades.count > 0"))
+		})
+	})
+
+})

--- a/internal/servers/cluster_versions_server.go
+++ b/internal/servers/cluster_versions_server.go
@@ -1,0 +1,323 @@
+/*
+Copyright (c) 2025 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package servers
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+
+	"github.com/prometheus/client_golang/prometheus"
+	grpccodes "google.golang.org/grpc/codes"
+	grpcstatus "google.golang.org/grpc/status"
+
+	privatev1 "github.com/osac-project/fulfillment-service/internal/api/osac/private/v1"
+	publicv1 "github.com/osac-project/fulfillment-service/internal/api/osac/public/v1"
+	"github.com/osac-project/fulfillment-service/internal/auth"
+	"github.com/osac-project/fulfillment-service/internal/events"
+)
+
+// clusterVersionFilterDefaults defines per-field default predicates for public List requests.
+// Each default is applied independently: if the user's filter references a field, that field's
+// default is skipped. Uses numeric enum values because CEL types proto enums as int.
+var clusterVersionFilterDefaults = []filterDefault{
+	{
+		field: "this.spec.state",
+		predicate: fmt.Sprintf("(this.spec.state == %d || this.spec.state == %d)",
+			int32(privatev1.ClusterVersionState_CLUSTER_VERSION_STATE_ACTIVE),
+			int32(privatev1.ClusterVersionState_CLUSTER_VERSION_STATE_DEPRECATED)),
+	},
+	{
+		field:     "this.spec.enabled",
+		predicate: "this.spec.enabled == true",
+	},
+}
+
+type ClusterVersionsServerBuilder struct {
+	logger            *slog.Logger
+	notifier          events.Notifier
+	attributionLogic  auth.AttributionLogic
+	tenancyLogic      auth.TenancyLogic
+	metricsRegisterer prometheus.Registerer
+}
+
+var _ publicv1.ClusterVersionsServer = (*ClusterVersionsServer)(nil)
+
+type ClusterVersionsServer struct {
+	publicv1.UnimplementedClusterVersionsServer
+
+	logger    *slog.Logger
+	delegate  privatev1.ClusterVersionsServer
+	inMapper  *GenericMapper[*publicv1.ClusterVersion, *privatev1.ClusterVersion]
+	outMapper *GenericMapper[*privatev1.ClusterVersion, *publicv1.ClusterVersion]
+}
+
+func NewClusterVersionsServer() *ClusterVersionsServerBuilder {
+	return &ClusterVersionsServerBuilder{}
+}
+
+// SetLogger sets the logger to use. This is mandatory.
+func (b *ClusterVersionsServerBuilder) SetLogger(value *slog.Logger) *ClusterVersionsServerBuilder {
+	b.logger = value
+	return b
+}
+
+// SetNotifier sets the notifier to use. This is optional.
+func (b *ClusterVersionsServerBuilder) SetNotifier(value events.Notifier) *ClusterVersionsServerBuilder {
+	b.notifier = value
+	return b
+}
+
+// SetAttributionLogic sets the attribution logic to use. This is mandatory.
+func (b *ClusterVersionsServerBuilder) SetAttributionLogic(value auth.AttributionLogic) *ClusterVersionsServerBuilder {
+	b.attributionLogic = value
+	return b
+}
+
+// SetTenancyLogic sets the tenancy logic to use. This is mandatory.
+func (b *ClusterVersionsServerBuilder) SetTenancyLogic(value auth.TenancyLogic) *ClusterVersionsServerBuilder {
+	b.tenancyLogic = value
+	return b
+}
+
+// SetMetricsRegisterer sets the Prometheus registerer used to register the metrics for the underlying database
+// access objects. This is optional. If not set, no metrics will be recorded.
+func (b *ClusterVersionsServerBuilder) SetMetricsRegisterer(value prometheus.Registerer) *ClusterVersionsServerBuilder {
+	b.metricsRegisterer = value
+	return b
+}
+
+func (b *ClusterVersionsServerBuilder) Build() (*ClusterVersionsServer, error) {
+	if b.logger == nil {
+		return nil, errors.New("logger is mandatory")
+	}
+	if b.attributionLogic == nil {
+		return nil, errors.New("attribution logic is mandatory")
+	}
+	if b.tenancyLogic == nil {
+		return nil, errors.New("tenancy logic is mandatory")
+	}
+
+	inMapper, err := NewGenericMapper[*publicv1.ClusterVersion, *privatev1.ClusterVersion]().
+		SetLogger(b.logger).
+		SetStrict(true).
+		AddIgnoredFields("osac.public.v1.ClusterVersionSpec.is_default").
+		Build()
+	if err != nil {
+		return nil, err
+	}
+	outMapper, err := NewGenericMapper[*privatev1.ClusterVersion, *publicv1.ClusterVersion]().
+		SetLogger(b.logger).
+		SetStrict(false).
+		Build()
+	if err != nil {
+		return nil, err
+	}
+
+	delegate, err := NewPrivateClusterVersionsServer().
+		SetLogger(b.logger).
+		SetNotifier(b.notifier).
+		SetAttributionLogic(b.attributionLogic).
+		SetTenancyLogic(b.tenancyLogic).
+		SetMetricsRegisterer(b.metricsRegisterer).
+		Build()
+	if err != nil {
+		return nil, err
+	}
+
+	return &ClusterVersionsServer{
+		logger:    b.logger,
+		delegate:  delegate,
+		inMapper:  inMapper,
+		outMapper: outMapper,
+	}, nil
+}
+
+func (s *ClusterVersionsServer) List(ctx context.Context,
+	request *publicv1.ClusterVersionsListRequest) (*publicv1.ClusterVersionsListResponse, error) {
+	privateRequest := &privatev1.ClusterVersionsListRequest{}
+	privateRequest.SetOffset(request.GetOffset())
+	privateRequest.SetLimit(request.GetLimit())
+	composedFilter, err := composeFilterDefaults(request.GetFilter(), clusterVersionFilterDefaults)
+	if err != nil {
+		return nil, grpcstatus.Errorf(grpccodes.InvalidArgument, "%v", err)
+	}
+	privateRequest.SetFilter(composedFilter)
+	privateRequest.SetOrder(request.GetOrder())
+
+	privateResponse, err := s.delegate.List(ctx, privateRequest)
+	if err != nil {
+		return nil, err
+	}
+
+	privateItems := privateResponse.GetItems()
+	publicItems := make([]*publicv1.ClusterVersion, len(privateItems))
+	for i, privateItem := range privateItems {
+		publicItem := &publicv1.ClusterVersion{}
+		err = s.outMapper.Copy(ctx, privateItem, publicItem)
+		if err != nil {
+			s.logger.ErrorContext(
+				ctx,
+				"Failed to map private cluster version to public",
+				slog.Any("error", err),
+			)
+			return nil, grpcstatus.Errorf(grpccodes.Internal, "failed to process cluster versions")
+		}
+		publicItems[i] = publicItem
+	}
+
+	response := &publicv1.ClusterVersionsListResponse{}
+	response.SetSize(privateResponse.GetSize())
+	response.SetTotal(privateResponse.GetTotal())
+	response.SetItems(publicItems)
+	return response, nil
+}
+
+func (s *ClusterVersionsServer) Get(ctx context.Context,
+	request *publicv1.ClusterVersionsGetRequest) (*publicv1.ClusterVersionsGetResponse, error) {
+	privateRequest := &privatev1.ClusterVersionsGetRequest{}
+	privateRequest.SetId(request.GetId())
+
+	privateResponse, err := s.delegate.Get(ctx, privateRequest)
+	if err != nil {
+		return nil, err
+	}
+
+	privateClusterVersion := privateResponse.GetObject()
+	publicClusterVersion := &publicv1.ClusterVersion{}
+	err = s.outMapper.Copy(ctx, privateClusterVersion, publicClusterVersion)
+	if err != nil {
+		s.logger.ErrorContext(
+			ctx,
+			"Failed to map private cluster version to public",
+			slog.Any("error", err),
+		)
+		return nil, grpcstatus.Errorf(grpccodes.Internal, "failed to process cluster version")
+	}
+
+	response := &publicv1.ClusterVersionsGetResponse{}
+	response.SetObject(publicClusterVersion)
+	return response, nil
+}
+
+func (s *ClusterVersionsServer) Create(ctx context.Context,
+	request *publicv1.ClusterVersionsCreateRequest) (*publicv1.ClusterVersionsCreateResponse, error) {
+	publicClusterVersion := request.GetObject()
+	if publicClusterVersion == nil {
+		return nil, grpcstatus.Errorf(grpccodes.InvalidArgument, "object is mandatory")
+	}
+	privateClusterVersion := &privatev1.ClusterVersion{}
+	err := s.inMapper.Copy(ctx, publicClusterVersion, privateClusterVersion)
+	if err != nil {
+		s.logger.ErrorContext(
+			ctx,
+			"Failed to map public cluster version to private",
+			slog.Any("error", err),
+		)
+		return nil, grpcstatus.Errorf(grpccodes.Internal, "failed to process cluster version")
+	}
+
+	privateRequest := &privatev1.ClusterVersionsCreateRequest{}
+	privateRequest.SetObject(privateClusterVersion)
+	privateResponse, err := s.delegate.Create(ctx, privateRequest)
+	if err != nil {
+		return nil, err
+	}
+
+	createdPrivateClusterVersion := privateResponse.GetObject()
+	createdPublicClusterVersion := &publicv1.ClusterVersion{}
+	err = s.outMapper.Copy(ctx, createdPrivateClusterVersion, createdPublicClusterVersion)
+	if err != nil {
+		s.logger.ErrorContext(
+			ctx,
+			"Failed to map private cluster version to public",
+			slog.Any("error", err),
+		)
+		return nil, grpcstatus.Errorf(grpccodes.Internal, "failed to process cluster version")
+	}
+
+	response := &publicv1.ClusterVersionsCreateResponse{}
+	response.SetObject(createdPublicClusterVersion)
+	return response, nil
+}
+
+func (s *ClusterVersionsServer) Update(ctx context.Context,
+	request *publicv1.ClusterVersionsUpdateRequest) (*publicv1.ClusterVersionsUpdateResponse, error) {
+	publicClusterVersion := request.GetObject()
+	if publicClusterVersion == nil {
+		return nil, grpcstatus.Errorf(grpccodes.InvalidArgument, "object is mandatory")
+	}
+	id := publicClusterVersion.GetId()
+	if id == "" {
+		return nil, grpcstatus.Errorf(grpccodes.InvalidArgument, "object identifier is mandatory")
+	}
+
+	getRequest := &privatev1.ClusterVersionsGetRequest{}
+	getRequest.SetId(id)
+	getResponse, err := s.delegate.Get(ctx, getRequest)
+	if err != nil {
+		return nil, err
+	}
+	privateClusterVersion := getResponse.GetObject()
+
+	// Map the public changes to the private object (preserving private-only fields like spec.image):
+	err = s.inMapper.Copy(ctx, publicClusterVersion, privateClusterVersion)
+	if err != nil {
+		s.logger.ErrorContext(
+			ctx,
+			"Failed to map public cluster version to private",
+			slog.Any("error", err),
+		)
+		return nil, grpcstatus.Errorf(grpccodes.Internal, "failed to process cluster version")
+	}
+
+	privateRequest := &privatev1.ClusterVersionsUpdateRequest{}
+	privateRequest.SetObject(privateClusterVersion)
+	privateRequest.SetUpdateMask(request.GetUpdateMask())
+	privateRequest.SetLock(request.GetLock())
+	privateResponse, err := s.delegate.Update(ctx, privateRequest)
+	if err != nil {
+		return nil, err
+	}
+
+	updatedPrivateClusterVersion := privateResponse.GetObject()
+	updatedPublicClusterVersion := &publicv1.ClusterVersion{}
+	err = s.outMapper.Copy(ctx, updatedPrivateClusterVersion, updatedPublicClusterVersion)
+	if err != nil {
+		s.logger.ErrorContext(
+			ctx,
+			"Failed to map private cluster version to public",
+			slog.Any("error", err),
+		)
+		return nil, grpcstatus.Errorf(grpccodes.Internal, "failed to process cluster version")
+	}
+
+	response := &publicv1.ClusterVersionsUpdateResponse{}
+	response.SetObject(updatedPublicClusterVersion)
+	return response, nil
+}
+
+func (s *ClusterVersionsServer) Delete(ctx context.Context,
+	request *publicv1.ClusterVersionsDeleteRequest) (*publicv1.ClusterVersionsDeleteResponse, error) {
+	privateRequest := &privatev1.ClusterVersionsDeleteRequest{}
+	privateRequest.SetId(request.GetId())
+
+	_, err := s.delegate.Delete(ctx, privateRequest)
+	if err != nil {
+		return nil, err
+	}
+
+	return &publicv1.ClusterVersionsDeleteResponse{}, nil
+}

--- a/internal/servers/cluster_versions_server_test.go
+++ b/internal/servers/cluster_versions_server_test.go
@@ -1,0 +1,223 @@
+/*
+Copyright (c) 2025 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package servers
+
+import (
+	"fmt"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"google.golang.org/protobuf/types/known/fieldmaskpb"
+
+	privatev1 "github.com/osac-project/fulfillment-service/internal/api/osac/private/v1"
+	publicv1 "github.com/osac-project/fulfillment-service/internal/api/osac/public/v1"
+)
+
+var _ = Describe("Public cluster versions server", func() {
+	Describe("Behaviour", func() {
+		var (
+			publicServer         *ClusterVersionsServer
+			privateServer        *PrivateClusterVersionsServer
+			createClusterVersion func(name, version string, opts ...func(*privatev1.ClusterVersionSpec_builder)) *privatev1.ClusterVersion
+		)
+
+		BeforeEach(func() {
+			var err error
+
+			// Create the public server:
+			publicServer, err = NewClusterVersionsServer().
+				SetLogger(logger).
+				SetAttributionLogic(attribution).
+				SetTenancyLogic(tenancy).
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+
+			// Create a private server for test data setup:
+			privateServer, err = NewPrivateClusterVersionsServer().
+				SetLogger(logger).
+				SetAttributionLogic(attribution).
+				SetTenancyLogic(tenancy).
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+
+			// Helper to create a cluster version via the private server.
+			createClusterVersion = func(name string, version string,
+				opts ...func(*privatev1.ClusterVersionSpec_builder)) *privatev1.ClusterVersion {
+				spec := privatev1.ClusterVersionSpec_builder{
+					Version: version,
+					Image:   "quay.io/ocp:" + version,
+				}
+				for _, opt := range opts {
+					opt(&spec)
+				}
+				response, err := privateServer.Create(ctx, privatev1.ClusterVersionsCreateRequest_builder{
+					Object: privatev1.ClusterVersion_builder{
+						Metadata: privatev1.Metadata_builder{
+							Name: name,
+						}.Build(),
+						Spec: spec.Build(),
+					}.Build(),
+				}.Build())
+				Expect(err).ToNot(HaveOccurred())
+				return response.GetObject()
+			}
+		})
+
+		It("Lists ACTIVE and DEPRECATED by default, hides OBSOLETE and disabled", func() {
+			active := createClusterVersion("pub-active", "4.17.0")
+			deprecated := createClusterVersion("pub-deprecated", "4.16.0", func(s *privatev1.ClusterVersionSpec_builder) {
+				s.State = privatev1.ClusterVersionState_CLUSTER_VERSION_STATE_DEPRECATED
+			})
+			obsolete := createClusterVersion("pub-obsolete", "4.15.0", func(s *privatev1.ClusterVersionSpec_builder) {
+				s.State = privatev1.ClusterVersionState_CLUSTER_VERSION_STATE_OBSOLETE
+			})
+			disabled := createClusterVersion("pub-disabled", "4.14.0", func(s *privatev1.ClusterVersionSpec_builder) {
+				s.Enabled = new(false)
+			})
+
+			// Public List without filter should return only ACTIVE + DEPRECATED + enabled:
+			response, err := publicServer.List(ctx,
+				publicv1.ClusterVersionsListRequest_builder{}.Build())
+			Expect(err).ToNot(HaveOccurred())
+			Expect(response.GetItems()).To(HaveLen(2))
+
+			ids := make([]string, len(response.GetItems()))
+			for i, item := range response.GetItems() {
+				ids[i] = item.GetId()
+			}
+			Expect(ids).To(ContainElement(active.GetId()))
+			Expect(ids).To(ContainElement(deprecated.GetId()))
+			Expect(ids).ToNot(ContainElement(obsolete.GetId()))
+			Expect(ids).ToNot(ContainElement(disabled.GetId()))
+		})
+
+		It("Lists OBSOLETE when filter includes state", func() {
+			createClusterVersion("filter-active", "4.17.0")
+			obsolete := createClusterVersion("filter-obsolete", "4.15.0", func(s *privatev1.ClusterVersionSpec_builder) {
+				s.State = privatev1.ClusterVersionState_CLUSTER_VERSION_STATE_OBSOLETE
+			})
+
+			response, err := publicServer.List(ctx, publicv1.ClusterVersionsListRequest_builder{
+				Filter: new(fmt.Sprintf("this.spec.state == %d",
+					int32(privatev1.ClusterVersionState_CLUSTER_VERSION_STATE_OBSOLETE))),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+			Expect(response.GetItems()).To(HaveLen(1))
+			Expect(response.GetItems()[0].GetId()).To(Equal(obsolete.GetId()))
+		})
+
+		It("Lists disabled when filter includes enabled", func() {
+			createClusterVersion("enabled-active", "4.17.0")
+			disabled := createClusterVersion("enabled-disabled", "4.16.0", func(s *privatev1.ClusterVersionSpec_builder) {
+				s.Enabled = new(false)
+			})
+
+			response, err := publicServer.List(ctx, publicv1.ClusterVersionsListRequest_builder{
+				Filter: new("this.spec.enabled == false"),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+			Expect(response.GetItems()).To(HaveLen(1))
+			Expect(response.GetItems()[0].GetId()).To(Equal(disabled.GetId()))
+		})
+
+		It("Filter by is_default still applies state and enabled defaults", func() {
+			// Create an ACTIVE default version and a non-default ACTIVE version:
+			defaultCv := createClusterVersion("isdef-active", "4.17.0", func(s *privatev1.ClusterVersionSpec_builder) {
+				s.IsDefault = new(true)
+			})
+
+			createClusterVersion("isdef-other", "4.16.0")
+
+			// Filter by is_default — should still apply state and enabled defaults,
+			// returning only the ACTIVE default version:
+			response, err := publicServer.List(ctx, publicv1.ClusterVersionsListRequest_builder{
+				Filter: new("this.spec.is_default == true"),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+			Expect(response.GetItems()).To(HaveLen(1))
+			Expect(response.GetItems()[0].GetId()).To(Equal(defaultCv.GetId()))
+		})
+
+		It("Filter by state only still applies enabled default", func() {
+			createClusterVersion("state-only-active", "4.17.0")
+			createClusterVersion("state-only-obsolete", "4.15.0", func(s *privatev1.ClusterVersionSpec_builder) {
+				s.State = privatev1.ClusterVersionState_CLUSTER_VERSION_STATE_OBSOLETE
+				s.Enabled = new(false)
+			})
+
+			response, err := publicServer.List(ctx, publicv1.ClusterVersionsListRequest_builder{
+				Filter: new(fmt.Sprintf("this.spec.state == %d",
+					int32(privatev1.ClusterVersionState_CLUSTER_VERSION_STATE_OBSOLETE))),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+			// The disabled OBSOLETE version should be hidden by the enabled default:
+			Expect(response.GetItems()).To(BeEmpty())
+		})
+
+		It("Gets any cluster version regardless of state", func() {
+			obsolete := createClusterVersion("get-obsolete", "4.15.0", func(s *privatev1.ClusterVersionSpec_builder) {
+				s.State = privatev1.ClusterVersionState_CLUSTER_VERSION_STATE_OBSOLETE
+			})
+
+			getResponse, err := publicServer.Get(ctx, publicv1.ClusterVersionsGetRequest_builder{
+				Id: obsolete.GetId(),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+			Expect(getResponse.GetObject()).ToNot(BeNil())
+			Expect(getResponse.GetObject().GetId()).To(Equal(obsolete.GetId()))
+		})
+
+		It("Public response includes is_default", func() {
+			cv := createClusterVersion("default-visible", "4.17.0", func(s *privatev1.ClusterVersionSpec_builder) {
+				s.IsDefault = new(true)
+			})
+
+			getResponse, err := publicServer.Get(ctx, publicv1.ClusterVersionsGetRequest_builder{
+				Id: cv.GetId(),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+			Expect(getResponse.GetObject().GetSpec().GetIsDefault()).To(BeTrue())
+		})
+
+		It("Public Update ignores caller-set is_default", func() {
+			// Create a default version via private:
+			defaultCv := createClusterVersion("existing-default", "4.17.0", func(s *privatev1.ClusterVersionSpec_builder) {
+				s.IsDefault = new(true)
+			})
+
+			// Create a non-default version via private:
+			other := createClusterVersion("non-default", "4.18.0")
+
+			// Try to set is_default via public Update — should be ignored by the inMapper:
+			_, err := publicServer.Update(ctx, publicv1.ClusterVersionsUpdateRequest_builder{
+				Object: publicv1.ClusterVersion_builder{
+					Id: other.GetId(),
+					Spec: publicv1.ClusterVersionSpec_builder{
+						IsDefault: new(true),
+					}.Build(),
+				}.Build(),
+				UpdateMask: &fieldmaskpb.FieldMask{Paths: []string{"spec.is_default"}},
+			}.Build())
+			// The inMapper ignores is_default, so the update goes through but the field
+			// is not changed. Verify the original default is still the default:
+			Expect(err).ToNot(HaveOccurred())
+
+			getResponse, err := publicServer.Get(ctx, publicv1.ClusterVersionsGetRequest_builder{
+				Id: defaultCv.GetId(),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+			Expect(getResponse.GetObject().GetSpec().GetIsDefault()).To(BeTrue())
+		})
+	})
+})

--- a/internal/servers/instance_types_server.go
+++ b/internal/servers/instance_types_server.go
@@ -18,7 +18,6 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
-	"strings"
 
 	"github.com/prometheus/client_golang/prometheus"
 	grpccodes "google.golang.org/grpc/codes"
@@ -30,14 +29,17 @@ import (
 	"github.com/osac-project/fulfillment-service/internal/events"
 )
 
-// defaultInstanceTypeStateFilter is the default CEL filter applied to public List requests.
-// It hides OBSOLETE instance types unless the user explicitly filters by state.
-// Uses numeric enum values because CEL types proto enums as int.
-var defaultInstanceTypeStateFilter = fmt.Sprintf(
-	"this.spec.state == %d || this.spec.state == %d",
-	int32(privatev1.InstanceTypeState_INSTANCE_TYPE_STATE_ACTIVE),
-	int32(privatev1.InstanceTypeState_INSTANCE_TYPE_STATE_DEPRECATED),
-)
+// instanceTypeFilterDefaults defines per-field default predicates for public List requests.
+// Each default is applied independently: if the user's filter references a field, that field's
+// default is skipped. Uses numeric enum values because CEL types proto enums as int.
+var instanceTypeFilterDefaults = []filterDefault{
+	{
+		field: "this.spec.state",
+		predicate: fmt.Sprintf("(this.spec.state == %d || this.spec.state == %d)",
+			int32(privatev1.InstanceTypeState_INSTANCE_TYPE_STATE_ACTIVE),
+			int32(privatev1.InstanceTypeState_INSTANCE_TYPE_STATE_DEPRECATED)),
+	},
+}
 
 type InstanceTypesServerBuilder struct {
 	logger            *slog.Logger
@@ -152,9 +154,9 @@ func (s *InstanceTypesServer) List(ctx context.Context,
 	privateRequest := &privatev1.InstanceTypesListRequest{}
 	privateRequest.SetOffset(request.GetOffset())
 	privateRequest.SetLimit(request.GetLimit())
-	composedFilter, err := s.addDefaultStateFilter(request.GetFilter())
+	composedFilter, err := composeFilterDefaults(request.GetFilter(), instanceTypeFilterDefaults)
 	if err != nil {
-		return nil, err
+		return nil, grpcstatus.Errorf(grpccodes.InvalidArgument, "%v", err)
 	}
 	privateRequest.SetFilter(composedFilter)
 	privateRequest.SetOrder(request.GetOrder())
@@ -188,23 +190,6 @@ func (s *InstanceTypesServer) List(ctx context.Context,
 	response.SetTotal(privateResponse.GetTotal())
 	response.SetItems(publicItems)
 	return
-}
-
-// addDefaultStateFilter composes the default state filter with the user-provided filter.
-// If the user provides no filter, returns the default (ACTIVE + DEPRECATED only).
-// If the user explicitly filters by this.spec.state, the default is not applied (allowing OBSOLETE opt-in).
-// Otherwise, the user filter is composed with the default using AND.
-func (s *InstanceTypesServer) addDefaultStateFilter(filter string) (string, error) {
-	if filter == "" {
-		return defaultInstanceTypeStateFilter, nil
-	}
-	if err := validateCELSyntax(filter); err != nil {
-		return "", grpcstatus.Errorf(grpccodes.InvalidArgument, "invalid filter: %v", err)
-	}
-	if strings.Contains(filter, "this.spec.state") {
-		return filter, nil
-	}
-	return "(" + filter + ") && (" + defaultInstanceTypeStateFilter + ")", nil
 }
 
 func (s *InstanceTypesServer) Get(ctx context.Context,

--- a/internal/servers/private_cluster_versions_server.go
+++ b/internal/servers/private_cluster_versions_server.go
@@ -1,0 +1,520 @@
+/*
+Copyright (c) 2025 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package servers
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"hash/fnv"
+	"log/slog"
+	"strconv"
+	"strings"
+
+	semver "github.com/Masterminds/semver/v3"
+	"github.com/prometheus/client_golang/prometheus"
+	grpccodes "google.golang.org/grpc/codes"
+	grpcstatus "google.golang.org/grpc/status"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	privatev1 "github.com/osac-project/fulfillment-service/internal/api/osac/private/v1"
+	"github.com/osac-project/fulfillment-service/internal/auth"
+	"github.com/osac-project/fulfillment-service/internal/database/dao"
+	"github.com/osac-project/fulfillment-service/internal/events"
+)
+
+const maxSemVerLength = 256
+
+type PrivateClusterVersionsServerBuilder struct {
+	logger            *slog.Logger
+	notifier          events.Notifier
+	attributionLogic  auth.AttributionLogic
+	tenancyLogic      auth.TenancyLogic
+	metricsRegisterer prometheus.Registerer
+}
+
+var _ privatev1.ClusterVersionsServer = (*PrivateClusterVersionsServer)(nil)
+
+type PrivateClusterVersionsServer struct {
+	privatev1.UnimplementedClusterVersionsServer
+
+	logger  *slog.Logger
+	generic *GenericServer[*privatev1.ClusterVersion]
+}
+
+func NewPrivateClusterVersionsServer() *PrivateClusterVersionsServerBuilder {
+	return &PrivateClusterVersionsServerBuilder{}
+}
+
+func (b *PrivateClusterVersionsServerBuilder) SetLogger(value *slog.Logger) *PrivateClusterVersionsServerBuilder {
+	b.logger = value
+	return b
+}
+
+func (b *PrivateClusterVersionsServerBuilder) SetNotifier(value events.Notifier) *PrivateClusterVersionsServerBuilder {
+	b.notifier = value
+	return b
+}
+
+func (b *PrivateClusterVersionsServerBuilder) SetAttributionLogic(value auth.AttributionLogic) *PrivateClusterVersionsServerBuilder {
+	b.attributionLogic = value
+	return b
+}
+
+func (b *PrivateClusterVersionsServerBuilder) SetTenancyLogic(value auth.TenancyLogic) *PrivateClusterVersionsServerBuilder {
+	b.tenancyLogic = value
+	return b
+}
+
+// SetMetricsRegisterer sets the Prometheus registerer used to register the metrics for the underlying database
+// access objects. This is optional. If not set, no metrics will be recorded.
+func (b *PrivateClusterVersionsServerBuilder) SetMetricsRegisterer(value prometheus.Registerer) *PrivateClusterVersionsServerBuilder {
+	b.metricsRegisterer = value
+	return b
+}
+
+func (b *PrivateClusterVersionsServerBuilder) Build() (*PrivateClusterVersionsServer, error) {
+	if b.logger == nil {
+		return nil, errors.New("logger is mandatory")
+	}
+	if b.tenancyLogic == nil {
+		return nil, errors.New("tenancy logic is mandatory")
+	}
+
+	generic, err := NewGenericServer[*privatev1.ClusterVersion]().
+		SetLogger(b.logger).
+		SetService(privatev1.ClusterVersions_ServiceDesc.ServiceName).
+		SetNotifier(b.notifier).
+		SetAttributionLogic(b.attributionLogic).
+		SetTenancyLogic(b.tenancyLogic).
+		SetMetricsRegisterer(b.metricsRegisterer).
+		Build()
+	if err != nil {
+		return nil, err
+	}
+
+	return &PrivateClusterVersionsServer{
+		logger:  b.logger,
+		generic: generic,
+	}, nil
+}
+
+func (s *PrivateClusterVersionsServer) List(ctx context.Context,
+	request *privatev1.ClusterVersionsListRequest) (*privatev1.ClusterVersionsListResponse, error) {
+	var response *privatev1.ClusterVersionsListResponse
+	err := s.generic.List(ctx, request, &response)
+	return response, err
+}
+
+func (s *PrivateClusterVersionsServer) Get(ctx context.Context,
+	request *privatev1.ClusterVersionsGetRequest) (*privatev1.ClusterVersionsGetResponse, error) {
+	var response *privatev1.ClusterVersionsGetResponse
+	err := s.generic.Get(ctx, request, &response)
+	return response, err
+}
+
+func (s *PrivateClusterVersionsServer) Create(ctx context.Context,
+	request *privatev1.ClusterVersionsCreateRequest) (*privatev1.ClusterVersionsCreateResponse, error) {
+	cv, err := validateClusterVersionCreateRequest(request)
+	if err != nil {
+		return nil, err
+	}
+
+	applyClusterVersionDefaults(cv)
+
+	// Clear caller-provided ID so the DAO always generates a UUID:
+	cv.SetId("")
+
+	// Safe to clear existing defaults before Create: the gRPC interceptor wraps the entire
+	// RPC in a single transaction, so the clear and Insert commit together — other connections
+	// never see a state with zero defaults.
+	if cv.GetSpec().GetIsDefault() {
+		if err := validateIsDefaultEligibility(cv); err != nil {
+			return nil, err
+		}
+		if err := s.unsetPreviousDefaultClusterVersion(ctx, cv.GetId()); err != nil {
+			return nil, err
+		}
+	}
+
+	var response *privatev1.ClusterVersionsCreateResponse
+	err = s.generic.Create(ctx, request, &response)
+	return response, err
+}
+
+func (s *PrivateClusterVersionsServer) Update(ctx context.Context,
+	request *privatev1.ClusterVersionsUpdateRequest) (*privatev1.ClusterVersionsUpdateResponse, error) {
+	id := request.GetObject().GetId()
+	if id == "" {
+		return nil, grpcstatus.Errorf(grpccodes.InvalidArgument, "object identifier is mandatory")
+	}
+
+	var getResponse *privatev1.ClusterVersionsGetResponse
+	err := s.generic.Get(ctx, &privatev1.ClusterVersionsGetRequest{Id: id}, &getResponse)
+	if err != nil {
+		return nil, err
+	}
+
+	existing := getResponse.GetObject()
+
+	if updateIncludesField(request.GetUpdateMask(), "spec") && request.GetObject().GetSpec() == nil {
+		return nil, grpcstatus.Errorf(grpccodes.InvalidArgument, "object spec is mandatory when updating spec fields")
+	}
+
+	if err := validateClusterVersionImmutability(existing, request); err != nil {
+		return nil, err
+	}
+
+	// Reject explicit is_default=true on ineligible versions (OBSOLETE or disabled).
+	// The auto-clear path in applyClusterVersionStateEffects handles the transition case
+	// where is_default is not in the mask.
+	if updateIncludesField(request.GetUpdateMask(), "spec.is_default") &&
+		request.GetObject().GetSpec().GetIsDefault() {
+		if !resolveEnabled(existing, request) {
+			return nil, grpcstatus.Errorf(grpccodes.InvalidArgument,
+				"cannot set 'is_default' on a disabled cluster version")
+		}
+		if resolveState(existing, request) == privatev1.ClusterVersionState_CLUSTER_VERSION_STATE_OBSOLETE {
+			return nil, grpcstatus.Errorf(grpccodes.InvalidArgument,
+				"cannot set 'is_default' on an obsolete cluster version")
+		}
+	}
+
+	applyClusterVersionStateEffects(existing, request)
+
+	if resolveIsDefault(existing, request) {
+		if err := s.unsetPreviousDefaultClusterVersion(ctx, id); err != nil {
+			return nil, err
+		}
+	}
+
+	var response *privatev1.ClusterVersionsUpdateResponse
+	err = s.generic.Update(ctx, request, &response)
+	if err != nil {
+		// Concurrent default-swap: remap AlreadyExists to FailedPrecondition.
+		if request.GetObject().GetSpec().GetIsDefault() {
+			if st, ok := grpcstatus.FromError(err); ok && st.Code() == grpccodes.AlreadyExists {
+				return nil, grpcstatus.Errorf(grpccodes.FailedPrecondition,
+					"concurrent default ClusterVersion change detected, please retry")
+			}
+		}
+	}
+	return response, err
+}
+
+func (s *PrivateClusterVersionsServer) Delete(ctx context.Context,
+	request *privatev1.ClusterVersionsDeleteRequest) (*privatev1.ClusterVersionsDeleteResponse, error) {
+	var response *privatev1.ClusterVersionsDeleteResponse
+	err := s.generic.Delete(ctx, request, &response)
+	return response, err
+}
+
+func (s *PrivateClusterVersionsServer) Signal(ctx context.Context,
+	request *privatev1.ClusterVersionsSignalRequest) (*privatev1.ClusterVersionsSignalResponse, error) {
+	var response *privatev1.ClusterVersionsSignalResponse
+	err := s.generic.Signal(ctx, request, &response)
+	return response, err
+}
+
+// unsetPreviousDefaultClusterVersion fetches all non-deleted ClusterVersions with spec.is_default == true,
+// except the one with the given excludeID, and clears the is_default flag on each. Used during
+// default-swap to ensure only one default exists at a time even if the invariant was previously
+// violated.
+//
+// Concurrent default-swap requests are safe: the unique partial index
+// cluster_versions_single_default (migration 74) prevents two concurrent transactions from both
+// committing is_default=true. The losing transaction receives AlreadyExists from the DAO;
+// callers that need a more specific error code should remap it (see Update).
+func (s *PrivateClusterVersionsServer) unsetPreviousDefaultClusterVersion(ctx context.Context, excludeID string) error {
+	filter := "this.spec.is_default == true && !has(this.metadata.deletion_timestamp)"
+	if excludeID != "" {
+		filter += fmt.Sprintf(" && this.id != %s", strconv.Quote(excludeID))
+	}
+	listResponse, err := s.generic.dao.List().
+		SetFilter(filter).
+		Do(ctx)
+	if err != nil {
+		s.logger.ErrorContext(ctx, "Failed to list default ClusterVersions",
+			slog.Any("error", err),
+		)
+		return grpcstatus.Errorf(grpccodes.Internal, "failed to clear existing default ClusterVersions")
+	}
+	for _, cv := range listResponse.GetItems() {
+		s.logger.DebugContext(ctx, "unsetting previous default ClusterVersion",
+			"old_default_id", cv.GetId(),
+		)
+		cv.GetSpec().SetIsDefault(false)
+		_, err = s.generic.dao.Update().SetObject(cv).Do(ctx)
+		if err != nil {
+			if _, ok := errors.AsType[*dao.ErrNotFound](err); ok {
+				s.logger.DebugContext(ctx, "Skipping deleted ClusterVersion during default clear",
+					slog.String("cluster_version_id", cv.GetId()),
+				)
+				continue
+			}
+			s.logger.ErrorContext(ctx, "Failed to clear default on ClusterVersion",
+				slog.String("cluster_version_id", cv.GetId()),
+				slog.Any("error", err),
+			)
+			return grpcstatus.Errorf(grpccodes.Internal, "failed to clear existing default ClusterVersions")
+		}
+	}
+	return nil
+}
+
+func validateClusterVersionCreateRequest(request *privatev1.ClusterVersionsCreateRequest) (*privatev1.ClusterVersion, error) {
+	cv := request.GetObject()
+	if cv == nil {
+		return nil, grpcstatus.Errorf(grpccodes.InvalidArgument, "object is mandatory")
+	}
+
+	spec := cv.GetSpec()
+	if spec == nil {
+		return nil, grpcstatus.Errorf(grpccodes.InvalidArgument, "object spec is mandatory")
+	}
+
+	if spec.GetVersion() == "" {
+		return nil, grpcstatus.Errorf(grpccodes.InvalidArgument, "field 'spec.version' is required")
+	}
+	if spec.GetImage() == "" {
+		return nil, grpcstatus.Errorf(grpccodes.InvalidArgument, "field 'spec.image' is required")
+	}
+
+	// Validate semver format:
+	if err := validateSemVer(spec.GetVersion()); err != nil {
+		return nil, err
+	}
+
+	return cv, nil
+}
+
+// resolveState returns the state that will be effective after the update: the request's value
+// if spec.state is in the mask, otherwise the existing value.
+func resolveState(existing *privatev1.ClusterVersion,
+	request *privatev1.ClusterVersionsUpdateRequest) privatev1.ClusterVersionState {
+	if updateIncludesField(request.GetUpdateMask(), "spec.state") {
+		return request.GetObject().GetSpec().GetState()
+	}
+	return existing.GetSpec().GetState()
+}
+
+// resolveIsDefault returns the is_default value that will be effective after the update.
+// If spec.is_default is in the mask, reads from the request; otherwise reads from existing.
+func resolveIsDefault(existing *privatev1.ClusterVersion,
+	request *privatev1.ClusterVersionsUpdateRequest) bool {
+	if updateIncludesField(request.GetUpdateMask(), "spec.is_default") {
+		return request.GetObject().GetSpec().GetIsDefault()
+	}
+	return existing.GetSpec().GetIsDefault()
+}
+
+// resolveEnabled returns the enabled value that will be effective after the update. If
+// spec.enabled is in the mask, reads from the request (defaulting to true when cleared).
+// Otherwise reads from existing (defaulting to true when unset).
+func resolveEnabled(existing *privatev1.ClusterVersion,
+	request *privatev1.ClusterVersionsUpdateRequest) bool {
+	if updateIncludesField(request.GetUpdateMask(), "spec.enabled") {
+		if request.GetObject().GetSpec().HasEnabled() {
+			return request.GetObject().GetSpec().GetEnabled()
+		}
+		return true
+	}
+	if existing.GetSpec().HasEnabled() {
+		return existing.GetSpec().GetEnabled()
+	}
+	return true
+}
+
+// validateIsDefaultEligibility rejects is_default on disabled or obsolete versions.
+func validateIsDefaultEligibility(cv *privatev1.ClusterVersion) error {
+	if !cv.GetSpec().GetEnabled() {
+		return grpcstatus.Errorf(grpccodes.InvalidArgument,
+			"cannot set 'is_default' on a disabled cluster version")
+	}
+	if cv.GetSpec().GetState() == privatev1.ClusterVersionState_CLUSTER_VERSION_STATE_OBSOLETE {
+		return grpcstatus.Errorf(grpccodes.InvalidArgument,
+			"cannot set 'is_default' on an obsolete cluster version")
+	}
+	return nil
+}
+
+// applyClusterVersionDefaults defaults enabled to true and state to ACTIVE when unset,
+// auto-generates metadata.name from spec.version if not provided, clears any caller-supplied
+// deprecation timestamps (OUTPUT_ONLY), and initializes the deprecation/obsolescence timestamp
+// matching the initial state.
+func applyClusterVersionDefaults(cv *privatev1.ClusterVersion) {
+	spec := cv.GetSpec()
+
+	// Default enabled to true if not explicitly set:
+	if !spec.HasEnabled() {
+		spec.SetEnabled(true)
+	}
+
+	// Default is_default to false if not explicitly set:
+	if !spec.HasIsDefault() {
+		spec.SetIsDefault(false)
+	}
+
+	// Default state to ACTIVE if unspecified:
+	if spec.GetState() == privatev1.ClusterVersionState_CLUSTER_VERSION_STATE_UNSPECIFIED {
+		spec.SetState(privatev1.ClusterVersionState_CLUSTER_VERSION_STATE_ACTIVE)
+	}
+
+	// Auto-generate metadata.name from spec.version if not provided:
+	if cv.GetMetadata() == nil || cv.GetMetadata().GetName() == "" {
+		if cv.GetMetadata() == nil {
+			cv.SetMetadata(&privatev1.Metadata{})
+		}
+		cv.GetMetadata().SetName(generateNameFromVersion(spec.GetVersion()))
+	}
+
+	// Set initial timestamps based on state (OUTPUT_ONLY — clear any caller-supplied values first):
+	spec.ClearDeprecation()
+	switch spec.GetState() {
+	case privatev1.ClusterVersionState_CLUSTER_VERSION_STATE_DEPRECATED:
+		spec.SetDeprecation(&privatev1.ClusterVersionDeprecation{})
+		spec.GetDeprecation().SetDeprecationTimestamp(timestamppb.Now())
+	case privatev1.ClusterVersionState_CLUSTER_VERSION_STATE_OBSOLETE:
+		spec.SetDeprecation(&privatev1.ClusterVersionDeprecation{})
+		spec.GetDeprecation().SetObsolescenceTimestamp(timestamppb.Now())
+	}
+}
+
+// applyClusterVersionStateEffects applies side effects of state and enabled changes:
+// deprecation timestamp management and is_default auto-clear on ineligible transitions.
+// When a state change occurs, the target state's deprecation timestamp is set and existing
+// timestamps are retained as historical record on backward transitions. When no state change
+// occurs, any client-supplied deprecation timestamps are replaced with the existing values
+// (OUTPUT_ONLY enforcement).
+func applyClusterVersionStateEffects(existing *privatev1.ClusterVersion,
+	request *privatev1.ClusterVersionsUpdateRequest) {
+	spec := request.GetObject().GetSpec()
+	if spec == nil {
+		return
+	}
+	oldState := existing.GetSpec().GetState()
+	newState := resolveState(existing, request)
+	mask := request.GetUpdateMask()
+
+	// Same-state update — enforce OUTPUT_ONLY contract on deprecation timestamps by
+	// unconditionally restoring existing values, regardless of what the client sent:
+	if oldState == newState {
+		if existingDep := existing.GetSpec().GetDeprecation(); existingDep != nil {
+			spec.SetDeprecation(proto.Clone(existingDep).(*privatev1.ClusterVersionDeprecation))
+		} else {
+			spec.ClearDeprecation()
+		}
+	} else {
+		// Start from existing deprecation to retain historical timestamps on backward transitions:
+		existingDep := existing.GetSpec().GetDeprecation()
+		var dep *privatev1.ClusterVersionDeprecation
+		if existingDep != nil {
+			dep = proto.Clone(existingDep).(*privatev1.ClusterVersionDeprecation)
+		} else {
+			dep = &privatev1.ClusterVersionDeprecation{}
+		}
+		spec.SetDeprecation(dep)
+
+		// Set timestamp only for the target state:
+		switch newState {
+		case privatev1.ClusterVersionState_CLUSTER_VERSION_STATE_DEPRECATED:
+			dep.SetDeprecationTimestamp(timestamppb.Now())
+		case privatev1.ClusterVersionState_CLUSTER_VERSION_STATE_OBSOLETE:
+			dep.SetObsolescenceTimestamp(timestamppb.Now())
+		case privatev1.ClusterVersionState_CLUSTER_VERSION_STATE_ACTIVE:
+			// Retain existing timestamps as historical record.
+		}
+
+		if mask != nil {
+			mask.Paths = append(mask.Paths, "spec.deprecation")
+		}
+	}
+
+	// Auto-clear is_default if becoming ineligible (OBSOLETE or disabled):
+	if resolveIsDefault(existing, request) {
+		newEnabled := resolveEnabled(existing, request)
+		if newState == privatev1.ClusterVersionState_CLUSTER_VERSION_STATE_OBSOLETE || !newEnabled {
+			spec.SetIsDefault(false)
+			if mask != nil {
+				mask.Paths = append(mask.Paths, "spec.is_default")
+			}
+		}
+	}
+}
+
+func validateClusterVersionImmutability(existing *privatev1.ClusterVersion,
+	request *privatev1.ClusterVersionsUpdateRequest) error {
+	mask := request.GetUpdateMask()
+	update := request.GetObject()
+	if updateIncludesField(mask, "spec.version") &&
+		update.GetSpec().GetVersion() != existing.GetSpec().GetVersion() {
+		return grpcstatus.Errorf(grpccodes.InvalidArgument,
+			"field 'spec.version' is immutable and cannot be changed from '%s' to '%s'",
+			existing.GetSpec().GetVersion(), update.GetSpec().GetVersion())
+	}
+	if updateIncludesField(mask, "spec.image") &&
+		update.GetSpec().GetImage() != existing.GetSpec().GetImage() {
+		return grpcstatus.Errorf(grpccodes.InvalidArgument,
+			"field 'spec.image' is immutable and cannot be changed from '%s' to '%s'",
+			existing.GetSpec().GetImage(), update.GetSpec().GetImage())
+	}
+	if updateIncludesField(mask, "metadata.name") &&
+		update.GetMetadata().GetName() != existing.GetMetadata().GetName() {
+		return grpcstatus.Errorf(grpccodes.InvalidArgument,
+			"field 'name' is immutable and cannot be changed from '%s' to '%s'",
+			existing.GetMetadata().GetName(), update.GetMetadata().GetName())
+	}
+	return nil
+}
+
+// validateSemVer validates that the version string is a valid Semantic Version 2.0.0 string.
+func validateSemVer(version string) error {
+	if len(version) > maxSemVerLength {
+		return grpcstatus.Errorf(grpccodes.InvalidArgument,
+			"field 'spec.version' exceeds maximum length of %d characters", maxSemVerLength)
+	}
+	_, err := semver.StrictNewVersion(version)
+	if err != nil {
+		return grpcstatus.Errorf(grpccodes.InvalidArgument,
+			"field 'spec.version' is not a valid SemVer 2.0.0 string: %v", err)
+	}
+	return nil
+}
+
+// generateNameFromVersion converts a semver string to a DNS-1123 compliant name.
+// Lowercases, replaces non-[a-z0-9-] with dashes, trims leading/trailing dashes,
+// and appends a 4-character FNV-32a hex suffix derived from the original version string.
+// If the sanitized base exceeds 58 characters, it is truncated to keep the total within 63.
+func generateNameFromVersion(version string) string {
+	result := strings.ToLower(version)
+
+	var sanitized strings.Builder
+	for _, r := range result {
+		if (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') || r == '-' {
+			sanitized.WriteRune(r)
+		} else {
+			sanitized.WriteRune('-')
+		}
+	}
+	result = strings.Trim(sanitized.String(), "-")
+
+	if len(result) > 58 {
+		result = strings.TrimRight(result[:58], "-")
+	}
+
+	h := fnv.New32a()
+	h.Write([]byte(version))
+	return fmt.Sprintf("%s-%04x", result, h.Sum32()%0x10000)
+}

--- a/internal/servers/private_cluster_versions_server_test.go
+++ b/internal/servers/private_cluster_versions_server_test.go
@@ -1,0 +1,1041 @@
+/*
+Copyright (c) 2025 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package servers
+
+import (
+	"fmt"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	grpccodes "google.golang.org/grpc/codes"
+	grpcstatus "google.golang.org/grpc/status"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/fieldmaskpb"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	privatev1 "github.com/osac-project/fulfillment-service/internal/api/osac/private/v1"
+)
+
+var _ = Describe("Private cluster versions server", func() {
+	Describe("Creation", func() {
+		It("Can be built if all the required parameters are set", func() {
+			server, err := NewPrivateClusterVersionsServer().
+				SetLogger(logger).
+				SetAttributionLogic(attribution).
+				SetTenancyLogic(tenancy).
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(server).ToNot(BeNil())
+		})
+
+		It("Fails if logger is not set", func() {
+			server, err := NewPrivateClusterVersionsServer().
+				SetAttributionLogic(attribution).
+				SetTenancyLogic(tenancy).
+				Build()
+			Expect(err).To(MatchError("logger is mandatory"))
+			Expect(server).To(BeNil())
+		})
+
+		It("Fails if tenancy logic is not set", func() {
+			server, err := NewPrivateClusterVersionsServer().
+				SetLogger(logger).
+				SetAttributionLogic(attribution).
+				Build()
+			Expect(err).To(MatchError("tenancy logic is mandatory"))
+			Expect(server).To(BeNil())
+		})
+	})
+
+	Describe("Behaviour", func() {
+		var server *PrivateClusterVersionsServer
+
+		// Shared test helpers:
+		var (
+			createCV              func(name, version string) *privatev1.ClusterVersion
+			createWithState       func(name, version string, state privatev1.ClusterVersionState) *privatev1.ClusterVersion
+			transitionTo          func(id string, state privatev1.ClusterVersionState)
+			expectInvalidArgument func(err error, substring string)
+		)
+
+		BeforeEach(func() {
+			var err error
+
+			// Create the server:
+			server, err = NewPrivateClusterVersionsServer().
+				SetLogger(logger).
+				SetAttributionLogic(attribution).
+				SetTenancyLogic(tenancy).
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+
+			// Helper to create a cluster version with default image derived from version.
+			createCV = func(name, version string) *privatev1.ClusterVersion {
+				response, err := server.Create(ctx, privatev1.ClusterVersionsCreateRequest_builder{
+					Object: privatev1.ClusterVersion_builder{
+						Metadata: privatev1.Metadata_builder{Name: name}.Build(),
+						Spec: privatev1.ClusterVersionSpec_builder{
+							Version: version,
+							Image:   "quay.io/ocp:" + version,
+						}.Build(),
+					}.Build(),
+				}.Build())
+				Expect(err).ToNot(HaveOccurred())
+				return response.GetObject()
+			}
+
+			// Helper to create a cluster version in a specific state.
+			createWithState = func(name, version string, state privatev1.ClusterVersionState) *privatev1.ClusterVersion {
+				response, err := server.Create(ctx, privatev1.ClusterVersionsCreateRequest_builder{
+					Object: privatev1.ClusterVersion_builder{
+						Metadata: privatev1.Metadata_builder{Name: name}.Build(),
+						Spec: privatev1.ClusterVersionSpec_builder{
+							Version: version,
+							Image:   "quay.io/ocp:" + version,
+							State:   state,
+						}.Build(),
+					}.Build(),
+				}.Build())
+				Expect(err).ToNot(HaveOccurred())
+				return response.GetObject()
+			}
+
+			// Helper to transition a cluster version to a given state.
+			transitionTo = func(id string, state privatev1.ClusterVersionState) {
+				_, err := server.Update(ctx, privatev1.ClusterVersionsUpdateRequest_builder{
+					Object: privatev1.ClusterVersion_builder{
+						Id:   id,
+						Spec: privatev1.ClusterVersionSpec_builder{State: state}.Build(),
+					}.Build(),
+					UpdateMask: &fieldmaskpb.FieldMask{Paths: []string{"spec.state"}},
+				}.Build())
+				Expect(err).ToNot(HaveOccurred())
+			}
+
+			// Helper to assert a gRPC InvalidArgument error containing a substring.
+			expectInvalidArgument = func(err error, substring string) {
+				Expect(err).To(HaveOccurred())
+				status, ok := grpcstatus.FromError(err)
+				Expect(ok).To(BeTrue())
+				Expect(status.Code()).To(Equal(grpccodes.InvalidArgument))
+				Expect(status.Message()).To(ContainSubstring(substring))
+			}
+		})
+
+		It("Creates object", func() {
+			object := createCV("4-17-0", "4.17.0")
+			Expect(object.GetId()).ToNot(BeEmpty())
+			Expect(object.GetSpec().GetVersion()).To(Equal("4.17.0"))
+			Expect(object.GetSpec().GetImage()).To(Equal("quay.io/ocp:4.17.0"))
+			Expect(object.GetSpec().GetState()).To(Equal(
+				privatev1.ClusterVersionState_CLUSTER_VERSION_STATE_ACTIVE))
+			Expect(object.GetSpec().GetEnabled()).To(BeTrue())
+		})
+
+		It("Lists objects", func() {
+			const count = 10
+			for i := range count {
+				createCV(fmt.Sprintf("version-%d", i), fmt.Sprintf("4.17.%d", i))
+			}
+
+			response, err := server.List(ctx, privatev1.ClusterVersionsListRequest_builder{}.Build())
+			Expect(err).ToNot(HaveOccurred())
+			Expect(response.GetItems()).To(HaveLen(count))
+		})
+
+		It("Gets object", func() {
+			created := createCV("4-17-0", "4.17.0")
+
+			getResponse, err := server.Get(ctx, privatev1.ClusterVersionsGetRequest_builder{
+				Id: created.GetId(),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+			Expect(proto.Equal(created, getResponse.GetObject())).To(BeTrue())
+		})
+
+		It("Updates object", func() {
+			object := createCV("4-17-0", "4.17.0")
+
+			// Update enabled using a field mask:
+			updateResponse, err := server.Update(ctx, privatev1.ClusterVersionsUpdateRequest_builder{
+				Object: privatev1.ClusterVersion_builder{
+					Id: object.GetId(),
+					Spec: privatev1.ClusterVersionSpec_builder{
+						Enabled: new(false),
+					}.Build(),
+				}.Build(),
+				UpdateMask: &fieldmaskpb.FieldMask{Paths: []string{"spec.enabled"}},
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+			Expect(updateResponse.GetObject().GetSpec().GetEnabled()).To(BeFalse())
+
+			// Get and verify:
+			getResponse, err := server.Get(ctx, privatev1.ClusterVersionsGetRequest_builder{
+				Id: object.GetId(),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+			Expect(getResponse.GetObject().GetSpec().GetEnabled()).To(BeFalse())
+		})
+
+		It("Deletes object", func() {
+			response, err := server.Create(ctx, privatev1.ClusterVersionsCreateRequest_builder{
+				Object: privatev1.ClusterVersion_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name:       "4-17-0",
+						Finalizers: []string{"a"},
+					}.Build(),
+					Spec: privatev1.ClusterVersionSpec_builder{
+						Version: "4.17.0",
+						Image:   "quay.io/ocp:4.17.0",
+					}.Build(),
+				}.Build(),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+			object := response.GetObject()
+
+			_, err = server.Delete(ctx, privatev1.ClusterVersionsDeleteRequest_builder{
+				Id: object.GetId(),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+
+			getResponse, err := server.Get(ctx, privatev1.ClusterVersionsGetRequest_builder{
+				Id: object.GetId(),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+			Expect(getResponse.GetObject().GetMetadata().GetDeletionTimestamp()).ToNot(BeNil())
+		})
+
+		Describe("Field mask merge", func() {
+			It("Updating state via mask preserves other spec fields", func() {
+				object := createCV("merge-state", "4.17.0")
+				Expect(object.GetSpec().GetState()).To(Equal(
+					privatev1.ClusterVersionState_CLUSTER_VERSION_STATE_ACTIVE))
+				Expect(object.GetSpec().GetEnabled()).To(BeTrue())
+
+				_, err := server.Update(ctx, privatev1.ClusterVersionsUpdateRequest_builder{
+					Object: privatev1.ClusterVersion_builder{
+						Id: object.GetId(),
+						Spec: privatev1.ClusterVersionSpec_builder{
+							State: privatev1.ClusterVersionState_CLUSTER_VERSION_STATE_DEPRECATED,
+						}.Build(),
+					}.Build(),
+					UpdateMask: &fieldmaskpb.FieldMask{Paths: []string{"spec.state"}},
+				}.Build())
+				Expect(err).ToNot(HaveOccurred())
+
+				getResponse, err := server.Get(ctx, privatev1.ClusterVersionsGetRequest_builder{
+					Id: object.GetId(),
+				}.Build())
+				Expect(err).ToNot(HaveOccurred())
+				updated := getResponse.GetObject()
+				Expect(updated.GetSpec().GetState()).To(Equal(
+					privatev1.ClusterVersionState_CLUSTER_VERSION_STATE_DEPRECATED))
+				Expect(updated.GetSpec().GetEnabled()).To(BeTrue())
+				Expect(updated.GetSpec().GetVersion()).To(Equal("4.17.0"))
+				Expect(updated.GetSpec().GetImage()).To(Equal("quay.io/ocp:4.17.0"))
+			})
+
+			It("Updating enabled via mask preserves other spec fields", func() {
+				object := createCV("merge-enabled", "4.17.0")
+
+				_, err := server.Update(ctx, privatev1.ClusterVersionsUpdateRequest_builder{
+					Object: privatev1.ClusterVersion_builder{
+						Id: object.GetId(),
+						Spec: privatev1.ClusterVersionSpec_builder{
+							Enabled: new(false),
+						}.Build(),
+					}.Build(),
+					UpdateMask: &fieldmaskpb.FieldMask{Paths: []string{"spec.enabled"}},
+				}.Build())
+				Expect(err).ToNot(HaveOccurred())
+
+				getResponse, err := server.Get(ctx, privatev1.ClusterVersionsGetRequest_builder{
+					Id: object.GetId(),
+				}.Build())
+				Expect(err).ToNot(HaveOccurred())
+				updated := getResponse.GetObject()
+				Expect(updated.GetSpec().GetEnabled()).To(BeFalse())
+				Expect(updated.GetSpec().GetState()).To(Equal(
+					privatev1.ClusterVersionState_CLUSTER_VERSION_STATE_ACTIVE))
+				Expect(updated.GetSpec().GetVersion()).To(Equal("4.17.0"))
+				Expect(updated.GetSpec().GetImage()).To(Equal("quay.io/ocp:4.17.0"))
+			})
+
+		})
+
+		Describe("Create defaults", func() {
+			It("Defaults enabled to true when not set", func() {
+				object := createCV("default-enabled", "4.17.0")
+				Expect(object.GetSpec().GetEnabled()).To(BeTrue())
+				Expect(object.GetSpec().HasEnabled()).To(BeTrue())
+			})
+
+			It("Respects explicit enabled=false", func() {
+				response, err := server.Create(ctx, privatev1.ClusterVersionsCreateRequest_builder{
+					Object: privatev1.ClusterVersion_builder{
+						Metadata: privatev1.Metadata_builder{Name: "explicit-disabled"}.Build(),
+						Spec: privatev1.ClusterVersionSpec_builder{
+							Version: "4.17.0",
+							Image:   "quay.io/ocp:4.17.0",
+							Enabled: new(false),
+						}.Build(),
+					}.Build(),
+				}.Build())
+				Expect(err).ToNot(HaveOccurred())
+				Expect(response.GetObject().GetSpec().GetEnabled()).To(BeFalse())
+			})
+
+			It("Defaults state to ACTIVE when unspecified", func() {
+				object := createCV("default-state", "4.17.0")
+				Expect(object.GetSpec().GetState()).To(Equal(
+					privatev1.ClusterVersionState_CLUSTER_VERSION_STATE_ACTIVE))
+			})
+
+			It("Creates with DEPRECATED state and sets deprecation timestamp", func() {
+				response, err := server.Create(ctx, privatev1.ClusterVersionsCreateRequest_builder{
+					Object: privatev1.ClusterVersion_builder{
+						Metadata: privatev1.Metadata_builder{Name: "created-deprecated"}.Build(),
+						Spec: privatev1.ClusterVersionSpec_builder{
+							Version: "4.16.0",
+							Image:   "quay.io/ocp:4.16.0",
+							State:   privatev1.ClusterVersionState_CLUSTER_VERSION_STATE_DEPRECATED,
+						}.Build(),
+					}.Build(),
+				}.Build())
+				Expect(err).ToNot(HaveOccurred())
+				spec := response.GetObject().GetSpec()
+				Expect(spec.GetState()).To(Equal(
+					privatev1.ClusterVersionState_CLUSTER_VERSION_STATE_DEPRECATED))
+				dep := spec.GetDeprecation()
+				Expect(dep).ToNot(BeNil())
+				Expect(dep.GetDeprecationTimestamp()).ToNot(BeNil())
+				Expect(dep.GetDeprecationTimestamp().AsTime()).To(
+					BeTemporally("~", time.Now(), time.Second))
+				Expect(dep.GetObsolescenceTimestamp()).To(BeNil())
+			})
+
+			It("Creates with OBSOLETE state and sets obsolescence timestamp", func() {
+				response, err := server.Create(ctx, privatev1.ClusterVersionsCreateRequest_builder{
+					Object: privatev1.ClusterVersion_builder{
+						Metadata: privatev1.Metadata_builder{Name: "created-obsolete"}.Build(),
+						Spec: privatev1.ClusterVersionSpec_builder{
+							Version: "4.15.0",
+							Image:   "quay.io/ocp:4.15.0",
+							State:   privatev1.ClusterVersionState_CLUSTER_VERSION_STATE_OBSOLETE,
+						}.Build(),
+					}.Build(),
+				}.Build())
+				Expect(err).ToNot(HaveOccurred())
+				spec := response.GetObject().GetSpec()
+				Expect(spec.GetState()).To(Equal(
+					privatev1.ClusterVersionState_CLUSTER_VERSION_STATE_OBSOLETE))
+				dep := spec.GetDeprecation()
+				Expect(dep).ToNot(BeNil())
+				Expect(dep.GetObsolescenceTimestamp()).ToNot(BeNil())
+				Expect(dep.GetObsolescenceTimestamp().AsTime()).To(
+					BeTemporally("~", time.Now(), time.Second))
+				Expect(dep.GetDeprecationTimestamp()).To(BeNil())
+			})
+		})
+
+		Describe("SemVer validation", func() {
+			DescribeTable("validates version and image",
+				func(name, version, image, expectedError string) {
+					response, err := server.Create(ctx, privatev1.ClusterVersionsCreateRequest_builder{
+						Object: privatev1.ClusterVersion_builder{
+							Metadata: privatev1.Metadata_builder{Name: name}.Build(),
+							Spec: privatev1.ClusterVersionSpec_builder{
+								Version: version,
+								Image:   image,
+							}.Build(),
+						}.Build(),
+					}.Build())
+					if expectedError != "" {
+						expectInvalidArgument(err, expectedError)
+					} else {
+						Expect(err).ToNot(HaveOccurred())
+						Expect(response.GetObject().GetSpec().GetVersion()).To(Equal(version))
+					}
+				},
+				Entry("rejects invalid semver", "bad-semver", "not-a-version", "quay.io/ocp:latest", "SemVer"),
+				Entry("rejects empty version", "empty-version", "", "quay.io/ocp:latest", "spec.version"),
+				Entry("rejects empty image", "empty-image", "4.17.0", "", "spec.image"),
+				Entry("accepts prerelease", "prerelease", "4.17.0-rc.1", "quay.io/ocp:4.17.0-rc.1", ""),
+			)
+		})
+
+		Describe("Name auto-generation", func() {
+			DescribeTable("generates name from version",
+				func(inputName, version, expectedBase string) {
+					cvBuilder := privatev1.ClusterVersion_builder{
+						Spec: privatev1.ClusterVersionSpec_builder{
+							Version: version,
+							Image:   "quay.io/ocp:" + version,
+						}.Build(),
+					}
+					if inputName != "" {
+						cvBuilder.Metadata = privatev1.Metadata_builder{
+							Name: inputName,
+						}.Build()
+					}
+					response, err := server.Create(ctx, privatev1.ClusterVersionsCreateRequest_builder{
+						Object: cvBuilder.Build(),
+					}.Build())
+					Expect(err).ToNot(HaveOccurred())
+					name := response.GetObject().GetMetadata().GetName()
+					if inputName != "" {
+						Expect(name).To(Equal(inputName))
+					} else {
+						Expect(name).To(HavePrefix(expectedBase + "-"))
+						Expect(name).To(MatchRegexp(`-[0-9a-f]{4}$`))
+						Expect(len(name)).To(BeNumerically("<=", 63))
+					}
+				},
+				Entry("simple semver", "", "4.17.0", "4-17-0"),
+				Entry("build metadata", "", "4.17.0+build.1", "4-17-0-build-1"),
+				Entry("prerelease", "", "4.17.0-rc.1", "4-17-0-rc-1"),
+				Entry("caller-provided name", "my-custom-name", "4.17.0", ""),
+				Entry("long version truncates to 63 chars",
+					"", "1.2.3-alpha.beta.gamma.delta.epsilon.zeta.eta.theta.iota.kappa.lambda",
+					"1-2-3-alpha-beta-gamma-delta-epsilon-zeta-eta-theta-iota-k"),
+			)
+		})
+
+		Describe("Immutability", func() {
+			It("Rejects update of spec.version", func() {
+				object := createCV("immutable-version", "4.17.0")
+
+				_, err := server.Update(ctx, privatev1.ClusterVersionsUpdateRequest_builder{
+					Object: privatev1.ClusterVersion_builder{
+						Id: object.GetId(),
+						Spec: privatev1.ClusterVersionSpec_builder{
+							Version: "4.18.0",
+							Image:   "quay.io/ocp:4.17.0",
+						}.Build(),
+					}.Build(),
+				}.Build())
+				expectInvalidArgument(err, "spec.version")
+			})
+
+			It("Rejects update of spec.image", func() {
+				object := createCV("immutable-image", "4.17.0")
+
+				_, err := server.Update(ctx, privatev1.ClusterVersionsUpdateRequest_builder{
+					Object: privatev1.ClusterVersion_builder{
+						Id: object.GetId(),
+						Spec: privatev1.ClusterVersionSpec_builder{
+							Version: "4.17.0",
+							Image:   "quay.io/ocp:4.17.0-NEW",
+						}.Build(),
+					}.Build(),
+				}.Build())
+				expectInvalidArgument(err, "spec.image")
+			})
+
+			It("Rejects update of name", func() {
+				object := createCV("original-name", "4.17.0")
+
+				_, err := server.Update(ctx, privatev1.ClusterVersionsUpdateRequest_builder{
+					Object: privatev1.ClusterVersion_builder{
+						Id: object.GetId(),
+						Metadata: privatev1.Metadata_builder{
+							Name: "renamed",
+						}.Build(),
+						Spec: privatev1.ClusterVersionSpec_builder{
+							Version: "4.17.0",
+							Image:   "quay.io/ocp:4.17.0",
+						}.Build(),
+					}.Build(),
+				}.Build())
+				expectInvalidArgument(err, "name")
+			})
+		})
+
+		It("Rejects update with spec field in mask but nil spec", func() {
+			object := createCV("nil-spec-guard", "4.17.0")
+
+			_, err := server.Update(ctx, privatev1.ClusterVersionsUpdateRequest_builder{
+				Object: privatev1.ClusterVersion_builder{
+					Id: object.GetId(),
+				}.Build(),
+				UpdateMask: &fieldmaskpb.FieldMask{Paths: []string{"spec.state"}},
+			}.Build())
+			expectInvalidArgument(err, "object spec is mandatory")
+		})
+
+		It("Metadata-only update preserves spec when spec is nil in request", func() {
+			object := createWithState("metadata-only", "4.17.0",
+				privatev1.ClusterVersionState_CLUSTER_VERSION_STATE_DEPRECATED)
+			originalDep := object.GetSpec().GetDeprecation()
+			Expect(originalDep).ToNot(BeNil())
+
+			// Update only metadata labels (no spec in request):
+			_, err := server.Update(ctx, privatev1.ClusterVersionsUpdateRequest_builder{
+				Object: privatev1.ClusterVersion_builder{
+					Id: object.GetId(),
+					Metadata: privatev1.Metadata_builder{
+						Labels: map[string]string{"env": "prod"},
+					}.Build(),
+				}.Build(),
+				UpdateMask: &fieldmaskpb.FieldMask{Paths: []string{"metadata.labels"}},
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+
+			getResponse, err := server.Get(ctx, privatev1.ClusterVersionsGetRequest_builder{
+				Id: object.GetId(),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+			updated := getResponse.GetObject()
+			Expect(updated.GetSpec().GetState()).To(Equal(
+				privatev1.ClusterVersionState_CLUSTER_VERSION_STATE_DEPRECATED))
+			Expect(proto.Equal(updated.GetSpec().GetDeprecation(), originalDep)).To(BeTrue())
+			Expect(updated.GetMetadata().GetLabels()).To(HaveKeyWithValue("env", "prod"))
+		})
+
+		Describe("State transitions", func() {
+			It("Transitions ACTIVE to DEPRECATED", func() {
+				object := createWithState("active-to-deprecated", "4.17.0",
+					privatev1.ClusterVersionState_CLUSTER_VERSION_STATE_ACTIVE)
+
+				transitionTo(object.GetId(),
+					privatev1.ClusterVersionState_CLUSTER_VERSION_STATE_DEPRECATED)
+
+				getResponse, err := server.Get(ctx, privatev1.ClusterVersionsGetRequest_builder{
+					Id: object.GetId(),
+				}.Build())
+				Expect(err).ToNot(HaveOccurred())
+				spec := getResponse.GetObject().GetSpec()
+				Expect(spec.GetState()).To(Equal(
+					privatev1.ClusterVersionState_CLUSTER_VERSION_STATE_DEPRECATED))
+				dep := spec.GetDeprecation()
+				Expect(dep).ToNot(BeNil())
+				Expect(dep.GetDeprecationTimestamp()).ToNot(BeNil())
+				Expect(dep.GetDeprecationTimestamp().AsTime()).To(
+					BeTemporally("~", time.Now(), time.Second))
+				Expect(dep.GetObsolescenceTimestamp()).To(BeNil())
+			})
+
+			It("Transitions ACTIVE to OBSOLETE", func() {
+				object := createWithState("active-to-obsolete", "4.17.1",
+					privatev1.ClusterVersionState_CLUSTER_VERSION_STATE_ACTIVE)
+
+				transitionTo(object.GetId(),
+					privatev1.ClusterVersionState_CLUSTER_VERSION_STATE_OBSOLETE)
+
+				getResponse, err := server.Get(ctx, privatev1.ClusterVersionsGetRequest_builder{
+					Id: object.GetId(),
+				}.Build())
+				Expect(err).ToNot(HaveOccurred())
+				spec := getResponse.GetObject().GetSpec()
+				Expect(spec.GetState()).To(Equal(
+					privatev1.ClusterVersionState_CLUSTER_VERSION_STATE_OBSOLETE))
+				dep := spec.GetDeprecation()
+				Expect(dep).ToNot(BeNil())
+				Expect(dep.GetObsolescenceTimestamp()).ToNot(BeNil())
+				Expect(dep.GetObsolescenceTimestamp().AsTime()).To(
+					BeTemporally("~", time.Now(), time.Second))
+				// Only target state timestamp is set:
+				Expect(dep.GetDeprecationTimestamp()).To(BeNil())
+			})
+
+			It("Transitions DEPRECATED to ACTIVE", func() {
+				object := createWithState("deprecated-to-active", "4.17.2",
+					privatev1.ClusterVersionState_CLUSTER_VERSION_STATE_DEPRECATED)
+				originalDepTimestamp := object.GetSpec().GetDeprecation().GetDeprecationTimestamp()
+
+				transitionTo(object.GetId(),
+					privatev1.ClusterVersionState_CLUSTER_VERSION_STATE_ACTIVE)
+
+				getResponse, err := server.Get(ctx, privatev1.ClusterVersionsGetRequest_builder{
+					Id: object.GetId(),
+				}.Build())
+				Expect(err).ToNot(HaveOccurred())
+				spec := getResponse.GetObject().GetSpec()
+				Expect(spec.GetState()).To(Equal(
+					privatev1.ClusterVersionState_CLUSTER_VERSION_STATE_ACTIVE))
+				// Backward transitions retain existing timestamps as historical record:
+				dep := spec.GetDeprecation()
+				Expect(dep).ToNot(BeNil())
+				Expect(dep.GetDeprecationTimestamp()).ToNot(BeNil())
+				Expect(proto.Equal(dep.GetDeprecationTimestamp(), originalDepTimestamp)).To(BeTrue())
+			})
+
+			It("Transitions DEPRECATED to OBSOLETE", func() {
+				object := createWithState("deprecated-to-obsolete", "4.17.3",
+					privatev1.ClusterVersionState_CLUSTER_VERSION_STATE_DEPRECATED)
+				originalDepTimestamp := object.GetSpec().GetDeprecation().GetDeprecationTimestamp()
+
+				transitionTo(object.GetId(),
+					privatev1.ClusterVersionState_CLUSTER_VERSION_STATE_OBSOLETE)
+
+				getResponse, err := server.Get(ctx, privatev1.ClusterVersionsGetRequest_builder{
+					Id: object.GetId(),
+				}.Build())
+				Expect(err).ToNot(HaveOccurred())
+				spec := getResponse.GetObject().GetSpec()
+				Expect(spec.GetState()).To(Equal(
+					privatev1.ClusterVersionState_CLUSTER_VERSION_STATE_OBSOLETE))
+				dep := spec.GetDeprecation()
+				Expect(dep).ToNot(BeNil())
+				// Both timestamps should be present: deprecation retained from prior,
+				// obsolescence newly set.
+				Expect(dep.GetDeprecationTimestamp()).ToNot(BeNil())
+				Expect(proto.Equal(dep.GetDeprecationTimestamp(), originalDepTimestamp)).To(BeTrue())
+				Expect(dep.GetObsolescenceTimestamp()).ToNot(BeNil())
+				Expect(dep.GetObsolescenceTimestamp().AsTime()).To(
+					BeTemporally("~", time.Now(), time.Second))
+			})
+
+			It("Transitions OBSOLETE to DEPRECATED", func() {
+				object := createWithState("obsolete-to-deprecated", "4.17.4",
+					privatev1.ClusterVersionState_CLUSTER_VERSION_STATE_OBSOLETE)
+				originalObsTimestamp := object.GetSpec().GetDeprecation().GetObsolescenceTimestamp()
+
+				transitionTo(object.GetId(),
+					privatev1.ClusterVersionState_CLUSTER_VERSION_STATE_DEPRECATED)
+
+				getResponse, err := server.Get(ctx, privatev1.ClusterVersionsGetRequest_builder{
+					Id: object.GetId(),
+				}.Build())
+				Expect(err).ToNot(HaveOccurred())
+				spec := getResponse.GetObject().GetSpec()
+				Expect(spec.GetState()).To(Equal(
+					privatev1.ClusterVersionState_CLUSTER_VERSION_STATE_DEPRECATED))
+				// Backward transitions retain existing timestamps:
+				dep := spec.GetDeprecation()
+				Expect(dep).ToNot(BeNil())
+				Expect(dep.GetObsolescenceTimestamp()).ToNot(BeNil())
+				Expect(proto.Equal(dep.GetObsolescenceTimestamp(), originalObsTimestamp)).To(BeTrue())
+				// Deprecation timestamp is newly set because DEPRECATED is the target state:
+				Expect(dep.GetDeprecationTimestamp()).ToNot(BeNil())
+				Expect(dep.GetDeprecationTimestamp().AsTime()).To(
+					BeTemporally("~", time.Now(), time.Second))
+			})
+
+			It("Transitions OBSOLETE to ACTIVE", func() {
+				object := createWithState("obsolete-to-active", "4.17.5",
+					privatev1.ClusterVersionState_CLUSTER_VERSION_STATE_OBSOLETE)
+				originalObsTimestamp := object.GetSpec().GetDeprecation().GetObsolescenceTimestamp()
+
+				transitionTo(object.GetId(),
+					privatev1.ClusterVersionState_CLUSTER_VERSION_STATE_ACTIVE)
+
+				getResponse, err := server.Get(ctx, privatev1.ClusterVersionsGetRequest_builder{
+					Id: object.GetId(),
+				}.Build())
+				Expect(err).ToNot(HaveOccurred())
+				spec := getResponse.GetObject().GetSpec()
+				Expect(spec.GetState()).To(Equal(
+					privatev1.ClusterVersionState_CLUSTER_VERSION_STATE_ACTIVE))
+				// Backward transitions retain existing timestamps as historical record:
+				dep := spec.GetDeprecation()
+				Expect(dep).ToNot(BeNil())
+				Expect(dep.GetObsolescenceTimestamp()).ToNot(BeNil())
+				Expect(proto.Equal(dep.GetObsolescenceTimestamp(), originalObsTimestamp)).To(BeTrue())
+			})
+
+			It("Same-state update is no-op", func() {
+				object := createWithState("same-state-noop", "4.17.6",
+					privatev1.ClusterVersionState_CLUSTER_VERSION_STATE_DEPRECATED)
+				originalDep := object.GetSpec().GetDeprecation()
+
+				transitionTo(object.GetId(),
+					privatev1.ClusterVersionState_CLUSTER_VERSION_STATE_DEPRECATED)
+
+				getResponse, err := server.Get(ctx, privatev1.ClusterVersionsGetRequest_builder{
+					Id: object.GetId(),
+				}.Build())
+				Expect(err).ToNot(HaveOccurred())
+				// Verify no timestamp changes:
+				updatedDep := getResponse.GetObject().GetSpec().GetDeprecation()
+				Expect(proto.Equal(updatedDep.GetDeprecationTimestamp(),
+					originalDep.GetDeprecationTimestamp())).To(BeTrue())
+			})
+
+			It("Re-entry updates timestamp", func() {
+				object := createWithState("re-entry-timestamp", "4.17.7",
+					privatev1.ClusterVersionState_CLUSTER_VERSION_STATE_DEPRECATED)
+				t1 := object.GetSpec().GetDeprecation().GetDeprecationTimestamp()
+
+				// Transition DEPRECATED -> ACTIVE:
+				transitionTo(object.GetId(),
+					privatev1.ClusterVersionState_CLUSTER_VERSION_STATE_ACTIVE)
+
+				// Wait to ensure distinct timestamps:
+				time.Sleep(10 * time.Millisecond)
+
+				// Transition ACTIVE -> DEPRECATED again:
+				transitionTo(object.GetId(),
+					privatev1.ClusterVersionState_CLUSTER_VERSION_STATE_DEPRECATED)
+
+				getResponse, err := server.Get(ctx, privatev1.ClusterVersionsGetRequest_builder{
+					Id: object.GetId(),
+				}.Build())
+				Expect(err).ToNot(HaveOccurred())
+
+				// Verify new deprecation timestamp differs from T1:
+				t2 := getResponse.GetObject().GetSpec().GetDeprecation().GetDeprecationTimestamp()
+				Expect(t2).ToNot(BeNil())
+				Expect(proto.Equal(t1, t2)).To(BeFalse())
+			})
+		})
+
+		Describe("Default swap", func() {
+			It("Create with is_default clears previous default", func() {
+				// Create first version as default:
+				first, err := server.Create(ctx, privatev1.ClusterVersionsCreateRequest_builder{
+					Object: privatev1.ClusterVersion_builder{
+						Metadata: privatev1.Metadata_builder{Name: "default-first"}.Build(),
+						Spec: privatev1.ClusterVersionSpec_builder{
+							Version:   "4.17.0",
+							Image:     "quay.io/ocp:4.17.0",
+							IsDefault: new(true),
+						}.Build(),
+					}.Build(),
+				}.Build())
+				Expect(err).ToNot(HaveOccurred())
+				Expect(first.GetObject().GetSpec().GetIsDefault()).To(BeTrue())
+
+				// Create second version as default:
+				second, err := server.Create(ctx, privatev1.ClusterVersionsCreateRequest_builder{
+					Object: privatev1.ClusterVersion_builder{
+						Metadata: privatev1.Metadata_builder{Name: "default-second"}.Build(),
+						Spec: privatev1.ClusterVersionSpec_builder{
+							Version:   "4.18.0",
+							Image:     "quay.io/ocp:4.18.0",
+							IsDefault: new(true),
+						}.Build(),
+					}.Build(),
+				}.Build())
+				Expect(err).ToNot(HaveOccurred())
+				Expect(second.GetObject().GetSpec().GetIsDefault()).To(BeTrue())
+
+				// Verify first is no longer default:
+				getResponse, err := server.Get(ctx, privatev1.ClusterVersionsGetRequest_builder{
+					Id: first.GetObject().GetId(),
+				}.Build())
+				Expect(err).ToNot(HaveOccurred())
+				Expect(getResponse.GetObject().GetSpec().GetIsDefault()).To(BeFalse())
+			})
+
+			It("Update setting is_default clears previous default", func() {
+				// Create first version as default:
+				first, err := server.Create(ctx, privatev1.ClusterVersionsCreateRequest_builder{
+					Object: privatev1.ClusterVersion_builder{
+						Metadata: privatev1.Metadata_builder{Name: "swap-first"}.Build(),
+						Spec: privatev1.ClusterVersionSpec_builder{
+							Version:   "4.17.0",
+							Image:     "quay.io/ocp:4.17.0",
+							IsDefault: new(true),
+						}.Build(),
+					}.Build(),
+				}.Build())
+				Expect(err).ToNot(HaveOccurred())
+
+				// Create second version (not default):
+				second := createCV("swap-second", "4.18.0")
+
+				// Update second to become default:
+				_, err = server.Update(ctx, privatev1.ClusterVersionsUpdateRequest_builder{
+					Object: privatev1.ClusterVersion_builder{
+						Id: second.GetId(),
+						Spec: privatev1.ClusterVersionSpec_builder{
+							IsDefault: new(true),
+						}.Build(),
+					}.Build(),
+					UpdateMask: &fieldmaskpb.FieldMask{Paths: []string{"spec.is_default"}},
+				}.Build())
+				Expect(err).ToNot(HaveOccurred())
+
+				// Verify second is now default:
+				getResponse, err := server.Get(ctx, privatev1.ClusterVersionsGetRequest_builder{
+					Id: second.GetId(),
+				}.Build())
+				Expect(err).ToNot(HaveOccurred())
+				Expect(getResponse.GetObject().GetSpec().GetIsDefault()).To(BeTrue())
+
+				// Verify first is no longer default:
+				getResponse, err = server.Get(ctx, privatev1.ClusterVersionsGetRequest_builder{
+					Id: first.GetObject().GetId(),
+				}.Build())
+				Expect(err).ToNot(HaveOccurred())
+				Expect(getResponse.GetObject().GetSpec().GetIsDefault()).To(BeFalse())
+			})
+
+			It("Updating unrelated field on current default preserves is_default", func() {
+				cv, err := server.Create(ctx, privatev1.ClusterVersionsCreateRequest_builder{
+					Object: privatev1.ClusterVersion_builder{
+						Metadata: privatev1.Metadata_builder{Name: "keep-default"}.Build(),
+						Spec: privatev1.ClusterVersionSpec_builder{
+							Version:   "4.17.0",
+							Image:     "quay.io/ocp:4.17.0",
+							IsDefault: new(true),
+						}.Build(),
+					}.Build(),
+				}.Build())
+				Expect(err).ToNot(HaveOccurred())
+				Expect(cv.GetObject().GetSpec().GetIsDefault()).To(BeTrue())
+
+				// Update state to DEPRECATED (is_default not in mask):
+				_, err = server.Update(ctx, privatev1.ClusterVersionsUpdateRequest_builder{
+					Object: privatev1.ClusterVersion_builder{
+						Id: cv.GetObject().GetId(),
+						Spec: privatev1.ClusterVersionSpec_builder{
+							State: privatev1.ClusterVersionState_CLUSTER_VERSION_STATE_DEPRECATED,
+						}.Build(),
+					}.Build(),
+					UpdateMask: &fieldmaskpb.FieldMask{Paths: []string{"spec.state"}},
+				}.Build())
+				Expect(err).ToNot(HaveOccurred())
+
+				getResponse, err := server.Get(ctx, privatev1.ClusterVersionsGetRequest_builder{
+					Id: cv.GetObject().GetId(),
+				}.Build())
+				Expect(err).ToNot(HaveOccurred())
+				Expect(getResponse.GetObject().GetSpec().GetIsDefault()).To(BeTrue())
+				Expect(getResponse.GetObject().GetSpec().GetState()).To(Equal(
+					privatev1.ClusterVersionState_CLUSTER_VERSION_STATE_DEPRECATED))
+			})
+		})
+
+		Describe("Auto-clear is_default", func() {
+			It("Clears is_default when transitioning to OBSOLETE", func() {
+				// Create as default:
+				cv, err := server.Create(ctx, privatev1.ClusterVersionsCreateRequest_builder{
+					Object: privatev1.ClusterVersion_builder{
+						Metadata: privatev1.Metadata_builder{Name: "auto-clear-obsolete"}.Build(),
+						Spec: privatev1.ClusterVersionSpec_builder{
+							Version:   "4.17.0",
+							Image:     "quay.io/ocp:4.17.0",
+							IsDefault: new(true),
+						}.Build(),
+					}.Build(),
+				}.Build())
+				Expect(err).ToNot(HaveOccurred())
+
+				// Transition to OBSOLETE:
+				transitionTo(cv.GetObject().GetId(),
+					privatev1.ClusterVersionState_CLUSTER_VERSION_STATE_OBSOLETE)
+
+				getResponse, err := server.Get(ctx, privatev1.ClusterVersionsGetRequest_builder{
+					Id: cv.GetObject().GetId(),
+				}.Build())
+				Expect(err).ToNot(HaveOccurred())
+				Expect(getResponse.GetObject().GetSpec().GetIsDefault()).To(BeFalse())
+			})
+
+			It("Clears is_default when disabling", func() {
+				// Create as default:
+				cv, err := server.Create(ctx, privatev1.ClusterVersionsCreateRequest_builder{
+					Object: privatev1.ClusterVersion_builder{
+						Metadata: privatev1.Metadata_builder{Name: "auto-clear-disabled"}.Build(),
+						Spec: privatev1.ClusterVersionSpec_builder{
+							Version:   "4.17.0",
+							Image:     "quay.io/ocp:4.17.0",
+							IsDefault: new(true),
+						}.Build(),
+					}.Build(),
+				}.Build())
+				Expect(err).ToNot(HaveOccurred())
+
+				// Disable:
+				_, err = server.Update(ctx, privatev1.ClusterVersionsUpdateRequest_builder{
+					Object: privatev1.ClusterVersion_builder{
+						Id: cv.GetObject().GetId(),
+						Spec: privatev1.ClusterVersionSpec_builder{
+							Enabled: new(false),
+						}.Build(),
+					}.Build(),
+					UpdateMask: &fieldmaskpb.FieldMask{Paths: []string{"spec.enabled"}},
+				}.Build())
+				Expect(err).ToNot(HaveOccurred())
+
+				getResponse, err := server.Get(ctx, privatev1.ClusterVersionsGetRequest_builder{
+					Id: cv.GetObject().GetId(),
+				}.Build())
+				Expect(err).ToNot(HaveOccurred())
+				Expect(getResponse.GetObject().GetSpec().GetIsDefault()).To(BeFalse())
+			})
+
+			It("Rejects is_default on OBSOLETE update", func() {
+				object := createWithState("reject-default-obsolete", "4.17.0",
+					privatev1.ClusterVersionState_CLUSTER_VERSION_STATE_OBSOLETE)
+
+				_, err := server.Update(ctx, privatev1.ClusterVersionsUpdateRequest_builder{
+					Object: privatev1.ClusterVersion_builder{
+						Id: object.GetId(),
+						Spec: privatev1.ClusterVersionSpec_builder{
+							IsDefault: new(true),
+						}.Build(),
+					}.Build(),
+					UpdateMask: &fieldmaskpb.FieldMask{Paths: []string{"spec.is_default"}},
+				}.Build())
+				expectInvalidArgument(err, "obsolete")
+			})
+
+			It("Rejects is_default on disabled update", func() {
+				response, err := server.Create(ctx, privatev1.ClusterVersionsCreateRequest_builder{
+					Object: privatev1.ClusterVersion_builder{
+						Metadata: privatev1.Metadata_builder{Name: "reject-default-disabled"}.Build(),
+						Spec: privatev1.ClusterVersionSpec_builder{
+							Version: "4.17.0",
+							Image:   "quay.io/ocp:4.17.0",
+							Enabled: new(false),
+						}.Build(),
+					}.Build(),
+				}.Build())
+				Expect(err).ToNot(HaveOccurred())
+
+				_, err = server.Update(ctx, privatev1.ClusterVersionsUpdateRequest_builder{
+					Object: privatev1.ClusterVersion_builder{
+						Id: response.GetObject().GetId(),
+						Spec: privatev1.ClusterVersionSpec_builder{
+							IsDefault: new(true),
+						}.Build(),
+					}.Build(),
+					UpdateMask: &fieldmaskpb.FieldMask{Paths: []string{"spec.is_default"}},
+				}.Build())
+				expectInvalidArgument(err, "disabled")
+			})
+
+			It("Rejects is_default combined with OBSOLETE transition", func() {
+				cv, err := server.Create(ctx, privatev1.ClusterVersionsCreateRequest_builder{
+					Object: privatev1.ClusterVersion_builder{
+						Metadata: privatev1.Metadata_builder{Name: "combo-obsolete"}.Build(),
+						Spec: privatev1.ClusterVersionSpec_builder{
+							Version:   "4.17.0",
+							Image:     "quay.io/ocp:4.17.0",
+							IsDefault: new(true),
+						}.Build(),
+					}.Build(),
+				}.Build())
+				Expect(err).ToNot(HaveOccurred())
+
+				_, err = server.Update(ctx, privatev1.ClusterVersionsUpdateRequest_builder{
+					Object: privatev1.ClusterVersion_builder{
+						Id: cv.GetObject().GetId(),
+						Spec: privatev1.ClusterVersionSpec_builder{
+							State:     privatev1.ClusterVersionState_CLUSTER_VERSION_STATE_OBSOLETE,
+							IsDefault: new(true),
+						}.Build(),
+					}.Build(),
+					UpdateMask: &fieldmaskpb.FieldMask{Paths: []string{
+						"spec.state", "spec.is_default",
+					}},
+				}.Build())
+				expectInvalidArgument(err, "obsolete")
+			})
+
+			It("Rejects is_default on OBSOLETE create", func() {
+				_, err := server.Create(ctx, privatev1.ClusterVersionsCreateRequest_builder{
+					Object: privatev1.ClusterVersion_builder{
+						Metadata: privatev1.Metadata_builder{Name: "create-default-obsolete"}.Build(),
+						Spec: privatev1.ClusterVersionSpec_builder{
+							Version:   "4.17.0",
+							Image:     "quay.io/ocp:4.17.0",
+							State:     privatev1.ClusterVersionState_CLUSTER_VERSION_STATE_OBSOLETE,
+							IsDefault: new(true),
+						}.Build(),
+					}.Build(),
+				}.Build())
+				expectInvalidArgument(err, "obsolete")
+			})
+
+			It("Rejects is_default on disabled create", func() {
+				_, err := server.Create(ctx, privatev1.ClusterVersionsCreateRequest_builder{
+					Object: privatev1.ClusterVersion_builder{
+						Metadata: privatev1.Metadata_builder{Name: "create-default-disabled"}.Build(),
+						Spec: privatev1.ClusterVersionSpec_builder{
+							Version:   "4.17.0",
+							Image:     "quay.io/ocp:4.17.0",
+							Enabled:   new(false),
+							IsDefault: new(true),
+						}.Build(),
+					}.Build(),
+				}.Build())
+				expectInvalidArgument(err, "disabled")
+			})
+		})
+
+		It("Same-state update preserves timestamps when request omits deprecation", func() {
+			object := createWithState("omitted-dep", "4.17.0",
+				privatev1.ClusterVersionState_CLUSTER_VERSION_STATE_DEPRECATED)
+			serverTimestamp := object.GetSpec().GetDeprecation().GetDeprecationTimestamp()
+			Expect(serverTimestamp).ToNot(BeNil())
+
+			// Send a same-state update with spec.deprecation in the mask but no deprecation message:
+			_, err := server.Update(ctx, privatev1.ClusterVersionsUpdateRequest_builder{
+				Object: privatev1.ClusterVersion_builder{
+					Id: object.GetId(),
+					Spec: privatev1.ClusterVersionSpec_builder{
+						State: privatev1.ClusterVersionState_CLUSTER_VERSION_STATE_DEPRECATED,
+					}.Build(),
+				}.Build(),
+				UpdateMask: &fieldmaskpb.FieldMask{Paths: []string{
+					"spec.state", "spec.deprecation",
+				}},
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+
+			getResponse, err := server.Get(ctx, privatev1.ClusterVersionsGetRequest_builder{
+				Id: object.GetId(),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+			dep := getResponse.GetObject().GetSpec().GetDeprecation()
+			Expect(dep).ToNot(BeNil())
+			Expect(proto.Equal(dep.GetDeprecationTimestamp(), serverTimestamp)).To(BeTrue(),
+				"deprecation timestamp must survive when request omits deprecation message")
+		})
+
+		It("Same-state update ignores client-supplied OUTPUT_ONLY deprecation timestamps", func() {
+			// Create a DEPRECATED version (server sets deprecation_timestamp):
+			object := createWithState("output-only-guard", "4.17.0",
+				privatev1.ClusterVersionState_CLUSTER_VERSION_STATE_DEPRECATED)
+			serverTimestamp := object.GetSpec().GetDeprecation().GetDeprecationTimestamp()
+			Expect(serverTimestamp).ToNot(BeNil())
+
+			// Send a same-state update with a client-supplied deprecation timestamp:
+			fakeTimestamp := timestamppb.New(time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC))
+			_, err := server.Update(ctx, privatev1.ClusterVersionsUpdateRequest_builder{
+				Object: privatev1.ClusterVersion_builder{
+					Id: object.GetId(),
+					Spec: privatev1.ClusterVersionSpec_builder{
+						State: privatev1.ClusterVersionState_CLUSTER_VERSION_STATE_DEPRECATED,
+						Deprecation: privatev1.ClusterVersionDeprecation_builder{
+							DeprecationTimestamp: fakeTimestamp,
+						}.Build(),
+					}.Build(),
+				}.Build(),
+				UpdateMask: &fieldmaskpb.FieldMask{Paths: []string{
+					"spec.state", "spec.deprecation",
+				}},
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+
+			// Verify the server-set timestamp was preserved, not the client's fake:
+			getResponse, err := server.Get(ctx, privatev1.ClusterVersionsGetRequest_builder{
+				Id: object.GetId(),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+			dep := getResponse.GetObject().GetSpec().GetDeprecation()
+			Expect(dep).ToNot(BeNil())
+			Expect(proto.Equal(dep.GetDeprecationTimestamp(), serverTimestamp)).To(BeTrue(),
+				"server-set timestamp should be preserved, not overwritten by client")
+			Expect(proto.Equal(dep.GetDeprecationTimestamp(), fakeTimestamp)).To(BeFalse(),
+				"client-supplied OUTPUT_ONLY timestamp should not be persisted")
+		})
+
+	})
+})

--- a/it/it_access_test.go
+++ b/it/it_access_test.go
@@ -63,6 +63,39 @@ var _ = Describe("Access control", func() {
 			Expect(err).ToNot(HaveOccurred())
 		})
 
+		It("Allows regular users to list cluster versions", func() {
+			client := publicv1.NewClusterVersionsClient(tool.ExternalView().UserConn())
+			_, err := client.List(ctx, publicv1.ClusterVersionsListRequest_builder{}.Build())
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("Denies regular users creating cluster versions", func() {
+			client := publicv1.NewClusterVersionsClient(tool.ExternalView().UserConn())
+			_, err := client.Create(ctx, publicv1.ClusterVersionsCreateRequest_builder{}.Build())
+			Expect(err).To(HaveOccurred())
+			status, ok := grpcstatus.FromError(err)
+			Expect(ok).To(BeTrue())
+			Expect(status.Code()).To(Equal(grpccodes.PermissionDenied))
+		})
+
+		It("Denies regular users updating cluster versions", func() {
+			client := publicv1.NewClusterVersionsClient(tool.ExternalView().UserConn())
+			_, err := client.Update(ctx, publicv1.ClusterVersionsUpdateRequest_builder{}.Build())
+			Expect(err).To(HaveOccurred())
+			status, ok := grpcstatus.FromError(err)
+			Expect(ok).To(BeTrue())
+			Expect(status.Code()).To(Equal(grpccodes.PermissionDenied))
+		})
+
+		It("Denies regular users deleting cluster versions", func() {
+			client := publicv1.NewClusterVersionsClient(tool.ExternalView().UserConn())
+			_, err := client.Delete(ctx, publicv1.ClusterVersionsDeleteRequest_builder{}.Build())
+			Expect(err).To(HaveOccurred())
+			status, ok := grpcstatus.FromError(err)
+			Expect(ok).To(BeTrue())
+			Expect(status.Code()).To(Equal(grpccodes.PermissionDenied))
+		})
+
 		It("Allows admin users to list cluster templates", func() {
 			client := publicv1.NewClusterTemplatesClient(tool.ExternalView().AdminConn())
 
@@ -91,6 +124,12 @@ var _ = Describe("Access control", func() {
 		It("Allows admin users to list compute instances", func() {
 			client := publicv1.NewComputeInstancesClient(tool.ExternalView().AdminConn())
 			_, err := client.List(ctx, publicv1.ComputeInstancesListRequest_builder{}.Build())
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("Allows admin users to list cluster versions", func() {
+			client := publicv1.NewClusterVersionsClient(tool.ExternalView().AdminConn())
+			_, err := client.List(ctx, publicv1.ClusterVersionsListRequest_builder{}.Build())
 			Expect(err).ToNot(HaveOccurred())
 		})
 	})
@@ -129,6 +168,12 @@ var _ = Describe("Access control", func() {
 		It("Allows admin users to list private compute instances", func() {
 			client := privatev1.NewComputeInstancesClient(tool.InternalView().AdminConn())
 			_, err := client.List(ctx, privatev1.ComputeInstancesListRequest_builder{}.Build())
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("Allows admin users to list private cluster versions", func() {
+			client := privatev1.NewClusterVersionsClient(tool.InternalView().AdminConn())
+			_, err := client.List(ctx, privatev1.ClusterVersionsListRequest_builder{}.Build())
 			Expect(err).ToNot(HaveOccurred())
 		})
 
@@ -180,6 +225,15 @@ var _ = Describe("Access control", func() {
 		It("Denies regular users access to private compute instances", func() {
 			client := privatev1.NewComputeInstancesClient(tool.InternalView().UserConn())
 			_, err := client.List(ctx, privatev1.ComputeInstancesListRequest_builder{}.Build())
+			Expect(err).To(HaveOccurred())
+			status, ok := grpcstatus.FromError(err)
+			Expect(ok).To(BeTrue())
+			Expect(status.Code()).To(Equal(grpccodes.PermissionDenied))
+		})
+
+		It("Denies regular users access to private cluster versions", func() {
+			client := privatev1.NewClusterVersionsClient(tool.InternalView().UserConn())
+			_, err := client.List(ctx, privatev1.ClusterVersionsListRequest_builder{}.Build())
 			Expect(err).To(HaveOccurred())
 			status, ok := grpcstatus.FromError(err)
 			Expect(ok).To(BeTrue())

--- a/proto/private/osac/private/v1/cluster_version_type.proto
+++ b/proto/private/osac/private/v1/cluster_version_type.proto
@@ -30,7 +30,7 @@ enum ClusterVersionState {
   // The cluster version is fully available for new cluster creation.
   //
   // This is the default state assigned on creation. Returning to ACTIVE from DEPRECATED or OBSOLETE
-  // clears the corresponding deprecation timestamps.
+  // retains the corresponding deprecation timestamps as historical record.
   CLUSTER_VERSION_STATE_ACTIVE = 1;
 
   // The cluster version is available with warnings; migration to a newer version is recommended.
@@ -49,8 +49,8 @@ enum ClusterVersionState {
 // Contains deprecation details for a cluster version.
 //
 // The timestamps are managed by the server during lifecycle state transitions. The deprecation_timestamp is set when
-// the version transitions to DEPRECATED, and the obsolescence_timestamp is set when it transitions to OBSOLETE. Both
-// are cleared if the version returns to ACTIVE.
+// the version transitions to DEPRECATED, and the obsolescence_timestamp is set when it transitions to OBSOLETE.
+// Timestamps are retained as historical record when the version returns to ACTIVE.
 message ClusterVersionDeprecation {
   // When deprecation was announced. Auto-set on transition to DEPRECATED.
   google.protobuf.Timestamp deprecation_timestamp = 1 [(google.api.field_behavior) = OUTPUT_ONLY];

--- a/proto/public/osac/public/v1/cluster_version_type.proto
+++ b/proto/public/osac/public/v1/cluster_version_type.proto
@@ -30,7 +30,7 @@ enum ClusterVersionState {
   // The cluster version is fully available for new cluster creation.
   //
   // This is the default state assigned on creation. Returning to ACTIVE from DEPRECATED or OBSOLETE
-  // clears the corresponding deprecation timestamps.
+  // retains the corresponding deprecation timestamps as historical record.
   CLUSTER_VERSION_STATE_ACTIVE = 1;
 
   // The cluster version is available with warnings; migration to a newer version is recommended.
@@ -49,8 +49,8 @@ enum ClusterVersionState {
 // Contains deprecation details for a cluster version.
 //
 // The timestamps are managed by the server during lifecycle state transitions. The deprecation_timestamp is set when
-// the version transitions to DEPRECATED, and the obsolescence_timestamp is set when it transitions to OBSOLETE. Both
-// are cleared if the version returns to ACTIVE.
+// the version transitions to DEPRECATED, and the obsolescence_timestamp is set when it transitions to OBSOLETE.
+// Timestamps are retained as historical record when the version returns to ACTIVE.
 message ClusterVersionDeprecation {
   // When deprecation was announced. Auto-set on transition to DEPRECATED.
   google.protobuf.Timestamp deprecation_timestamp = 1 [(google.api.field_behavior) = OUTPUT_ONLY];


### PR DESCRIPTION
## Summary

- Extract `validateCELSyntax` and composable per-field filter defaults (`composeFilterDefaults`) into `cel_filter.go`, refactoring `InstanceTypesServer` to use the shared helper
- Implement public and private ClusterVersion gRPC servers with state lifecycle (ACTIVE/DEPRECATED/OBSOLETE), `is_default` management with atomic swap via partial unique index, immutability guards on version/image/name, SemVer validation, and auto-generated DNS-safe names
- Public server uses composable filter defaults (state + enabled), maps `is_default` as read-only, and delegates to the private server preserving private-only fields (e.g. `spec.image`)
- Add OPA policy for ClusterVersions public access and integration tests for access control

## Test plan

- [x] `ginkgo run -r internal` -- all 80 suites pass
- [x] `uv run dev.py lint` -- 0 issues
- [x] `buf lint` -- clean
- [x] Integration tests (`ginkgo run it`) -- requires kind cluster

Assisted-by: Claude <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added public and private Cluster Versions APIs (list, view, create, update, delete, signaling) with default visibility and filter-aware behavior.
  * Improved Cluster Versions and Instance Types list filtering by composing default predicates with CEL expressions.
* **Bug Fixes**
  * Retained deprecation/obsolescence timestamps when transitioning back to active status.
  * Expanded authorization to allow additional cluster-versions gRPC methods for permitted client-permission subjects.
* **Documentation**
  * Updated cluster-version proto comments to reflect timestamp retention semantics.
* **Tests**
  * Added end-to-end and unit test coverage for public/private Cluster Versions behavior and filtering utilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->