### PR TITLE
NO-ISSUE: grant pull-requests:write to ok-to-test-label-cleanup caller

### DIFF
--- a/.github/workflows/ok-to-test-label-cleanup.yml
+++ b/.github/workflows/ok-to-test-label-cleanup.yml
@@ -6,6 +6,8 @@ on:
 
 jobs:
   remove-label:
+    permissions:
+      pull-requests: write
     if: contains(github.event.pull_request.labels.*.name, 'ok-to-test')
     uses: osac-project/osac-test-infra/.github/workflows/ok-to-test-label-cleanup.yml@main
     secrets: inherit


### PR DESCRIPTION
## Summary

The `ok-to-test-label-cleanup.yml` caller in this repo has been failing with `startup_failure` on every run since at least 2026-07-14 — identically across every repo that calls this reusable workflow (`fulfillment-service`, `osac-operator`, `osac-aap`, `osac-installer`).

## Root cause

The reusable workflow (`osac-project/osac-test-infra/.github/workflows/ok-to-test-label-cleanup.yml`) declares `permissions: pull-requests: write` at its job level — it needs that to remove the label and post a comment. This caller granted no permissions at all, so its `GITHUB_TOKEN` was implicitly restricted to `none`. GitHub refuses to start a job that calls a reusable workflow requesting more permission than the caller itself has:

```
The nested job 'remove-label' is requesting 'pull-requests: write',
but is only allowed 'pull-requests: none'.
```

## Fix

Explicitly grant `pull-requests: write` on the calling job, so that scope is available to hand down to the reusable workflow.

## Impact

Not a required status check, so this wasn't blocking merges — but it silently defeats the fork-PR safety net this workflow exists for: new commits on an already-`ok-to-test`-approved fork PR should force a re-approval, and that reset hasn't been happening.