### PR TITLE
NO-ISSUE: enable nakedret linter and resolve all naked returns

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -27,8 +27,11 @@ linters:
     - gocyclo
     - gosec
     - misspell
+    - nakedret
     - nolintlint
   settings:
+    nakedret:
+      max-func-lines: 10
     gosec:
       excludes:
         # G104 (unhandled errors) is redundant with errcheck. The std-error-handling

--- a/internal/apiclient/client.go
+++ b/internal/apiclient/client.go
@@ -96,15 +96,15 @@ func (b *ClientBuilder) SetHTTPClient(value *http.Client) *ClientBuilder {
 func (b *ClientBuilder) Build() (result *Client, err error) {
 	if b.logger == nil {
 		err = errors.New("logger is mandatory")
-		return
+		return result, err
 	}
 	if b.baseURL == "" {
 		err = errors.New("base URL is mandatory")
-		return
+		return result, err
 	}
 	if b.tokenSource == nil {
 		err = errors.New("token source is mandatory")
-		return
+		return result, err
 	}
 
 	httpClient := b.httpClient
@@ -126,7 +126,7 @@ func (b *ClientBuilder) Build() (result *Client, err error) {
 		tokenSource: b.tokenSource,
 		logger:      b.logger,
 	}
-	return
+	return result, err
 }
 
 // DoRequest performs an authenticated HTTP request with JSON handling.
@@ -148,7 +148,7 @@ func (c *Client) DoRequest(ctx context.Context, method, path string, body any) (
 	token, err := c.tokenSource.Token(ctx)
 	if err != nil {
 		err = fmt.Errorf("failed to get authentication token: %w", err)
-		return
+		return response, err
 	}
 
 	var bodyReader io.Reader
@@ -156,7 +156,7 @@ func (c *Client) DoRequest(ctx context.Context, method, path string, body any) (
 		bodyBytes, marshalErr := json.Marshal(body)
 		if marshalErr != nil {
 			err = fmt.Errorf("failed to marshal request body: %w", marshalErr)
-			return
+			return response, err
 		}
 		bodyReader = bytes.NewReader(bodyBytes)
 	}
@@ -165,7 +165,7 @@ func (c *Client) DoRequest(ctx context.Context, method, path string, body any) (
 	request, err := http.NewRequestWithContext(ctx, method, requestURL, bodyReader)
 	if err != nil {
 		err = fmt.Errorf("failed to create HTTP request: %w", err)
-		return
+		return response, err
 	}
 
 	request.Header.Set("Authorization", fmt.Sprintf("Bearer %s", token.Access))
@@ -181,7 +181,7 @@ func (c *Client) DoRequest(ctx context.Context, method, path string, body any) (
 	response, err = c.httpClient.Do(request)
 	if err != nil {
 		err = fmt.Errorf("failed to send HTTP request: %w", err)
-		return
+		return response, err
 	}
 
 	if response.StatusCode >= 400 {
@@ -197,10 +197,10 @@ func (c *Client) DoRequest(ctx context.Context, method, path string, body any) (
 		// Set response to nil so callers can't accidentally access a closed response.
 		// This enforces checking err before using response.
 		response = nil
-		return
+		return response, err
 	}
 
-	return
+	return response, err
 }
 
 // RefreshToken invalidates the cached token, forcing a fresh token to be generated on the next request.

--- a/internal/auth/auth_file_token_source.go
+++ b/internal/auth/auth_file_token_source.go
@@ -59,17 +59,17 @@ func (b *FileTokenSourceBuilder) Build() (result TokenSource, err error) {
 	// Check parameters:
 	if b.logger == nil {
 		err = errors.New("logger is mandatory")
-		return
+		return result, err
 	}
 	if b.file == "" {
 		err = errors.New("file is mandatory")
-		return
+		return result, err
 	}
 
 	// Check that the file exists:
 	_, err = os.Stat(b.file)
 	if err != nil {
-		return
+		return result, err
 	}
 
 	// Add the file name to the logger:
@@ -82,7 +82,7 @@ func (b *FileTokenSourceBuilder) Build() (result TokenSource, err error) {
 		logger: logger,
 		file:   b.file,
 	}
-	return
+	return result, err
 }
 
 // Token is the implementation of the TokenSource interface.
@@ -95,7 +95,7 @@ func (s *fileTokenSource) Token(ctx context.Context) (result *Token, err error) 
 			"Failed to get file info for token file",
 			slog.Any("error", err),
 		)
-		return
+		return result, err
 	}
 	timestamp := info.ModTime()
 
@@ -120,7 +120,7 @@ func (s *fileTokenSource) Token(ctx context.Context) (result *Token, err error) 
 		token := strings.TrimSpace(string(data))
 		if token == "" {
 			err = errors.New("token file is empty")
-			return
+			return result, err
 		}
 		s.token = &Token{
 			Access: token,
@@ -130,7 +130,7 @@ func (s *fileTokenSource) Token(ctx context.Context) (result *Token, err error) 
 
 	// Return the token:
 	result = s.token
-	return
+	return result, err
 }
 
 // Invalidate clears the cached token, forcing the file to be re-read on the next Token() call.

--- a/internal/auth/auth_jwks_cache.go
+++ b/internal/auth/auth_jwks_cache.go
@@ -192,19 +192,19 @@ func (b *JwksCacheBuilder) Build() (result JwksCache, err error) {
 	// Check parameters:
 	if b.logger == nil {
 		err = errors.New("logger is mandatory")
-		return
+		return result, err
 	}
 	if b.minTTL < 0 {
 		err = errors.New("minimum TTL must be zero or positive")
-		return
+		return result, err
 	}
 	if b.maxTTL < 0 {
 		err = errors.New("maximum TTL must be zero or positive")
-		return
+		return result, err
 	}
 	if b.minTTL > b.maxTTL {
 		err = errors.New("minimum TTL must be less than or equal to maximum TTL")
-		return
+		return result, err
 	}
 
 	// Check the list of issuers provided by the caller:
@@ -213,17 +213,17 @@ func (b *JwksCacheBuilder) Build() (result JwksCache, err error) {
 		issuerUrl = strings.TrimSpace(issuerUrl)
 		if issuerUrl == "" {
 			err = errors.New("invalid empty issuer URL")
-			return
+			return result, err
 		}
 		var parsed *url.URL
 		parsed, err = url.Parse(issuerUrl)
 		if err != nil {
 			err = fmt.Errorf("invalid issuer URL '%s': %w", issuerUrl, err)
-			return
+			return result, err
 		}
 		if parsed.Scheme != "https" {
 			err = fmt.Errorf("issuer URL '%s' must use the HTTPS scheme", issuerUrl)
-			return
+			return result, err
 		}
 		issuerUrl = parsed.String()
 		issuersInfo[issuerUrl] = &jwksCacheIssuerInfo{
@@ -237,7 +237,7 @@ func (b *JwksCacheBuilder) Build() (result JwksCache, err error) {
 		var tokenObject *jwt.Token
 		tokenObject, err = b.loadKubeToken(tokenFile)
 		if err != nil {
-			return
+			return result, err
 		}
 		if tokenObject != nil {
 			var issuerUrl string
@@ -247,7 +247,7 @@ func (b *JwksCacheBuilder) Build() (result JwksCache, err error) {
 					"failed to get the 'iss' claim from Kubernetes service account token: %w",
 					err,
 				)
-				return
+				return result, err
 			}
 			var issuerParsed *url.URL
 			issuerParsed, err = url.Parse(issuerUrl)
@@ -256,21 +256,21 @@ func (b *JwksCacheBuilder) Build() (result JwksCache, err error) {
 					"failed to parse the 'iss' claim '%s' from Kubernetes service account token: %w",
 					issuerUrl, err,
 				)
-				return
+				return result, err
 			}
 			if issuerParsed.Scheme != "https" {
 				err = fmt.Errorf(
 					"the 'iss' claim '%s' from Kubernetes service account token must use HTTPS",
 					issuerUrl,
 				)
-				return
+				return result, err
 			}
 			if issuerParsed.Host == "" {
 				err = fmt.Errorf(
 					"the 'iss' claim '%s' from Kubernetes service account token must have a host",
 					issuerUrl,
 				)
-				return
+				return result, err
 			}
 			issuerUrl = issuerParsed.String()
 			issuersInfo[issuerUrl] = &jwksCacheIssuerInfo{
@@ -284,7 +284,7 @@ func (b *JwksCacheBuilder) Build() (result JwksCache, err error) {
 	// authenticate any request.
 	if len(issuersInfo) == 0 {
 		err = errors.New("at least one issuer must be configured")
-		return
+		return result, err
 	}
 
 	// Create the HTTP client used to download JSON web key sets:
@@ -308,7 +308,7 @@ func (b *JwksCacheBuilder) Build() (result JwksCache, err error) {
 		minTTL:      b.minTTL,
 		cache:       map[jwksCacheTag]any{},
 	}
-	return
+	return result, err
 }
 
 // loadKubeToken loads the Kubernetes service account token file and parses it, but without verifying the signature.
@@ -318,14 +318,14 @@ func (b *JwksCacheBuilder) loadKubeToken(tokenFile string) (result *jwt.Token, e
 	tokenBytes, err := os.ReadFile(tokenFile) //nolint:gosec
 	if errors.Is(err, os.ErrNotExist) {
 		err = nil
-		return
+		return result, err
 	}
 	if err != nil {
 		err = fmt.Errorf(
 			"failed to read Kubernetes service account token file '%s': %w",
 			tokenFile, err,
 		)
-		return
+		return result, err
 	}
 	tokenText := strings.TrimSpace(string(tokenBytes))
 
@@ -339,12 +339,12 @@ func (b *JwksCacheBuilder) loadKubeToken(tokenFile string) (result *jwt.Token, e
 			"failed to parse Kubernetes service account token from file '%s': %w",
 			tokenFile, err,
 		)
-		return
+		return result, err
 	}
 
 	// Return the token:
 	result = tokenObject
-	return
+	return result, err
 }
 
 // resolvePath resolves a file path using the custom root directory if set. If no root is set, returns the original
@@ -364,7 +364,7 @@ func (c *jwksCache) Get(ctx context.Context, issuerUrl string, keyId string) (re
 	issuerInfo, ok := c.issuersInfo[issuerUrl]
 	if !ok {
 		err = ErrBadIssuer
-		return
+		return result, err
 	}
 
 	// Try to find the key in the cache. If found but expired according to the TTL, return it immediately (so the
@@ -389,25 +389,25 @@ func (c *jwksCache) Get(ctx context.Context, issuerUrl string, keyId string) (re
 			}()
 		}
 		result = keyObj
-		return
+		return result, err
 	}
 
 	// If the key is not in the cache, try to refresh synchronously:
 	err = c.refresh(ctx, issuerInfo)
 	if err != nil {
-		return
+		return result, err
 	}
 
 	// Try again after refresh:
 	keyObj, ok = c.getEntry(issuerUrl, keyId)
 	if ok {
 		result = keyObj
-		return
+		return result, err
 	}
 
 	// Report that we do not have a matching key:
 	err = ErrBadKey
-	return
+	return result, err
 }
 
 // getEntry returns the key for the given issuer and key identifier. If the key is not found, the second return value
@@ -533,19 +533,19 @@ func (c *jwksCache) loadJwksUrl(ctx context.Context, issuerInfo *jwksCacheIssuer
 	err error) {
 	request, err := http.NewRequestWithContext(ctx, http.MethodGet, issuerInfo.jwksUrl, nil)
 	if err != nil {
-		return
+		return result, err
 	}
 	if issuerInfo.tokenFile != "" {
 		var tokenText string
 		tokenText, err = c.loadTokenFile(issuerInfo.tokenFile)
 		if err != nil {
-			return
+			return result, err
 		}
 		request.Header.Set(Authorization, fmt.Sprintf("Bearer %s", tokenText))
 	}
 	response, err := c.httpClient.Do(request)
 	if err != nil {
-		return
+		return result, err
 	}
 	defer func() {
 		err := response.Body.Close()
@@ -563,10 +563,10 @@ func (c *jwksCache) loadJwksUrl(ctx context.Context, issuerInfo *jwksCacheIssuer
 			"request to load keys from '%s' failed with status code %d",
 			issuerInfo.jwksUrl, response.StatusCode,
 		)
-		return
+		return result, err
 	}
 	result, err = c.readKeys(ctx, issuerInfo, response.Body)
-	return
+	return result, err
 }
 
 // loadTokenFile loads a token from a file.
@@ -586,16 +586,16 @@ func (c *jwksCache) readKeys(ctx context.Context, issuerInfo *jwksCacheIssuerInf
 	jsonReader := io.LimitReader(reader, jwksMaxSize+1)
 	jsonData, err := io.ReadAll(jsonReader)
 	if err != nil {
-		return
+		return result, err
 	}
 	if len(jsonData) > jwksMaxSize {
 		err = fmt.Errorf("JSON web key set is too large, maximum size is %d bytes", jwksMaxSize)
-		return
+		return result, err
 	}
 	var setData jwksCacheKeySetData
 	err = json.Unmarshal(jsonData, &setData)
 	if err != nil {
-		return
+		return result, err
 	}
 	keyMap := map[string]any{}
 	for _, keyData := range setData.Keys {
@@ -629,36 +629,36 @@ func (c *jwksCache) readKeys(ctx context.Context, issuerInfo *jwksCacheIssuerInf
 		)
 	}
 	result = keyMap
-	return
+	return result, err
 }
 
 // parseKey converts JWKS key data to an RSA public key.
 func (c *jwksCache) parseKey(data jwksCacheKeyData) (result any, err error) {
 	if data.Kty == "" {
 		err = errors.New("key type is missing")
-		return
+		return result, err
 	}
 	if !strings.EqualFold(data.Kty, "RSA") {
 		err = fmt.Errorf("key type '%s' is not supported", data.Kty)
-		return
+		return result, err
 	}
 	if data.N == "" || data.E == "" {
 		err = errors.New("RSA key is missing required 'n' or 'e' field")
-		return
+		return result, err
 	}
 	nb, err := base64.RawURLEncoding.DecodeString(data.N)
 	if err != nil {
-		return
+		return result, err
 	}
 	eb, err := base64.RawURLEncoding.DecodeString(data.E)
 	if err != nil {
-		return
+		return result, err
 	}
 	result = &rsa.PublicKey{
 		N: new(big.Int).SetBytes(nb),
 		E: int(new(big.Int).SetBytes(eb).Int64()),
 	}
-	return
+	return result, err
 }
 
 // jwksCacheKeySetData is the JSON representation of a key set.

--- a/internal/auth/auth_jwt_validator.go
+++ b/internal/auth/auth_jwt_validator.go
@@ -133,19 +133,19 @@ func (b *JwtValidatorBuilder) Build() (result JwtValidator, err error) {
 	// Check parameters:
 	if b.logger == nil {
 		err = errors.New("logger is mandatory")
-		return
+		return result, err
 	}
 	if b.jwksCache == nil {
 		err = errors.New("JWKS cache is mandatory")
-		return
+		return result, err
 	}
 	if b.tokenLeeway < 0 {
 		err = errors.New("leeway must be zero or positive")
-		return
+		return result, err
 	}
 	if b.cleanupInterval < 0 {
 		err = errors.New("cleanup interval must be zero or positive")
-		return
+		return result, err
 	}
 
 	// Apply defaults:
@@ -184,7 +184,7 @@ func (b *JwtValidatorBuilder) Build() (result JwtValidator, err error) {
 		cacheMap:        cacheMap,
 		cleanupInterval: cleanupInterval,
 	}
-	return
+	return result, err
 }
 
 // Validate parses and validates the bearer token.
@@ -198,7 +198,7 @@ func (v *jwtValidator) Validate(ctx context.Context, bearer string) (result *jwt
 				v.cacheMap.Delete(bearer)
 			} else {
 				result = entry.tokenObject
-				return
+				return result, err
 			}
 		}
 	}
@@ -210,7 +210,7 @@ func (v *jwtValidator) Validate(ctx context.Context, bearer string) (result *jwt
 	)
 	if err != nil {
 		err = v.translateError(ctx, token, err)
-		return
+		return result, err
 	}
 	claims, ok := token.Claims.(jwt.MapClaims)
 	if !ok {
@@ -220,11 +220,11 @@ func (v *jwtValidator) Validate(ctx context.Context, bearer string) (result *jwt
 			slog.String("type", fmt.Sprintf("%T", token.Claims)),
 		)
 		err = errors.New("token is not valid")
-		return
+		return result, err
 	}
 	err = v.validateClaims(claims)
 	if err != nil {
-		return
+		return result, err
 	}
 	if v.cacheMap != nil {
 		exp, _ := claims.GetExpirationTime()
@@ -236,7 +236,7 @@ func (v *jwtValidator) Validate(ctx context.Context, bearer string) (result *jwt
 		}
 	}
 	result = token
-	return
+	return result, err
 }
 
 // maybeCleanup checks whether enough time has elapsed since the last cache cleanup, and if so launches a background
@@ -380,15 +380,15 @@ func (v *jwtValidator) selectKey(ctx context.Context, token *jwt.Token) (result 
 	issuerUrl, err := token.Claims.GetIssuer()
 	if err != nil {
 		err = errors.New("token does not contain the 'iss' claim")
-		return
+		return result, err
 	}
 	keyId, ok := token.Header["kid"].(string)
 	if !ok || keyId == "" {
 		err = errors.New("token does not contain the 'kid' claim")
-		return
+		return result, err
 	}
 	result, err = v.jwksCache.Get(ctx, issuerUrl, keyId)
-	return
+	return result, err
 }
 
 // validateClaims validates the application-level claims.

--- a/internal/auth/auth_memory_token_store.go
+++ b/internal/auth/auth_memory_token_store.go
@@ -47,14 +47,14 @@ func (b *MemoryTokenStoreBuilder) Build() (result TokenStore, err error) {
 	// Check parameters:
 	if b.logger == nil {
 		err = errors.New("logger is mandatory")
-		return
+		return result, err
 	}
 
 	// Create and populate the object:
 	result = &memoryTokenStore{
 		logger: b.logger,
 	}
-	return
+	return result, err
 }
 
 // Load loads the tokens from memory. Returns a clone of the stored token to prevent side effects.
@@ -62,14 +62,14 @@ func (s *memoryTokenStore) Load(ctx context.Context) (result *Token, err error) 
 	s.lock.RLock()
 	defer s.lock.RUnlock()
 	if s.token == nil {
-		return
+		return result, err
 	}
 	result = &Token{
 		Access:  s.token.Access,
 		Refresh: s.token.Refresh,
 		Expiry:  s.token.Expiry,
 	}
-	return
+	return result, err
 }
 
 // Save saves the tokens to memory. Clones the provided token to prevent side effects.

--- a/internal/auth/auth_script_token_source.go
+++ b/internal/auth/auth_script_token_source.go
@@ -71,15 +71,15 @@ func (b *ScriptTokenSourceBuilder) Build() (result TokenSource, err error) {
 	// Check parameters:
 	if b.logger == nil {
 		err = errors.New("logger is mandatory")
-		return
+		return result, err
 	}
 	if b.script == "" {
 		err = errors.New("token generation script is mandatory")
-		return
+		return result, err
 	}
 	if b.store == nil {
 		err = errors.New("token store is mandatory")
-		return
+		return result, err
 	}
 
 	// Create the token parser:
@@ -97,7 +97,7 @@ func (b *ScriptTokenSourceBuilder) Build() (result TokenSource, err error) {
 		store:       b.store,
 		tokenParser: parser,
 	}
-	return
+	return result, err
 }
 
 // Token is the implementation of the TokenSource interface.
@@ -105,7 +105,7 @@ func (s *scriptTokenSource) Token(ctx context.Context) (result *Token, err error
 	// Try to load an existing token first:
 	existingToken, err := s.store.Load(ctx)
 	if err != nil {
-		return
+		return result, err
 	}
 
 	// If we have a token and it's still fresh, use it:
@@ -115,14 +115,14 @@ func (s *scriptTokenSource) Token(ctx context.Context) (result *Token, err error
 		parsedToken, parseErr := s.parseToken(existingToken.Access)
 		if parseErr == nil && !parsedToken.Expiry.Before(time.Now()) {
 			result = parsedToken
-			return
+			return result, err
 		}
 	}
 
 	// Generate a new token:
 	rawToken, err := s.generateToken()
 	if err != nil {
-		return
+		return result, err
 	}
 
 	// Try to parse the token to get expiry information:
@@ -132,17 +132,17 @@ func (s *scriptTokenSource) Token(ctx context.Context) (result *Token, err error
 		result = &Token{
 			Access: rawToken,
 		}
-		return
+		return result, err
 	}
 
 	// Save the parsed token to storage:
 	err = s.store.Save(ctx, parsedToken)
 	if err != nil {
-		return
+		return result, err
 	}
 
 	result = parsedToken
-	return
+	return result, err
 }
 
 func (s *scriptTokenSource) generateToken() (result string, err error) {
@@ -163,27 +163,27 @@ func (s *scriptTokenSource) generateToken() (result string, err error) {
 	err = cmd.Run()
 	if err != nil {
 		err = fmt.Errorf("failed to execute token generation script '%s': %w", s.script, err)
-		return
+		return result, err
 	}
 	result = strings.TrimSpace(out.String())
-	return
+	return result, err
 }
 
 func (s *scriptTokenSource) parseToken(tokenText string) (result *Token, err error) {
 	tokenClaims := jwt.MapClaims{}
 	_, _, err = s.tokenParser.ParseUnverified(tokenText, tokenClaims)
 	if err != nil {
-		return
+		return result, err
 	}
 	tokenEpirationTime, err := tokenClaims.GetExpirationTime()
 	if err != nil {
-		return
+		return result, err
 	}
 	result = &Token{
 		Access: tokenText,
 		Expiry: tokenEpirationTime.Time,
 	}
-	return
+	return result, err
 }
 
 // Invalidate clears the cached token, forcing a new token to be generated on the next Token() call.

--- a/internal/auth/auth_static_token_source.go
+++ b/internal/auth/auth_static_token_source.go
@@ -53,11 +53,11 @@ func (b *StaticTokenSourceBuilder) Build() (result TokenSource, err error) {
 	// Check parameters:
 	if b.logger == nil {
 		err = errors.New("logger is mandatory")
-		return
+		return result, err
 	}
 	if b.token == nil {
 		err = errors.New("token is mandatory")
-		return
+		return result, err
 	}
 
 	// Create and populate the object:
@@ -65,7 +65,7 @@ func (b *StaticTokenSourceBuilder) Build() (result TokenSource, err error) {
 		logger: b.logger,
 		token:  b.token,
 	}
-	return
+	return result, err
 }
 
 // Token is the implementation of the TokenSource interface.

--- a/internal/auth/auth_subject.go
+++ b/internal/auth/auth_subject.go
@@ -78,13 +78,13 @@ func (s *Subject) MarshalJSON() (data []byte, err error) {
 		tenants = s.Tenants.Inclusions()
 	} else {
 		err = fmt.Errorf("the tenant set is infinite")
-		return
+		return data, err
 	}
 	data, err = json.Marshal(subjectJson{
 		User:    s.User,
 		Tenants: tenants,
 	})
-	return
+	return data, err
 }
 
 // universalMarker is the special value used in the subject's tenant list to indicate that the subject has access to all

--- a/internal/auth/auth_token_credentials.go
+++ b/internal/auth/auth_token_credentials.go
@@ -57,11 +57,11 @@ func (b *TokenCredentialsBuilder) Build() (result credentials.PerRPCCredentials,
 	// Check parameters:
 	if b.logger == nil {
 		err = errors.New("logger is mandatory")
-		return
+		return result, err
 	}
 	if b.source == nil {
 		err = errors.New("source is mandatory")
-		return
+		return result, err
 	}
 
 	// Create and populate the object:
@@ -69,7 +69,7 @@ func (b *TokenCredentialsBuilder) Build() (result credentials.PerRPCCredentials,
 		logger: b.logger,
 		source: b.source,
 	}
-	return
+	return result, err
 }
 
 // GetRequestMetadata is the implementation of the gRPC PerRPCCredentials interface. It retrieves the current request

--- a/internal/auth/default_attribution_logic.go
+++ b/internal/auth/default_attribution_logic.go
@@ -61,7 +61,7 @@ func (b *DefaultAttributionLogicBuilder) Build() (result *DefaultAttributionLogi
 	// Check that the logger has been set:
 	if b.logger == nil {
 		err = fmt.Errorf("logger is mandatory")
-		return
+		return result, err
 	}
 
 	// Create the attribution logic:
@@ -69,7 +69,7 @@ func (b *DefaultAttributionLogicBuilder) Build() (result *DefaultAttributionLogi
 		logger:         b.logger,
 		userIDResolver: b.userIDResolver,
 	}
-	return
+	return result, err
 }
 
 // DetermineAssignedCreator looks up the authenticated user and returns their ID as the creator.
@@ -84,7 +84,7 @@ func (l *DefaultAttributionLogic) DetermineAssignedCreator(ctx context.Context) 
 			slog.String("!username", username),
 		)
 		result = username
-		return
+		return result, err
 	}
 
 	// Try to resolve the username to a user ID
@@ -98,7 +98,7 @@ func (l *DefaultAttributionLogic) DetermineAssignedCreator(ctx context.Context) 
 			slog.Any("error", resolveErr),
 		)
 		result = username
-		return
+		return result, err
 	}
 
 	if userID == "" {
@@ -108,10 +108,10 @@ func (l *DefaultAttributionLogic) DetermineAssignedCreator(ctx context.Context) 
 			slog.String("!username", username),
 		)
 		result = username
-		return
+		return result, err
 	}
 
 	// Found the user - return their ID
 	result = userID
-	return
+	return result, err
 }

--- a/internal/auth/default_tenancy_logic.go
+++ b/internal/auth/default_tenancy_logic.go
@@ -69,9 +69,9 @@ func (p *DefaultTenancyLogic) DetermineAssignableTenants(ctx context.Context) (r
 			slog.String("user", subject.User),
 		)
 		err = fmt.Errorf("subject must belong to at least one tenant to create objects")
-		return
+		return result, err
 	}
-	return
+	return result, err
 }
 
 // DetermineDefaultTenant extracts the subject from the auth context and returns the tenant that will be assigned
@@ -80,17 +80,17 @@ func (p *DefaultTenancyLogic) DetermineAssignableTenants(ctx context.Context) (r
 func (p *DefaultTenancyLogic) DetermineDefaultTenant(ctx context.Context) (result string, err error) {
 	assignable, err := p.DetermineAssignableTenants(ctx)
 	if err != nil {
-		return
+		return result, err
 	}
 	if !assignable.Finite() {
 		result = SharedTenant
-		return
+		return result, err
 	}
 	inclusions := assignable.Inclusions()
 	if len(inclusions) > 0 {
 		result = inclusions[0]
 	}
-	return
+	return result, err
 }
 
 // DetermineVisibleTenants extracts the subject from the auth context and returns the identifiers of the tenants

--- a/internal/auth/grpc_authn_interceptor.go
+++ b/internal/auth/grpc_authn_interceptor.go
@@ -80,11 +80,11 @@ func (b *GrpcAuthnInterceptorBuilder) Build() (result *GrpcAuthnInterceptor, err
 	// Check parameters:
 	if b.logger == nil {
 		err = errors.New("logger is mandatory")
-		return
+		return result, err
 	}
 	if b.jwtValidator == nil {
 		err = errors.New("JWT validator is mandatory")
-		return
+		return result, err
 	}
 
 	// Compile anonymous method regexes:
@@ -93,7 +93,7 @@ func (b *GrpcAuthnInterceptorBuilder) Build() (result *GrpcAuthnInterceptor, err
 		anonymousMethods[i], err = regexp.Compile(expr)
 		if err != nil {
 			err = fmt.Errorf("failed to compile anonymous method regex '%s': %w", expr, err)
-			return
+			return result, err
 		}
 	}
 
@@ -103,7 +103,7 @@ func (b *GrpcAuthnInterceptorBuilder) Build() (result *GrpcAuthnInterceptor, err
 		jwtValidator:     b.jwtValidator,
 		anonymousMethods: anonymousMethods,
 	}
-	return
+	return result, err
 }
 
 // UnaryServer is the unary server interceptor function.
@@ -168,7 +168,7 @@ func (s *grpcAuthnStream) SetTrailer(md metadata.MD) {
 func (i *GrpcAuthnInterceptor) authenticate(ctx context.Context, method string) (result context.Context, err error) {
 	if i.isAnonymous(method) {
 		result = ctx
-		return
+		return result, err
 	}
 	values := metadata.ValueFromIncomingContext(ctx, Authorization)
 	length := len(values)
@@ -185,21 +185,21 @@ func (i *GrpcAuthnInterceptor) authenticate(ctx context.Context, method string) 
 			length,
 		)
 	}
-	return
+	return result, err
 }
 
 func (i *GrpcAuthnInterceptor) withHeader(ctx context.Context, header string) (result context.Context, err error) {
 	bearer, err := i.extractBearer(header)
 	if err != nil {
-		return
+		return result, err
 	}
 	token, err := i.jwtValidator.Validate(ctx, bearer)
 	if err != nil {
 		err = grpcstatus.Errorf(grpccodes.Unauthenticated, "%s", err.Error())
-		return
+		return result, err
 	}
 	result = ContextWithToken(ctx, token)
-	return
+	return result, err
 }
 
 // extractBearer extracts the bearer token from the authorization header value.
@@ -210,7 +210,7 @@ func (i *GrpcAuthnInterceptor) extractBearer(auth string) (result string, err er
 			grpccodes.Unauthenticated,
 			"authorization header value should be 'Bearer TOKEN'",
 		)
-		return
+		return result, err
 	}
 	scheme := matches[1]
 	if !strings.EqualFold(scheme, "Bearer") {
@@ -219,10 +219,10 @@ func (i *GrpcAuthnInterceptor) extractBearer(auth string) (result string, err er
 			"authentication scheme '%s' is not supported",
 			scheme,
 		)
-		return
+		return result, err
 	}
 	result = matches[2]
-	return
+	return result, err
 }
 
 // isAnonymous checks if the given method is anonymous by matching it against the configured anonymous method

--- a/internal/auth/grpc_authz_interceptor.go
+++ b/internal/auth/grpc_authz_interceptor.go
@@ -119,7 +119,7 @@ func (b *GrpcAuthzInterceptorBuilder) AddEmergencyServiceAccounts(
 func (b *GrpcAuthzInterceptorBuilder) Build() (result *GrpcAuthzInterceptor, err error) {
 	if b.logger == nil {
 		err = errors.New("logger is mandatory")
-		return
+		return result, err
 	}
 
 	// If we are running in a Kubernetes pod we want to add a 'nsName' to the external data, so that it can be
@@ -139,7 +139,7 @@ func (b *GrpcAuthzInterceptorBuilder) Build() (result *GrpcAuthzInterceptor, err
 				"failed to read Kubernetes namespace file '%s': %w",
 				k8sfiles.ServiceAccountNamespace, err,
 			)
-			return
+			return result, err
 		}
 	} else {
 		nsName = strings.TrimSpace(string(nsBytes))
@@ -162,7 +162,7 @@ func (b *GrpcAuthzInterceptorBuilder) Build() (result *GrpcAuthzInterceptor, err
 				"emergency service account name '%s' is not a valid Kubernetes service account name",
 				emergencyServiceAccount,
 			)
-			return
+			return result, err
 		}
 
 		emergencyServiceAccountName := fmt.Sprintf(
@@ -187,7 +187,7 @@ func (b *GrpcAuthzInterceptorBuilder) Build() (result *GrpcAuthzInterceptor, err
 	).PrepareForEval(context.Background())
 	if err != nil {
 		err = fmt.Errorf("failed to compile authorization policy: %w", err)
-		return
+		return result, err
 	}
 
 	// Compile anonymous method regexes:
@@ -196,7 +196,7 @@ func (b *GrpcAuthzInterceptorBuilder) Build() (result *GrpcAuthzInterceptor, err
 		anonymousMethods[i], err = regexp.Compile(expr)
 		if err != nil {
 			err = fmt.Errorf("failed to compile public method regex '%s': %w", expr, err)
-			return
+			return result, err
 		}
 	}
 
@@ -208,7 +208,7 @@ func (b *GrpcAuthzInterceptorBuilder) Build() (result *GrpcAuthzInterceptor, err
 		inputCallback:    b.inputCallback,
 		query:            query,
 	}
-	return
+	return result, err
 }
 
 // UnaryServer is the unary server interceptor function.
@@ -299,7 +299,7 @@ func (i *GrpcAuthzInterceptor) authorizeWithToken(ctx context.Context, method st
 			slog.Any("error", err),
 		)
 		err = grpcstatus.Error(grpccodes.Internal, "failed to process authorization")
-		return
+		return result, err
 	}
 
 	// If there is an input callback, call it:
@@ -312,7 +312,7 @@ func (i *GrpcAuthzInterceptor) authorizeWithToken(ctx context.Context, method st
 				slog.Any("error", err),
 			)
 			err = grpcstatus.Error(grpccodes.Internal, "internal error")
-			return
+			return result, err
 		}
 	}
 
@@ -326,12 +326,12 @@ func (i *GrpcAuthzInterceptor) authorizeWithToken(ctx context.Context, method st
 			slog.Any("error", err),
 		)
 		err = grpcstatus.Error(grpccodes.Internal, "failed to evaluate authorization policy")
-		return
+		return result, err
 	}
 	if len(results) == 0 {
 		logger.DebugContext(ctx, "Authorization policy returned no results")
 		err = grpcstatus.Error(grpccodes.PermissionDenied, "permission denied")
-		return
+		return result, err
 	}
 
 	// The query is 'data.authz' so 'results[0].Expressions[0].Value' is a map of all exported variables:
@@ -339,7 +339,7 @@ func (i *GrpcAuthzInterceptor) authorizeWithToken(ctx context.Context, method st
 	if !ok {
 		logger.ErrorContext(ctx, "Authorization policy returned unexpected result type")
 		err = grpcstatus.Error(grpccodes.Internal, "failed to evaluate authorization policy")
-		return
+		return result, err
 	}
 
 	// Check if the request is allowed:
@@ -347,7 +347,7 @@ func (i *GrpcAuthzInterceptor) authorizeWithToken(ctx context.Context, method st
 	if !allow {
 		logger.DebugContext(ctx, "Permission denied by authorization policy")
 		err = grpcstatus.Error(grpccodes.PermissionDenied, "permission denied")
-		return
+		return result, err
 	}
 
 	// Build the subject from the policy output:
@@ -359,7 +359,7 @@ func (i *GrpcAuthzInterceptor) authorizeWithToken(ctx context.Context, method st
 			slog.Any("error", err),
 		)
 		err = grpcstatus.Error(grpccodes.Internal, "failed to process authorization")
-		return
+		return result, err
 	}
 
 	// Store subject in context
@@ -370,7 +370,7 @@ func (i *GrpcAuthzInterceptor) authorizeWithToken(ctx context.Context, method st
 		"Permission granted by authorization policy",
 		slog.String("user", subject.User),
 	)
-	return
+	return result, err
 }
 
 // extractId tries to extract the identifier of the object from the incoming request message. For get and delete
@@ -427,7 +427,7 @@ func (i *GrpcAuthzInterceptor) buildInput(ctx context.Context, method string, re
 	claims, ok := token.Claims.(jwt.MapClaims)
 	if !ok {
 		err = fmt.Errorf("unexpected claims type")
-		return
+		return result, err
 	}
 
 	// Check if this the token corresponds to a Kubernetes service account:
@@ -507,7 +507,7 @@ func (i *GrpcAuthzInterceptor) buildInput(ctx context.Context, method string, re
 			"identity": identity,
 		},
 	}
-	return
+	return result, err
 }
 
 // shouldFetchProjectMetadata determines if we should fetch project metadata from the database for authorization.
@@ -549,7 +549,7 @@ func (i *GrpcAuthzInterceptor) buildSubject(authzData map[string]any) (result *S
 	user, _ := authzData["subject_user"].(string)
 	if user == "" {
 		err = fmt.Errorf("policy did not produce a subject_user")
-		return
+		return result, err
 	}
 
 	tenantValues, _ := authzData["subject_tenant_result"].([]any)
@@ -561,7 +561,7 @@ func (i *GrpcAuthzInterceptor) buildSubject(authzData map[string]any) (result *S
 					User:    user,
 					Tenants: AllTenants,
 				}
-				return
+				return result, err
 			}
 			tenantNames = append(tenantNames, s)
 		}
@@ -571,7 +571,7 @@ func (i *GrpcAuthzInterceptor) buildSubject(authzData map[string]any) (result *S
 		User:    user,
 		Tenants: collections.NewSet(tenantNames...),
 	}
-	return
+	return result, err
 }
 
 // k8sTokenFile is the value of the 'namespace' external data item passed to the Rego policy when we aren't running

--- a/internal/cmd/cli/annotate/annotate_cmd.go
+++ b/internal/cmd/cli/annotate/annotate_cmd.go
@@ -172,28 +172,28 @@ func (c *runnerContext) parseAnnotationOperation(text string) (operation annotat
 	if ok {
 		if key == "" {
 			err = fmt.Errorf("annotation name can't be empty in %q", text)
-			return
+			return operation, err
 		}
 		operation = annotationOperation{
 			key:   key,
 			value: &value,
 		}
-		return
+		return operation, err
 	}
 	if strings.HasSuffix(text, "-") {
 		key := strings.TrimSuffix(text, "-")
 		if key == "" {
 			err = fmt.Errorf("annotation name can't be empty in %q", text)
-			return
+			return operation, err
 		}
 		operation = annotationOperation{
 			key:    key,
 			remove: true,
 		}
-		return
+		return operation, err
 	}
 	err = fmt.Errorf("invalid annotation specification %q, expected 'annotation=value' or 'annotation-'", text)
-	return
+	return operation, err
 }
 
 func (c *runnerContext) applyAnnotationOperations(metadata reflection.Metadata, operations []annotationOperation) {

--- a/internal/cmd/cli/console/connect/testserver_test.go
+++ b/internal/cmd/cli/console/connect/testserver_test.go
@@ -134,7 +134,7 @@ func openTestStream(proxySrv publicv1.ConsoleProxyServer) (
 		conn.Close()
 		grpcCleanup()
 	}
-	return
+	return stream, ctx, cancel, cleanup
 }
 
 // drainHandler is a StreamHandler that reads from the stream until

--- a/internal/cmd/cli/create/cluster/create_cluster_cmd.go
+++ b/internal/cmd/cli/create/cluster/create_cluster_cmd.go
@@ -272,7 +272,7 @@ func (c *runnerContext) resolveCredentials() (pullSecret, sshPublicKey string, e
 		data, readErr := os.ReadFile(c.args.pullSecretFile)
 		if readErr != nil {
 			err = fmt.Errorf("failed to read pull secret file '%s': %w", c.args.pullSecretFile, readErr)
-			return
+			return pullSecret, sshPublicKey, err
 		}
 		pullSecret = strings.TrimSpace(string(data))
 	}
@@ -281,11 +281,11 @@ func (c *runnerContext) resolveCredentials() (pullSecret, sshPublicKey string, e
 		data, readErr := os.ReadFile(c.args.sshPublicKeyFile)
 		if readErr != nil {
 			err = fmt.Errorf("failed to read SSH public key file '%s': %w", c.args.sshPublicKeyFile, readErr)
-			return
+			return pullSecret, sshPublicKey, err
 		}
 		sshPublicKey = strings.TrimSpace(string(data))
 	}
-	return
+	return pullSecret, sshPublicKey, err
 }
 
 // applyOptionalSpecFields sets pull secret, SSH public key, release image, and network CIDRs
@@ -357,7 +357,7 @@ func (c *runnerContext) findTemplate(ctx context.Context) (result *publicv1.Clus
 	// If there is exactly one match, use it:
 	if len(matches) == 1 {
 		result = matches[0]
-		return
+		return result, err
 	}
 
 	// If there are multiple matches, display them and advise to use the identifier:
@@ -368,7 +368,7 @@ func (c *runnerContext) findTemplate(ctx context.Context) (result *publicv1.Clus
 			"Total":   total,
 		})
 		err = exit.Error(1)
-		return
+		return result, err
 	}
 
 	// If we are here then no matches were found, we will show to the user some of the available templates:
@@ -384,7 +384,7 @@ func (c *runnerContext) findTemplate(ctx context.Context) (result *publicv1.Clus
 		"Ref":      c.args.template,
 	})
 	err = exit.Error(1)
-	return
+	return result, err
 }
 
 // parseTemplateParameters parses the '--template-parameter' and '--template-parameter-file' flags into a map of
@@ -561,7 +561,7 @@ func (c *runnerContext) parseTemplateParameters(ctx context.Context,
 		)
 	}
 
-	return
+	return result, issues
 }
 
 // convertTextToTemplateParameterValue converts a string value to the appropriate protobuf type based on the kind. It
@@ -586,7 +586,7 @@ func (c *runnerContext) convertTextToTemplateParameterValue(ctx context.Context,
 				"value '%s' isn't a valid boolean, valid values are 'true' and 'false'",
 				text,
 			)
-			return
+			return result, issue
 		}
 		wrapper = &wrapperspb.BoolValue{Value: value}
 	case "type.googleapis.com/google.protobuf.Int32Value":
@@ -601,7 +601,7 @@ func (c *runnerContext) convertTextToTemplateParameterValue(ctx context.Context,
 				slog.Any("error", err),
 			)
 			issue = fmt.Sprintf("value '%s' isn't a valid 32-bit integer", text)
-			return
+			return result, issue
 		}
 		wrapper = &wrapperspb.Int32Value{Value: int32(value)}
 	case "type.googleapis.com/google.protobuf.Int64Value":
@@ -616,7 +616,7 @@ func (c *runnerContext) convertTextToTemplateParameterValue(ctx context.Context,
 				slog.Any("error", err),
 			)
 			issue = fmt.Sprintf("value '%s' isn't a valid 64-bit integer", text)
-			return
+			return result, issue
 		}
 		wrapper = &wrapperspb.Int64Value{Value: value}
 	case "type.googleapis.com/google.protobuf.FloatValue":
@@ -631,7 +631,7 @@ func (c *runnerContext) convertTextToTemplateParameterValue(ctx context.Context,
 				slog.Any("error", err),
 			)
 			issue = fmt.Sprintf("value '%s' isn't a valid 32-bit floating point number", text)
-			return
+			return result, issue
 		}
 		wrapper = &wrapperspb.FloatValue{Value: float32(value)}
 	case "type.googleapis.com/google.protobuf.DoubleValue":
@@ -646,7 +646,7 @@ func (c *runnerContext) convertTextToTemplateParameterValue(ctx context.Context,
 				slog.Any("error", err),
 			)
 			issue = fmt.Sprintf("value '%s' isn't a valid 64-bit floating point numberw", text)
-			return
+			return result, issue
 		}
 		wrapper = &wrapperspb.DoubleValue{Value: value}
 	case "type.googleapis.com/google.protobuf.BytesValue":
@@ -663,7 +663,7 @@ func (c *runnerContext) convertTextToTemplateParameterValue(ctx context.Context,
 				slog.Any("error", err),
 			)
 			issue = fmt.Sprintf("value '%s' isn't a valid RFC3339 timestamp", text)
-			return
+			return result, issue
 		}
 		wrapper = timestamppb.New(value)
 	case "type.googleapis.com/google.protobuf.Duration":
@@ -677,15 +677,15 @@ func (c *runnerContext) convertTextToTemplateParameterValue(ctx context.Context,
 				slog.Any("error", err),
 			)
 			issue = fmt.Sprintf("value '%s' isn't a valid duration", text)
-			return
+			return result, issue
 		}
 		wrapper = durationpb.New(value)
 	default:
 		issue = fmt.Sprintf("flag has is of an unsupported type '%s'", kind)
-		return
+		return result, issue
 	}
 	if issue != "" {
-		return
+		return result, issue
 	}
 	result, err := anypb.New(wrapper)
 	if err != nil {
@@ -697,9 +697,9 @@ func (c *runnerContext) convertTextToTemplateParameterValue(ctx context.Context,
 			slog.Any("error", err),
 		)
 		issue = fmt.Sprintf("Failed to create protobuf value for template parameter: %v", err)
-		return
+		return result, issue
 	}
-	return
+	return result, issue
 }
 
 // validTemplateParameter contains the information about a valid template parameter, for use in the error messages that

--- a/internal/cmd/cli/create/computeinstance/create_compute_instance_cmd.go
+++ b/internal/cmd/cli/create/computeinstance/create_compute_instance_cmd.go
@@ -350,7 +350,7 @@ func (c *runnerContext) findTemplate(ctx context.Context) (result *publicv1.Comp
 	// If there is exactly one match, use it:
 	if len(matches) == 1 {
 		result = matches[0]
-		return
+		return result, err
 	}
 
 	// If there are multiple matches, display them and advise to use the identifier:
@@ -361,7 +361,7 @@ func (c *runnerContext) findTemplate(ctx context.Context) (result *publicv1.Comp
 			"Total":   total,
 		})
 		err = exit.Error(1)
-		return
+		return result, err
 	}
 
 	// If we are here then no matches were found, we will show to the user some of the available templates:
@@ -377,7 +377,7 @@ func (c *runnerContext) findTemplate(ctx context.Context) (result *publicv1.Comp
 		"Ref":      c.args.template,
 	})
 	err = exit.Error(1)
-	return
+	return result, err
 }
 
 // parseTemplateParameters parses the '--template-parameter' and '--template-parameter-file' flags into a map of
@@ -554,7 +554,7 @@ func (c *runnerContext) parseTemplateParameters(ctx context.Context,
 		)
 	}
 
-	return
+	return result, issues
 }
 
 // convertTextToTemplateParameterValue converts a string value to the appropriate protobuf type based on the kind. It
@@ -579,7 +579,7 @@ func (c *runnerContext) convertTextToTemplateParameterValue(ctx context.Context,
 				"value '%s' isn't a valid boolean, valid values are 'true' and 'false'",
 				text,
 			)
-			return
+			return result, issue
 		}
 		wrapper = &wrapperspb.BoolValue{Value: value}
 	case "type.googleapis.com/google.protobuf.Int32Value":
@@ -594,7 +594,7 @@ func (c *runnerContext) convertTextToTemplateParameterValue(ctx context.Context,
 				slog.Any("error", err),
 			)
 			issue = fmt.Sprintf("value '%s' isn't a valid 32-bit integer", text)
-			return
+			return result, issue
 		}
 		wrapper = &wrapperspb.Int32Value{Value: int32(value)}
 	case "type.googleapis.com/google.protobuf.Int64Value":
@@ -609,7 +609,7 @@ func (c *runnerContext) convertTextToTemplateParameterValue(ctx context.Context,
 				slog.Any("error", err),
 			)
 			issue = fmt.Sprintf("value '%s' isn't a valid 64-bit integer", text)
-			return
+			return result, issue
 		}
 		wrapper = &wrapperspb.Int64Value{Value: value}
 	case "type.googleapis.com/google.protobuf.FloatValue":
@@ -624,7 +624,7 @@ func (c *runnerContext) convertTextToTemplateParameterValue(ctx context.Context,
 				slog.Any("error", err),
 			)
 			issue = fmt.Sprintf("value '%s' isn't a valid 32-bit floating point number", text)
-			return
+			return result, issue
 		}
 		wrapper = &wrapperspb.FloatValue{Value: float32(value)}
 	case "type.googleapis.com/google.protobuf.DoubleValue":
@@ -639,7 +639,7 @@ func (c *runnerContext) convertTextToTemplateParameterValue(ctx context.Context,
 				slog.Any("error", err),
 			)
 			issue = fmt.Sprintf("value '%s' isn't a valid 64-bit floating point numberw", text)
-			return
+			return result, issue
 		}
 		wrapper = &wrapperspb.DoubleValue{Value: value}
 	case "type.googleapis.com/google.protobuf.BytesValue":
@@ -656,7 +656,7 @@ func (c *runnerContext) convertTextToTemplateParameterValue(ctx context.Context,
 				slog.Any("error", err),
 			)
 			issue = fmt.Sprintf("value '%s' isn't a valid RFC3339 timestamp", text)
-			return
+			return result, issue
 		}
 		wrapper = timestamppb.New(value)
 	case "type.googleapis.com/google.protobuf.Duration":
@@ -670,15 +670,15 @@ func (c *runnerContext) convertTextToTemplateParameterValue(ctx context.Context,
 				slog.Any("error", err),
 			)
 			issue = fmt.Sprintf("value '%s' isn't a valid duration", text)
-			return
+			return result, issue
 		}
 		wrapper = durationpb.New(value)
 	default:
 		issue = fmt.Sprintf("flag has is of an unsupported type '%s'", kind)
-		return
+		return result, issue
 	}
 	if issue != "" {
-		return
+		return result, issue
 	}
 	result, err := anypb.New(wrapper)
 	if err != nil {
@@ -690,9 +690,9 @@ func (c *runnerContext) convertTextToTemplateParameterValue(ctx context.Context,
 			slog.Any("error", err),
 		)
 		issue = fmt.Sprintf("Failed to create protobuf value for template parameter: %v", err)
-		return
+		return result, issue
 	}
-	return
+	return result, issue
 }
 
 // buildSpec constructs the ComputeInstanceSpec from template info and CLI flags.

--- a/internal/cmd/cli/create/create_cmd.go
+++ b/internal/cmd/cli/create/create_cmd.go
@@ -213,7 +213,7 @@ func (c *runnerContext) decodeObjects(input io.Reader) (result []proto.Message, 
 			break
 		}
 		if err != nil {
-			return
+			return result, err
 		}
 		items = append(items, item)
 	}
@@ -238,7 +238,7 @@ func (c *runnerContext) decodeObjects(input io.Reader) (result []proto.Message, 
 		data, err = json.Marshal(item)
 		if err != nil {
 			err = fmt.Errorf("failed to convert item at index %d to JSON: %w", i, err)
-			return
+			return result, err
 		}
 		value := &anypb.Any{}
 		err = protojson.Unmarshal(data, value)
@@ -247,7 +247,7 @@ func (c *runnerContext) decodeObjects(input io.Reader) (result []proto.Message, 
 				"failed to unmarshal item at index %d to a protocol buffers any: %w",
 				i, err,
 			)
-			return
+			return result, err
 		}
 		var object proto.Message
 		object, err = value.UnmarshalNew()
@@ -256,13 +256,13 @@ func (c *runnerContext) decodeObjects(input io.Reader) (result []proto.Message, 
 				"failed to unmarshal object at index %d to a protocol buffers object: %w",
 				i, err,
 			)
-			return
+			return result, err
 		}
 		objects[i] = object
 	}
 
 	result = objects
-	return
+	return result, err
 }
 
 const shortHelp = `Create objects`

--- a/internal/cmd/cli/delete/delete_cmd.go
+++ b/internal/cmd/cli/delete/delete_cmd.go
@@ -203,7 +203,7 @@ func (c *runnerContext) findMatches(ctx context.Context, refs []string) (result 
 	})
 	if err != nil {
 		err = fmt.Errorf("failed to find objects of type '%s': %w", c.helper, err)
-		return
+		return result, err
 	}
 
 	// Build a map where the key is the reference and the value is the list of matching objects:
@@ -219,7 +219,7 @@ func (c *runnerContext) findMatches(ctx context.Context, refs []string) (result 
 		}
 	}
 
-	return
+	return result, err
 }
 
 const shortHelp = `Delete objects`

--- a/internal/cmd/cli/edit/edit_cmd.go
+++ b/internal/cmd/cli/edit/edit_cmd.go
@@ -315,22 +315,22 @@ func (c *runnerContext) renderJson(object proto.Message) (result []byte, err err
 func (c *runnerContext) renderYaml(object proto.Message) (result []byte, err error) {
 	data, err := c.renderJson(object)
 	if err != nil {
-		return
+		return result, err
 	}
 	var value any
 	err = json.Unmarshal(data, &value)
 	if err != nil {
-		return
+		return result, err
 	}
 	buffer := &bytes.Buffer{}
 	encoder := yaml.NewEncoder(buffer)
 	encoder.SetIndent(2)
 	err = encoder.Encode(value)
 	if err != nil {
-		return
+		return result, err
 	}
 	result = buffer.Bytes()
-	return
+	return result, err
 }
 
 func (c *runnerContext) parseJson(data []byte) (result proto.Message, err error) {
@@ -347,14 +347,14 @@ func (c *runnerContext) parseYaml(data []byte) (result proto.Message, err error)
 	var value any
 	err = yaml.Unmarshal(data, &value)
 	if err != nil {
-		return
+		return result, err
 	}
 	data, err = json.Marshal(value)
 	if err != nil {
-		return
+		return result, err
 	}
 	result, err = c.parseJson(data)
-	return
+	return result, err
 }
 
 // editorEnvVars is the list of environment variables that will be used to obtain the name of the editor command.

--- a/internal/cmd/cli/get/get_cmd.go
+++ b/internal/cmd/cli/get/get_cmd.go
@@ -228,10 +228,10 @@ func (c *runnerContext) list(ctx context.Context, keys []string) (results []prot
 
 	listResult, err := c.objectHelper.List(ctx, options)
 	if err != nil {
-		return
+		return results, err
 	}
 	results = listResult.Items
-	return
+	return results, err
 }
 
 func (c *runnerContext) renderTable(ctx context.Context, objects []proto.Message) error {
@@ -296,15 +296,15 @@ func (c *runnerContext) encodeObjects(objects []proto.Message) (result []any, er
 func (c *runnerContext) encodeObject(object proto.Message) (result any, err error) {
 	wrapper, err := anypb.New(object)
 	if err != nil {
-		return
+		return result, err
 	}
 	var data []byte
 	data, err = c.marshalOptions.Marshal(wrapper)
 	if err != nil {
-		return
+		return result, err
 	}
 	err = json.Unmarshal(data, &result)
-	return
+	return result, err
 }
 
 const shortHelp = `Get objects`

--- a/internal/cmd/cli/label/label_cmd.go
+++ b/internal/cmd/cli/label/label_cmd.go
@@ -172,22 +172,22 @@ func (c *runnerContext) parseLabelOperation(text string) (operation labelOperati
 			label: label,
 			value: &value,
 		}
-		return
+		return operation, err
 	}
 	if strings.HasSuffix(text, "-") {
 		label := strings.TrimSuffix(text, "-")
 		if label == "" {
 			err = fmt.Errorf("label name can't be empty in %q", text)
-			return
+			return operation, err
 		}
 		operation = labelOperation{
 			label:  label,
 			remove: true,
 		}
-		return
+		return operation, err
 	}
 	err = fmt.Errorf("invalid label specification %q, expected 'label=value' or 'label-'", text)
-	return
+	return operation, err
 }
 
 func (c *runnerContext) applyLabelOperations(metadata reflection.Metadata, operations []labelOperation) {

--- a/internal/cmd/cli/login/login_cmd.go
+++ b/internal/cmd/cli/login/login_cmd.go
@@ -491,7 +491,7 @@ func (c *runnerContext) selectTokenIssuer(ctx context.Context, capabilities *pub
 			slog.Any("selected", result),
 		)
 	}
-	return
+	return result, err
 }
 
 // createTokenSource creates a token source from the configuration. The token source will be nil if no token, token
@@ -508,7 +508,7 @@ func (c *runnerContext) createTokenSource(ctx context.Context, tokenIssuer strin
 		if err != nil {
 			err = fmt.Errorf("failed to create static token source: %w", err)
 		}
-		return
+		return result, err
 	}
 
 	// Use a token script if specified::
@@ -521,7 +521,7 @@ func (c *runnerContext) createTokenSource(ctx context.Context, tokenIssuer strin
 		if err != nil {
 			err = fmt.Errorf("failed to create script token source: %w", err)
 		}
-		return
+		return result, err
 	}
 
 	// If a token issuer has been selected, then use OAuth to create a token source:
@@ -547,12 +547,12 @@ func (c *runnerContext) createTokenSource(ctx context.Context, tokenIssuer strin
 		if err != nil {
 			err = fmt.Errorf("failed to create OAuth token source: %w", err)
 		}
-		return
+		return result, err
 	}
 
 	// Finally, if there is no token, toke script or token issuer, return nil:
 	result = nil
-	return
+	return result, err
 }
 
 // inferFlow infers the OAuth flow from other command line flags when the user hasn't explicitly set the '--flow' flag.

--- a/internal/cmd/cli/lookup/lookup.go
+++ b/internal/cmd/cli/lookup/lookup.go
@@ -47,12 +47,12 @@ func (e *ErrAmbiguous) Error() string {
 func Find[T any](ref, kind string, list ListFunc[T]) (result T, err error) {
 	if ref == "" {
 		err = fmt.Errorf("%s name or ID must not be empty", kind)
-		return
+		return result, err
 	}
 	filter := fmt.Sprintf(`this.id == %[1]q || this.metadata.name == %[1]q`, ref)
 	items, err := list(filter, 2)
 	if err != nil {
-		return
+		return result, err
 	}
 	switch len(items) {
 	case 0:
@@ -62,5 +62,5 @@ func Find[T any](ref, kind string, list ListFunc[T]) (result T, err error) {
 	default:
 		err = &ErrAmbiguous{Ref: ref, Kind: kind}
 	}
-	return
+	return result, err
 }

--- a/internal/cmd/cli/root_cmd.go
+++ b/internal/cmd/cli/root_cmd.go
@@ -60,7 +60,7 @@ func Root() (result *cobra.Command, err error) {
 	userConfigDir, err := os.UserConfigDir()
 	if err != nil {
 		err = fmt.Errorf("failed to determine user configuration directory: %w", err)
-		return
+		return result, err
 	}
 	defaultConfigDir := filepath.Join(userConfigDir, runner.binaryName)
 
@@ -68,7 +68,7 @@ func Root() (result *cobra.Command, err error) {
 	userCacheDir, err := os.UserCacheDir()
 	if err != nil {
 		err = fmt.Errorf("failed to determine user cache directory: %w", err)
-		return
+		return result, err
 	}
 	defaultCacheDir := filepath.Join(userCacheDir, runner.binaryName)
 
@@ -112,7 +112,7 @@ func Root() (result *cobra.Command, err error) {
 	// Configure the root command, and therefore all its subcommands, to use Markdown for their help output:
 	help.Setup(result)
 
-	return
+	return result, err
 }
 
 type runnerContext struct {

--- a/internal/cmd/osac-dev/generate/openapi/generate_openapi_cmd.go
+++ b/internal/cmd/osac-dev/generate/openapi/generate_openapi_cmd.go
@@ -442,15 +442,15 @@ func (r *runnerContext) downloadFile(ctx context.Context, args downloadFileArgs)
 	// Check parameters:
 	if args.Url == "" {
 		err = fmt.Errorf("URL is required")
-		return
+		return result, err
 	}
 	if args.Name == "" {
 		err = fmt.Errorf("name for URL '%s' is required", args.Url)
-		return
+		return result, err
 	}
 	if args.Sum == "" {
 		err = fmt.Errorf("checksum for URL '%s' is required", args.Url)
-		return
+		return result, err
 	}
 
 	// Create the cache directory:
@@ -458,14 +458,14 @@ func (r *runnerContext) downloadFile(ctx context.Context, args downloadFileArgs)
 	err = os.MkdirAll(cacheDir, 0700)
 	if err != nil {
 		err = fmt.Errorf("failed to create cache directory '%s': %w", cacheDir, err)
-		return
+		return result, err
 	}
 
 	// Calculate the absolute path of the cacheFile in the cache:
 	cacheFile := filepath.Join(cacheDir, args.Name)
 	cacheFile, err = filepath.Abs(cacheFile)
 	if err != nil {
-		return
+		return result, err
 	}
 
 	// If the file already exists then we can use it directly, but first we need to verify its checksum. If that
@@ -474,16 +474,16 @@ func (r *runnerContext) downloadFile(ctx context.Context, args downloadFileArgs)
 	if err == nil {
 		if r.verifyChecksum(ctx, cacheFile, args.Sum) == nil {
 			result = cacheFile
-			return
+			return result, err
 		}
 		err = os.Remove(cacheFile)
 		if err != nil {
 			err = fmt.Errorf("failed to remove cached file '%s': %w", cacheFile, err)
-			return
+			return result, err
 		}
 	} else if !errors.Is(err, os.ErrNotExist) {
 		err = fmt.Errorf("failed to check cached file '%s': %w", cacheFile, err)
-		return
+		return result, err
 	}
 
 	// We use 'curl' to download files because it supports redirection and other details that we do not wish to
@@ -505,14 +505,14 @@ func (r *runnerContext) downloadFile(ctx context.Context, args downloadFileArgs)
 	err = curlCmd.Run()
 	if err != nil {
 		err = fmt.Errorf("failed to download file from '%s': %w", args.Url, err)
-		return
+		return result, err
 	}
 
 	// Verify the checksum of the file:
 	err = r.verifyChecksum(ctx, cacheFile, args.Sum)
 	if err != nil {
 		err = fmt.Errorf("failed to verify checksum of file '%s': %w", cacheFile, err)
-		return
+		return result, err
 	}
 
 	// Make the file executable:
@@ -520,13 +520,13 @@ func (r *runnerContext) downloadFile(ctx context.Context, args downloadFileArgs)
 		err = os.Chmod(cacheFile, 0700) // #nosec G302 -- making downloaded tool executable
 		if err != nil {
 			err = fmt.Errorf("failed to set executable permission on file '%s': %w", cacheFile, err)
-			return
+			return result, err
 		}
 	}
 
 	// Return the resulting cache file:
 	result = cacheFile
-	return
+	return result, err
 }
 
 // verifyChecksum verifies the checksum of a file using the 'sha256sum' tool.

--- a/internal/cmd/osac-dev/root_cmd.go
+++ b/internal/cmd/osac-dev/root_cmd.go
@@ -47,7 +47,7 @@ func Root() (result *cobra.Command, err error) {
 	userCacheDir, err := os.UserCacheDir()
 	if err != nil {
 		err = fmt.Errorf("failed to determine user cache directory: %w", err)
-		return
+		return result, err
 	}
 	defaultCacheDir := filepath.Join(userCacheDir, runner.binaryName)
 
@@ -67,7 +67,7 @@ func Root() (result *cobra.Command, err error) {
 	// Configure the root command, and therefore all its subcommands, to use Markdown for their help output:
 	help.Setup(result)
 
-	return
+	return result, err
 }
 
 type runnerContext struct {

--- a/internal/cmd/service/start/controller/start_controller_cmd.go
+++ b/internal/cmd/service/start/controller/start_controller_cmd.go
@@ -1241,7 +1241,7 @@ func (r *runnerContext) createTokenSource(ctx context.Context, caPool *x509.Cert
 			err = fmt.Errorf(
 				"failed to read issuer URL from file '%s': %w", r.args.authIssuerUrlFile, err,
 			)
-			return
+			return result, err
 		}
 	}
 	clientId := r.args.authClientId
@@ -1252,7 +1252,7 @@ func (r *runnerContext) createTokenSource(ctx context.Context, caPool *x509.Cert
 				"failed to read client identifier from file '%s': %w",
 				r.args.authClientIdFile, err,
 			)
-			return
+			return result, err
 		}
 	}
 	clientSecret := r.args.authClientSecret
@@ -1263,7 +1263,7 @@ func (r *runnerContext) createTokenSource(ctx context.Context, caPool *x509.Cert
 				"failed to read client secret from file '%s': %w",
 				r.args.authClientSecretFile, err,
 			)
-			return
+			return result, err
 		}
 	}
 	r.logger.DebugContext(
@@ -1298,7 +1298,7 @@ func (r *runnerContext) createTokenSource(ctx context.Context, caPool *x509.Cert
 
 	// Return the token source:
 	result = tokenSource
-	return
+	return result, err
 }
 
 // createIDPClient creates the IDP client. The IDP URL and credentials are mandatory.

--- a/internal/config/config_secret_store.go
+++ b/internal/config/config_secret_store.go
@@ -71,7 +71,7 @@ func (b *SecretStoreBuilder) Build() (result SecretStore, err error) {
 	// Check parameters:
 	if b.logger == nil {
 		err = errors.New("logger is mandatory")
-		return
+		return result, err
 	}
 
 	// Select the store based on the availability of the keyring:
@@ -88,7 +88,7 @@ func (b *SecretStoreBuilder) Build() (result SecretStore, err error) {
 			Build()
 	}
 
-	return
+	return result, err
 }
 
 // KeyringSecretStoreBuilder contains the data and logic needed to build a secret store backed by the operating system
@@ -121,11 +121,11 @@ func (b *KeyringSecretStoreBuilder) Build() (result SecretStore, err error) {
 	// Check parameters:
 	if b.logger == nil {
 		err = errors.New("logger is mandatory")
-		return
+		return result, err
 	}
 	if b.dir == "" {
 		err = errors.New("directory is mandatory")
-		return
+		return result, err
 	}
 
 	// The keyring key is always 'secrets:<dir>' where 'dir' is the absolute path of the configuration directory.
@@ -136,7 +136,7 @@ func (b *KeyringSecretStoreBuilder) Build() (result SecretStore, err error) {
 		logger: b.logger,
 		key:    key,
 	}
-	return
+	return result, err
 }
 
 // keyringSecretStore stores secret data as a single entry in the operating system keyring. The key field is
@@ -233,7 +233,7 @@ func (b *FileSecretStoreBuilder) Build() (result SecretStore, err error) {
 	// Check parameters:
 	if b.logger == nil {
 		err = errors.New("logger is mandatory")
-		return
+		return result, err
 	}
 
 	// Use the default directory if not set:
@@ -242,7 +242,7 @@ func (b *FileSecretStoreBuilder) Build() (result SecretStore, err error) {
 		var configDir string
 		configDir, err = os.UserConfigDir()
 		if err != nil {
-			return
+			return result, err
 		}
 		dir = filepath.Join(configDir, "osac")
 	}
@@ -253,7 +253,7 @@ func (b *FileSecretStoreBuilder) Build() (result SecretStore, err error) {
 		logger: b.logger,
 		file:   file,
 	}
-	return
+	return result, err
 }
 
 // fileSecretStore stores secret data as a file named secrets.json in the same directory as the main configuration

--- a/internal/config/config_settings.go
+++ b/internal/config/config_settings.go
@@ -75,11 +75,11 @@ func (b *SettingsBuilder) Build() (result *Settings, err error) {
 	// Check parameters:
 	if b.logger == nil {
 		err = errors.New("logger is mandatory")
-		return
+		return result, err
 	}
 	if b.dir == "" {
 		err = errors.New("directory is mandatory")
-		return
+		return result, err
 	}
 
 	// Create the object:
@@ -88,7 +88,7 @@ func (b *SettingsBuilder) Build() (result *Settings, err error) {
 		dir:    b.dir,
 		lock:   &sync.RWMutex{},
 	}
-	return
+	return result, err
 }
 
 // generalSettings contains the non-secret fields of the configuration. These are persisted to a JSON file.
@@ -424,7 +424,7 @@ func (c *Settings) TokenSource(ctx context.Context) (result auth.TokenSource, er
 		caPool, err = c.CaPool(ctx)
 		if err != nil {
 			err = fmt.Errorf("failed to get CA pool: %w", err)
-			return
+			return result, err
 		}
 		result, err = oauth.NewTokenSource().
 			SetLogger(c.logger).
@@ -444,7 +444,7 @@ func (c *Settings) TokenSource(ctx context.Context) (result auth.TokenSource, er
 		if err != nil {
 			err = fmt.Errorf("failed to create OAuth token source: %w", err)
 		}
-		return
+		return result, err
 	}
 
 	// If a token script has been configured, then use it to create a script token source:
@@ -457,7 +457,7 @@ func (c *Settings) TokenSource(ctx context.Context) (result auth.TokenSource, er
 		if err != nil {
 			err = fmt.Errorf("failed to create script token source: %w", err)
 		}
-		return
+		return result, err
 	}
 
 	// Finally, if there is an access token try to use it:
@@ -471,12 +471,12 @@ func (c *Settings) TokenSource(ctx context.Context) (result auth.TokenSource, er
 		if err != nil {
 			err = fmt.Errorf("failed to create static token source: %w", err)
 		}
-		return
+		return result, err
 	}
 
 	// If we are here then there is no way to get tokens, so it will all be anonymous.
 	result = nil
-	return
+	return result, err
 }
 
 // Conect creates a gRPC connection from the configuration.
@@ -507,14 +507,14 @@ func (c *Settings) connect(ctx context.Context, flags *pflag.FlagSet, tokenSourc
 		Build()
 	if err != nil {
 		err = fmt.Errorf("failed to create version interceptor: %w", err)
-		return
+		return result, err
 	}
 
 	// Create the gRPC client:
 	caPool, err := c.CaPool(ctx)
 	if err != nil {
 		err = fmt.Errorf("failed to get CA pool: %w", err)
-		return
+		return result, err
 	}
 	result, err = network.NewGrpcClient().
 		SetLogger(c.logger).
@@ -530,10 +530,10 @@ func (c *Settings) connect(ctx context.Context, flags *pflag.FlagSet, tokenSourc
 		Build()
 	if err != nil {
 		err = fmt.Errorf("failed to create gRPC client: %w", err)
-		return
+		return result, err
 	}
 
-	return
+	return result, err
 }
 
 // Packages returns the list of packages that should be enabled according to the configuration. The public packages
@@ -572,11 +572,11 @@ func (c *Settings) CaPool(ctx context.Context) (result *x509.CertPool, err error
 	if c.caPool == nil {
 		err = c.createCaPool(ctx)
 		if err != nil {
-			return
+			return result, err
 		}
 	}
 	result = c.caPool
-	return
+	return result, err
 }
 
 func (c *Settings) createCaPool(ctx context.Context) error {
@@ -656,14 +656,14 @@ func (s *settingsTokenStore) Load(ctx context.Context) (result *auth.Token, err 
 	s.lock.RLock()
 	defer s.lock.RUnlock()
 	if s.settings.secret.AccessToken == "" {
-		return
+		return result, err
 	}
 	result = &auth.Token{
 		Access:  s.settings.secret.AccessToken,
 		Refresh: s.settings.secret.RefreshToken,
 		Expiry:  s.settings.secret.TokenExpiry,
 	}
-	return
+	return result, err
 }
 
 func (s *settingsTokenStore) Save(ctx context.Context, token *auth.Token) error {

--- a/internal/controllers/baremetalinstance/baremetalinstance_reconciler_function.go
+++ b/internal/controllers/baremetalinstance/baremetalinstance_reconciler_function.go
@@ -102,15 +102,15 @@ func (b *FunctionBuilder) SetHubCache(value controllers.HubCache) *FunctionBuild
 func (b *FunctionBuilder) Build() (result controllers.ReconcilerFunction[*privatev1.BareMetalInstance], err error) {
 	if b.logger == nil {
 		err = errors.New("logger is mandatory")
-		return
+		return result, err
 	}
 	if b.connection == nil {
 		err = errors.New("client is mandatory")
-		return
+		return result, err
 	}
 	if b.hubCache == nil {
 		err = errors.New("hub cache is mandatory")
-		return
+		return result, err
 	}
 
 	object := &function{
@@ -122,7 +122,7 @@ func (b *FunctionBuilder) Build() (result controllers.ReconcilerFunction[*privat
 		maskCalculator:                      masks.NewCalculator().Build(),
 	}
 	result = object.run
-	return
+	return result, err
 }
 
 func (r *function) run(ctx context.Context, bareMetalInstance *privatev1.BareMetalInstance) error {
@@ -259,12 +259,12 @@ func (t *task) delete(ctx context.Context) (err error) {
 			controllers.RemoveFinalizerOnDecommissionedHub(ctx, t.r.logger, t.hubId, "bare_metal_instance_id", t.bareMetalInstance.GetId(), t.removeFinalizer)
 			return nil
 		}
-		return
+		return err
 	}
 
 	object, err := t.getKubeObject(ctx)
 	if err != nil {
-		return
+		return err
 	}
 	if object == nil {
 		t.r.logger.DebugContext(
@@ -273,13 +273,13 @@ func (t *task) delete(ctx context.Context) (err error) {
 			slog.String("id", t.bareMetalInstance.GetId()),
 		)
 		t.removeFinalizer()
-		return
+		return err
 	}
 
 	if object.GetDeletionTimestamp() == nil {
 		err = t.hubClient.Delete(ctx, object)
 		if err != nil {
-			return
+			return err
 		}
 		t.r.logger.DebugContext(
 			ctx,
@@ -296,7 +296,7 @@ func (t *task) delete(ctx context.Context) (err error) {
 		)
 	}
 
-	return
+	return err
 }
 
 func (t *task) selectHub(ctx context.Context) error {
@@ -346,7 +346,7 @@ func (t *task) getKubeObject(ctx context.Context) (result *bmfov1alpha1.BareMeta
 		},
 	)
 	if err != nil {
-		return
+		return result, err
 	}
 	items := list.Items
 	count := len(items)
@@ -355,12 +355,12 @@ func (t *task) getKubeObject(ctx context.Context) (result *bmfov1alpha1.BareMeta
 			"expected at most one bare metal instance with identifier '%s' but found %d",
 			t.bareMetalInstance.GetId(), count,
 		)
-		return
+		return result, err
 	}
 	if count > 0 {
 		result = &items[0]
 	}
-	return
+	return result, err
 }
 
 func (t *task) addFinalizer() bool {

--- a/internal/controllers/cluster/cluster_reconciler_function.go
+++ b/internal/controllers/cluster/cluster_reconciler_function.go
@@ -92,15 +92,15 @@ func (b *FunctionBuilder) Build() (result controllers.ReconcilerFunction[*privat
 	// Check parameters:
 	if b.logger == nil {
 		err = errors.New("logger is mandatory")
-		return
+		return result, err
 	}
 	if b.connection == nil {
 		err = errors.New("client is mandatory")
-		return
+		return result, err
 	}
 	if b.hubCache == nil {
 		err = errors.New("hub cache is mandatory")
-		return
+		return result, err
 	}
 
 	// Create and populate the object:
@@ -112,7 +112,7 @@ func (b *FunctionBuilder) Build() (result controllers.ReconcilerFunction[*privat
 		maskCalculator: masks.NewCalculator().Build(),
 	}
 	result = object.run
-	return
+	return result, err
 }
 
 func (r *function) run(ctx context.Context, cluster *privatev1.Cluster) error {
@@ -360,7 +360,7 @@ func (t *task) delete(ctx context.Context) (err error) {
 	// Do nothing if we don't know the hub yet:
 	t.hubId = t.cluster.GetStatus().GetHub()
 	if t.hubId == "" {
-		return
+		return err
 	}
 	err = t.getHub(ctx)
 	if err != nil {
@@ -370,13 +370,13 @@ func (t *task) delete(ctx context.Context) (err error) {
 			return nil
 		}
 		// For transient errors (network, timeout, etc.), continue retrying
-		return
+		return err
 	}
 
 	// Delete the K8S object:
 	object, err := t.getKubeObject(ctx)
 	if err != nil {
-		return
+		return err
 	}
 	if object == nil {
 		t.r.logger.DebugContext(
@@ -385,11 +385,11 @@ func (t *task) delete(ctx context.Context) (err error) {
 			slog.String("id", t.cluster.GetId()),
 		)
 		t.removeFinalizer()
-		return
+		return err
 	}
 	err = t.hubClient.Delete(ctx, object)
 	if err != nil {
-		return
+		return err
 	}
 	t.r.logger.DebugContext(
 		ctx,
@@ -399,7 +399,7 @@ func (t *task) delete(ctx context.Context) (err error) {
 	)
 
 	t.removeFinalizer()
-	return
+	return err
 }
 
 func (t *task) selectHub(ctx context.Context) error {
@@ -449,7 +449,7 @@ func (t *task) getKubeObject(ctx context.Context) (result *osacv1alpha1.ClusterO
 		},
 	)
 	if err != nil {
-		return
+		return result, err
 	}
 	items := list.Items
 	count := len(items)
@@ -458,12 +458,12 @@ func (t *task) getKubeObject(ctx context.Context) (result *osacv1alpha1.ClusterO
 			"expected at most one cluster order with identifier '%s' but found %d",
 			t.cluster.GetId(), count,
 		)
-		return
+		return result, err
 	}
 	if count > 0 {
 		result = &items[0]
 	}
-	return
+	return result, err
 }
 
 // updateCondition updates or creates a condition with the specified type, status, reason, and message.

--- a/internal/controllers/computeinstance/computeinstance_reconciler_function.go
+++ b/internal/controllers/computeinstance/computeinstance_reconciler_function.go
@@ -105,15 +105,15 @@ func (b *FunctionBuilder) Build() (result controllers.ReconcilerFunction[*privat
 	// Check parameters:
 	if b.logger == nil {
 		err = errors.New("logger is mandatory")
-		return
+		return result, err
 	}
 	if b.connection == nil {
 		err = errors.New("client is mandatory")
-		return
+		return result, err
 	}
 	if b.hubCache == nil {
 		err = errors.New("hub cache is mandatory")
-		return
+		return result, err
 	}
 
 	// Create and populate the object:
@@ -126,7 +126,7 @@ func (b *FunctionBuilder) Build() (result controllers.ReconcilerFunction[*privat
 		maskCalculator:         masks.NewCalculator().Build(),
 	}
 	result = object.run
-	return
+	return result, err
 }
 
 func (r *function) run(ctx context.Context, computeInstance *privatev1.ComputeInstance) error {
@@ -304,13 +304,13 @@ func (t *task) delete(ctx context.Context) (err error) {
 			return nil
 		}
 		// For transient errors (network, timeout, etc.), continue retrying
-		return
+		return err
 	}
 
 	// Check if the K8S object still exists:
 	object, err := t.getKubeObject(ctx)
 	if err != nil {
-		return
+		return err
 	}
 	if object == nil {
 		// K8s object is fully gone (all K8s finalizers processed).
@@ -321,14 +321,14 @@ func (t *task) delete(ctx context.Context) (err error) {
 			slog.String("id", t.computeInstance.GetId()),
 		)
 		t.removeFinalizer()
-		return
+		return err
 	}
 
 	// Initiate K8s deletion if not already in progress:
 	if object.GetDeletionTimestamp() == nil {
 		err = t.hubClient.Delete(ctx, object)
 		if err != nil {
-			return
+			return err
 		}
 		t.r.logger.DebugContext(
 			ctx,
@@ -346,7 +346,7 @@ func (t *task) delete(ctx context.Context) (err error) {
 	}
 
 	// Don't remove finalizer — K8s object still exists with finalizers being processed.
-	return
+	return err
 }
 
 func (t *task) selectHub(ctx context.Context) error {
@@ -396,7 +396,7 @@ func (t *task) getKubeObject(ctx context.Context) (result *osacv1alpha1.ComputeI
 		},
 	)
 	if err != nil {
-		return
+		return result, err
 	}
 	items := list.Items
 	count := len(items)
@@ -405,12 +405,12 @@ func (t *task) getKubeObject(ctx context.Context) (result *osacv1alpha1.ComputeI
 			"expected at most one compute instance with identifier '%s' but found %d",
 			t.computeInstance.GetId(), count,
 		)
-		return
+		return result, err
 	}
 	if count > 0 {
 		result = &items[0]
 	}
-	return
+	return result, err
 }
 
 // getSubnetCR looks up a Subnet CR in the hub cluster by its fulfillment UUID label.

--- a/internal/controllers/externalip/external_ip_reconciler_function.go
+++ b/internal/controllers/externalip/external_ip_reconciler_function.go
@@ -91,15 +91,15 @@ func (b *FunctionBuilder) Build() (result controllers.ReconcilerFunction[*privat
 	// Check parameters:
 	if b.logger == nil {
 		err = errors.New("logger is mandatory")
-		return
+		return result, err
 	}
 	if b.connection == nil {
 		err = errors.New("client is mandatory")
-		return
+		return result, err
 	}
 	if b.hubCache == nil {
 		err = errors.New("hub cache is mandatory")
-		return
+		return result, err
 	}
 
 	// Create and populate the object:
@@ -111,7 +111,7 @@ func (b *FunctionBuilder) Build() (result controllers.ReconcilerFunction[*privat
 		maskCalculator:        masks.NewCalculator().Build(),
 	}
 	result = object.run
-	return
+	return result, err
 }
 
 func (r *function) run(ctx context.Context, externalIP *privatev1.ExternalIP) error {
@@ -252,13 +252,13 @@ func (t *task) delete(ctx context.Context) (err error) {
 			return nil
 		}
 		// For transient errors (network, timeout, etc.), continue retrying
-		return
+		return err
 	}
 
 	// Check if the K8S object still exists:
 	object, err := t.getKubeObject(ctx)
 	if err != nil {
-		return
+		return err
 	}
 	if object == nil {
 		// K8s object is fully gone (all K8s finalizers processed).
@@ -269,14 +269,14 @@ func (t *task) delete(ctx context.Context) (err error) {
 			slog.String("id", t.externalIP.GetId()),
 		)
 		t.removeFinalizer()
-		return
+		return err
 	}
 
 	// Initiate K8s deletion if not already in progress:
 	if object.GetDeletionTimestamp() == nil {
 		err = t.hubClient.Delete(ctx, object)
 		if err != nil {
-			return
+			return err
 		}
 		t.r.logger.DebugContext(
 			ctx,
@@ -294,7 +294,7 @@ func (t *task) delete(ctx context.Context) (err error) {
 	}
 
 	// Don't remove finalizer: K8s object still exists with finalizers being processed.
-	return
+	return err
 }
 
 // selectHub derives the hub from the parent ExternalIPPool instead of random selection.
@@ -354,7 +354,7 @@ func (t *task) getKubeObject(ctx context.Context) (result *osacv1alpha1.External
 		},
 	)
 	if err != nil {
-		return
+		return result, err
 	}
 	items := list.Items
 	count := len(items)
@@ -363,12 +363,12 @@ func (t *task) getKubeObject(ctx context.Context) (result *osacv1alpha1.External
 			"expected at most one external IP with identifier '%s' but found %d",
 			t.externalIP.GetId(), count,
 		)
-		return
+		return result, err
 	}
 	if count > 0 {
 		result = &items[0]
 	}
-	return
+	return result, err
 }
 
 // addFinalizer adds the controller finalizer if it is not already present. Returns true if the finalizer was added,

--- a/internal/controllers/externalipattachment/external_ip_attachment_reconciler_function.go
+++ b/internal/controllers/externalipattachment/external_ip_attachment_reconciler_function.go
@@ -87,15 +87,15 @@ func (b *FunctionBuilder) SetHubCache(value controllers.HubCache) *FunctionBuild
 func (b *FunctionBuilder) Build() (result controllers.ReconcilerFunction[*privatev1.ExternalIPAttachment], err error) {
 	if b.logger == nil {
 		err = errors.New("logger is mandatory")
-		return
+		return result, err
 	}
 	if b.connection == nil {
 		err = errors.New("client is mandatory")
-		return
+		return result, err
 	}
 	if b.hubCache == nil {
 		err = errors.New("hub cache is mandatory")
-		return
+		return result, err
 	}
 
 	object := &function{
@@ -106,7 +106,7 @@ func (b *FunctionBuilder) Build() (result controllers.ReconcilerFunction[*privat
 		maskCalculator:              masks.NewCalculator().Build(),
 	}
 	result = object.run
-	return
+	return result, err
 }
 
 func (r *function) run(ctx context.Context, externalIPAttachment *privatev1.ExternalIPAttachment) error {
@@ -231,12 +231,12 @@ func (t *task) delete(ctx context.Context) (err error) {
 			controllers.RemoveFinalizerOnDecommissionedHub(ctx, t.r.logger, t.hubId, "external_ip_attachment_id", t.externalIPAttachment.GetId(), t.removeFinalizer)
 			return nil
 		}
-		return
+		return err
 	}
 
 	object, err := t.getKubeObject(ctx)
 	if err != nil {
-		return
+		return err
 	}
 	if object == nil {
 		t.r.logger.DebugContext(
@@ -245,13 +245,13 @@ func (t *task) delete(ctx context.Context) (err error) {
 			slog.String("id", t.externalIPAttachment.GetId()),
 		)
 		t.removeFinalizer()
-		return
+		return err
 	}
 
 	if object.GetDeletionTimestamp() == nil {
 		err = t.hubClient.Delete(ctx, object)
 		if err != nil {
-			return
+			return err
 		}
 		t.r.logger.DebugContext(
 			ctx,
@@ -268,7 +268,7 @@ func (t *task) delete(ctx context.Context) (err error) {
 		)
 	}
 
-	return
+	return err
 }
 
 func (t *task) selectHub(ctx context.Context) error {
@@ -324,7 +324,7 @@ func (t *task) getKubeObject(ctx context.Context) (result *osacv1alpha1.External
 		},
 	)
 	if err != nil {
-		return
+		return result, err
 	}
 	items := list.Items
 	count := len(items)
@@ -333,12 +333,12 @@ func (t *task) getKubeObject(ctx context.Context) (result *osacv1alpha1.External
 			"expected at most one external IP attachment with identifier '%s' but found %d",
 			t.externalIPAttachment.GetId(), count,
 		)
-		return
+		return result, err
 	}
 	if count > 0 {
 		result = &items[0]
 	}
-	return
+	return result, err
 }
 
 func (t *task) addFinalizer() bool {

--- a/internal/controllers/hub_cache.go
+++ b/internal/controllers/hub_cache.go
@@ -105,15 +105,15 @@ func (b *HubCacheBuilder) Build() (result HubCache, err error) {
 	// Check parameters:
 	if b.logger == nil {
 		err = errors.New("logger is mandatory")
-		return
+		return result, err
 	}
 	if b.connection == nil {
 		err = errors.New("gRPC connection is mandatory")
-		return
+		return result, err
 	}
 	if b.scheme == nil {
 		err = errors.New("scheme is mandatory")
-		return
+		return result, err
 	}
 
 	// Set default TTL if not specified:
@@ -131,7 +131,7 @@ func (b *HubCacheBuilder) Build() (result HubCache, err error) {
 		entriesLock: &sync.Mutex{},
 		ttl:         ttl,
 	}
-	return
+	return result, err
 }
 
 func (r *hubCache) Get(ctx context.Context, id string) (result *HubEntry, err error) {
@@ -153,7 +153,7 @@ func (r *hubCache) Get(ctx context.Context, id string) (result *HubEntry, err er
 		// Classify the error to distinguish decommissioned hubs (NotFound)
 		// from transient failures (network, timeout, etc.)
 		err = ClassifyHubError(err)
-		return
+		return result, err
 	}
 
 	r.entries[id] = &cachedHubEntry{
@@ -169,20 +169,20 @@ func (r *hubCache) create(ctx context.Context, id string) (result *HubEntry, err
 		Id: id,
 	}.Build())
 	if err != nil {
-		return
+		return result, err
 	}
 	hub := response.GetObject()
 	config, err := clientcmd.RESTConfigFromKubeConfig(hub.GetSpec().GetKubeconfig())
 	if err != nil {
-		return
+		return result, err
 	}
 	client, err := clnt.New(config, clnt.Options{Scheme: r.scheme})
 	if err != nil {
-		return
+		return result, err
 	}
 	result = &HubEntry{
 		Namespace: hub.GetSpec().GetNamespace(),
 		Client:    client,
 	}
-	return
+	return result, err
 }

--- a/internal/controllers/identityprovider/identity_provider_reconciler_function.go
+++ b/internal/controllers/identityprovider/identity_provider_reconciler_function.go
@@ -66,15 +66,15 @@ func (b *FunctionBuilder) SetIdpClient(value idp.ClientInterface) *FunctionBuild
 func (b *FunctionBuilder) Build() (result *function, err error) {
 	if b.logger == nil {
 		err = errors.New("logger is mandatory")
-		return
+		return result, err
 	}
 	if b.connection == nil {
 		err = errors.New("connection is mandatory")
-		return
+		return result, err
 	}
 	if b.idpClient == nil {
 		err = errors.New("IDP client is mandatory")
-		return
+		return result, err
 	}
 
 	result = &function{
@@ -83,7 +83,7 @@ func (b *FunctionBuilder) Build() (result *function, err error) {
 		idpClient:               b.idpClient,
 		maskCalculator:          masks.NewCalculator().Build(),
 	}
-	return
+	return result, err
 }
 
 // function is the implementation of the reconciler function.

--- a/internal/controllers/natgateway/nat_gateway_reconciler_function.go
+++ b/internal/controllers/natgateway/nat_gateway_reconciler_function.go
@@ -87,15 +87,15 @@ func (b *FunctionBuilder) SetHubCache(value controllers.HubCache) *FunctionBuild
 func (b *FunctionBuilder) Build() (result controllers.ReconcilerFunction[*privatev1.NATGateway], err error) {
 	if b.logger == nil {
 		err = errors.New("logger is mandatory")
-		return
+		return result, err
 	}
 	if b.connection == nil {
 		err = errors.New("client is mandatory")
-		return
+		return result, err
 	}
 	if b.hubCache == nil {
 		err = errors.New("hub cache is mandatory")
-		return
+		return result, err
 	}
 
 	object := &function{
@@ -106,7 +106,7 @@ func (b *FunctionBuilder) Build() (result controllers.ReconcilerFunction[*privat
 		maskCalculator:        masks.NewCalculator().Build(),
 	}
 	result = object.run
-	return
+	return result, err
 }
 
 func (r *function) run(ctx context.Context, natGateway *privatev1.NATGateway) error {
@@ -231,12 +231,12 @@ func (t *task) delete(ctx context.Context) (err error) {
 			controllers.RemoveFinalizerOnDecommissionedHub(ctx, t.r.logger, t.hubId, "nat_gateway_id", t.natGateway.GetId(), t.removeFinalizer)
 			return nil
 		}
-		return
+		return err
 	}
 
 	object, err := t.getKubeObject(ctx)
 	if err != nil {
-		return
+		return err
 	}
 	if object == nil {
 		t.r.logger.DebugContext(
@@ -245,13 +245,13 @@ func (t *task) delete(ctx context.Context) (err error) {
 			slog.String("id", t.natGateway.GetId()),
 		)
 		t.removeFinalizer()
-		return
+		return err
 	}
 
 	if object.GetDeletionTimestamp() == nil {
 		err = t.hubClient.Delete(ctx, object)
 		if err != nil {
-			return
+			return err
 		}
 		t.r.logger.DebugContext(
 			ctx,
@@ -268,7 +268,7 @@ func (t *task) delete(ctx context.Context) (err error) {
 		)
 	}
 
-	return
+	return err
 }
 
 func (t *task) selectHub(ctx context.Context) error {
@@ -324,7 +324,7 @@ func (t *task) getKubeObject(ctx context.Context) (result *osacv1alpha1.NATGatew
 		},
 	)
 	if err != nil {
-		return
+		return result, err
 	}
 	items := list.Items
 	count := len(items)
@@ -333,12 +333,12 @@ func (t *task) getKubeObject(ctx context.Context) (result *osacv1alpha1.NATGatew
 			"expected at most one NAT gateway with identifier '%s' but found %d",
 			t.natGateway.GetId(), count,
 		)
-		return
+		return result, err
 	}
 	if count > 0 {
 		result = &items[0]
 	}
-	return
+	return result, err
 }
 
 func (t *task) addFinalizer() bool {

--- a/internal/controllers/onboarding/tenant_reconciler_function.go
+++ b/internal/controllers/onboarding/tenant_reconciler_function.go
@@ -83,15 +83,15 @@ func (b *FunctionBuilder) SetHubCache(value controllers.HubCache) *FunctionBuild
 func (b *FunctionBuilder) Build() (result controllers.ReconcilerFunction[*privatev1.Tenant], err error) {
 	if b.logger == nil {
 		err = errors.New("logger is mandatory")
-		return
+		return result, err
 	}
 	if b.connection == nil {
 		err = errors.New("connection is mandatory")
-		return
+		return result, err
 	}
 	if b.hubCache == nil {
 		err = errors.New("hub cache is mandatory")
-		return
+		return result, err
 	}
 
 	object := &function{
@@ -103,7 +103,7 @@ func (b *FunctionBuilder) Build() (result controllers.ReconcilerFunction[*privat
 		maskCalculator: masks.NewCalculator().Build(),
 	}
 	result = object.run
-	return
+	return result, err
 }
 
 func (r *function) run(ctx context.Context, tenant *privatev1.Tenant) error {
@@ -348,12 +348,12 @@ func (t *task) getKubeObject(ctx context.Context, hubEntry *controllers.HubEntry
 	if err != nil {
 		if apierrors.IsNotFound(err) {
 			err = nil
-			return
+			return result, err
 		}
-		return
+		return result, err
 	}
 	result = object
-	return
+	return result, err
 }
 
 func (t *task) listAllHubs(ctx context.Context) ([]*privatev1.Hub, error) {

--- a/internal/controllers/project/project_reconciler_function.go
+++ b/internal/controllers/project/project_reconciler_function.go
@@ -77,15 +77,15 @@ func (b *FunctionBuilder) SetUsersClient(value privatev1.UsersClient) *FunctionB
 func (b *FunctionBuilder) Build() (result *function, err error) {
 	if b.logger == nil {
 		err = errors.New("logger is mandatory")
-		return
+		return result, err
 	}
 	if b.connection == nil {
 		err = errors.New("connection is mandatory")
-		return
+		return result, err
 	}
 	if b.projectGroupManager == nil {
 		err = errors.New("project group manager is mandatory")
-		return
+		return result, err
 	}
 
 	usersClient := b.usersClient
@@ -101,7 +101,7 @@ func (b *FunctionBuilder) Build() (result *function, err error) {
 		projectGroupManager: b.projectGroupManager,
 		maskCalculator:      masks.NewCalculator().Build(),
 	}
-	return
+	return result, err
 }
 
 // function is the implementation of the reconciler function.

--- a/internal/controllers/projectmembership/project_membership_reconciler_function.go
+++ b/internal/controllers/projectmembership/project_membership_reconciler_function.go
@@ -69,15 +69,15 @@ func (b *FunctionBuilder) SetIdpClient(value idp.ClientInterface) *FunctionBuild
 func (b *FunctionBuilder) Build() (result *function, err error) {
 	if b.logger == nil {
 		err = errors.New("logger is mandatory")
-		return
+		return result, err
 	}
 	if b.connection == nil {
 		err = errors.New("connection is mandatory")
-		return
+		return result, err
 	}
 	if b.idpClient == nil {
 		err = errors.New("IDP client is mandatory")
-		return
+		return result, err
 	}
 
 	result = &function{
@@ -88,7 +88,7 @@ func (b *FunctionBuilder) Build() (result *function, err error) {
 		idpClient:                b.idpClient,
 		maskCalculator:           masks.NewCalculator().Build(),
 	}
-	return
+	return result, err
 }
 
 // function is the implementation of the reconciler function.

--- a/internal/controllers/publicip/public_ip_reconciler_function.go
+++ b/internal/controllers/publicip/public_ip_reconciler_function.go
@@ -91,15 +91,15 @@ func (b *FunctionBuilder) Build() (result controllers.ReconcilerFunction[*privat
 	// Check parameters:
 	if b.logger == nil {
 		err = errors.New("logger is mandatory")
-		return
+		return result, err
 	}
 	if b.connection == nil {
 		err = errors.New("client is mandatory")
-		return
+		return result, err
 	}
 	if b.hubCache == nil {
 		err = errors.New("hub cache is mandatory")
-		return
+		return result, err
 	}
 
 	// Create and populate the object:
@@ -111,7 +111,7 @@ func (b *FunctionBuilder) Build() (result controllers.ReconcilerFunction[*privat
 		maskCalculator:      masks.NewCalculator().Build(),
 	}
 	result = object.run
-	return
+	return result, err
 }
 
 func (r *function) run(ctx context.Context, publicIP *privatev1.PublicIP) error {
@@ -252,13 +252,13 @@ func (t *task) delete(ctx context.Context) (err error) {
 			return nil
 		}
 		// For transient errors (network, timeout, etc.), continue retrying
-		return
+		return err
 	}
 
 	// Check if the K8S object still exists:
 	object, err := t.getKubeObject(ctx)
 	if err != nil {
-		return
+		return err
 	}
 	if object == nil {
 		// K8s object is fully gone (all K8s finalizers processed).
@@ -269,14 +269,14 @@ func (t *task) delete(ctx context.Context) (err error) {
 			slog.String("id", t.publicIP.GetId()),
 		)
 		t.removeFinalizer()
-		return
+		return err
 	}
 
 	// Initiate K8s deletion if not already in progress:
 	if object.GetDeletionTimestamp() == nil {
 		err = t.hubClient.Delete(ctx, object)
 		if err != nil {
-			return
+			return err
 		}
 		t.r.logger.DebugContext(
 			ctx,
@@ -294,7 +294,7 @@ func (t *task) delete(ctx context.Context) (err error) {
 	}
 
 	// Don't remove finalizer: K8s object still exists with finalizers being processed.
-	return
+	return err
 }
 
 // selectHub derives the hub from the parent PublicIPPool instead of random selection.
@@ -354,7 +354,7 @@ func (t *task) getKubeObject(ctx context.Context) (result *osacv1alpha1.PublicIP
 		},
 	)
 	if err != nil {
-		return
+		return result, err
 	}
 	items := list.Items
 	count := len(items)
@@ -363,12 +363,12 @@ func (t *task) getKubeObject(ctx context.Context) (result *osacv1alpha1.PublicIP
 			"expected at most one public IP with identifier '%s' but found %d",
 			t.publicIP.GetId(), count,
 		)
-		return
+		return result, err
 	}
 	if count > 0 {
 		result = &items[0]
 	}
-	return
+	return result, err
 }
 
 // addFinalizer adds the controller finalizer if it is not already present. Returns true if the finalizer was added,

--- a/internal/controllers/publicipattachment/public_ip_attachment_reconciler_function.go
+++ b/internal/controllers/publicipattachment/public_ip_attachment_reconciler_function.go
@@ -87,15 +87,15 @@ func (b *FunctionBuilder) SetHubCache(value controllers.HubCache) *FunctionBuild
 func (b *FunctionBuilder) Build() (result controllers.ReconcilerFunction[*privatev1.PublicIPAttachment], err error) {
 	if b.logger == nil {
 		err = errors.New("logger is mandatory")
-		return
+		return result, err
 	}
 	if b.connection == nil {
 		err = errors.New("client is mandatory")
-		return
+		return result, err
 	}
 	if b.hubCache == nil {
 		err = errors.New("hub cache is mandatory")
-		return
+		return result, err
 	}
 
 	object := &function{
@@ -106,7 +106,7 @@ func (b *FunctionBuilder) Build() (result controllers.ReconcilerFunction[*privat
 		maskCalculator:            masks.NewCalculator().Build(),
 	}
 	result = object.run
-	return
+	return result, err
 }
 
 func (r *function) run(ctx context.Context, publicIPAttachment *privatev1.PublicIPAttachment) error {
@@ -231,12 +231,12 @@ func (t *task) delete(ctx context.Context) (err error) {
 			controllers.RemoveFinalizerOnDecommissionedHub(ctx, t.r.logger, t.hubId, "public_ip_attachment_id", t.publicIPAttachment.GetId(), t.removeFinalizer)
 			return nil
 		}
-		return
+		return err
 	}
 
 	object, err := t.getKubeObject(ctx)
 	if err != nil {
-		return
+		return err
 	}
 	if object == nil {
 		t.r.logger.DebugContext(
@@ -245,13 +245,13 @@ func (t *task) delete(ctx context.Context) (err error) {
 			slog.String("id", t.publicIPAttachment.GetId()),
 		)
 		t.removeFinalizer()
-		return
+		return err
 	}
 
 	if object.GetDeletionTimestamp() == nil {
 		err = t.hubClient.Delete(ctx, object)
 		if err != nil {
-			return
+			return err
 		}
 		t.r.logger.DebugContext(
 			ctx,
@@ -268,7 +268,7 @@ func (t *task) delete(ctx context.Context) (err error) {
 		)
 	}
 
-	return
+	return err
 }
 
 func (t *task) selectHub(ctx context.Context) error {
@@ -324,7 +324,7 @@ func (t *task) getKubeObject(ctx context.Context) (result *osacv1alpha1.PublicIP
 		},
 	)
 	if err != nil {
-		return
+		return result, err
 	}
 	items := list.Items
 	count := len(items)
@@ -333,12 +333,12 @@ func (t *task) getKubeObject(ctx context.Context) (result *osacv1alpha1.PublicIP
 			"expected at most one public IP attachment with identifier '%s' but found %d",
 			t.publicIPAttachment.GetId(), count,
 		)
-		return
+		return result, err
 	}
 	if count > 0 {
 		result = &items[0]
 	}
-	return
+	return result, err
 }
 
 func (t *task) addFinalizer() bool {

--- a/internal/controllers/reconciler.go
+++ b/internal/controllers/reconciler.go
@@ -150,36 +150,36 @@ func (b *ReconcilerBuilder[O]) Build() (result *Reconciler[O], err error) {
 	// Check parameters:
 	if b.logger == nil {
 		err = errors.New("logger is mandatory")
-		return
+		return result, err
 	}
 	if b.name == "" {
 		err = errors.New("name is mandatory")
-		return
+		return result, err
 	}
 	if b.grpcClient == nil {
 		err = errors.New("gRPC client is mandatory")
-		return
+		return result, err
 	}
 	if b.function == nil {
 		err = errors.New("function is mandatory")
-		return
+		return result, err
 	}
 	if b.syncInterval <= 0 {
 		err = fmt.Errorf("sync interval should be positive, but it is %s", b.syncInterval)
-		return
+		return result, err
 	}
 	// Find the field of the event payload that contains the type of objects supported by the reconciler:
 	payloadField, err := b.findPayloadField()
 	if err != nil {
 		err = fmt.Errorf("failed to find payload field: %w", err)
-		return
+		return result, err
 	}
 
 	// Find the method that will be used to list objects during synchronization:
 	listMethod, listRequest, listResponse, err := b.findListMethod()
 	if err != nil {
 		err = fmt.Errorf("failed to find list method: %w", err)
-		return
+		return result, err
 	}
 
 	// Set the default event filter:
@@ -228,7 +228,7 @@ func (b *ReconcilerBuilder[O]) Build() (result *Reconciler[O], err error) {
 		Build()
 	if err != nil {
 		err = fmt.Errorf("failed to create sync loop: %w", err)
-		return
+		return result, err
 	}
 
 	// Create the watch loop:
@@ -240,12 +240,12 @@ func (b *ReconcilerBuilder[O]) Build() (result *Reconciler[O], err error) {
 		Build()
 	if err != nil {
 		err = fmt.Errorf("failed to create watch loop: %w", err)
-		return
+		return result, err
 	}
 
 	// Return the result:
 	result = reconciler
-	return
+	return result, err
 }
 
 // findPayloadField finds the field of the event type that contains the payload for the type supported by the
@@ -266,11 +266,11 @@ func (b *ReconcilerBuilder[O]) findPayloadField() (result protoreflect.FieldDesc
 		}
 		if eventField.Message().FullName() == objectDesc.FullName() {
 			result = eventField
-			return
+			return result, err
 		}
 	}
 	err = fmt.Errorf("failed to find event field for type '%T'", object)
-	return
+	return result, err
 }
 
 // findListMethod finds the method that will be used to list objects.
@@ -311,18 +311,18 @@ func (b *ReconcilerBuilder[O]) findListMethod() (name string, request, response 
 	)
 	if methodDesc == nil {
 		err = fmt.Errorf("failed to find list method for type '%T", object)
-		return
+		return name, request, response, err
 	}
 
 	// Find the request and response types:
 	requestType, err := protoregistry.GlobalTypes.FindMessageByName(methodDesc.Input().FullName())
 	if err != nil {
-		return
+		return name, request, response, err
 	}
 	request = requestType.New().Interface()
 	responseType, err := protoregistry.GlobalTypes.FindMessageByName(methodDesc.Output().FullName())
 	if err != nil {
-		return
+		return name, request, response, err
 	}
 	response = responseType.New().Interface()
 
@@ -330,7 +330,7 @@ func (b *ReconcilerBuilder[O]) findListMethod() (name string, request, response 
 	fullMethodName := methodDesc.FullName()
 	name = fmt.Sprintf("/%s/%s", fullMethodName.Parent(), fullMethodName.Name())
 
-	return
+	return name, request, response, err
 }
 
 // Start starts the controller. To stop it cancel the context.

--- a/internal/controllers/role/role_reconciler_function.go
+++ b/internal/controllers/role/role_reconciler_function.go
@@ -54,11 +54,11 @@ func (b *FunctionBuilder) SetConnection(value *grpc.ClientConn) *FunctionBuilder
 func (b *FunctionBuilder) Build() (result *function, err error) {
 	if b.logger == nil {
 		err = errors.New("logger is mandatory")
-		return
+		return result, err
 	}
 	if b.connection == nil {
 		err = errors.New("connection is mandatory")
-		return
+		return result, err
 	}
 
 	result = &function{
@@ -67,7 +67,7 @@ func (b *FunctionBuilder) Build() (result *function, err error) {
 		maskCalculator: masks.NewCalculator().
 			Build(),
 	}
-	return
+	return result, err
 }
 
 // function is the implementation of the reconciler function.

--- a/internal/controllers/rolebinding/role_binding_reconciler_function.go
+++ b/internal/controllers/rolebinding/role_binding_reconciler_function.go
@@ -63,15 +63,15 @@ func (b *FunctionBuilder) SetIdpClient(value idp.ClientInterface) *FunctionBuild
 func (b *FunctionBuilder) Build() (result *function, err error) {
 	if b.logger == nil {
 		err = errors.New("logger is mandatory")
-		return
+		return result, err
 	}
 	if b.connection == nil {
 		err = errors.New("connection is mandatory")
-		return
+		return result, err
 	}
 	if b.idpClient == nil {
 		err = errors.New("IDP client is mandatory")
-		return
+		return result, err
 	}
 
 	result = &function{
@@ -83,7 +83,7 @@ func (b *FunctionBuilder) Build() (result *function, err error) {
 		maskCalculator: masks.NewCalculator().
 			Build(),
 	}
-	return
+	return result, err
 }
 
 // function is the implementation of the reconciler function.

--- a/internal/controllers/securitygroup/securitygroup_reconciler_function.go
+++ b/internal/controllers/securitygroup/securitygroup_reconciler_function.go
@@ -91,15 +91,15 @@ func (b *FunctionBuilder) Build() (result controllers.ReconcilerFunction[*privat
 	// Check parameters:
 	if b.logger == nil {
 		err = errors.New("logger is mandatory")
-		return
+		return result, err
 	}
 	if b.connection == nil {
 		err = errors.New("client is mandatory")
-		return
+		return result, err
 	}
 	if b.hubCache == nil {
 		err = errors.New("hub cache is mandatory")
-		return
+		return result, err
 	}
 
 	// Create and populate the object:
@@ -112,7 +112,7 @@ func (b *FunctionBuilder) Build() (result controllers.ReconcilerFunction[*privat
 		maskCalculator:        masks.NewCalculator().Build(),
 	}
 	result = object.run
-	return
+	return result, err
 }
 
 func (r *function) run(ctx context.Context, securityGroup *privatev1.SecurityGroup) error {
@@ -290,7 +290,7 @@ func (t *task) delete(ctx context.Context) (err error) {
 			return nil
 		}
 		// For transient errors (network, timeout, etc.), continue retrying
-		return
+		return err
 	}
 	t.hubNamespace = hubEntry.Namespace
 	t.hubClient = hubEntry.Client
@@ -298,7 +298,7 @@ func (t *task) delete(ctx context.Context) (err error) {
 	// Check if the K8S object still exists:
 	object, err := t.getKubeObject(ctx)
 	if err != nil {
-		return
+		return err
 	}
 	if object == nil {
 		// K8s object is fully gone (all K8s finalizers processed).
@@ -309,14 +309,14 @@ func (t *task) delete(ctx context.Context) (err error) {
 			slog.String("id", t.securityGroup.GetId()),
 		)
 		t.removeFinalizer()
-		return
+		return err
 	}
 
 	// Initiate K8s deletion if not already in progress:
 	if object.GetDeletionTimestamp() == nil {
 		err = t.hubClient.Delete(ctx, object)
 		if err != nil {
-			return
+			return err
 		}
 		t.r.logger.DebugContext(
 			ctx,
@@ -334,7 +334,7 @@ func (t *task) delete(ctx context.Context) (err error) {
 	}
 
 	// Don't remove finalizer — K8s object still exists with finalizers being processed.
-	return
+	return err
 }
 
 func (t *task) getKubeObject(ctx context.Context) (result *osacv1alpha1.SecurityGroup, err error) {
@@ -347,7 +347,7 @@ func (t *task) getKubeObject(ctx context.Context) (result *osacv1alpha1.Security
 		},
 	)
 	if err != nil {
-		return
+		return result, err
 	}
 	items := list.Items
 	count := len(items)
@@ -356,12 +356,12 @@ func (t *task) getKubeObject(ctx context.Context) (result *osacv1alpha1.Security
 			"expected at most one security group with identifier '%s' but found %d",
 			t.securityGroup.GetId(), count,
 		)
-		return
+		return result, err
 	}
 	if count > 0 {
 		result = &items[0]
 	}
-	return
+	return result, err
 }
 
 // addFinalizer adds the controller finalizer if it is not already present. Returns true if the finalizer was added,

--- a/internal/controllers/subnet/subnet_reconciler_function.go
+++ b/internal/controllers/subnet/subnet_reconciler_function.go
@@ -92,15 +92,15 @@ func (b *FunctionBuilder) Build() (result controllers.ReconcilerFunction[*privat
 	// Check parameters:
 	if b.logger == nil {
 		err = errors.New("logger is mandatory")
-		return
+		return result, err
 	}
 	if b.connection == nil {
 		err = errors.New("client is mandatory")
-		return
+		return result, err
 	}
 	if b.hubCache == nil {
 		err = errors.New("hub cache is mandatory")
-		return
+		return result, err
 	}
 
 	// Create and populate the object:
@@ -112,7 +112,7 @@ func (b *FunctionBuilder) Build() (result controllers.ReconcilerFunction[*privat
 		maskCalculator: masks.NewCalculator().Build(),
 	}
 	result = object.run
-	return
+	return result, err
 }
 
 func (r *function) run(ctx context.Context, subnet *privatev1.Subnet) error {
@@ -253,13 +253,13 @@ func (t *task) delete(ctx context.Context) (err error) {
 			return nil
 		}
 		// For transient errors (network, timeout, etc.), continue retrying
-		return
+		return err
 	}
 
 	// Check if the K8S object still exists:
 	object, err := t.getKubeObject(ctx)
 	if err != nil {
-		return
+		return err
 	}
 	if object == nil {
 		// K8s object is fully gone (all K8s finalizers processed).
@@ -270,14 +270,14 @@ func (t *task) delete(ctx context.Context) (err error) {
 			slog.String("id", t.subnet.GetId()),
 		)
 		t.removeFinalizer()
-		return
+		return err
 	}
 
 	// Initiate K8s deletion if not already in progress:
 	if object.GetDeletionTimestamp() == nil {
 		err = t.hubClient.Delete(ctx, object)
 		if err != nil {
-			return
+			return err
 		}
 		t.r.logger.DebugContext(
 			ctx,
@@ -295,7 +295,7 @@ func (t *task) delete(ctx context.Context) (err error) {
 	}
 
 	// Don't remove finalizer — K8s object still exists with finalizers being processed.
-	return
+	return err
 }
 
 func (t *task) selectHub(ctx context.Context) error {
@@ -345,7 +345,7 @@ func (t *task) getKubeObject(ctx context.Context) (result *osacv1alpha1.Subnet, 
 		},
 	)
 	if err != nil {
-		return
+		return result, err
 	}
 	items := list.Items
 	count := len(items)
@@ -354,12 +354,12 @@ func (t *task) getKubeObject(ctx context.Context) (result *osacv1alpha1.Subnet, 
 			"expected at most one subnet with identifier '%s' but found %d",
 			t.subnet.GetId(), count,
 		)
-		return
+		return result, err
 	}
 	if count > 0 {
 		result = &items[0]
 	}
-	return
+	return result, err
 }
 
 // addFinalizer adds the controller finalizer if it is not already present. Returns true if the finalizer was added,

--- a/internal/controllers/tenant/tenant_reconciler_function.go
+++ b/internal/controllers/tenant/tenant_reconciler_function.go
@@ -66,15 +66,15 @@ func (b *FunctionBuilder) SetIdpManager(value *idp.TenantManager) *FunctionBuild
 func (b *FunctionBuilder) Build() (result *function, err error) {
 	if b.logger == nil {
 		err = errors.New("logger is mandatory")
-		return
+		return result, err
 	}
 	if b.connection == nil {
 		err = errors.New("connection is mandatory")
-		return
+		return result, err
 	}
 	if b.idpManager == nil {
 		err = errors.New("IDP manager is mandatory")
-		return
+		return result, err
 	}
 
 	result = &function{
@@ -84,7 +84,7 @@ func (b *FunctionBuilder) Build() (result *function, err error) {
 		idpManager:     b.idpManager,
 		maskCalculator: masks.NewCalculator().Build(),
 	}
-	return
+	return result, err
 }
 
 // function is the implementation of the reconciler function.

--- a/internal/controllers/user/user_reconciler_function.go
+++ b/internal/controllers/user/user_reconciler_function.go
@@ -60,15 +60,15 @@ func (b *FunctionBuilder) SetIdpClient(value idp.ClientInterface) *FunctionBuild
 func (b *FunctionBuilder) Build() (result *function, err error) {
 	if b.logger == nil {
 		err = errors.New("logger is mandatory")
-		return
+		return result, err
 	}
 	if b.connection == nil {
 		err = errors.New("connection is mandatory")
-		return
+		return result, err
 	}
 	if b.idpClient == nil {
 		err = errors.New("IDP client is mandatory")
-		return
+		return result, err
 	}
 
 	result = &function{
@@ -77,7 +77,7 @@ func (b *FunctionBuilder) Build() (result *function, err error) {
 		idpClient:      b.idpClient,
 		maskCalculator: masks.NewCalculator().Build(),
 	}
-	return
+	return result, err
 }
 
 // function is the implementation of the reconciler function.

--- a/internal/controllers/virtualnetwork/virtual_network_reconciler_function.go
+++ b/internal/controllers/virtualnetwork/virtual_network_reconciler_function.go
@@ -92,15 +92,15 @@ func (b *FunctionBuilder) Build() (result controllers.ReconcilerFunction[*privat
 	// Check parameters:
 	if b.logger == nil {
 		err = errors.New("logger is mandatory")
-		return
+		return result, err
 	}
 	if b.connection == nil {
 		err = errors.New("client is mandatory")
-		return
+		return result, err
 	}
 	if b.hubCache == nil {
 		err = errors.New("hub cache is mandatory")
-		return
+		return result, err
 	}
 
 	// Create and populate the object:
@@ -112,7 +112,7 @@ func (b *FunctionBuilder) Build() (result controllers.ReconcilerFunction[*privat
 		maskCalculator:        masks.NewCalculator().Build(),
 	}
 	result = object.run
-	return
+	return result, err
 }
 
 func (r *function) run(ctx context.Context, virtualNetwork *privatev1.VirtualNetwork) error {
@@ -253,13 +253,13 @@ func (t *task) delete(ctx context.Context) (err error) {
 			return nil
 		}
 		// For transient errors (network, timeout, etc.), continue retrying
-		return
+		return err
 	}
 
 	// Check if the K8S object still exists:
 	object, err := t.getKubeObject(ctx)
 	if err != nil {
-		return
+		return err
 	}
 	if object == nil {
 		// K8s object is fully gone (all K8s finalizers processed).
@@ -270,14 +270,14 @@ func (t *task) delete(ctx context.Context) (err error) {
 			slog.String("id", t.virtualNetwork.GetId()),
 		)
 		t.removeFinalizer()
-		return
+		return err
 	}
 
 	// Initiate K8s deletion if not already in progress:
 	if object.GetDeletionTimestamp() == nil {
 		err = t.hubClient.Delete(ctx, object)
 		if err != nil {
-			return
+			return err
 		}
 		t.r.logger.DebugContext(
 			ctx,
@@ -295,7 +295,7 @@ func (t *task) delete(ctx context.Context) (err error) {
 	}
 
 	// Don't remove finalizer — K8s object still exists with finalizers being processed.
-	return
+	return err
 }
 
 func (t *task) selectHub(ctx context.Context) error {
@@ -345,7 +345,7 @@ func (t *task) getKubeObject(ctx context.Context) (result *osacv1alpha1.VirtualN
 		},
 	)
 	if err != nil {
-		return
+		return result, err
 	}
 	items := list.Items
 	count := len(items)
@@ -354,12 +354,12 @@ func (t *task) getKubeObject(ctx context.Context) (result *osacv1alpha1.VirtualN
 			"expected at most one virtual network with identifier '%s' but found %d",
 			t.virtualNetwork.GetId(), count,
 		)
-		return
+		return result, err
 	}
 	if count > 0 {
 		result = &items[0]
 	}
-	return
+	return result, err
 }
 
 // addFinalizer adds the controller finalizer if it is not already present. Returns true if the finalizer was added,

--- a/internal/database/dao/filter_translator.go
+++ b/internal/database/dao/filter_translator.go
@@ -188,7 +188,7 @@ func (b *FilterTranslatorBuilder[O]) Build() (result *FilterTranslator[O], err e
 	// Check parameters:
 	if b.logger == nil {
 		err = errors.New("logger is mandatory")
-		return
+		return result, err
 	}
 
 	// Get the descriptors of well known types:
@@ -206,7 +206,7 @@ func (b *FilterTranslatorBuilder[O]) Build() (result *FilterTranslator[O], err e
 	celEnv, err := b.createCelEnv()
 	if err != nil {
 		err = fmt.Errorf("failed to create CEL environment")
-		return
+		return result, err
 	}
 
 	// Create and populate the object:
@@ -217,7 +217,7 @@ func (b *FilterTranslatorBuilder[O]) Build() (result *FilterTranslator[O], err e
 		projectDesc: projectDesc,
 		celEnv:      celEnv,
 	}
-	return
+	return result, err
 }
 
 func (b *FilterTranslatorBuilder[O]) createCelEnv() (result *cel.Env, err error) {
@@ -237,7 +237,7 @@ func (b *FilterTranslatorBuilder[O]) createCelEnv() (result *cel.Env, err error)
 
 	// Create the CEL environment:
 	result, err = cel.NewEnv(options...)
-	return
+	return result, err
 }
 
 // Translate translate the given filter expression into a SQL where statement.
@@ -246,15 +246,15 @@ func (t *FilterTranslator[O]) Translate(ctx context.Context, filter string) (sql
 	if issues != nil {
 		err = issues.Err()
 		if err != nil {
-			return
+			return sql, err
 		}
 	}
 	result, err := t.translate(ast.NativeRep().Expr())
 	if err != nil {
-		return
+		return sql, err
 	}
 	sql = result.sql
-	return
+	return sql, err
 }
 
 func (t *FilterTranslator[O]) translate(expr ast.Expr) (result filterTranslatorResult, err error) {
@@ -269,9 +269,9 @@ func (t *FilterTranslator[O]) translate(expr ast.Expr) (result filterTranslatorR
 		result, err = t.translateSelectField(expr.AsSelect())
 	default:
 		err = fmt.Errorf("unsupported expression kind %d", expr.Kind())
-		return
+		return result, err
 	}
-	return
+	return result, err
 }
 
 func (t *FilterTranslator[O]) translateCall(expr ast.CallExpr) (result filterTranslatorResult, err error) {
@@ -296,7 +296,7 @@ func (t *FilterTranslator[O]) translateCall(expr ast.CallExpr) (result filterTra
 				"expected exactly two arguments for operator '%s' but got %d",
 				funcName, len(funcArgs),
 			)
-			return
+			return result, err
 		}
 		result, err = t.translateBinary(funcName, funcArgs[0], funcArgs[1])
 	case operators.LogicalNot:
@@ -311,7 +311,7 @@ func (t *FilterTranslator[O]) translateCall(expr ast.CallExpr) (result filterTra
 				"expected exactly one argument for function '%s' but got %d",
 				funcName, len(funcArgs),
 			)
-			return
+			return result, err
 		}
 		result, err = t.translateToLike(funcName, expr.Target(), funcArgs[0], "%", "%")
 	case "startsWith":
@@ -320,7 +320,7 @@ func (t *FilterTranslator[O]) translateCall(expr ast.CallExpr) (result filterTra
 				"expected exactly one argument for function '%s' but got %d",
 				funcName, len(funcArgs),
 			)
-			return
+			return result, err
 		}
 		result, err = t.translateToLike(funcName, expr.Target(), funcArgs[0], "", "%")
 	case "endsWith":
@@ -329,24 +329,24 @@ func (t *FilterTranslator[O]) translateCall(expr ast.CallExpr) (result filterTra
 				"expected exactly one argument for function '%s' but got %d",
 				funcName, len(funcArgs),
 			)
-			return
+			return result, err
 		}
 		result, err = t.translateToLike(funcName, expr.Target(), funcArgs[0], "%", "")
 	default:
 		err = fmt.Errorf("function '%s' isn't supported", funcName)
-		return
+		return result, err
 	}
-	return
+	return result, err
 }
 
 func (t *FilterTranslator[O]) translateBinary(name string, left, right ast.Expr) (result filterTranslatorResult, err error) {
 	leftTr, err := t.translate(left)
 	if err != nil {
-		return
+		return result, err
 	}
 	rightTr, err := t.translate(right)
 	if err != nil {
-		return
+		return result, err
 	}
 	switch name {
 	case operators.Equals:
@@ -357,7 +357,7 @@ func (t *FilterTranslator[O]) translateBinary(name string, left, right ast.Expr)
 		op, ok := binaryOps[name]
 		if !ok {
 			err = fmt.Errorf("unsupported operator '%s'", name)
-			return
+			return result, err
 		}
 		resultKind := filterTranslatorBooleanKind
 		if op.inheritKind {
@@ -380,24 +380,24 @@ func (t *FilterTranslator[O]) translateEquals(leftTr, rightTr filterTranslatorRe
 	if leftTr.mapIndexOperand != "" && rightTr.hasStringValue {
 		result.sql, err = t.translateMapEquals(leftTr.mapIndexOperand, leftTr.mapIndexKey, rightTr.stringValue)
 		if err != nil {
-			return
+			return result, err
 		}
 		result.precedence = filterTranslatorComparisonPrecedence
 		result.kind = filterTranslatorBooleanKind
-		return
+		return result, err
 	}
 	if rightTr.mapIndexOperand != "" && leftTr.hasStringValue {
 		result.sql, err = t.translateMapEquals(rightTr.mapIndexOperand, rightTr.mapIndexKey, leftTr.stringValue)
 		if err != nil {
-			return
+			return result, err
 		}
 		result.precedence = filterTranslatorComparisonPrecedence
 		result.kind = filterTranslatorBooleanKind
-		return
+		return result, err
 	}
 	result, err = t.translateEnumEquals(leftTr, rightTr)
 	if err != nil || result.sql != "" {
-		return
+		return result, err
 	}
 	return assembleBinarySQL(leftTr, rightTr, "=", filterTranslatorComparisonPrecedence, filterTranslatorBooleanKind), nil
 }
@@ -415,24 +415,24 @@ func (t *FilterTranslator[O]) translateNotEquals(leftTr, rightTr filterTranslato
 	if leftTr.mapIndexOperand != "" && rightTr.hasStringValue {
 		result.sql, err = t.translateMapNotEquals(leftTr.mapIndexOperand, leftTr.mapIndexKey, rightTr.stringValue)
 		if err != nil {
-			return
+			return result, err
 		}
 		result.precedence = filterTranslatorComparisonPrecedence
 		result.kind = filterTranslatorBooleanKind
-		return
+		return result, err
 	}
 	if rightTr.mapIndexOperand != "" && leftTr.hasStringValue {
 		result.sql, err = t.translateMapNotEquals(rightTr.mapIndexOperand, rightTr.mapIndexKey, leftTr.stringValue)
 		if err != nil {
-			return
+			return result, err
 		}
 		result.precedence = filterTranslatorComparisonPrecedence
 		result.kind = filterTranslatorBooleanKind
-		return
+		return result, err
 	}
 	result, err = t.translateEnumNotEquals(leftTr, rightTr)
 	if err != nil || result.sql != "" {
-		return
+		return result, err
 	}
 	return assembleBinarySQL(leftTr, rightTr, "!=", filterTranslatorComparisonPrecedence, filterTranslatorBooleanKind), nil
 }
@@ -468,7 +468,7 @@ func assembleBinarySQL(leftTr, rightTr filterTranslatorResult, operatorSQL strin
 func (t *FilterTranslator[O]) translateNot(value ast.Expr) (result filterTranslatorResult, err error) {
 	valueTr, err := t.translate(value)
 	if err != nil {
-		return
+		return result, err
 	}
 	var buffer bytes.Buffer
 	buffer.WriteString("not ")
@@ -482,7 +482,7 @@ func (t *FilterTranslator[O]) translateNot(value ast.Expr) (result filterTransla
 	result.sql = buffer.String()
 	result.precedence = filterTranslatorNotPrecedence
 	result.kind = filterTranslatorBooleanKind
-	return
+	return result, err
 }
 
 func (t *FilterTranslator[O]) translateIdent(name string) (result filterTranslatorResult, err error) {
@@ -495,10 +495,10 @@ func (t *FilterTranslator[O]) translateIdent(name string) (result filterTranslat
 		result.kind = filterTranslatorTimeKind
 	default:
 		err = fmt.Errorf("unknown identifier '%s'", name)
-		return
+		return result, err
 	}
 	result.precedence = filterTranslatorMaxPrecedence
-	return
+	return result, err
 }
 
 func (t *FilterTranslator[O]) translateLiteral(value ref.Val) (result filterTranslatorResult, err error) {
@@ -528,7 +528,7 @@ func (t *FilterTranslator[O]) translateLiteral(value ref.Val) (result filterTran
 		err = fmt.Errorf("unknown literal type '%T'", value)
 	}
 	result.precedence = filterTranslatorMaxPrecedence
-	return
+	return result, err
 }
 
 // translateString translates the given string. If special is not empty then it is interpreted as an addition set of
@@ -562,7 +562,7 @@ func (t *FilterTranslator[O]) translateString(value, special string) (text strin
 		}
 	}
 	text = buffer.String()
-	return
+	return text, escaped
 }
 
 func (t *FilterTranslator[O]) translateIn(args []ast.Expr) (result filterTranslatorResult, err error) {
@@ -575,29 +575,29 @@ func (t *FilterTranslator[O]) translateIn(args []ast.Expr) (result filterTransla
 		result, err = t.translateInField(key, values.AsSelect())
 	default:
 		err = fmt.Errorf("second argument of the 'in' operator must be a list or a select expression")
-		return
+		return result, err
 	}
-	return
+	return result, err
 }
 
 func (t *FilterTranslator[O]) translateIndex(args []ast.Expr) (result filterTranslatorResult, err error) {
 	if len(args) != 2 {
 		err = fmt.Errorf("expected exactly two arguments for index but got %d", len(args))
-		return
+		return result, err
 	}
 	targetTr, err := t.translate(args[0])
 	if err != nil {
-		return
+		return result, err
 	}
 	if args[1].Kind() != ast.LiteralKind {
 		err = fmt.Errorf("index must be a literal string")
-		return
+		return result, err
 	}
 	keyLiteral := args[1].AsLiteral()
 	keyValue, ok := keyLiteral.Value().(string)
 	if !ok {
 		err = fmt.Errorf("index must be a literal string")
-		return
+		return result, err
 	}
 	keyText, keyEscaped := t.translateString(keyValue, "")
 	var keySql string
@@ -616,7 +616,7 @@ func (t *FilterTranslator[O]) translateIndex(args []ast.Expr) (result filterTran
 	default:
 		err = fmt.Errorf("index of kind '%s' isn't supported", targetTr.kind)
 	}
-	return
+	return result, err
 }
 
 func (t *FilterTranslator[O]) translateMapEquals(operand, key, value string) (string, error) {
@@ -656,12 +656,12 @@ func (t *FilterTranslator[O]) translateEnumEquals(leftTr, rightTr filterTranslat
 	enumDesc, intVal, fieldSql, ok := t.extractEnumComparison(leftTr, rightTr)
 	if !ok {
 		err = t.checkUnsupportedEnumComparison(leftTr, rightTr)
-		return
+		return result, err
 	}
 	name, found := t.resolveEnumName(enumDesc, intVal)
 	if !found {
 		err = fmt.Errorf("unknown enum value %d for %s", intVal, enumDesc.FullName())
-		return
+		return result, err
 	}
 	text, escaped := t.translateString(name, "")
 	if escaped {
@@ -671,19 +671,19 @@ func (t *FilterTranslator[O]) translateEnumEquals(leftTr, rightTr filterTranslat
 	}
 	result.precedence = filterTranslatorComparisonPrecedence
 	result.kind = filterTranslatorBooleanKind
-	return
+	return result, err
 }
 
 func (t *FilterTranslator[O]) translateEnumNotEquals(leftTr, rightTr filterTranslatorResult) (result filterTranslatorResult, err error) {
 	enumDesc, intVal, fieldSql, ok := t.extractEnumComparison(leftTr, rightTr)
 	if !ok {
 		err = t.checkUnsupportedEnumComparison(leftTr, rightTr)
-		return
+		return result, err
 	}
 	name, found := t.resolveEnumName(enumDesc, intVal)
 	if !found {
 		err = fmt.Errorf("unknown enum value %d for %s", intVal, enumDesc.FullName())
-		return
+		return result, err
 	}
 	text, escaped := t.translateString(name, "")
 	if escaped {
@@ -693,7 +693,7 @@ func (t *FilterTranslator[O]) translateEnumNotEquals(leftTr, rightTr filterTrans
 	}
 	result.precedence = filterTranslatorComparisonPrecedence
 	result.kind = filterTranslatorBooleanKind
-	return
+	return result, err
 }
 
 func (t *FilterTranslator[O]) checkUnsupportedEnumComparison(leftTr, rightTr filterTranslatorResult) error {
@@ -730,21 +730,21 @@ func (t *FilterTranslator[O]) translateInList(key ast.Expr, list ast.ListExpr) (
 		result.sql = "false"
 		result.kind = filterTranslatorBooleanKind
 		result.precedence = filterTranslatorMaxPrecedence
-		return
+		return result, err
 	}
 	keyTr, err := t.translate(key)
 	if err != nil {
-		return
+		return result, err
 	}
 	valueTrs := make([]filterTranslatorResult, len(values))
 	for i, value := range values {
 		if value.Kind() != ast.LiteralKind {
 			err = fmt.Errorf("value %d isn't a literal", i)
-			return
+			return result, err
 		}
 		valueTrs[i], err = t.translate(value)
 		if err != nil {
-			return
+			return result, err
 		}
 	}
 	var buffer bytes.Buffer
@@ -763,17 +763,17 @@ func (t *FilterTranslator[O]) translateInList(key ast.Expr, list ast.ListExpr) (
 	buffer.WriteString(")")
 	result.sql = buffer.String()
 	result.precedence = filterTranslatorInPrecedence
-	return
+	return result, err
 }
 
 func (t *FilterTranslator[O]) translateInField(key ast.Expr, value ast.SelectExpr) (result filterTranslatorResult, err error) {
 	keyTr, err := t.translate(key)
 	if err != nil {
-		return
+		return result, err
 	}
 	valueTr, err := t.translateSelectField(value)
 	if err != nil {
-		return
+		return result, err
 	}
 	var buffer bytes.Buffer
 	switch valueTr.kind {
@@ -790,7 +790,7 @@ func (t *FilterTranslator[O]) translateInField(key ast.Expr, value ast.SelectExp
 		result.precedence = filterTranslatorInPrecedence
 	}
 	result.sql = buffer.String()
-	return
+	return result, err
 }
 
 func (t *FilterTranslator[O]) translateToLike(funcName string, target ast.Expr, pattern ast.Expr,
@@ -799,11 +799,11 @@ func (t *FilterTranslator[O]) translateToLike(funcName string, target ast.Expr, 
 	var buffer bytes.Buffer
 	targetTr, err := t.translate(target)
 	if err != nil {
-		return
+		return result, err
 	}
 	targetTr, err = t.castToString(targetTr)
 	if err != nil {
-		return
+		return result, err
 	}
 	if targetTr.precedence < filterTranslatorInPrecedence {
 		buffer.WriteString("(")
@@ -815,13 +815,13 @@ func (t *FilterTranslator[O]) translateToLike(funcName string, target ast.Expr, 
 	buffer.WriteString(" like ")
 	if pattern.Kind() != ast.LiteralKind {
 		err = fmt.Errorf("argument of the '%s' function must be a string literal", funcName)
-		return
+		return result, err
 	}
 	patternLiteral := pattern.AsLiteral()
 	patternValue, ok := patternLiteral.Value().(string)
 	if !ok {
 		err = fmt.Errorf("argument of the '%s' function must be a string literal", funcName)
-		return
+		return result, err
 	}
 	patternText, patternEscaped := t.translateString(patternValue, "%_")
 	if patternEscaped {
@@ -835,13 +835,13 @@ func (t *FilterTranslator[O]) translateToLike(funcName string, target ast.Expr, 
 	result.sql = buffer.String()
 	result.kind = filterTranslatorBooleanKind
 	result.precedence = filterTranslatorInPrecedence
-	return
+	return result, err
 }
 
 func (t *FilterTranslator[O]) translateSelectField(expr ast.SelectExpr) (result filterTranslatorResult, err error) {
 	operandTr, err := t.translate(expr.Operand())
 	if err != nil {
-		return
+		return result, err
 	}
 	fieldName := expr.FieldName()
 	testOnly := expr.IsTestOnly()
@@ -854,10 +854,10 @@ func (t *FilterTranslator[O]) translateSelectField(expr ast.SelectExpr) (result 
 		result, err = t.translateSelectJsonField(operandTr.sql, operandTr.desc, fieldName, testOnly)
 	default:
 		err = fmt.Errorf("select of field '%s' of kind '%s' isn't supported", fieldName, operandTr.kind)
-		return
+		return result, err
 	}
 	result.precedence = filterTranslatorMaxPrecedence
-	return
+	return result, err
 }
 
 func (t *FilterTranslator[O]) translateSelectThisField(fieldName string, testOnly bool) (result filterTranslatorResult,
@@ -886,7 +886,7 @@ func (t *FilterTranslator[O]) translateSelectThisField(fieldName string, testOnl
 	default:
 		result, err = t.translateSelectJsonField("data", t.thisDesc, fieldName, testOnly)
 	}
-	return
+	return result, err
 }
 
 func (t *FilterTranslator[O]) translateSelectThisMdField(fieldName string,
@@ -976,7 +976,7 @@ func (t *FilterTranslator[O]) translateSelectThisMdField(fieldName string,
 	default:
 		err = fmt.Errorf("metadata doesn't have a '%s' field", fieldName)
 	}
-	return
+	return result, err
 }
 
 func (t *FilterTranslator[O]) translateSelectJsonField(operandSql string, msgDesc protoreflect.MessageDescriptor,
@@ -985,7 +985,7 @@ func (t *FilterTranslator[O]) translateSelectJsonField(operandSql string, msgDes
 		result.sql = fmt.Sprintf("%s ? '%s'", operandSql, fieldName)
 		result.kind = filterTranslatorBooleanKind
 		result.precedence = filterTranslatorOtherPrecedence
-		return
+		return result, err
 	}
 	fieldDesc := msgDesc.Fields().ByName(protoreflect.Name(fieldName))
 	fieldKind := fieldDesc.Kind()
@@ -1028,10 +1028,10 @@ func (t *FilterTranslator[O]) translateSelectJsonField(operandSql string, msgDes
 			"select of JSON field '%s' of operand '%s' of type '%s' of kind '%s' isn't supported",
 			fieldName, operandSql, msgDesc.FullName(), fieldKind,
 		)
-		return
+		return result, err
 	}
 	result.precedence = filterTranslatorMaxPrecedence
-	return
+	return result, err
 }
 
 func (t *FilterTranslator[O]) castToString(input filterTranslatorResult) (result filterTranslatorResult, err error) {

--- a/internal/database/dao/generic_dao.go
+++ b/internal/database/dao/generic_dao.go
@@ -194,15 +194,15 @@ func (b *GenericDAOBuilder[O]) Build() (result *GenericDAO[O], err error) {
 	// Check parameters:
 	if b.logger == nil {
 		err = errors.New("logger is mandatory")
-		return
+		return result, err
 	}
 	if b.defaultLimit <= 0 {
 		err = fmt.Errorf("default limit must be a possitive integer, but it is %d", b.defaultLimit)
-		return
+		return result, err
 	}
 	if b.maxLimit <= 0 {
 		err = fmt.Errorf("max limit must be a possitive integer, but it is %d", b.maxLimit)
-		return
+		return result, err
 	}
 	if b.maxLimit < b.defaultLimit {
 		err = fmt.Errorf(
@@ -210,11 +210,11 @@ func (b *GenericDAOBuilder[O]) Build() (result *GenericDAO[O], err error) {
 				"is %d",
 			b.maxLimit, b.defaultLimit,
 		)
-		return
+		return result, err
 	}
 	if b.tenancyLogic == nil {
 		err = errors.New("tenancy logic is mandatory")
-		return
+		return result, err
 	}
 
 	// Get descriptors of well known types:
@@ -234,7 +234,7 @@ func (b *GenericDAOBuilder[O]) Build() (result *GenericDAO[O], err error) {
 			"object of type '%s' doesn't have a '%s' field",
 			objectDesc.FullName(), idFieldName,
 		)
-		return
+		return result, err
 	}
 	metadataField := objectFields.ByName(metadataFieldName)
 	if metadataField == nil {
@@ -242,7 +242,7 @@ func (b *GenericDAOBuilder[O]) Build() (result *GenericDAO[O], err error) {
 			"object of type '%s' doesn't have a '%s' field",
 			objectDesc.FullName(), metadataFieldName,
 		)
-		return
+		return result, err
 	}
 
 	// Create the template that we will clone when we need to create a new metadata object:
@@ -260,7 +260,7 @@ func (b *GenericDAOBuilder[O]) Build() (result *GenericDAO[O], err error) {
 		Build()
 	if err != nil {
 		err = fmt.Errorf("failed to create JSON encoder: %w", err)
-		return
+		return result, err
 	}
 
 	// Prepare the JSON marshalling options:
@@ -277,7 +277,7 @@ func (b *GenericDAOBuilder[O]) Build() (result *GenericDAO[O], err error) {
 		Build()
 	if err != nil {
 		err = fmt.Errorf("failed to create filter translator: %w", err)
-		return
+		return result, err
 	}
 
 	// Register metrics:
@@ -285,7 +285,7 @@ func (b *GenericDAOBuilder[O]) Build() (result *GenericDAO[O], err error) {
 	if b.metricsRegisterer != nil {
 		opDurationMetric, err = b.registerOpDurationMetric()
 		if err != nil {
-			return
+			return result, err
 		}
 	}
 
@@ -307,7 +307,7 @@ func (b *GenericDAOBuilder[O]) Build() (result *GenericDAO[O], err error) {
 		tenancyLogic:     b.tenancyLogic,
 		opDurationMetric: opDurationMetric,
 	}
-	return
+	return result, err
 }
 
 // resolveTableName returns the explicit table name if one was set via SetTableName, otherwise it
@@ -362,7 +362,7 @@ func (b *GenericDAOBuilder[O]) registerOpDurationMetric() (result *prometheus.Hi
 	if err != nil {
 		var alreadyRegisteredErr prometheus.AlreadyRegisteredError
 		if !errors.As(err, &alreadyRegisteredErr) {
-			return
+			return result, err
 		}
 		registered, ok := alreadyRegisteredErr.ExistingCollector.(*prometheus.HistogramVec)
 		if !ok {
@@ -370,14 +370,14 @@ func (b *GenericDAOBuilder[O]) registerOpDurationMetric() (result *prometheus.Hi
 				"metric '%s' can't be registered as an histogram vector because it is already registered as a '%T'",
 				name, alreadyRegisteredErr.ExistingCollector,
 			)
-			return
+			return result, err
 		}
 		result = registered
 		err = nil
-		return
+		return result, err
 	}
 	result = metric
-	return
+	return result, err
 }
 
 // Names of well known fields:

--- a/internal/database/dao/generic_dao_create.go
+++ b/internal/database/dao/generic_dao_create.go
@@ -45,15 +45,15 @@ func (r *CreateRequest[O]) SetObject(value O) *CreateRequest[O] {
 func (r *CreateRequest[O]) Do(ctx context.Context) (response *CreateResponse[O], err error) {
 	err = r.init(ctx)
 	if err != nil {
-		return
+		return response, err
 	}
 	r.tx, err = database.TxFromContext(ctx)
 	if err != nil {
-		return
+		return response, err
 	}
 	defer r.tx.ReportError(&err)
 	response, err = r.do(ctx)
-	return
+	return response, err
 }
 
 func (r *CreateRequest[O]) do(ctx context.Context) (response *CreateResponse[O], err error) {
@@ -91,21 +91,21 @@ func (r *CreateRequest[O]) do(ctx context.Context) (response *CreateResponse[O],
 	// Validate that tenant is not empty:
 	if tenant == "" {
 		err = errors.New("cannot create object with empty tenant")
-		return
+		return response, err
 	}
 
 	// Save the object:
 	data, err := r.marshalData(r.object)
 	if err != nil {
-		return
+		return response, err
 	}
 	labelsData, err := r.marshalMap(labels)
 	if err != nil {
-		return
+		return response, err
 	}
 	annotationsData, err := r.marshalMap(annotations)
 	if err != nil {
-		return
+		return response, err
 	}
 	sql := fmt.Sprintf(
 		`
@@ -169,7 +169,7 @@ func (r *CreateRequest[O]) do(ctx context.Context) (response *CreateResponse[O],
 	}()
 	if err != nil {
 		err = r.translateError(ctx, id, tenant, project, name, err)
-		return
+		return response, err
 	}
 	created := r.cloneObject(r.object)
 	metadata = r.makeMetadata(makeMetadataArgs{
@@ -193,14 +193,14 @@ func (r *CreateRequest[O]) do(ctx context.Context) (response *CreateResponse[O],
 		Object: created,
 	})
 	if err != nil {
-		return
+		return response, err
 	}
 
 	// Create the response:
 	response = &CreateResponse[O]{
 		object: created,
 	}
-	return
+	return response, err
 }
 
 // translateError translates raw PostgreSQL errors into domain-specific error types.

--- a/internal/database/dao/generic_dao_delete.go
+++ b/internal/database/dao/generic_dao_delete.go
@@ -46,28 +46,28 @@ func (r *DeleteRequest[O]) SetId(value string) *DeleteRequest[O] {
 func (r *DeleteRequest[O]) Do(ctx context.Context) (response *DeleteResponse, err error) {
 	err = r.init(ctx)
 	if err != nil {
-		return
+		return response, err
 	}
 	r.tx, err = database.TxFromContext(ctx)
 	if err != nil {
-		return
+		return response, err
 	}
 	defer r.tx.ReportError(&err)
 	response, err = r.do(ctx)
-	return
+	return response, err
 }
 
 func (r *DeleteRequest[O]) do(ctx context.Context) (response *DeleteResponse, err error) {
 	// Add the tenancy filter:
 	err = r.addTenancyFilter(ctx)
 	if err != nil {
-		return
+		return response, err
 	}
 
 	// Add the id parameter:
 	if r.args.id == "" {
 		err = errors.New("object identifier is mandatory")
-		return
+		return response, err
 	}
 	if r.sql.filter.Len() > 0 {
 		r.sql.filter.WriteString(` and`)
@@ -141,24 +141,24 @@ func (r *DeleteRequest[O]) do(ctx context.Context) (response *DeleteResponse, er
 		err = &ErrNotFound{
 			IDs: []string{r.args.id},
 		}
-		return
+		return response, err
 	}
 	if err != nil {
 		err = r.translateError(ctx, tenant, err)
-		return
+		return response, err
 	}
 	object := r.newObject()
 	err = r.unmarshalData(data, object)
 	if err != nil {
-		return
+		return response, err
 	}
 	labels, err := r.unmarshalMap(labelsData)
 	if err != nil {
-		return
+		return response, err
 	}
 	annotations, err := r.unmarshalMap(annotationsData)
 	if err != nil {
-		return
+		return response, err
 	}
 	metadata := r.makeMetadata(makeMetadataArgs{
 		creationTs:  creationTs,
@@ -181,7 +181,7 @@ func (r *DeleteRequest[O]) do(ctx context.Context) (response *DeleteResponse, er
 			Type:   EventTypeUpdated,
 			Object: object,
 		})
-		return
+		return response, err
 	}
 
 	// If there are no finalizers we can now archive the object and fire the delete event:
@@ -200,19 +200,19 @@ func (r *DeleteRequest[O]) do(ctx context.Context) (response *DeleteResponse, er
 	})
 	if err != nil {
 		err = r.translateError(ctx, tenant, err)
-		return
+		return response, err
 	}
 	err = r.fireEvent(ctx, Event{
 		Type:   EventTypeDeleted,
 		Object: object,
 	})
 	if err != nil {
-		return
+		return response, err
 	}
 
 	// Create and return the response:
 	response = &DeleteResponse{}
-	return
+	return response, err
 }
 
 // translateError translates raw PostgreSQL errors into domain-specific error types.

--- a/internal/database/dao/generic_dao_exists.go
+++ b/internal/database/dao/generic_dao_exists.go
@@ -39,28 +39,28 @@ func (r *ExistsRequest[O]) SetId(value string) *ExistsRequest[O] {
 func (r *ExistsRequest[O]) Do(ctx context.Context) (response *ExistsResponse, err error) {
 	err = r.init(ctx)
 	if err != nil {
-		return
+		return response, err
 	}
 	r.tx, err = database.TxFromContext(ctx)
 	if err != nil {
-		return
+		return response, err
 	}
 	defer r.tx.ReportError(&err)
 	response, err = r.do(ctx)
-	return
+	return response, err
 }
 
 func (r *ExistsRequest[O]) do(ctx context.Context) (response *ExistsResponse, err error) {
 	// Add the tenancy filter:
 	err = r.addTenancyFilter(ctx)
 	if err != nil {
-		return
+		return response, err
 	}
 
 	// Add the id parameter:
 	if r.id == "" {
 		err = errors.New("object identifier is mandatory")
-		return
+		return response, err
 	}
 	r.sql.params = append(r.sql.params, r.id)
 	if r.sql.filter.Len() > 0 {
@@ -91,12 +91,12 @@ func (r *ExistsRequest[O]) do(ctx context.Context) (response *ExistsResponse, er
 		return row.Scan(&count)
 	}()
 	if err != nil {
-		return
+		return response, err
 	}
 	response = &ExistsResponse{
 		exists: count > 0,
 	}
-	return
+	return response, err
 }
 
 // ExistsResponse represents the result of an exists operation.

--- a/internal/database/dao/generic_dao_get.go
+++ b/internal/database/dao/generic_dao_get.go
@@ -47,28 +47,28 @@ func (r *GetRequest[O]) SetLock(value bool) *GetRequest[O] {
 func (r *GetRequest[O]) Do(ctx context.Context) (response *GetResponse[O], err error) {
 	err = r.init(ctx)
 	if err != nil {
-		return
+		return response, err
 	}
 	r.tx, err = database.TxFromContext(ctx)
 	if err != nil {
-		return
+		return response, err
 	}
 	defer r.tx.ReportError(&err)
 	response, err = r.do(ctx)
-	return
+	return response, err
 }
 
 func (r *GetRequest[O]) do(ctx context.Context) (response *GetResponse[O], err error) {
 	// Add the where clause to filter by tenant:
 	err = r.addTenancyFilter(ctx)
 	if err != nil {
-		return
+		return response, err
 	}
 
 	// Add the where clause to filter by identifier:
 	if r.id == "" {
 		err = errors.New("object identifier is mandatory")
-		return
+		return response, err
 	}
 	r.sql.params = append(r.sql.params, r.id)
 	if r.sql.filter.Len() > 0 {
@@ -144,25 +144,25 @@ func (r *GetRequest[O]) do(ctx context.Context) (response *GetResponse[O], err e
 		err = &ErrNotFound{
 			IDs: []string{r.id},
 		}
-		return
+		return response, err
 	}
 	if err != nil {
-		return
+		return response, err
 	}
 
 	// Prepare the object:
 	object := r.cloneObject(r.newObject())
 	err = r.unmarshalData(data, object)
 	if err != nil {
-		return
+		return response, err
 	}
 	labels, err := r.unmarshalMap(labelsData)
 	if err != nil {
-		return
+		return response, err
 	}
 	annotations, err := r.unmarshalMap(annotationsData)
 	if err != nil {
-		return
+		return response, err
 	}
 	metadata := r.makeMetadata(makeMetadataArgs{
 		creationTs:  creationTs,
@@ -183,7 +183,7 @@ func (r *GetRequest[O]) do(ctx context.Context) (response *GetResponse[O], err e
 	response = &GetResponse[O]{
 		object: object,
 	}
-	return
+	return response, err
 }
 
 // GetResponse represents the result of a get operation.

--- a/internal/database/dao/generic_dao_list.go
+++ b/internal/database/dao/generic_dao_list.go
@@ -52,22 +52,22 @@ func (r *ListRequest[O]) SetOffset(value int32) *ListRequest[O] {
 func (r *ListRequest[O]) Do(ctx context.Context) (response *ListResponse[O], err error) {
 	err = r.init(ctx)
 	if err != nil {
-		return
+		return response, err
 	}
 	r.tx, err = database.TxFromContext(ctx)
 	if err != nil {
-		return
+		return response, err
 	}
 	defer r.tx.ReportError(&err)
 	response, err = r.do(ctx)
-	return
+	return response, err
 }
 
 func (r *ListRequest[O]) do(ctx context.Context) (response *ListResponse[O], err error) {
 	// Add tenant visibility filter:
 	err = r.addTenancyFilter(ctx)
 	if err != nil {
-		return
+		return response, err
 	}
 
 	// Calculate the requested filter:
@@ -75,7 +75,7 @@ func (r *ListRequest[O]) do(ctx context.Context) (response *ListResponse[O], err
 		var filter string
 		filter, err = r.dao.filterTranslator.Translate(ctx, r.filter)
 		if err != nil {
-			return
+			return response, err
 		}
 		if r.sql.filter.Len() > 0 {
 			r.sql.filter.WriteString(` and `)
@@ -104,7 +104,7 @@ func (r *ListRequest[O]) do(ctx context.Context) (response *ListResponse[O], err
 		return row.Scan(&total)
 	}()
 	if err != nil {
-		return
+		return response, err
 	}
 
 	// Fetch the results:
@@ -235,7 +235,7 @@ func (r *ListRequest[O]) do(ctx context.Context) (response *ListResponse[O], err
 		return rows.Err()
 	}()
 	if err != nil {
-		return
+		return response, err
 	}
 
 	// Create and return the response:
@@ -244,7 +244,7 @@ func (r *ListRequest[O]) do(ctx context.Context) (response *ListResponse[O], err
 		total: int32(total),      // #nosec G115 -- bounded by MaxLimit
 		items: items,
 	}
-	return
+	return response, err
 }
 
 // ListResponse represents the result of a list operation.

--- a/internal/database/dao/generic_dao_lock.go
+++ b/internal/database/dao/generic_dao_lock.go
@@ -51,22 +51,22 @@ func (r *LockRequest[O]) AddIds(values ...string) *LockRequest[O] {
 func (r *LockRequest[O]) Do(ctx context.Context) (response *LockResponse[O], err error) {
 	err = r.init(ctx)
 	if err != nil {
-		return
+		return response, err
 	}
 	r.tx, err = database.TxFromContext(ctx)
 	if err != nil {
-		return
+		return response, err
 	}
 	defer r.tx.ReportError(&err)
 	response, err = r.do(ctx)
-	return
+	return response, err
 }
 
 func (r *LockRequest[O]) do(ctx context.Context) (response *LockResponse[O], err error) {
 	// Add tenant visibility filter:
 	err = r.addTenancyFilter(ctx)
 	if err != nil {
-		return
+		return response, err
 	}
 
 	// Calculate the filter:
@@ -110,7 +110,7 @@ func (r *LockRequest[O]) do(ctx context.Context) (response *LockResponse[O], err
 		return rows.Err()
 	}()
 	if err != nil {
-		return
+		return response, err
 	}
 
 	// If the identifiers returned aren't exactly the ones requested then something failed. The only reasonable
@@ -126,12 +126,12 @@ func (r *LockRequest[O]) do(ctx context.Context) (response *LockResponse[O], err
 		err = &ErrNotFound{
 			IDs: notFoundIds,
 		}
-		return
+		return response, err
 	}
 
 	// Create and return the response:
 	response = &LockResponse[O]{}
-	return
+	return response, err
 }
 
 // LockResponse represents the result of a lock operation.

--- a/internal/database/dao/generic_dao_request.go
+++ b/internal/database/dao/generic_dao_request.go
@@ -300,15 +300,15 @@ func (r *request[O]) marshalMap(value map[string]string) (result []byte, err err
 
 func (r *request[O]) unmarshalMap(data []byte) (result map[string]string, err error) {
 	if len(data) == 0 {
-		return
+		return result, err
 	}
 	var value map[string]string
 	err = json.Unmarshal(data, &value)
 	if err != nil {
-		return
+		return result, err
 	}
 	result = value
-	return
+	return result, err
 }
 
 // queryRow executes a SQL query expected to return a single row. It logs the SQL statement before delegating to the
@@ -339,7 +339,7 @@ func (r *request[O]) query(ctx context.Context, op opType, sql string, args ...a
 		)
 	}
 	rows, err = r.tx.Query(ctx, sql, args...)
-	return
+	return rows, err
 }
 
 // exec executes a SQL statement that doesn't return rows. It logs the SQL statement before delegating to the

--- a/internal/database/dao/generic_dao_update.go
+++ b/internal/database/dao/generic_dao_update.go
@@ -45,29 +45,29 @@ func (r *UpdateRequest[O]) SetObject(value O) *UpdateRequest[O] {
 func (r *UpdateRequest[O]) Do(ctx context.Context) (response *UpdateResponse[O], err error) {
 	err = r.init(ctx)
 	if err != nil {
-		return
+		return response, err
 	}
 	r.tx, err = database.TxFromContext(ctx)
 	if err != nil {
-		return
+		return response, err
 	}
 	defer r.tx.ReportError(&err)
 	response, err = r.do(ctx)
-	return
+	return response, err
 }
 
 func (r *UpdateRequest[O]) do(ctx context.Context) (response *UpdateResponse[O], err error) {
 	// Add the where clause to filter by tenant:
 	err = r.addTenancyFilter(ctx)
 	if err != nil {
-		return
+		return response, err
 	}
 
 	// Add the where clause to filter by identifier:
 	id := r.object.GetId()
 	if id == "" {
 		err = errors.New("object identifier is mandatory")
-		return
+		return response, err
 	}
 	r.sql.params = append(r.sql.params, id)
 	if r.sql.filter.Len() > 0 {
@@ -96,21 +96,21 @@ func (r *UpdateRequest[O]) do(ctx context.Context) (response *UpdateResponse[O],
 	// Validate that tenant is not empty:
 	if tenant == "" {
 		err = errors.New("cannot update object with empty tenant")
-		return
+		return response, err
 	}
 
 	// Marshal the data, labels and annotations:
 	data, err := r.marshalData(r.object)
 	if err != nil {
-		return
+		return response, err
 	}
 	labelsData, err := r.marshalMap(labels)
 	if err != nil {
-		return
+		return response, err
 	}
 	annotationsData, err := r.marshalMap(annotations)
 	if err != nil {
-		return
+		return response, err
 	}
 
 	// Build the SQL statement. When optimistic locking is enabled add a version condition to the where clause
@@ -153,17 +153,17 @@ func (r *UpdateRequest[O]) do(ctx context.Context) (response *UpdateResponse[O],
 			&project,
 			&version,
 		)
-		return
+		return err
 	}()
 	if errors.Is(err, pgx.ErrNoRows) {
 		err = &ErrNotFound{
 			IDs: []string{id},
 		}
-		return
+		return response, err
 	}
 	if err != nil {
 		err = r.translateError(ctx, id, name, tenant, err)
-		return
+		return response, err
 	}
 
 	// Prepare the result:
@@ -189,7 +189,7 @@ func (r *UpdateRequest[O]) do(ctx context.Context) (response *UpdateResponse[O],
 		Object: object,
 	})
 	if err != nil {
-		return
+		return response, err
 	}
 
 	// If the object has been deleted and there are no finalizers we can now archive the object and fire the
@@ -209,14 +209,14 @@ func (r *UpdateRequest[O]) do(ctx context.Context) (response *UpdateResponse[O],
 			data:            data,
 		})
 		if err != nil {
-			return
+			return response, err
 		}
 		err = r.fireEvent(ctx, Event{
 			Type:   EventTypeDeleted,
 			Object: object,
 		})
 		if err != nil {
-			return
+			return response, err
 		}
 	}
 
@@ -224,7 +224,7 @@ func (r *UpdateRequest[O]) do(ctx context.Context) (response *UpdateResponse[O],
 	response = &UpdateResponse[O]{
 		object: object,
 	}
-	return
+	return response, err
 }
 
 // translateError translates raw PostgreSQL errors into domain-specific error types.

--- a/internal/database/database_container.go
+++ b/internal/database/database_container.go
@@ -95,7 +95,7 @@ func (b *ContainerBuilder) Build() (result *Container, err error) {
 	// Check parameters:
 	if b.logger == nil {
 		err = errors.New("logger is mandatory")
-		return
+		return result, err
 	}
 
 	// Select the container tool to use:
@@ -104,7 +104,7 @@ func (b *ContainerBuilder) Build() (result *Container, err error) {
 		tool, err = b.selectTool()
 		if err != nil {
 			err = fmt.Errorf("failed to select container tool: %w", err)
-			return
+			return result, err
 		}
 	}
 	b.logger.Info(
@@ -127,7 +127,7 @@ func (b *ContainerBuilder) Build() (result *Container, err error) {
 		Build()
 	if err != nil {
 		err = fmt.Errorf("failed to create writer for command output: %w", err)
-		return
+		return result, err
 	}
 	errLogger := b.logger.With(
 		slog.String("stream", "stderr"),
@@ -139,7 +139,7 @@ func (b *ContainerBuilder) Build() (result *Container, err error) {
 		Build()
 	if err != nil {
 		err = fmt.Errorf("failed to create writer for command errors: %w", err)
-		return
+		return result, err
 	}
 
 	// Create the server object:
@@ -151,7 +151,7 @@ func (b *ContainerBuilder) Build() (result *Container, err error) {
 		outWriter:      outWriter,
 		errWriter:      errWriter,
 	}
-	return
+	return result, err
 }
 
 // selectTool selects the tool to use to start the database server container.
@@ -168,10 +168,10 @@ func (b *ContainerBuilder) selectTool() (result string, err error) {
 			continue
 		}
 		result = toolPath
-		return
+		return result, err
 	}
 	err = errors.New("can't find any available container tool")
-	return
+	return result, err
 }
 
 // Start starts the database server inside a container and waits until it is ready to accept connections. Cleaning when
@@ -311,17 +311,17 @@ func (c *Container) createConfigFile(ctx context.Context) (err error) {
 	tmpFile, err = os.CreateTemp("", "*.conf")
 	if err != nil {
 		err = fmt.Errorf("failed to create configuration file: %w", err)
-		return
+		return err
 	}
 	_, err = tmpFile.WriteString(containerConfigText)
 	if err != nil {
 		err = fmt.Errorf("failed to write configuration file: %w", err)
-		return
+		return err
 	}
 	err = tmpFile.Close()
 	if err != nil {
 		err = fmt.Errorf("failed to close configuration file: %w", err)
-		return
+		return err
 	}
 
 	// The sclorg image runs PostgreSQL as UID 26, which in rootless podman maps to a different host UID. Since
@@ -330,7 +330,7 @@ func (c *Container) createConfigFile(ctx context.Context) (err error) {
 	err = os.Chmod(tmpFile.Name(), 0644)
 	if err != nil {
 		err = fmt.Errorf("failed to set permissions on configuration file: %w", err)
-		return
+		return err
 	}
 
 	// Store the file name so that it can be removed when the container is stopped.
@@ -636,15 +636,15 @@ func (i *Instance) Pool(ctx context.Context) (result *pgxpool.Pool, err error) {
 func (i *Instance) Connection(ctx context.Context) (result *pgx.Conn, err error) {
 	err = i.initIfNeeded(ctx)
 	if err != nil {
-		return
+		return result, err
 	}
 	conn, err := pgx.Connect(ctx, i.url)
 	if err != nil {
 		err = fmt.Errorf("failed to create database connection: %w", err)
-		return
+		return result, err
 	}
 	result = conn
-	return
+	return result, err
 }
 
 // Close deletes the database that was created for this instance.

--- a/internal/database/database_listener.go
+++ b/internal/database/database_listener.go
@@ -99,23 +99,23 @@ func (b *ListenerBuilder) Build() (result *Listener, err error) {
 	// Check parameters:
 	if b.logger == nil {
 		err = errors.New("logger is mandatory")
-		return
+		return result, err
 	}
 	if b.url == "" {
 		err = errors.New("database connection URL is mandatory")
-		return
+		return result, err
 	}
 	if b.channel == "" {
 		err = errors.New("channel is mandatory")
-		return
+		return result, err
 	}
 	if b.waitTimeout <= 0 {
 		err = fmt.Errorf("wait timeout should be positive, but it is %s", b.waitTimeout)
-		return
+		return result, err
 	}
 	if b.retryInterval <= 0 {
 		err = fmt.Errorf("retry interval should be positive, but it is %s", b.retryInterval)
-		return
+		return result, err
 	}
 
 	// Create and populate the object:
@@ -129,7 +129,7 @@ func (b *ListenerBuilder) Build() (result *Listener, err error) {
 		waitTimeout:   b.waitTimeout,
 		retryInterval: b.retryInterval,
 	}
-	return
+	return result, err
 }
 
 // Ready returns true when the listener has successfully connected to the database and issued the PostgreSQL LISTEN

--- a/internal/database/database_notifier.go
+++ b/internal/database/database_notifier.go
@@ -82,19 +82,19 @@ func (b *NotifierBuilder) Build() (result *Notifier, err error) {
 	// Check parameters:
 	if b.logger == nil {
 		err = errors.New("logger is mandatory")
-		return
+		return result, err
 	}
 	if b.channel == "" {
 		err = errors.New("channel is mandatory")
-		return
+		return result, err
 	}
 	if b.pool == nil {
 		err = errors.New("database connection pool is mandatory")
-		return
+		return result, err
 	}
 	if b.cleanupInterval <= 0 {
 		err = fmt.Errorf("cleanup interval should be positive, but it is %s", b.cleanupInterval)
-		return
+		return result, err
 	}
 
 	// Create and populate the object:
@@ -107,7 +107,7 @@ func (b *NotifierBuilder) Build() (result *Notifier, err error) {
 		pool:            b.pool,
 		cleanupInterval: b.cleanupInterval,
 	}
-	return
+	return result, err
 }
 
 // Notify sends a notification with the given payload using the configured channel. The payload is placed into an
@@ -118,7 +118,7 @@ func (n *Notifier) Notify(ctx context.Context, payload proto.Message) (err error
 	// Get the transaction fron the context:
 	tx, err := TxFromContext(ctx)
 	if err != nil {
-		return
+		return err
 	}
 	defer tx.ReportError(&err)
 

--- a/internal/database/database_tool.go
+++ b/internal/database/database_tool.go
@@ -165,7 +165,7 @@ func (b *ToolBuilder) Build() (result Tool, err error) {
 	// Check parameters:
 	if b.logger == nil {
 		err = errors.New("logger is mandatory")
-		return
+		return result, err
 	}
 
 	// Check that the URL and URL file are not both specified:
@@ -173,7 +173,7 @@ func (b *ToolBuilder) Build() (result Tool, err error) {
 		err = errors.New(
 			"database connection URL and URL file are incompatible, use one or the other but not both",
 		)
-		return
+		return result, err
 	}
 
 	// Resolve the URL and collect parameters. If the value points to a directory, the tool scans the directory
@@ -188,19 +188,19 @@ func (b *ToolBuilder) Build() (result Tool, err error) {
 		info, err = os.Stat(b.urlFile)
 		if err != nil {
 			err = fmt.Errorf("failed to stat database URL path '%s': %w", b.urlFile, err)
-			return
+			return result, err
 		}
 		if info.IsDir() {
 			url, parameters, err = b.readURLDirectory(b.urlFile)
 			if err != nil {
-				return
+				return result, err
 			}
 		} else {
 			var data []byte
 			data, err = os.ReadFile(b.urlFile)
 			if err != nil {
 				err = fmt.Errorf("failed to read database URL file '%s': %w", b.urlFile, err)
-				return
+				return result, err
 			}
 			url = strings.TrimSpace(string(data))
 		}
@@ -208,7 +208,7 @@ func (b *ToolBuilder) Build() (result Tool, err error) {
 
 	if url == "" {
 		err = errors.New("connection URL is mandatory")
-		return
+		return result, err
 	}
 
 	// Apply URL parameters. Some parameter names are special and modify the URL structure instead of
@@ -218,7 +218,7 @@ func (b *ToolBuilder) Build() (result Tool, err error) {
 		parsed, err = neturl.Parse(url)
 		if err != nil {
 			err = fmt.Errorf("failed to parse database URL: %w", err)
-			return
+			return result, err
 		}
 		query := parsed.Query()
 		for parameter, value := range parameters {
@@ -264,7 +264,7 @@ func (b *ToolBuilder) Build() (result Tool, err error) {
 		logger: b.logger,
 		url:    url,
 	}
-	return
+	return result, err
 }
 
 // readURLDirectory reads a directory containing database connection settings. Each file in the directory is treated
@@ -275,7 +275,7 @@ func (b *ToolBuilder) readURLDirectory(dir string) (url string, parameters map[s
 	entries, err := os.ReadDir(dir)
 	if err != nil {
 		err = fmt.Errorf("failed to read database URL directory '%s': %w", dir, err)
-		return
+		return url, parameters, err
 	}
 	for _, entry := range entries {
 		name := entry.Name()
@@ -287,7 +287,7 @@ func (b *ToolBuilder) readURLDirectory(dir string) (url string, parameters map[s
 			data, readErr := os.ReadFile(filepath.Clean(path))
 			if readErr != nil {
 				err = fmt.Errorf("failed to read 'url' from file '%s': %w", path, readErr)
-				return
+				return url, parameters, err
 			}
 			url = strings.TrimSpace(string(data))
 		} else if slices.Contains(toolFilePathParameters, name) {
@@ -298,7 +298,7 @@ func (b *ToolBuilder) readURLDirectory(dir string) (url string, parameters map[s
 				err = fmt.Errorf(
 					"failed to read parameter '%s' from file '%s': %w", name, path, readErr,
 				)
-				return
+				return url, parameters, err
 			}
 			parameters[name] = strings.TrimSpace(string(data))
 		}
@@ -309,7 +309,7 @@ func (b *ToolBuilder) readURLDirectory(dir string) (url string, parameters map[s
 	if url == "" {
 		url = "postgres://localhost:5432"
 	}
-	return
+	return url, parameters, err
 }
 
 // Wait waits for the database to be available.
@@ -516,7 +516,7 @@ func (t *tool) listObjectTables(ctx context.Context, pool *pgxpool.Pool) (result
 	)
 	if err != nil {
 		err = fmt.Errorf("failed to get list of object tables: %w", err)
-		return
+		return result, err
 	}
 	defer rows.Close()
 	var tables []string
@@ -525,17 +525,17 @@ func (t *tool) listObjectTables(ctx context.Context, pool *pgxpool.Pool) (result
 		err = rows.Scan(&name)
 		if err != nil {
 			err = fmt.Errorf("failed to scan table name: %w", err)
-			return
+			return result, err
 		}
 		tables = append(tables, name)
 	}
 	err = rows.Err()
 	if err != nil {
 		err = fmt.Errorf("failed to get list of object tables: %w", err)
-		return
+		return result, err
 	}
 	result = tables
-	return
+	return result, err
 }
 
 // listArchiveTables returns the sorted list of archive table names from the public schema.
@@ -559,7 +559,7 @@ func (t *tool) listArchiveTables(ctx context.Context, pool *pgxpool.Pool) (resul
 	)
 	if err != nil {
 		err = fmt.Errorf("failed to get list of archive tables: %w", err)
-		return
+		return result, err
 	}
 	defer rows.Close()
 	var tables []string
@@ -568,17 +568,17 @@ func (t *tool) listArchiveTables(ctx context.Context, pool *pgxpool.Pool) (resul
 		err = rows.Scan(&name)
 		if err != nil {
 			err = fmt.Errorf("failed to scan archive table name: %w", err)
-			return
+			return result, err
 		}
 		tables = append(tables, name)
 	}
 	err = rows.Err()
 	if err != nil {
 		err = fmt.Errorf("failed to get list of archive tables: %w", err)
-		return
+		return result, err
 	}
 	result = tables
-	return
+	return result, err
 }
 
 // checkObjectTable performs all consistency checks for a single object table: verifies that it has the expected columns
@@ -858,7 +858,7 @@ func (t *tool) fetchColumns(ctx context.Context, pool *pgxpool.Pool, table strin
 	)
 	if err != nil {
 		err = fmt.Errorf("failed to get columns for table '%s': %w", table, err)
-		return
+		return result, err
 	}
 	defer rows.Close()
 	columns := map[string]string{}
@@ -867,17 +867,17 @@ func (t *tool) fetchColumns(ctx context.Context, pool *pgxpool.Pool, table strin
 		err = rows.Scan(&name, &kind)
 		if err != nil {
 			err = fmt.Errorf("failed to scan column for table '%s': %w", table, err)
-			return
+			return result, err
 		}
 		columns[name] = kind
 	}
 	err = rows.Err()
 	if err != nil {
 		err = fmt.Errorf("failed to get columns for table '%s': %w", table, err)
-		return
+		return result, err
 	}
 	result = columns
-	return
+	return result, err
 }
 
 // migrationsLogger is an adapter to implement the logging interface of the underlying migrations library using our

--- a/internal/database/database_tx_interceptor.go
+++ b/internal/database/database_tx_interceptor.go
@@ -58,11 +58,11 @@ func (b *TxInterceptorBuilder) Build() (result *TxInterceptor, err error) {
 	// Check parameters:
 	if b.logger == nil {
 		err = errors.New("logger is mandatory")
-		return
+		return result, err
 	}
 	if b.manager == nil {
 		err = errors.New("transaction manager is mandatory")
-		return
+		return result, err
 	}
 
 	// Create and populate the object:
@@ -70,7 +70,7 @@ func (b *TxInterceptorBuilder) Build() (result *TxInterceptor, err error) {
 		logger:  b.logger,
 		manager: b.manager,
 	}
-	return
+	return result, err
 }
 
 // UnaryServer is the unary server interceptor function.
@@ -86,7 +86,7 @@ func (i *TxInterceptor) UnaryServer(ctx context.Context, request any, info *grpc
 			slog.Any("error", err),
 		)
 		err = grpcstatus.Errorf(grpccodes.Internal, "failed to begin transaction")
-		return
+		return response, err
 	}
 
 	// After calling the method we will try to end the transaction. If the method returns an error then we will
@@ -122,5 +122,5 @@ func (i *TxInterceptor) UnaryServer(ctx context.Context, request any, info *grpc
 
 	// Call the method:
 	response, err = handler(handlerCtx, request)
-	return
+	return response, err
 }

--- a/internal/database/database_tx_manager.go
+++ b/internal/database/database_tx_manager.go
@@ -83,11 +83,11 @@ func (b *TxManagerBuilder) Build() (result TxManager, err error) {
 	// Check parameters:
 	if b.logger == nil {
 		err = errors.New("logger is mandatory")
-		return
+		return result, err
 	}
 	if b.pool == nil {
 		err = errors.New("database connection pool is mandatory")
-		return
+		return result, err
 	}
 
 	// Create and populate the object:
@@ -95,7 +95,7 @@ func (b *TxManagerBuilder) Build() (result TxManager, err error) {
 		logger: b.logger,
 		pool:   b.pool,
 	}
-	return
+	return result, err
 }
 
 // Begin starts a new transaction. Note that the created transaction is lazy in the sense that it will not create a real
@@ -235,11 +235,11 @@ func runTxTask(ctx context.Context, tx Tx, task any, args []any) (taskErr error)
 	taskType := taskFunc.Type()
 	if taskType.Kind() != reflect.Func {
 		taskErr = fmt.Errorf("task must be a function, got '%T'", task)
-		return
+		return taskErr
 	}
 	if taskType.NumIn() == 0 {
 		taskErr = errors.New("task function must have at least one parameter, context or transaction")
-		return
+		return taskErr
 	}
 
 	// Check that the first parameter of the task is either a context or a transaction:
@@ -254,14 +254,14 @@ func runTxTask(ctx context.Context, tx Tx, task any, args []any) (taskErr error)
 		taskErr = fmt.Errorf(
 			"first parameter of task function must be context.Context or database.Tx, got %s", firstParam,
 		)
-		return
+		return taskErr
 	}
 
 	// Check that we got exactly the number of expected arguments:
 	expectedArgs := taskType.NumIn() - 1
 	if len(args) != expectedArgs {
 		taskErr = fmt.Errorf("task function expects %d additional argument(s), got %d", expectedArgs, len(args))
-		return
+		return taskErr
 	}
 
 	// Validate and build the argument list:
@@ -278,7 +278,7 @@ func runTxTask(ctx context.Context, tx Tx, task any, args []any) (taskErr error)
 					"argument %d is nil but parameter type %s is not nilable",
 					i+1, paramType,
 				)
-				return
+				return taskErr
 			}
 		} else {
 			argType := reflect.TypeOf(arg)
@@ -287,7 +287,7 @@ func runTxTask(ctx context.Context, tx Tx, task any, args []any) (taskErr error)
 					"argument %d has type %s which is not assignable to parameter type %s",
 					i+1, argType, paramType,
 				)
-				return
+				return taskErr
 			}
 			callArgs = append(callArgs, reflect.ValueOf(arg))
 		}
@@ -304,7 +304,7 @@ func runTxTask(ctx context.Context, tx Tx, task any, args []any) (taskErr error)
 			taskErr = lastResult.Interface().(error)
 		}
 	}
-	return
+	return taskErr
 }
 
 // Well-known reflection types:

--- a/internal/database/database_tx_scope.go
+++ b/internal/database/database_tx_scope.go
@@ -27,12 +27,12 @@ func WithNewTx[T any](ctx context.Context, fn func(context.Context) (T, error)) 
 	manager, err := TxManagerFromContext(ctx)
 	if err != nil {
 		err = fmt.Errorf("get transaction manager from context: %w", err)
-		return
+		return result, err
 	}
 	tx, err := manager.Begin(ctx)
 	if err != nil {
 		err = fmt.Errorf("begin transaction: %w", err)
-		return
+		return result, err
 	}
 	defer func() {
 		// If fn panicked, ensure the transaction is rolled back before re-panicking.
@@ -49,5 +49,5 @@ func WithNewTx[T any](ctx context.Context, fn func(context.Context) (T, error)) 
 	}()
 	result, err = fn(TxIntoContext(ctx, tx))
 	tx.ReportError(&err)
-	return
+	return result, err
 }

--- a/internal/health/health_aggregator.go
+++ b/internal/health/health_aggregator.go
@@ -61,11 +61,11 @@ func (b *AggregatorBuilder) Build() (result *Aggregator, err error) {
 	// Check parameters:
 	if b.logger == nil {
 		err = errors.New("logger is mandatory")
-		return
+		return result, err
 	}
 	if b.server == nil {
 		err = errors.New("server is mandatory")
-		return
+		return result, err
 	}
 
 	// Create and populate the object:
@@ -78,7 +78,7 @@ func (b *AggregatorBuilder) Build() (result *Aggregator, err error) {
 	// Initially set the health server to 'NOT_SERVING' until all components report healthy:
 	b.server.SetServingStatus("", healthv1.HealthCheckResponse_NOT_SERVING)
 
-	return
+	return result, err
 }
 
 // Report reports the health status for the given component. The aggregated status will be 'SERVING' only when all

--- a/internal/idp/client.go
+++ b/internal/idp/client.go
@@ -102,15 +102,15 @@ func (b *ClientBuilder) SetHTTPClient(value *http.Client) *ClientBuilder {
 func (b *ClientBuilder) Build() (result *Client, err error) {
 	if b.logger == nil {
 		err = errors.New("logger is mandatory")
-		return
+		return result, err
 	}
 	if b.baseURL == "" {
 		err = errors.New("base URL is mandatory")
-		return
+		return result, err
 	}
 	if b.tokenSource == nil {
 		err = errors.New("token source is mandatory")
-		return
+		return result, err
 	}
 	if b.realmName == "" {
 		b.realmName = "osac"
@@ -139,7 +139,7 @@ func (b *ClientBuilder) Build() (result *Client, err error) {
 		httpClient: httpClient,
 		realmName:  b.realmName,
 	}
-	return
+	return result, err
 }
 
 func isConflictError(err error) bool {

--- a/internal/idp/groups.go
+++ b/internal/idp/groups.go
@@ -274,7 +274,7 @@ func (c *Client) getGroupIDByPathWithOrgID(ctx context.Context, orgID, groupPath
 	normalizedPath := strings.Trim(groupPath, "/")
 	if normalizedPath == "" {
 		err = fmt.Errorf("empty group path")
-		return
+		return result, err
 	}
 	segments := strings.Split(normalizedPath, "/")
 
@@ -285,7 +285,7 @@ func (c *Client) getGroupIDByPathWithOrgID(ctx context.Context, orgID, groupPath
 		groupID, lookupErr := c.getGroupIDByName(ctx, orgID, currentParentID, segment)
 		if lookupErr != nil {
 			err = fmt.Errorf("failed to find group segment %d '%s' (parent: %s): %w", i, segment, currentParentID, lookupErr)
-			return
+			return result, err
 		}
 
 		// This segment becomes the parent for the next iteration
@@ -294,7 +294,7 @@ func (c *Client) getGroupIDByPathWithOrgID(ctx context.Context, orgID, groupPath
 
 	// The last segment's ID is the final group ID
 	result = currentParentID
-	return
+	return result, err
 }
 
 // GetGroupIDByPath gets a Keycloak organization group ID by its path.

--- a/internal/idp/project_group_manager.go
+++ b/internal/idp/project_group_manager.go
@@ -55,18 +55,18 @@ func (b *ProjectGroupManagerBuilder) SetClient(value ClientInterface) *ProjectGr
 func (b *ProjectGroupManagerBuilder) Build() (result *ProjectGroupManager, err error) {
 	if b.logger == nil {
 		err = errors.New("logger is mandatory")
-		return
+		return result, err
 	}
 	if b.client == nil {
 		err = errors.New("client is mandatory")
-		return
+		return result, err
 	}
 
 	result = &ProjectGroupManager{
 		logger: b.logger,
 		client: b.client,
 	}
-	return
+	return result, err
 }
 
 // DeleteProjectGroups deletes tenant authorization groups for a project.

--- a/internal/idp/tenant_manager.go
+++ b/internal/idp/tenant_manager.go
@@ -57,18 +57,18 @@ func (b *TenantManagerBuilder) SetClient(value ClientInterface) *TenantManagerBu
 func (b *TenantManagerBuilder) Build() (result *TenantManager, err error) {
 	if b.logger == nil {
 		err = errors.New("logger is mandatory")
-		return
+		return result, err
 	}
 	if b.client == nil {
 		err = errors.New("client is mandatory")
-		return
+		return result, err
 	}
 
 	result = &TenantManager{
 		logger: b.logger,
 		client: b.client,
 	}
-	return
+	return result, err
 }
 
 // TenantConfig contains configuration for creating a tenant in the identity provider.

--- a/internal/jq/jq_tool.go
+++ b/internal/jq/jq_tool.go
@@ -63,7 +63,7 @@ func (b *ToolBuilder) Build() (result *Tool, err error) {
 	// Check parameters:
 	if b.logger == nil {
 		err = errors.New("logger is mandatory")
-		return
+		return result, err
 	}
 
 	// Create and populate the object:
@@ -73,7 +73,7 @@ func (b *ToolBuilder) Build() (result *Tool, err error) {
 		cache:         map[string]*Query{},
 		compileOption: b.compileOption,
 	}
-	return
+	return result, err
 }
 
 // Compile compiles the given query and saves it in a cache, so that evaluating the same query with the same variables
@@ -84,51 +84,51 @@ func (t *Tool) Compile(source string, variables ...string) (result *Query, err e
 	sort.Strings(variables)
 	query, err := t.lookup(source, variables)
 	if err != nil {
-		return
+		return result, err
 	}
 	if query == nil {
 		query, err = t.compile(source, variables)
 		if err != nil {
-			return
+			return result, err
 		}
 		t.cache[source] = query
 	}
 	result = query
-	return
+	return result, err
 }
 
 func (t *Tool) lookup(source string, variables []string) (result *Query, err error) {
 	query, ok := t.cache[source]
 	if !ok {
-		return
+		return result, err
 	}
 	if !slices.Equal(variables, query.variables) {
 		err = fmt.Errorf(
 			"query was compiled with variables %v but used with %v",
 			query.variables, variables,
 		)
-		return
+		return result, err
 	}
 	result = query
-	return
+	return result, err
 }
 
 func (t *Tool) compile(source string, variables []string) (query *Query, err error) {
 	parsed, err := gojq.Parse(source)
 	if err != nil {
-		return
+		return query, err
 	}
 
 	var code *gojq.Code
 	if t.compileOption != nil {
 		code, err = gojq.Compile(parsed, gojq.WithVariables(variables), *t.compileOption)
 		if err != nil {
-			return
+			return query, err
 		}
 	} else {
 		code, err = gojq.Compile(parsed, gojq.WithVariables(variables))
 		if err != nil {
-			return
+			return query, err
 		}
 	}
 	query = &Query{
@@ -137,7 +137,7 @@ func (t *Tool) compile(source string, variables []string) (query *Query, err err
 		variables: variables,
 		code:      code,
 	}
-	return
+	return query, err
 }
 
 // Evaluate compiles the query and then evaluates it. The input can be any kind of object that can be serialized to

--- a/internal/json/json_encoder.go
+++ b/internal/json/json_encoder.go
@@ -81,7 +81,7 @@ func (b *EncoderBuilder) Build() (result *Encoder, err error) {
 	// Check parameters:
 	if b.logger == nil {
 		err = errors.New("logger is mandatory")
-		return
+		return result, err
 	}
 
 	// Get descriptors of well known types:
@@ -122,7 +122,7 @@ func (b *EncoderBuilder) Build() (result *Encoder, err error) {
 					"of type '%T'",
 				i, ignoredField,
 			)
-			return
+			return result, err
 		}
 	}
 
@@ -138,26 +138,26 @@ func (b *EncoderBuilder) Build() (result *Encoder, err error) {
 		structDesc:            structDesc,
 		jsonApi:               jsonApi,
 	}
-	return
+	return result, err
 }
 
 func (e *Encoder) Marshal(object proto.Message) (result []byte, err error) {
 	if object == nil {
 		result = []byte("{}")
-		return
+		return result, err
 	}
 	stream := e.jsonApi.BorrowStream(nil)
 	defer e.jsonApi.ReturnStream(stream)
 	err = e.marshalMessage(stream, object.ProtoReflect())
 	if err != nil {
-		return
+		return result, err
 	}
 	err = stream.Flush()
 	if err != nil {
-		return
+		return result, err
 	}
 	result = bytes.Clone(stream.Buffer())
-	return
+	return result, err
 }
 
 func (e *Encoder) marshalMessage(stream *jsoniter.Stream, message protoreflect.Message) (err error) {
@@ -165,12 +165,12 @@ func (e *Encoder) marshalMessage(stream *jsoniter.Stream, message protoreflect.M
 	if descriptor == e.anyDesc || descriptor == e.durationDesc || descriptor == e.timestampDesc ||
 		descriptor == e.valueDesc || descriptor == e.structDesc {
 		err = e.marshalWellKnown(stream, message.Interface())
-		return
+		return err
 	}
 	stream.WriteObjectStart()
 	if stream.Error != nil {
 		err = stream.Error
-		return
+		return err
 	}
 	first := true
 	message.Range(func(field protoreflect.FieldDescriptor, value protoreflect.Value) bool {
@@ -197,12 +197,12 @@ func (e *Encoder) marshalMessage(stream *jsoniter.Stream, message protoreflect.M
 		return true
 	})
 	if err != nil {
-		return
+		return err
 	}
 	stream.WriteObjectEnd()
 	err = stream.Error
 	if err != nil {
-		return
+		return err
 	}
 	return stream.Flush()
 }
@@ -298,7 +298,7 @@ func (e *Encoder) marshalMap(stream *jsoniter.Stream, m protoreflect.Map,
 	stream.WriteObjectStart()
 	if stream.Error != nil {
 		err = stream.Error
-		return
+		return err
 	}
 	first := true
 	m.Range(func(key protoreflect.MapKey, value protoreflect.Value) bool {
@@ -322,7 +322,7 @@ func (e *Encoder) marshalMap(stream *jsoniter.Stream, m protoreflect.Map,
 		return true
 	})
 	if err != nil {
-		return
+		return err
 	}
 	stream.WriteObjectEnd()
 	return stream.Error

--- a/internal/logging/logger.go
+++ b/internal/logging/logger.go
@@ -207,7 +207,7 @@ func (b *LoggerBuilder) parseFieldItem(item string) (name string, value any) {
 		}
 		name = strings.TrimSpace(name)
 	}
-	return
+	return name, value
 }
 
 // Build uses the data stored in the buider to create a new logger.
@@ -217,7 +217,7 @@ func (b *LoggerBuilder) Build() (result *slog.Logger, err error) {
 	if writer == nil {
 		writer, err = b.openWriter()
 		if err != nil {
-			return
+			return result, err
 		}
 	}
 
@@ -226,7 +226,7 @@ func (b *LoggerBuilder) Build() (result *slog.Logger, err error) {
 	if b.level != "" {
 		err = level.UnmarshalText([]byte(b.level))
 		if err != nil {
-			return
+			return result, err
 		}
 	}
 
@@ -263,13 +263,13 @@ func (b *LoggerBuilder) Build() (result *slog.Logger, err error) {
 	// Caculate the custom fields:
 	fields, err := b.customFields()
 	if err != nil {
-		return
+		return result, err
 	}
 
 	// Create the logger:
 	result = slog.New(handler).With(fields...)
 
-	return
+	return result, err
 }
 
 func (b *LoggerBuilder) openWriter() (result io.Writer, err error) {
@@ -289,7 +289,7 @@ func (b *LoggerBuilder) openWriter() (result io.Writer, err error) {
 	default:
 		result, err = b.openFile(b.file)
 	}
-	return
+	return result, err
 }
 
 func (b *LoggerBuilder) openFile(file string) (result io.Writer, err error) {
@@ -311,11 +311,11 @@ func (b *LoggerBuilder) customFields() (result []any, err error) {
 		fields[2*i] = name
 		fields[2*i+1], err = b.customField(name, value)
 		if err != nil {
-			return
+			return result, err
 		}
 	}
 	result = fields
-	return
+	return result, err
 }
 
 func (b *LoggerBuilder) customField(name string, value any) (result any, err error) {

--- a/internal/logging/logging_interceptor.go
+++ b/internal/logging/logging_interceptor.go
@@ -108,7 +108,7 @@ func (b *InterceptorBuilder) Build() (result *Interceptor, err error) {
 	// Check parameters:
 	if b.logger == nil {
 		err = errors.New("logger is mandatory")
-		return
+		return result, err
 	}
 
 	// Create and populate the object:
@@ -118,7 +118,7 @@ func (b *InterceptorBuilder) Build() (result *Interceptor, err error) {
 		bodies:  b.bodies,
 		redact:  b.redact,
 	}
-	return
+	return result, err
 }
 
 // UnaryServer is the unary server interceptor function.
@@ -127,13 +127,13 @@ func (i *Interceptor) UnaryServer(ctx context.Context, request any, info *grpc.U
 	// Ignore reflection and health check calls:
 	if i.isIgnoredMethod(info.FullMethod) {
 		response, err = handler(ctx, request)
-		return
+		return response, err
 	}
 
 	// The processing here is expensive, so better if we avoid it completely when debug is disabled:
 	if !i.logger.Enabled(ctx, slog.LevelDebug) {
 		response, err = handler(ctx, request)
-		return
+		return response, err
 	}
 
 	// Get the time before calling the handler so that we can later compute the duration of the call:
@@ -194,7 +194,7 @@ func (i *Interceptor) UnaryServer(ctx context.Context, request any, info *grpc.U
 	}
 	i.logger.DebugContext(ctx, "Sent unary response", responseFields...)
 
-	return
+	return response, err
 }
 
 // StreamServer is the stream server interceptor function.
@@ -360,14 +360,14 @@ func (i *Interceptor) StreamClient(ctx context.Context, desc *grpc.StreamDesc, c
 	// Wrap the stream so that we can log the details of the messages exchanged:
 	stream, err = streamer(ctx, desc, conn, method, opts...)
 	if err != nil {
-		return
+		return stream, err
 	}
 	stream = &interceptorClientStream{
 		parent: i,
 		logger: i.logger,
 		stream: stream,
 	}
-	return
+	return stream, err
 }
 
 func (i *Interceptor) isIgnoredMethod(method string) bool {
@@ -436,7 +436,7 @@ func (i *Interceptor) dumpMessage(ctx context.Context, key string, value any) (f
 				"Failed to marshal protocol buffers message",
 				slog.Any("error", err),
 			)
-			return
+			return field, ok
 		}
 		var data any
 		err = json.Unmarshal(bytes, &data)
@@ -446,7 +446,7 @@ func (i *Interceptor) dumpMessage(ctx context.Context, key string, value any) (f
 				"Failed to unmarshal protocol buffers message",
 				slog.Any("error", err),
 			)
-			return
+			return field, ok
 		}
 		ok = true
 		field = slog.Any(key, data)
@@ -457,7 +457,7 @@ func (i *Interceptor) dumpMessage(ctx context.Context, key string, value any) (f
 			slog.String("type", fmt.Sprintf("%T", value)),
 		)
 	}
-	return
+	return field, ok
 }
 
 type interceptorServerStream struct {

--- a/internal/logging/logging_writer.go
+++ b/internal/logging/logging_writer.go
@@ -81,7 +81,7 @@ func (b *WriterBuilder) Build() (result *Writer, err error) {
 	// Check arguments:
 	if b.logger == nil {
 		err = errors.New("logger is mandatory")
-		return
+		return result, err
 	}
 
 	// Remove empty secrets to prevent log amplification attacks:
@@ -99,7 +99,7 @@ func (b *WriterBuilder) Build() (result *Writer, err error) {
 		context: b.context,
 		secrets: secrets,
 	}
-	return
+	return result, err
 }
 
 // Write implements the io.Writer interface.
@@ -121,5 +121,5 @@ func (w *Writer) Write(p []byte) (n int, err error) {
 		slog.Int("size", n),
 		slog.String("data", text),
 	)
-	return
+	return n, err
 }

--- a/internal/masks/mask_path.go
+++ b/internal/masks/mask_path.go
@@ -99,20 +99,20 @@ func (p *Path[M]) Steps() []pathStep {
 // Get returns the value of the field and a boolean flag indicating if the field is present.
 func (p *Path[M]) Get(message M) (result protoreflect.Value, ok bool) {
 	if p.isNil(message) {
-		return
+		return result, ok
 	}
 	currentValue := protoreflect.ValueOfMessage(message.ProtoReflect())
 	for _, currentStep := range p.steps {
 		currentMessage := currentValue.Message()
 		if !currentMessage.Has(currentStep.field) {
-			return
+			return result, ok
 		}
 		currentValue = currentMessage.Get(currentStep.field)
 		switch currentStep.kind {
 		case pathStepKindListIndex:
 			listItems := currentValue.List()
 			if listItems.Len() < currentStep.index {
-				return
+				return result, ok
 			}
 			currentValue = listItems.Get(currentStep.index)
 		case pathStepKindMapKey:
@@ -120,13 +120,13 @@ func (p *Path[M]) Get(message M) (result protoreflect.Value, ok bool) {
 			mapKey := protoreflect.ValueOf(currentStep.key).MapKey()
 			currentValue = mapItems.Get(mapKey)
 			if !currentValue.IsValid() {
-				return
+				return result, ok
 			}
 		}
 	}
 	result = currentValue
 	ok = true
-	return
+	return result, ok
 }
 
 // Set sets the the field to the given value.

--- a/internal/masks/mask_path_compiler.go
+++ b/internal/masks/mask_path_compiler.go
@@ -63,7 +63,7 @@ func (b *PathCompilerBuilder[M]) Build() (result *PathCompiler[M], err error) {
 		logger: b.logger,
 		desc:   desc,
 	}
-	return
+	return result, err
 }
 
 // Compile compiles the field path from the given string.
@@ -76,7 +76,7 @@ func (c *PathCompiler[M]) Compile(path string) (result *Path[M], err error) {
 		field := desc.Fields().ByName(protoreflect.Name(segments[0]))
 		if field == nil {
 			err = fmt.Errorf("field '%s' not found", segments[0])
-			return
+			return result, err
 		}
 		step := pathStep{
 			kind:  pathStepKindField,
@@ -89,7 +89,7 @@ func (c *PathCompiler[M]) Compile(path string) (result *Path[M], err error) {
 				index, err = strconv.Atoi(segments[1])
 				if err != nil {
 					err = fmt.Errorf("invalid index '%s': %w", segments[1], err)
-					return
+					return result, err
 				}
 				step.kind = pathStepKindListIndex
 				step.index = index
@@ -129,7 +129,7 @@ func (c *PathCompiler[M]) Compile(path string) (result *Path[M], err error) {
 		text:  path,
 		steps: steps,
 	}
-	return
+	return result, err
 }
 
 func (c *PathCompiler[M]) split(path string) []string {

--- a/internal/metrics/grpc_metrics_interceptor.go
+++ b/internal/metrics/grpc_metrics_interceptor.go
@@ -105,11 +105,11 @@ func (b *GrpcInterceptorBuilder) Build() (result *GrpcInterceptor, err error) {
 	// Check parameters:
 	if b.subsystem == "" {
 		err = errors.New("subsystem is mandatory")
-		return
+		return result, err
 	}
 	if b.registerer == nil {
 		err = errors.New("registerer is mandatory")
-		return
+		return result, err
 	}
 
 	// Register the request count metric:
@@ -127,7 +127,7 @@ func (b *GrpcInterceptorBuilder) Build() (result *GrpcInterceptor, err error) {
 		if errors.As(err, &registered) {
 			requestCount = registered.ExistingCollector.(*prometheus.CounterVec)
 		} else {
-			return
+			return result, err
 		}
 	}
 
@@ -147,7 +147,7 @@ func (b *GrpcInterceptorBuilder) Build() (result *GrpcInterceptor, err error) {
 		if errors.As(err, &registered) {
 			requestDuration = registered.ExistingCollector.(*prometheus.HistogramVec)
 		} else {
-			return
+			return result, err
 		}
 	}
 
@@ -166,7 +166,7 @@ func (b *GrpcInterceptorBuilder) Build() (result *GrpcInterceptor, err error) {
 		if errors.As(err, &registered) {
 			streamCount = registered.ExistingCollector.(*prometheus.CounterVec)
 		} else {
-			return
+			return result, err
 		}
 	}
 
@@ -186,7 +186,7 @@ func (b *GrpcInterceptorBuilder) Build() (result *GrpcInterceptor, err error) {
 		if errors.As(err, &registered) {
 			streamDuration = registered.ExistingCollector.(*prometheus.HistogramVec)
 		} else {
-			return
+			return result, err
 		}
 	}
 
@@ -205,7 +205,7 @@ func (b *GrpcInterceptorBuilder) Build() (result *GrpcInterceptor, err error) {
 		if errors.As(err, &registered) {
 			streamMessagesSent = registered.ExistingCollector.(*prometheus.CounterVec)
 		} else {
-			return
+			return result, err
 		}
 	}
 
@@ -225,7 +225,7 @@ func (b *GrpcInterceptorBuilder) Build() (result *GrpcInterceptor, err error) {
 			streamMessagesReceived = registered.ExistingCollector.(*prometheus.CounterVec)
 			err = nil
 		} else {
-			return
+			return result, err
 		}
 	}
 
@@ -238,7 +238,7 @@ func (b *GrpcInterceptorBuilder) Build() (result *GrpcInterceptor, err error) {
 		streamMessagesSent:     streamMessagesSent,
 		streamMessagesReceived: streamMessagesReceived,
 	}
-	return
+	return result, err
 }
 
 // UnaryServer is the unary server interceptor function that records metrics.
@@ -256,7 +256,7 @@ func (i *GrpcInterceptor) UnaryServer(ctx context.Context, request any, info *gr
 	}
 	i.requestCount.With(labels).Inc()
 	i.requestDuration.With(labels).Observe(elapsed.Seconds())
-	return
+	return response, err
 }
 
 // StreamServer is the stream server interceptor function that records metrics.

--- a/internal/network/address_parser.go
+++ b/internal/network/address_parser.go
@@ -48,7 +48,7 @@ func (b *AddressParserBuilder) Build() (result *AddressParser, err error) {
 	// Check parameters:
 	if b.logger == nil {
 		err = fmt.Errorf("logger is mandatory")
-		return
+		return result, err
 	}
 
 	// Create and populate the object:
@@ -56,7 +56,7 @@ func (b *AddressParserBuilder) Build() (result *AddressParser, err error) {
 		logger: b.logger,
 	}
 
-	return
+	return result, err
 }
 
 // Parse parses the server address and handles both traditional host:port format and URL format (with http://
@@ -70,7 +70,7 @@ func (p *AddressParser) Parse(address string) (parsedAddress string, plaintext b
 		var url *neturl.URL
 		url, err = neturl.Parse(address)
 		if err != nil {
-			return
+			return parsedAddress, plaintext, err
 		}
 		return p.parseUrl(url)
 	}
@@ -101,7 +101,7 @@ func (p *AddressParser) parseUrl(url *neturl.URL) (address string, plaintext boo
 		}
 		address = fmt.Sprintf("%s:%s", host, port)
 		plaintext = true
-		return
+		return address, plaintext, err
 	case "https":
 		host := url.Hostname()
 		port := url.Port()
@@ -116,7 +116,7 @@ func (p *AddressParser) parseUrl(url *neturl.URL) (address string, plaintext boo
 			url.Scheme, url.String(),
 		)
 	}
-	return
+	return address, plaintext, err
 }
 
 func (p *AddressParser) parseHost(host string) (address string, plaintext bool, err error) {

--- a/internal/network/cert_pool.go
+++ b/internal/network/cert_pool.go
@@ -130,7 +130,7 @@ func (b *CertPoolBuilder) Build() (result *x509.CertPool, err error) {
 	// Check parameters:
 	if b.logger == nil {
 		err = errors.New("logger is mandatory")
-		return
+		return result, err
 	}
 
 	// Start with an empty pool, or with a copy of the system pool if the system files are enabled:
@@ -138,7 +138,7 @@ func (b *CertPoolBuilder) Build() (result *x509.CertPool, err error) {
 	if b.systemFiles {
 		pool, err = x509.SystemCertPool()
 		if err != nil {
-			return
+			return result, err
 		}
 	} else {
 		pool = x509.NewCertPool()
@@ -151,14 +151,14 @@ func (b *CertPoolBuilder) Build() (result *x509.CertPool, err error) {
 	if b.kubernetesFiles {
 		err = b.loadKubernetesFiles(pool)
 		if err != nil {
-			return
+			return result, err
 		}
 	}
 
 	// Load configured files:
 	err = b.loadConfiguredFiles(pool)
 	if err != nil {
-		return
+		return result, err
 	}
 
 	// Load configured certificates:
@@ -168,13 +168,13 @@ func (b *CertPoolBuilder) Build() (result *x509.CertPool, err error) {
 			ok := pool.AppendCertsFromPEM([]byte(cert))
 			if !ok {
 				err = fmt.Errorf("failed to add certificate to pool: %w", err)
-				return
+				return result, err
 			}
 		case []byte:
 			ok := pool.AppendCertsFromPEM(cert)
 			if !ok {
 				err = fmt.Errorf("failed to add certificate to pool: %w", err)
-				return
+				return result, err
 			}
 		case *x509.Certificate:
 			pool.AddCert(cert)
@@ -183,12 +183,12 @@ func (b *CertPoolBuilder) Build() (result *x509.CertPool, err error) {
 				"invalid certificate type '%T', should be 'string', '[]byte' or '*x509.Certificate'",
 				cert,
 			)
-			return
+			return result, err
 		}
 	}
 
 	result = pool
-	return
+	return result, err
 }
 
 // resolvePath resolves a file path using the custom root directory if set. If no root is set, returns the original

--- a/internal/network/cors.go
+++ b/internal/network/cors.go
@@ -94,7 +94,7 @@ func (b *CorsMiddlewareBuilder) Build() (result func(http.Handler) http.Handler,
 	// Check parameters:
 	if b.logger == nil {
 		err = errors.New("logger is mandatory")
-		return
+		return result, err
 	}
 
 	// If no allowed origins are set, use the default value:
@@ -125,5 +125,5 @@ func (b *CorsMiddlewareBuilder) Build() (result func(http.Handler) http.Handler,
 			"Content-Type",
 		}),
 	)
-	return
+	return result, err
 }

--- a/internal/network/grpc_client.go
+++ b/internal/network/grpc_client.go
@@ -252,15 +252,15 @@ func (b *GrpcClientBuilder) Build() (result *grpc.ClientConn, err error) {
 	// Check parameters:
 	if b.logger == nil {
 		err = errors.New("logger is mandatory")
-		return
+		return result, err
 	}
 	if b.address == "" {
 		err = errors.New("server address is mandatory")
-		return
+		return result, err
 	}
 	if b.keepAlive < 0 {
 		err = fmt.Errorf("keep alive interval should be positive, but it is %s", b.keepAlive)
-		return
+		return result, err
 	}
 
 	// Set the default network:
@@ -282,7 +282,7 @@ func (b *GrpcClientBuilder) Build() (result *grpc.ClientConn, err error) {
 		}
 	default:
 		err = fmt.Errorf("unknown network '%s'", b.network)
-		return
+		return result, err
 	}
 
 	// Set the default CA pool:
@@ -295,7 +295,7 @@ func (b *GrpcClientBuilder) Build() (result *grpc.ClientConn, err error) {
 			Build()
 		if err != nil {
 			err = fmt.Errorf("failed to build CA pool: %w", err)
-			return
+			return result, err
 		}
 	}
 
@@ -342,7 +342,7 @@ func (b *GrpcClientBuilder) Build() (result *grpc.ClientConn, err error) {
 			Build()
 		if err != nil {
 			err = fmt.Errorf("failed to create token credentials: %w", err)
-			return
+			return result, err
 		}
 		options = append(options, grpc.WithPerRPCCredentials(tokenCredentials))
 	}
@@ -394,7 +394,7 @@ func (b *GrpcClientBuilder) Build() (result *grpc.ClientConn, err error) {
 		Build()
 	if err != nil {
 		err = fmt.Errorf("failed to create logging interceptor: %w", err)
-		return
+		return result, err
 	}
 	unaryInterceptors = append(unaryInterceptors, loggingInterceptor.UnaryClient)
 	streamInterceptors = append(streamInterceptors, loggingInterceptor.StreamClient)
@@ -408,7 +408,7 @@ func (b *GrpcClientBuilder) Build() (result *grpc.ClientConn, err error) {
 			Build()
 		if err != nil {
 			err = fmt.Errorf("failed to create metrics interceptor: %w", err)
-			return
+			return result, err
 		}
 		unaryInterceptors = append(unaryInterceptors, metricsInterceptor.UnaryClient)
 		streamInterceptors = append(streamInterceptors, metricsInterceptor.StreamClient)
@@ -424,7 +424,7 @@ func (b *GrpcClientBuilder) Build() (result *grpc.ClientConn, err error) {
 
 	// Create the client:
 	result, err = grpc.NewClient(endpoint, options...)
-	return
+	return result, err
 }
 
 // unauthRetryInterceptor retries a gRPC call once when the server returns the unauthenticated status code. It

--- a/internal/network/listener.go
+++ b/internal/network/listener.go
@@ -145,23 +145,23 @@ func (b *ListenerBuilder) Build() (result net.Listener, err error) {
 	// Check parameters:
 	if b.logger == nil {
 		err = errors.New("logger is mandatory")
-		return
+		return result, err
 	}
 	if b.network == "" {
 		err = errors.New("network is mandatory")
-		return
+		return result, err
 	}
 	if b.address == "" {
 		err = errors.New("address is mandatory")
-		return
+		return result, err
 	}
 	if b.tlsCrt != "" && b.tlsKey == "" {
 		err = errors.New("TLS key is mandatory when certificate is specified")
-		return
+		return result, err
 	}
 	if b.tlsKey != "" && b.tlsCrt == "" {
 		err = errors.New("TLS certificate is mandatory when key is specified")
-		return
+		return result, err
 	}
 
 	// Try to load the certificates
@@ -169,7 +169,7 @@ func (b *ListenerBuilder) Build() (result net.Listener, err error) {
 	if b.tlsCrt != "" && b.tlsKey != "" {
 		tlsCrt, err = tls.LoadX509KeyPair(b.tlsCrt, b.tlsKey)
 		if err != nil {
-			return
+			return result, err
 		}
 		b.logger.Info(
 			"Loaded TLS key and certificate",
@@ -186,7 +186,7 @@ func (b *ListenerBuilder) Build() (result net.Listener, err error) {
 			err = nil
 		}
 		if err != nil {
-			return
+			return result, err
 		}
 		b.logger.Info(
 			"Removed existing unix socket",
@@ -197,7 +197,7 @@ func (b *ListenerBuilder) Build() (result net.Listener, err error) {
 	// Create the listener:
 	listener, err := net.Listen(b.network, b.address)
 	if err != nil {
-		return
+		return result, err
 	}
 	if tlsCrt.Certificate != nil {
 		listener = tls.NewListener(listener, &tls.Config{
@@ -211,7 +211,7 @@ func (b *ListenerBuilder) Build() (result net.Listener, err error) {
 	// Return the listener:
 	result = listener
 
-	return
+	return result, err
 }
 
 // Common listener names:

--- a/internal/oauth/oauth_code_flow.go
+++ b/internal/oauth/oauth_code_flow.go
@@ -76,7 +76,7 @@ func (f *codeFlow) run(ctx context.Context) (result *auth.Token, err error) {
 			"Failed to start redirect server",
 			slog.Any("error", err),
 		)
-		return
+		return result, err
 	}
 	defer func() {
 		err := server.Close()
@@ -101,7 +101,7 @@ func (f *codeFlow) run(ctx context.Context) (result *auth.Token, err error) {
 	}
 	authQuery, err := query.Values(authRequest)
 	if err != nil {
-		return
+		return result, err
 	}
 	authUri := fmt.Sprintf("%s?%s", f.source.authEndpoint, authQuery.Encode())
 	f.logger.DebugContext(
@@ -119,7 +119,7 @@ func (f *codeFlow) run(ctx context.Context) (result *auth.Token, err error) {
 			"Failed to start code flow",
 			slog.Any("error", err),
 		)
-		return
+		return result, err
 	}
 	f.logger.DebugContext(
 		ctx,
@@ -134,7 +134,7 @@ func (f *codeFlow) run(ctx context.Context) (result *auth.Token, err error) {
 			slog.String("!url", authUri),
 			slog.Any("error", err),
 		)
-		return
+		return result, err
 	}
 
 	// Wait till the redirect server receives the authorization code, or an error occurs:
@@ -175,7 +175,7 @@ func (f *codeFlow) run(ctx context.Context) (result *auth.Token, err error) {
 			)
 			err = listenerErr
 		}
-		return
+		return result, err
 	}
 
 	// Exchange the authorization code for the access token::
@@ -198,7 +198,7 @@ func (f *codeFlow) run(ctx context.Context) (result *auth.Token, err error) {
 			)
 			err = listenerErr
 		}
-		return
+		return result, err
 	}
 
 	// Notify user of authentication success:
@@ -206,7 +206,7 @@ func (f *codeFlow) run(ctx context.Context) (result *auth.Token, err error) {
 		Outcome: true,
 	})
 	if err != nil {
-		return
+		return result, err
 	}
 
 	// Return the token:
@@ -222,7 +222,7 @@ func (f *codeFlow) run(ctx context.Context) (result *auth.Token, err error) {
 		slog.Any("!refresh", result.Refresh),
 		slog.Time("expiry", result.Expiry),
 	)
-	return
+	return result, err
 }
 
 func (f *codeFlow) startServer(ctx context.Context) (server *http.Server, redirectUri string, err error) {
@@ -230,7 +230,7 @@ func (f *codeFlow) startServer(ctx context.Context) (server *http.Server, redire
 	parsedUri, err := url.Parse(f.source.redirectUri)
 	if err != nil {
 		err = fmt.Errorf("failed to parse redirect URI '%s': %w", f.source.redirectUri, err)
-		return
+		return server, redirectUri, err
 	}
 	address := parsedUri.Host
 
@@ -242,7 +242,7 @@ func (f *codeFlow) startServer(ctx context.Context) (server *http.Server, redire
 		Build()
 	if err != nil {
 		err = fmt.Errorf("failed to create listener: %w", err)
-		return
+		return server, redirectUri, err
 	}
 
 	// The port number may have been allocated dynamically if it was initially zero, so we need to get the actual
@@ -284,7 +284,7 @@ func (f *codeFlow) startServer(ctx context.Context) (server *http.Server, redire
 	}()
 	logger.DebugContext(ctx, "Started redirect server")
 
-	return
+	return server, redirectUri, err
 }
 
 func (f *codeFlow) serve(w http.ResponseWriter, r *http.Request) {

--- a/internal/oauth/oauth_credentials_flow.go
+++ b/internal/oauth/oauth_credentials_flow.go
@@ -34,12 +34,12 @@ func (f *credentialsFlow) run(ctx context.Context) (result *auth.Token, err erro
 	}
 	tokenResponse, err := f.source.sendTokenForm(ctx, tokenRequest)
 	if err != nil {
-		return
+		return result, err
 	}
 	result = &auth.Token{
 		Access:  tokenResponse.AccessToken,
 		Refresh: tokenResponse.RefreshToken,
 		Expiry:  f.source.secondsToTime(tokenResponse.ExpiresIn),
 	}
-	return
+	return result, err
 }

--- a/internal/oauth/oauth_device_flow.go
+++ b/internal/oauth/oauth_device_flow.go
@@ -63,7 +63,7 @@ func (f *deviceFlow) run(ctx context.Context) (result *auth.Token, err error) {
 		Scope:               f.source.scopes,
 	})
 	if err != nil {
-		return
+		return result, err
 	}
 	f.logger.DebugContext(
 		ctx,
@@ -115,7 +115,7 @@ func (f *deviceFlow) run(ctx context.Context) (result *auth.Token, err error) {
 			slog.Any("error", err),
 		)
 		err = fmt.Errorf("failed to prompt user for device code: %w", err)
-		return
+		return result, err
 	}
 
 	// If the user has specified a pool interval, then use that ignoring whatever the server suggests, or five
@@ -160,7 +160,7 @@ func (f *deviceFlow) run(ctx context.Context) (result *auth.Token, err error) {
 			if listenerErr != nil {
 				err = listenerErr
 			}
-			return
+			return result, err
 		}
 		var endpointErr *endpointError
 		if !errors.As(err, &endpointErr) {
@@ -205,7 +205,7 @@ func (f *deviceFlow) run(ctx context.Context) (result *auth.Token, err error) {
 				)
 			}
 			err = listenerErr
-			return
+			return result, err
 		}
 	}
 
@@ -214,7 +214,7 @@ func (f *deviceFlow) run(ctx context.Context) (result *auth.Token, err error) {
 		Outcome: true,
 	})
 	if err != nil {
-		return
+		return result, err
 	}
 
 	// Return the token:
@@ -223,7 +223,7 @@ func (f *deviceFlow) run(ctx context.Context) (result *auth.Token, err error) {
 		Refresh: tokenResponse.RefreshToken,
 		Expiry:  f.source.secondsToTime(tokenResponse.ExpiresIn),
 	}
-	return
+	return result, err
 }
 
 func (f *deviceFlow) sendAuthForm(ctx context.Context,

--- a/internal/oauth/oauth_discovery_tool.go
+++ b/internal/oauth/oauth_discovery_tool.go
@@ -138,7 +138,7 @@ func (b *DiscoveryToolBuilder) Build() (result *DiscoveryTool, err error) {
 		issuerUrl:  issuerUrl,
 		httpClient: httpClient,
 	}
-	return
+	return result, err
 }
 
 // Discover discovers endpoints from the configured issuer URL using the well-known configuration endpoints. This
@@ -150,7 +150,7 @@ func (t *DiscoveryTool) Discover(ctx context.Context) (result *ServerMetadata, e
 			ctx,
 			"Successfully discovered endpoints using OAuth endpoint",
 		)
-		return
+		return result, err
 	}
 	t.logger.InfoContext(
 		ctx,
@@ -163,7 +163,7 @@ func (t *DiscoveryTool) Discover(ctx context.Context) (result *ServerMetadata, e
 			ctx,
 			"Successfully discovered endpoints using OIDC",
 		)
-		return
+		return result, err
 	}
 	t.logger.InfoContext(
 		ctx,
@@ -171,7 +171,7 @@ func (t *DiscoveryTool) Discover(ctx context.Context) (result *ServerMetadata, e
 		slog.Any("error", err),
 	)
 	err = fmt.Errorf("failed to discover endpoints using OAuth or OIDC")
-	return
+	return result, err
 }
 
 func (t *DiscoveryTool) discover(ctx context.Context, endpoint string) (result *ServerMetadata, err error) {
@@ -193,7 +193,7 @@ func (t *DiscoveryTool) discover(ctx context.Context, endpoint string) (result *
 			slog.Any("error", err),
 		)
 		err = fmt.Errorf("failed to create metadata request: %w", err)
-		return
+		return result, err
 	}
 	response, err := t.httpClient.Do(request)
 	if err != nil {
@@ -204,12 +204,12 @@ func (t *DiscoveryTool) discover(ctx context.Context, endpoint string) (result *
 			slog.Any("error", err),
 		)
 		err = fmt.Errorf("failed to fetch metadata from '%s': %w", metadataUrl, err)
-		return
+		return result, err
 	}
 	defer response.Body.Close()
 	if response.StatusCode != http.StatusOK {
 		err = fmt.Errorf("failed to fetch metadata from '%s': %s", metadataUrl, response.Status)
-		return
+		return result, err
 	}
 
 	// Parse the discovery document:
@@ -223,7 +223,7 @@ func (t *DiscoveryTool) discover(ctx context.Context, endpoint string) (result *
 			slog.Any("error", err),
 		)
 		err = fmt.Errorf("failed to parse metadata: %w", err)
-		return
+		return result, err
 	}
 
 	// Validate required fields:
@@ -233,7 +233,7 @@ func (t *DiscoveryTool) discover(ctx context.Context, endpoint string) (result *
 			"Discovery document missing required 'issuer' field",
 		)
 		err = fmt.Errorf("discovery document missing required 'issuer' field")
-		return
+		return result, err
 	}
 	if serverMetadata.TokenEndpoint == "" {
 		t.logger.ErrorContext(
@@ -241,7 +241,7 @@ func (t *DiscoveryTool) discover(ctx context.Context, endpoint string) (result *
 			"Discovery document missing required 'token_endpoint' field",
 		)
 		err = fmt.Errorf("discovery document missing required 'token_endpoint' field")
-		return
+		return result, err
 	}
 
 	// Return the result:
@@ -255,5 +255,5 @@ func (t *DiscoveryTool) discover(ctx context.Context, endpoint string) (result *
 		slog.Any("scopes_supported", serverMetadata.ScopesSupported),
 	)
 	result = &serverMetadata
-	return
+	return result, err
 }

--- a/internal/oauth/oauth_password_flow.go
+++ b/internal/oauth/oauth_password_flow.go
@@ -36,12 +36,12 @@ func (f *passwordFlow) run(ctx context.Context) (result *auth.Token, err error) 
 	}
 	tokenResponse, err := f.source.sendTokenForm(ctx, tokenRequest)
 	if err != nil {
-		return
+		return result, err
 	}
 	result = &auth.Token{
 		Access:  tokenResponse.AccessToken,
 		Refresh: tokenResponse.RefreshToken,
 		Expiry:  f.source.secondsToTime(tokenResponse.ExpiresIn),
 	}
-	return
+	return result, err
 }

--- a/internal/oauth/oauth_token_source.go
+++ b/internal/oauth/oauth_token_source.go
@@ -281,32 +281,32 @@ func (b *TokenSourceBuilder) Build() (result *TokenSource, err error) {
 	// Check parameters:
 	if b.logger == nil {
 		err = errors.New("logger is mandatory")
-		return
+		return result, err
 	}
 	if b.issuer == "" {
 		err = errors.New("issuer is mandatory")
-		return
+		return result, err
 	}
 	if b.clientId == "" {
 		err = errors.New("client identifier is mandatory")
-		return
+		return result, err
 	}
 	if err = b.validateFlowParameters(); err != nil {
-		return
+		return result, err
 	}
 	if b.store == nil {
 		err = errors.New("token store is mandatory")
-		return
+		return result, err
 	}
 	if b.timeout < 0 {
 		err = fmt.Errorf("timeout must be greater than zero, but it is %s", b.timeout)
-		return
+		return result, err
 	}
 
 	// Resolve defaults into a local config without mutating the builder:
 	resolved, err := b.resolveDefaults()
 	if err != nil {
-		return
+		return result, err
 	}
 
 	// Create the object early, as we need its reference for the underlying flow:
@@ -334,7 +334,7 @@ func (b *TokenSourceBuilder) Build() (result *TokenSource, err error) {
 
 	// Return the source:
 	result = source
-	return
+	return result, err
 }
 
 // resolvedConfig holds the defaults computed during Build() without mutating the builder.
@@ -397,7 +397,7 @@ func (b *TokenSourceBuilder) resolveDefaults() (cfg resolvedConfig, err error) {
 		SetDir("templates").
 		Build()
 	if err != nil {
-		return
+		return cfg, err
 	}
 
 	// Set the default timeout:
@@ -416,7 +416,7 @@ func (b *TokenSourceBuilder) resolveDefaults() (cfg resolvedConfig, err error) {
 			Build()
 		if err != nil {
 			err = fmt.Errorf("failed to build CA pool: %w", err)
-			return
+			return cfg, err
 		}
 	}
 
@@ -451,14 +451,14 @@ func (b *TokenSourceBuilder) resolveDefaults() (cfg resolvedConfig, err error) {
 	parsedRedirectUri, parseErr := url.Parse(cfg.redirectUri)
 	if parseErr != nil {
 		err = fmt.Errorf("failed to parse redirect URI '%s': %w", cfg.redirectUri, parseErr)
-		return
+		return cfg, err
 	}
 	if parsedRedirectUri.Host == "" {
 		err = fmt.Errorf("redirect URI '%s' must include a host", cfg.redirectUri)
-		return
+		return cfg, err
 	}
 
-	return
+	return cfg, err
 }
 
 // createFlowRunner creates the appropriate flow runner for the configured OAuth flow.
@@ -498,7 +498,7 @@ func (s *TokenSource) Token(ctx context.Context) (result *auth.Token, err error)
 	loaded, err := s.store.Load(ctx)
 	if err != nil {
 		err = fmt.Errorf("failed to load token: %w", err)
-		return
+		return result, err
 	}
 	defer func() {
 		if result != nil && !s.sameTokens(loaded, result) {
@@ -516,7 +516,7 @@ func (s *TokenSource) Token(ctx context.Context) (result *auth.Token, err error)
 	// If the loaded token doesn't expire soon, then we can use it directly, there is no need to request a new one:
 	if loaded != nil && s.isFresh(loaded) {
 		result = loaded
-		return
+		return result, err
 	}
 
 	// If we have a refresh token, then we can try to use it to renew the access token. If this fails we will
@@ -524,7 +524,7 @@ func (s *TokenSource) Token(ctx context.Context) (result *auth.Token, err error)
 	if loaded != nil && loaded.Refresh != "" {
 		result, err = s.runRefresh(ctx, loaded.Refresh)
 		if err == nil {
-			return
+			return result, err
 		}
 		s.logger.DebugContext(
 			ctx,
@@ -542,7 +542,7 @@ func (s *TokenSource) Token(ctx context.Context) (result *auth.Token, err error)
 	}
 	if !flowInteractive || s.interactive {
 		result, err = s.runFlow(ctx)
-		return
+		return result, err
 	}
 
 	// If we are here then either there wasn't a token in the store, or it was about to expire, and we/ can't
@@ -555,13 +555,13 @@ func (s *TokenSource) Token(ctx context.Context) (result *auth.Token, err error)
 			slog.Time("expiry", loaded.Expiry),
 		)
 		result = loaded
-		return
+		return result, err
 	}
 
 	// If we are here there wasn't a token in the store, or it was already expired, all we can do is return
 	// an error.
 	err = errors.New("no token available")
-	return
+	return result, err
 }
 
 func (s *TokenSource) sameTokens(a, b *auth.Token) bool {
@@ -652,7 +652,7 @@ func (s *TokenSource) runRefresh(ctx context.Context, refreshToken string) (resu
 	})
 	if err != nil {
 		err = fmt.Errorf("failed to discover metadata: %w", err)
-		return
+		return result, err
 	}
 
 	// Send the request to get the new tokens:
@@ -662,7 +662,7 @@ func (s *TokenSource) runRefresh(ctx context.Context, refreshToken string) (resu
 		RefreshToken: refreshToken,
 	})
 	if err != nil {
-		return
+		return result, err
 	}
 
 	// Prepare the new token:
@@ -684,7 +684,7 @@ func (s *TokenSource) runRefresh(ctx context.Context, refreshToken string) (resu
 
 	// Return the new token:
 	result = token
-	return
+	return result, err
 }
 
 func (s *TokenSource) runFlow(ctx context.Context) (result *auth.Token, err error) {
@@ -694,18 +694,18 @@ func (s *TokenSource) runFlow(ctx context.Context) (result *auth.Token, err erro
 	})
 	if err != nil {
 		err = fmt.Errorf("failed to discover metadata: %w", err)
-		return
+		return result, err
 	}
 
 	// Run the flow:
 	token, err := s.flowRunner.run(ctx)
 	if err != nil {
 		err = fmt.Errorf("failed to obtain token: %w", err)
-		return
+		return result, err
 	}
 	if token == nil {
 		err = errors.New("flow ended without a token")
-		return
+		return result, err
 	}
 	s.logger.DebugContext(
 		ctx,
@@ -719,7 +719,7 @@ func (s *TokenSource) runFlow(ctx context.Context) (result *auth.Token, err erro
 	err = s.store.Save(ctx, token)
 	if err != nil {
 		err = fmt.Errorf("failed to save token: %w", err)
-		return
+		return result, err
 	}
 	s.logger.DebugContext(
 		ctx,
@@ -731,7 +731,7 @@ func (s *TokenSource) runFlow(ctx context.Context) (result *auth.Token, err erro
 
 	// Return the token:
 	result = token
-	return
+	return result, err
 }
 
 // sendForm sends a request containing a set of fields and returns the response. The request should be a struct with
@@ -827,9 +827,9 @@ func (s *TokenSource) sendTokenForm(ctx context.Context,
 			slog.Any("!request", request),
 			slog.Any("error", err),
 		)
-		return
+		return response, err
 	}
-	return
+	return response, err
 }
 
 func (s *TokenSource) secondsToDuration(seconds int) time.Duration {

--- a/internal/recovery/grpc_panic_interceptor.go
+++ b/internal/recovery/grpc_panic_interceptor.go
@@ -50,14 +50,14 @@ func (b *GrpcPanicInterceptorBuilder) Build() (result *GrpcPanicInterceptor, err
 	// Check parameters:
 	if b.logger == nil {
 		err = errors.New("logger is mandatory")
-		return
+		return result, err
 	}
 
 	// Create and populate the object:
 	result = &GrpcPanicInterceptor{
 		logger: b.logger,
 	}
-	return
+	return result, err
 }
 
 // UnaryServer is the unary server interceptor function that recovers from panics.
@@ -77,7 +77,7 @@ func (i *GrpcPanicInterceptor) UnaryServer(ctx context.Context, request any, inf
 		}
 	}()
 	response, err = handler(ctx, request)
-	return
+	return response, err
 }
 
 // StreamServer is the stream server interceptor function that recovers from panics.
@@ -96,5 +96,5 @@ func (i *GrpcPanicInterceptor) StreamServer(server any, stream grpc.ServerStream
 		}
 	}()
 	err = handler(server, stream)
-	return
+	return err
 }

--- a/internal/reflection/find_object.go
+++ b/internal/reflection/find_object.go
@@ -46,7 +46,7 @@ func (h *objectHelper) FindObject(ctx context.Context, ref string, console Rende
 			"failed to find object of type '%s' with identifier or name '%s': %w",
 			h, ref, err,
 		)
-		return
+		return result, err
 	}
 	items := response.Items
 	total := response.Total
@@ -68,5 +68,5 @@ func (h *objectHelper) FindObject(ctx context.Context, ref string, console Rende
 		})
 		err = exit.Error(1)
 	}
-	return
+	return result, err
 }

--- a/internal/reflection/reflection_functions.go
+++ b/internal/reflection/reflection_functions.go
@@ -31,12 +31,12 @@ func NormalizeFunc[T any](fn any) (result func(context.Context) (T, error), err 
 	fnType := reflect.TypeOf(fn)
 	if fnType == nil || fnType.Kind() != reflect.Func {
 		err = fmt.Errorf("expected a function, got %T", fn)
-		return
+		return result, err
 	}
 	fnValue := reflect.ValueOf(fn)
 	if fnValue.IsNil() {
 		err = fmt.Errorf("expected a non-nil function, got nil %s", fnType)
-		return
+		return result, err
 	}
 	resultType := reflect.TypeFor[T]()
 
@@ -51,7 +51,7 @@ func NormalizeFunc[T any](fn any) (result func(context.Context) (T, error), err 
 				"function must have a context.Context parameter, but has %s",
 				fnType.In(0),
 			)
-			return
+			return result, err
 		}
 		hasCtx = true
 	default:
@@ -59,7 +59,7 @@ func NormalizeFunc[T any](fn any) (result func(context.Context) (T, error), err 
 			"function must have at most one input parameter, but has %d",
 			fnType.NumIn(),
 		)
-		return
+		return result, err
 	}
 
 	// Check if the function has a error return value:
@@ -70,7 +70,7 @@ func NormalizeFunc[T any](fn any) (result func(context.Context) (T, error), err 
 				"function must return %s, but returns %s",
 				resultType, fnType.Out(0),
 			)
-			return
+			return result, err
 		}
 		hasErr = false
 	case 2:
@@ -79,7 +79,7 @@ func NormalizeFunc[T any](fn any) (result func(context.Context) (T, error), err 
 				"function must return %s and error, but returns %s and %s",
 				resultType, fnType.Out(0), fnType.Out(1),
 			)
-			return
+			return result, err
 		}
 		hasErr = true
 	default:
@@ -87,7 +87,7 @@ func NormalizeFunc[T any](fn any) (result func(context.Context) (T, error), err 
 			"function must return at most two values, but returns %d",
 			fnType.NumOut(),
 		)
-		return
+		return result, err
 	}
 
 	// Create a new function that calls the original function with the context parameter:
@@ -101,15 +101,15 @@ func NormalizeFunc[T any](fn any) (result func(context.Context) (T, error), err 
 		fnResults := fnValue.Call(fnArgs)
 		if hasErr && !fnResults[1].IsNil() {
 			err = fnResults[1].Interface().(error)
-			return
+			return result, err
 		}
 		fnResult := fnResults[0].Interface()
 		if fnResult != nil {
 			result = fnResult.(T)
 		}
-		return
+		return result, err
 	}
-	return
+	return result, err
 }
 
 // Well-known reflection types:

--- a/internal/reflection/reflection_helper.go
+++ b/internal/reflection/reflection_helper.go
@@ -158,15 +158,15 @@ func (b *HelperBuilder) Build() (result Helper, err error) {
 	// Check the parameters:
 	if b.logger == nil {
 		err = errors.New("logger is mandatory")
-		return
+		return result, err
 	}
 	if b.connection == nil {
 		err = errors.New("gRPC connection is mandatory")
-		return
+		return result, err
 	}
 	if len(b.packages) == 0 {
 		err = errors.New("at least one package is mandatory")
-		return
+		return result, err
 	}
 
 	// Normalize the tenant function to a canonical signature:
@@ -174,7 +174,7 @@ func (b *HelperBuilder) Build() (result Helper, err error) {
 	if b.tenantFunc != nil {
 		tenantFunc, err = NormalizeFunc[string](b.tenantFunc)
 		if err != nil {
-			return
+			return result, err
 		}
 	}
 
@@ -193,7 +193,7 @@ func (b *HelperBuilder) Build() (result Helper, err error) {
 		helpers:    []objectHelper{},
 		tenantFunc: tenantFunc,
 	}
-	return
+	return result, err
 }
 
 func (h *helper) scanIfNeeded() {
@@ -663,7 +663,7 @@ func (h *objectHelper) List(ctx context.Context, options ListOptions) (result Li
 		var tenant string
 		tenant, err = h.parent.tenantFunc(ctx)
 		if err != nil {
-			return
+			return result, err
 		}
 		if tenant != "" {
 			tenantFilter := fmt.Sprintf("this.metadata.tenant == %q", tenant)
@@ -685,7 +685,7 @@ func (h *objectHelper) List(ctx context.Context, options ListOptions) (result Li
 	response := proto.Clone(h.list.response)
 	err = h.parent.connection.Invoke(ctx, h.list.path, request, response)
 	if err != nil {
-		return
+		return result, err
 	}
 	list := response.ProtoReflect().Get(h.list.items).List()
 	result.Items = make([]proto.Message, list.Len())
@@ -697,7 +697,7 @@ func (h *objectHelper) List(ctx context.Context, options ListOptions) (result Li
 	} else {
 		result.Total = int32(len(result.Items)) // #nosec G115 -- bounded by MaxLimit
 	}
-	return
+	return result, err
 }
 
 func (h *objectHelper) Get(ctx context.Context, id string) (result proto.Message, err error) {

--- a/internal/reflection/reflection_helper_test.go
+++ b/internal/reflection/reflection_helper_test.go
@@ -319,7 +319,7 @@ var _ = Describe("Reflection helper", func() {
 							}.Build(),
 						}.Build(),
 					}.Build()
-					return
+					return response, err
 				},
 			})
 
@@ -356,7 +356,7 @@ var _ = Describe("Reflection helper", func() {
 							}.Build(),
 						},
 					}.Build()
-					return
+					return response, err
 				},
 			})
 
@@ -416,7 +416,7 @@ var _ = Describe("Reflection helper", func() {
 							}.Build(),
 						}.Build(),
 					}.Build()
-					return
+					return response, err
 				},
 			})
 
@@ -485,7 +485,7 @@ var _ = Describe("Reflection helper", func() {
 							}.Build(),
 						}.Build(),
 					}.Build()
-					return
+					return response, err
 				},
 			})
 
@@ -558,7 +558,7 @@ var _ = Describe("Reflection helper", func() {
 							}.Build(),
 						}.Build(),
 					}.Build()
-					return
+					return response, err
 				},
 			})
 

--- a/internal/rendering/table_renderer.go
+++ b/internal/rendering/table_renderer.go
@@ -123,15 +123,15 @@ func (b *TableRendererBuilder) Build() (result *TableRenderer, err error) {
 	// Check parameters:
 	if b.logger == nil {
 		err = fmt.Errorf("logger is mandatory")
-		return
+		return result, err
 	}
 	if b.helper == nil {
 		err = fmt.Errorf("helper is mandatory")
-		return
+		return result, err
 	}
 	if b.writer == nil {
 		err = fmt.Errorf("writer is mandatory")
-		return
+		return result, err
 	}
 
 	// Create a tab writer for proper column alignment of output:
@@ -147,7 +147,7 @@ func (b *TableRendererBuilder) Build() (result *TableRenderer, err error) {
 		writer: writer,
 		cache:  cache,
 	}
-	return
+	return result, err
 }
 
 // Render renders the given objects as a table to stdout. The objects parameter must be a slice of objects that
@@ -290,10 +290,10 @@ func (r *TableRenderer) loadTable(helper reflection.ObjectHelper) (result *table
 			"failed to unmarshal table definition file %q: %w",
 			file, err,
 		)
-		return
+		return result, err
 	}
 	result = &table
-	return
+	return result, err
 }
 
 // defaultTable returns a default table definition with ID and NAME columns.
@@ -468,7 +468,7 @@ func (r *TableRenderer) lookupName(ctx context.Context, messageFullName protoref
 			slog.String("type", string(messageFullName)),
 		)
 		result = key
-		return
+		return result
 	}
 
 	// Find the objects whose identifier or name matches the key:
@@ -489,13 +489,13 @@ func (r *TableRenderer) lookupName(ctx context.Context, messageFullName protoref
 			slog.Any("error", err),
 		)
 		result = key
-		return
+		return result
 	}
 
 	// If there is no match, or multiple matches, return the original key:
 	if len(listResult.Items) == 0 {
 		result = key
-		return
+		return result
 	}
 
 	// Return the name of the first object, falling back to the key if the name is empty:
@@ -505,7 +505,7 @@ func (r *TableRenderer) lookupName(ctx context.Context, messageFullName protoref
 	if result == "" {
 		result = key
 	}
-	return
+	return result
 }
 
 // renderCellAny renders any value type as a string.

--- a/internal/servers/baremetal_instance_catalog_items_server.go
+++ b/internal/servers/baremetal_instance_catalog_items_server.go
@@ -87,11 +87,11 @@ func (b *BareMetalInstanceCatalogItemsServerBuilder) SetMetricsRegisterer(value 
 func (b *BareMetalInstanceCatalogItemsServerBuilder) Build() (result *BareMetalInstanceCatalogItemsServer, err error) {
 	if b.logger == nil {
 		err = errors.New("logger is mandatory")
-		return
+		return result, err
 	}
 	if b.tenancyLogic == nil {
 		err = errors.New("tenancy logic is mandatory")
-		return
+		return result, err
 	}
 
 	inMapper, err := NewGenericMapper[*publicv1.BareMetalInstanceCatalogItem, *privatev1.BareMetalInstanceCatalogItem]().
@@ -99,14 +99,14 @@ func (b *BareMetalInstanceCatalogItemsServerBuilder) Build() (result *BareMetalI
 		SetStrict(true).
 		Build()
 	if err != nil {
-		return
+		return result, err
 	}
 	outMapper, err := NewGenericMapper[*privatev1.BareMetalInstanceCatalogItem, *publicv1.BareMetalInstanceCatalogItem]().
 		SetLogger(b.logger).
 		SetStrict(false).
 		Build()
 	if err != nil {
-		return
+		return result, err
 	}
 
 	bareMetalInstancesDao, err := dao.NewGenericDAO[*privatev1.BareMetalInstance]().
@@ -115,7 +115,7 @@ func (b *BareMetalInstanceCatalogItemsServerBuilder) Build() (result *BareMetalI
 		SetMetricsRegisterer(b.metricsRegisterer).
 		Build()
 	if err != nil {
-		return
+		return result, err
 	}
 	referenceChecker := &daoReferenceChecker[*privatev1.BareMetalInstance]{resourceDao: bareMetalInstancesDao}
 
@@ -128,7 +128,7 @@ func (b *BareMetalInstanceCatalogItemsServerBuilder) Build() (result *BareMetalI
 		SetReferenceChecker(referenceChecker).
 		Build()
 	if err != nil {
-		return
+		return result, err
 	}
 
 	result = &BareMetalInstanceCatalogItemsServer{
@@ -138,7 +138,7 @@ func (b *BareMetalInstanceCatalogItemsServerBuilder) Build() (result *BareMetalI
 		inMapper:         inMapper,
 		outMapper:        outMapper,
 	}
-	return
+	return result, err
 }
 
 func (s *BareMetalInstanceCatalogItemsServer) List(ctx context.Context,
@@ -175,7 +175,7 @@ func (s *BareMetalInstanceCatalogItemsServer) List(ctx context.Context,
 	response.SetSize(privateResponse.GetSize())
 	response.SetTotal(privateResponse.GetTotal())
 	response.SetItems(publicItems)
-	return
+	return response, err
 }
 
 func (s *BareMetalInstanceCatalogItemsServer) Get(ctx context.Context,
@@ -208,7 +208,7 @@ func (s *BareMetalInstanceCatalogItemsServer) Get(ctx context.Context,
 
 	response = &publicv1.BareMetalInstanceCatalogItemsGetResponse{}
 	response.SetObject(publicCatalogItem)
-	return
+	return response, err
 }
 
 func (s *BareMetalInstanceCatalogItemsServer) Create(ctx context.Context,
@@ -216,7 +216,7 @@ func (s *BareMetalInstanceCatalogItemsServer) Create(ctx context.Context,
 	publicCatalogItem := request.GetObject()
 	if publicCatalogItem == nil {
 		err = grpcstatus.Errorf(grpccodes.InvalidArgument, "object is mandatory")
-		return
+		return response, err
 	}
 	privateCatalogItem := &privatev1.BareMetalInstanceCatalogItem{}
 	err = s.inMapper.Copy(ctx, publicCatalogItem, privateCatalogItem)
@@ -224,7 +224,7 @@ func (s *BareMetalInstanceCatalogItemsServer) Create(ctx context.Context,
 		s.logger.ErrorContext(ctx, "Failed to map public bare metal instance catalog item to private",
 			slog.Any("error", err))
 		err = grpcstatus.Errorf(grpccodes.Internal, "failed to process bare metal instance catalog item")
-		return
+		return response, err
 	}
 
 	privateRequest := &privatev1.BareMetalInstanceCatalogItemsCreateRequest{}
@@ -240,12 +240,12 @@ func (s *BareMetalInstanceCatalogItemsServer) Create(ctx context.Context,
 		s.logger.ErrorContext(ctx, "Failed to map private bare metal instance catalog item to public",
 			slog.Any("error", err))
 		err = grpcstatus.Errorf(grpccodes.Internal, "failed to process bare metal instance catalog item")
-		return
+		return response, err
 	}
 
 	response = &publicv1.BareMetalInstanceCatalogItemsCreateResponse{}
 	response.SetObject(createdPublicCatalogItem)
-	return
+	return response, err
 }
 
 func (s *BareMetalInstanceCatalogItemsServer) Update(ctx context.Context,
@@ -253,12 +253,12 @@ func (s *BareMetalInstanceCatalogItemsServer) Update(ctx context.Context,
 	publicCatalogItem := request.GetObject()
 	if publicCatalogItem == nil {
 		err = grpcstatus.Errorf(grpccodes.InvalidArgument, "object is mandatory")
-		return
+		return response, err
 	}
 	id := publicCatalogItem.GetId()
 	if id == "" {
 		err = grpcstatus.Errorf(grpccodes.InvalidArgument, "object identifier is mandatory")
-		return
+		return response, err
 	}
 
 	getRequest := &privatev1.BareMetalInstanceCatalogItemsGetRequest{}
@@ -274,7 +274,7 @@ func (s *BareMetalInstanceCatalogItemsServer) Update(ctx context.Context,
 		s.logger.ErrorContext(ctx, "Failed to map public bare metal instance catalog item to private",
 			slog.Any("error", err))
 		err = grpcstatus.Errorf(grpccodes.Internal, "failed to process bare metal instance catalog item")
-		return
+		return response, err
 	}
 
 	privateRequest := &privatev1.BareMetalInstanceCatalogItemsUpdateRequest{}
@@ -291,12 +291,12 @@ func (s *BareMetalInstanceCatalogItemsServer) Update(ctx context.Context,
 		s.logger.ErrorContext(ctx, "Failed to map private bare metal instance catalog item to public",
 			slog.Any("error", err))
 		err = grpcstatus.Errorf(grpccodes.Internal, "failed to process bare metal instance catalog item")
-		return
+		return response, err
 	}
 
 	response = &publicv1.BareMetalInstanceCatalogItemsUpdateResponse{}
 	response.SetObject(updatedPublicCatalogItem)
-	return
+	return response, err
 }
 
 func (s *BareMetalInstanceCatalogItemsServer) Delete(ctx context.Context,
@@ -310,7 +310,7 @@ func (s *BareMetalInstanceCatalogItemsServer) Delete(ctx context.Context,
 	}
 
 	response = &publicv1.BareMetalInstanceCatalogItemsDeleteResponse{}
-	return
+	return response, err
 }
 
 func (s *BareMetalInstanceCatalogItemsServer) addPublishedFilter(filter string) (string, error) {

--- a/internal/servers/baremetal_instance_templates_server.go
+++ b/internal/servers/baremetal_instance_templates_server.go
@@ -84,11 +84,11 @@ func (b *BareMetalInstanceTemplatesServerBuilder) SetMetricsRegisterer(value pro
 func (b *BareMetalInstanceTemplatesServerBuilder) Build() (result *BareMetalInstanceTemplatesServer, err error) {
 	if b.logger == nil {
 		err = errors.New("logger is mandatory")
-		return
+		return result, err
 	}
 	if b.tenancyLogic == nil {
 		err = errors.New("tenancy logic is mandatory")
-		return
+		return result, err
 	}
 
 	outMapper, err := NewGenericMapper[*privatev1.BareMetalInstanceTemplate, *publicv1.BareMetalInstanceTemplate]().
@@ -96,7 +96,7 @@ func (b *BareMetalInstanceTemplatesServerBuilder) Build() (result *BareMetalInst
 		SetStrict(false).
 		Build()
 	if err != nil {
-		return
+		return result, err
 	}
 
 	delegate, err := NewPrivateBareMetalInstanceTemplatesServer().
@@ -107,7 +107,7 @@ func (b *BareMetalInstanceTemplatesServerBuilder) Build() (result *BareMetalInst
 		SetMetricsRegisterer(b.metricsRegisterer).
 		Build()
 	if err != nil {
-		return
+		return result, err
 	}
 
 	result = &BareMetalInstanceTemplatesServer{
@@ -115,7 +115,7 @@ func (b *BareMetalInstanceTemplatesServerBuilder) Build() (result *BareMetalInst
 		delegate:  delegate,
 		outMapper: outMapper,
 	}
-	return
+	return result, err
 }
 
 func (s *BareMetalInstanceTemplatesServer) List(ctx context.Context,
@@ -147,7 +147,7 @@ func (s *BareMetalInstanceTemplatesServer) List(ctx context.Context,
 	response.SetSize(privateResponse.GetSize())
 	response.SetTotal(privateResponse.GetTotal())
 	response.SetItems(publicItems)
-	return
+	return response, err
 }
 
 func (s *BareMetalInstanceTemplatesServer) Get(ctx context.Context,
@@ -170,5 +170,5 @@ func (s *BareMetalInstanceTemplatesServer) Get(ctx context.Context,
 
 	response = &publicv1.BareMetalInstanceTemplatesGetResponse{}
 	response.SetObject(publicTemplate)
-	return
+	return response, err
 }

--- a/internal/servers/baremetal_instances_server.go
+++ b/internal/servers/baremetal_instances_server.go
@@ -85,11 +85,11 @@ func (b *BareMetalInstancesServerBuilder) SetMetricsRegisterer(value prometheus.
 func (b *BareMetalInstancesServerBuilder) Build() (result *BareMetalInstancesServer, err error) {
 	if b.logger == nil {
 		err = errors.New("logger is mandatory")
-		return
+		return result, err
 	}
 	if b.tenancyLogic == nil {
 		err = errors.New("tenancy logic is mandatory")
-		return
+		return result, err
 	}
 
 	inMapper, err := NewGenericMapper[*publicv1.BareMetalInstance, *privatev1.BareMetalInstance]().
@@ -97,14 +97,14 @@ func (b *BareMetalInstancesServerBuilder) Build() (result *BareMetalInstancesSer
 		SetStrict(true).
 		Build()
 	if err != nil {
-		return
+		return result, err
 	}
 	outMapper, err := NewGenericMapper[*privatev1.BareMetalInstance, *publicv1.BareMetalInstance]().
 		SetLogger(b.logger).
 		SetStrict(false).
 		Build()
 	if err != nil {
-		return
+		return result, err
 	}
 
 	delegate, err := NewPrivateBareMetalInstancesServer().
@@ -115,7 +115,7 @@ func (b *BareMetalInstancesServerBuilder) Build() (result *BareMetalInstancesSer
 		SetMetricsRegisterer(b.metricsRegisterer).
 		Build()
 	if err != nil {
-		return
+		return result, err
 	}
 
 	result = &BareMetalInstancesServer{
@@ -124,7 +124,7 @@ func (b *BareMetalInstancesServerBuilder) Build() (result *BareMetalInstancesSer
 		inMapper:  inMapper,
 		outMapper: outMapper,
 	}
-	return
+	return result, err
 }
 
 func (s *BareMetalInstancesServer) List(ctx context.Context,
@@ -156,7 +156,7 @@ func (s *BareMetalInstancesServer) List(ctx context.Context,
 	response.SetSize(privateResponse.GetSize())
 	response.SetTotal(privateResponse.GetTotal())
 	response.SetItems(publicItems)
-	return
+	return response, err
 }
 
 func (s *BareMetalInstancesServer) Get(ctx context.Context,
@@ -179,7 +179,7 @@ func (s *BareMetalInstancesServer) Get(ctx context.Context,
 
 	response = &publicv1.BareMetalInstancesGetResponse{}
 	response.SetObject(publicBMI)
-	return
+	return response, err
 }
 
 func (s *BareMetalInstancesServer) Create(ctx context.Context,
@@ -187,7 +187,7 @@ func (s *BareMetalInstancesServer) Create(ctx context.Context,
 	publicBMI := request.GetObject()
 	if publicBMI == nil {
 		err = grpcstatus.Errorf(grpccodes.InvalidArgument, "object is mandatory")
-		return
+		return response, err
 	}
 	privateBMI := &privatev1.BareMetalInstance{}
 	err = s.inMapper.Copy(ctx, publicBMI, privateBMI)
@@ -195,7 +195,7 @@ func (s *BareMetalInstancesServer) Create(ctx context.Context,
 		s.logger.ErrorContext(ctx, "Failed to map public bare metal instance to private",
 			slog.Any("error", err))
 		err = grpcstatus.Errorf(grpccodes.Internal, "failed to process bare metal instance")
-		return
+		return response, err
 	}
 
 	privateRequest := &privatev1.BareMetalInstancesCreateRequest{}
@@ -211,12 +211,12 @@ func (s *BareMetalInstancesServer) Create(ctx context.Context,
 		s.logger.ErrorContext(ctx, "Failed to map private bare metal instance to public",
 			slog.Any("error", err))
 		err = grpcstatus.Errorf(grpccodes.Internal, "failed to process bare metal instance")
-		return
+		return response, err
 	}
 
 	response = &publicv1.BareMetalInstancesCreateResponse{}
 	response.SetObject(createdPublicBMI)
-	return
+	return response, err
 }
 
 func (s *BareMetalInstancesServer) Update(ctx context.Context,
@@ -224,12 +224,12 @@ func (s *BareMetalInstancesServer) Update(ctx context.Context,
 	publicBMI := request.GetObject()
 	if publicBMI == nil {
 		err = grpcstatus.Errorf(grpccodes.InvalidArgument, "object is mandatory")
-		return
+		return response, err
 	}
 	id := publicBMI.GetId()
 	if id == "" {
 		err = grpcstatus.Errorf(grpccodes.InvalidArgument, "object identifier is mandatory")
-		return
+		return response, err
 	}
 
 	// When there's a field mask, copy to a new private object and let the generic server handle the
@@ -253,7 +253,7 @@ func (s *BareMetalInstancesServer) Update(ctx context.Context,
 		s.logger.ErrorContext(ctx, "Failed to map public bare metal instance to private",
 			slog.Any("error", err))
 		err = grpcstatus.Errorf(grpccodes.Internal, "failed to process bare metal instance")
-		return
+		return response, err
 	}
 
 	privateRequest := &privatev1.BareMetalInstancesUpdateRequest{}
@@ -271,12 +271,12 @@ func (s *BareMetalInstancesServer) Update(ctx context.Context,
 		s.logger.ErrorContext(ctx, "Failed to map private bare metal instance to public",
 			slog.Any("error", err))
 		err = grpcstatus.Errorf(grpccodes.Internal, "failed to process bare metal instance")
-		return
+		return response, err
 	}
 
 	response = &publicv1.BareMetalInstancesUpdateResponse{}
 	response.SetObject(updatedPublicBMI)
-	return
+	return response, err
 }
 
 func (s *BareMetalInstancesServer) Delete(ctx context.Context,
@@ -290,5 +290,5 @@ func (s *BareMetalInstancesServer) Delete(ctx context.Context,
 	}
 
 	response = &publicv1.BareMetalInstancesDeleteResponse{}
-	return
+	return response, err
 }

--- a/internal/servers/capabilities_server.go
+++ b/internal/servers/capabilities_server.go
@@ -61,7 +61,7 @@ func (b *CapabilitiesServerBuilder) Build() (result *CapabilitiesServer, err err
 	// Check parameters:
 	if b.logger == nil {
 		err = errors.New("logger is mandatory")
-		return
+		return result, err
 	}
 
 	// Make sure that the list of issuers doens't have duplicates, and that it is sorted in a predictable way:
@@ -74,7 +74,7 @@ func (b *CapabilitiesServerBuilder) Build() (result *CapabilitiesServer, err err
 		logger:                   b.logger,
 		authnTrustedTokenIssuers: authnTrustedTokenIssuers,
 	}
-	return
+	return result, err
 }
 
 // Get is the implementation of the method that returns the capabilities of the server.

--- a/internal/servers/cluster_catalog_items_server.go
+++ b/internal/servers/cluster_catalog_items_server.go
@@ -81,11 +81,11 @@ func (b *ClusterCatalogItemsServerBuilder) SetMetricsRegisterer(value prometheus
 func (b *ClusterCatalogItemsServerBuilder) Build() (result *ClusterCatalogItemsServer, err error) {
 	if b.logger == nil {
 		err = errors.New("logger is mandatory")
-		return
+		return result, err
 	}
 	if b.tenancyLogic == nil {
 		err = errors.New("tenancy logic is mandatory")
-		return
+		return result, err
 	}
 
 	inMapper, err := NewGenericMapper[*publicv1.ClusterCatalogItem, *privatev1.ClusterCatalogItem]().
@@ -93,14 +93,14 @@ func (b *ClusterCatalogItemsServerBuilder) Build() (result *ClusterCatalogItemsS
 		SetStrict(true).
 		Build()
 	if err != nil {
-		return
+		return result, err
 	}
 	outMapper, err := NewGenericMapper[*privatev1.ClusterCatalogItem, *publicv1.ClusterCatalogItem]().
 		SetLogger(b.logger).
 		SetStrict(false).
 		Build()
 	if err != nil {
-		return
+		return result, err
 	}
 
 	clustersDao, err := dao.NewGenericDAO[*privatev1.Cluster]().
@@ -109,7 +109,7 @@ func (b *ClusterCatalogItemsServerBuilder) Build() (result *ClusterCatalogItemsS
 		SetMetricsRegisterer(b.metricsRegisterer).
 		Build()
 	if err != nil {
-		return
+		return result, err
 	}
 	referenceChecker := &daoReferenceChecker[*privatev1.Cluster]{resourceDao: clustersDao}
 
@@ -121,7 +121,7 @@ func (b *ClusterCatalogItemsServerBuilder) Build() (result *ClusterCatalogItemsS
 		SetMetricsRegisterer(b.metricsRegisterer).
 		Build()
 	if err != nil {
-		return
+		return result, err
 	}
 
 	result = &ClusterCatalogItemsServer{
@@ -131,7 +131,7 @@ func (b *ClusterCatalogItemsServerBuilder) Build() (result *ClusterCatalogItemsS
 		inMapper:         inMapper,
 		outMapper:        outMapper,
 	}
-	return
+	return result, err
 }
 
 func (s *ClusterCatalogItemsServer) List(ctx context.Context,
@@ -167,7 +167,7 @@ func (s *ClusterCatalogItemsServer) List(ctx context.Context,
 	response.SetSize(privateResponse.GetSize())
 	response.SetTotal(privateResponse.GetTotal())
 	response.SetItems(publicItems)
-	return
+	return response, err
 }
 
 func (s *ClusterCatalogItemsServer) Get(ctx context.Context,
@@ -199,7 +199,7 @@ func (s *ClusterCatalogItemsServer) Get(ctx context.Context,
 
 	response = &publicv1.ClusterCatalogItemsGetResponse{}
 	response.SetObject(publicCatalogItem)
-	return
+	return response, err
 }
 
 func (s *ClusterCatalogItemsServer) Create(ctx context.Context,
@@ -207,14 +207,14 @@ func (s *ClusterCatalogItemsServer) Create(ctx context.Context,
 	publicCatalogItem := request.GetObject()
 	if publicCatalogItem == nil {
 		err = grpcstatus.Errorf(grpccodes.InvalidArgument, "object is mandatory")
-		return
+		return response, err
 	}
 	privateCatalogItem := &privatev1.ClusterCatalogItem{}
 	err = s.inMapper.Copy(ctx, publicCatalogItem, privateCatalogItem)
 	if err != nil {
 		s.logger.ErrorContext(ctx, "Failed to map public cluster catalog item to private", slog.Any("error", err))
 		err = grpcstatus.Errorf(grpccodes.Internal, "failed to process cluster catalog item")
-		return
+		return response, err
 	}
 
 	privateRequest := &privatev1.ClusterCatalogItemsCreateRequest{}
@@ -229,12 +229,12 @@ func (s *ClusterCatalogItemsServer) Create(ctx context.Context,
 	if err != nil {
 		s.logger.ErrorContext(ctx, "Failed to map private cluster catalog item to public", slog.Any("error", err))
 		err = grpcstatus.Errorf(grpccodes.Internal, "failed to process cluster catalog item")
-		return
+		return response, err
 	}
 
 	response = &publicv1.ClusterCatalogItemsCreateResponse{}
 	response.SetObject(createdPublicCatalogItem)
-	return
+	return response, err
 }
 
 func (s *ClusterCatalogItemsServer) Update(ctx context.Context,
@@ -242,12 +242,12 @@ func (s *ClusterCatalogItemsServer) Update(ctx context.Context,
 	publicCatalogItem := request.GetObject()
 	if publicCatalogItem == nil {
 		err = grpcstatus.Errorf(grpccodes.InvalidArgument, "object is mandatory")
-		return
+		return response, err
 	}
 	id := publicCatalogItem.GetId()
 	if id == "" {
 		err = grpcstatus.Errorf(grpccodes.InvalidArgument, "object identifier is mandatory")
-		return
+		return response, err
 	}
 
 	getRequest := &privatev1.ClusterCatalogItemsGetRequest{}
@@ -262,7 +262,7 @@ func (s *ClusterCatalogItemsServer) Update(ctx context.Context,
 	if err != nil {
 		s.logger.ErrorContext(ctx, "Failed to map public cluster catalog item to private", slog.Any("error", err))
 		err = grpcstatus.Errorf(grpccodes.Internal, "failed to process cluster catalog item")
-		return
+		return response, err
 	}
 
 	privateRequest := &privatev1.ClusterCatalogItemsUpdateRequest{}
@@ -278,12 +278,12 @@ func (s *ClusterCatalogItemsServer) Update(ctx context.Context,
 	if err != nil {
 		s.logger.ErrorContext(ctx, "Failed to map private cluster catalog item to public", slog.Any("error", err))
 		err = grpcstatus.Errorf(grpccodes.Internal, "failed to process cluster catalog item")
-		return
+		return response, err
 	}
 
 	response = &publicv1.ClusterCatalogItemsUpdateResponse{}
 	response.SetObject(updatedPublicCatalogItem)
-	return
+	return response, err
 }
 
 func (s *ClusterCatalogItemsServer) addPublishedFilter(filter string) (string, error) {
@@ -307,5 +307,5 @@ func (s *ClusterCatalogItemsServer) Delete(ctx context.Context,
 	}
 
 	response = &publicv1.ClusterCatalogItemsDeleteResponse{}
-	return
+	return response, err
 }

--- a/internal/servers/cluster_templates_server.go
+++ b/internal/servers/cluster_templates_server.go
@@ -86,11 +86,11 @@ func (b *ClusterTemplatesServerBuilder) Build() (result *ClusterTemplatesServer,
 	// Check parameters:
 	if b.logger == nil {
 		err = errors.New("logger is mandatory")
-		return
+		return result, err
 	}
 	if b.tenancyLogic == nil {
 		err = errors.New("tenancy logic is mandatory")
-		return
+		return result, err
 	}
 
 	// Create the mappers:
@@ -99,14 +99,14 @@ func (b *ClusterTemplatesServerBuilder) Build() (result *ClusterTemplatesServer,
 		SetStrict(true).
 		Build()
 	if err != nil {
-		return
+		return result, err
 	}
 	outMapper, err := NewGenericMapper[*privatev1.ClusterTemplate, *publicv1.ClusterTemplate]().
 		SetLogger(b.logger).
 		SetStrict(false).
 		Build()
 	if err != nil {
-		return
+		return result, err
 	}
 
 	// Create the private server to delegate to:
@@ -118,7 +118,7 @@ func (b *ClusterTemplatesServerBuilder) Build() (result *ClusterTemplatesServer,
 		SetMetricsRegisterer(b.metricsRegisterer).
 		Build()
 	if err != nil {
-		return
+		return result, err
 	}
 
 	// Create and populate the object:
@@ -128,7 +128,7 @@ func (b *ClusterTemplatesServerBuilder) Build() (result *ClusterTemplatesServer,
 		inMapper:  inMapper,
 		outMapper: outMapper,
 	}
-	return
+	return result, err
 }
 
 func (s *ClusterTemplatesServer) List(ctx context.Context,
@@ -167,7 +167,7 @@ func (s *ClusterTemplatesServer) List(ctx context.Context,
 	response.SetSize(privateResponse.GetSize())
 	response.SetTotal(privateResponse.GetTotal())
 	response.SetItems(publicItems)
-	return
+	return response, err
 }
 
 func (s *ClusterTemplatesServer) Get(ctx context.Context,
@@ -198,7 +198,7 @@ func (s *ClusterTemplatesServer) Get(ctx context.Context,
 	// Create the public response:
 	response = &publicv1.ClusterTemplatesGetResponse{}
 	response.SetObject(publicClusterTemplate)
-	return
+	return response, err
 }
 
 func (s *ClusterTemplatesServer) Create(ctx context.Context,
@@ -207,7 +207,7 @@ func (s *ClusterTemplatesServer) Create(ctx context.Context,
 	publicClusterTemplate := request.GetObject()
 	if publicClusterTemplate == nil {
 		err = grpcstatus.Errorf(grpccodes.InvalidArgument, "object is mandatory")
-		return
+		return response, err
 	}
 	privateClusterTemplate := &privatev1.ClusterTemplate{}
 	err = s.inMapper.Copy(ctx, publicClusterTemplate, privateClusterTemplate)
@@ -218,7 +218,7 @@ func (s *ClusterTemplatesServer) Create(ctx context.Context,
 			slog.Any("error", err),
 		)
 		err = grpcstatus.Errorf(grpccodes.Internal, "failed to process cluster template")
-		return
+		return response, err
 	}
 
 	// Delegate to the private server:
@@ -240,13 +240,13 @@ func (s *ClusterTemplatesServer) Create(ctx context.Context,
 			slog.Any("error", err),
 		)
 		err = grpcstatus.Errorf(grpccodes.Internal, "failed to process cluster template")
-		return
+		return response, err
 	}
 
 	// Create the public response:
 	response = &publicv1.ClusterTemplatesCreateResponse{}
 	response.SetObject(createdPublicClusterTemplate)
-	return
+	return response, err
 }
 
 func (s *ClusterTemplatesServer) Update(ctx context.Context,
@@ -255,12 +255,12 @@ func (s *ClusterTemplatesServer) Update(ctx context.Context,
 	publicClusterTemplate := request.GetObject()
 	if publicClusterTemplate == nil {
 		err = grpcstatus.Errorf(grpccodes.InvalidArgument, "object is mandatory")
-		return
+		return response, err
 	}
 	id := publicClusterTemplate.GetId()
 	if id == "" {
 		err = grpcstatus.Errorf(grpccodes.InvalidArgument, "object identifier is mandatory")
-		return
+		return response, err
 	}
 
 	// Get the existing object from the private server:
@@ -281,7 +281,7 @@ func (s *ClusterTemplatesServer) Update(ctx context.Context,
 			slog.Any("error", err),
 		)
 		err = grpcstatus.Errorf(grpccodes.Internal, "failed to process cluster template")
-		return
+		return response, err
 	}
 
 	// Delegate to the private server with the merged object:
@@ -304,13 +304,13 @@ func (s *ClusterTemplatesServer) Update(ctx context.Context,
 			slog.Any("error", err),
 		)
 		err = grpcstatus.Errorf(grpccodes.Internal, "failed to process cluster template")
-		return
+		return response, err
 	}
 
 	// Create the public response:
 	response = &publicv1.ClusterTemplatesUpdateResponse{}
 	response.SetObject(updatedPublicClusterTemplate)
-	return
+	return response, err
 }
 
 func (s *ClusterTemplatesServer) Delete(ctx context.Context,
@@ -327,5 +327,5 @@ func (s *ClusterTemplatesServer) Delete(ctx context.Context,
 
 	// Create the public response:
 	response = &publicv1.ClusterTemplatesDeleteResponse{}
-	return
+	return response, err
 }

--- a/internal/servers/clusters_server.go
+++ b/internal/servers/clusters_server.go
@@ -114,15 +114,15 @@ func (b *ClustersServerBuilder) Build() (result *ClustersServer, err error) {
 	// Check parameters:
 	if b.logger == nil {
 		err = errors.New("logger is mandatory")
-		return
+		return result, err
 	}
 	if b.tenancyLogic == nil {
 		err = errors.New("tenancy logic is mandatory")
-		return
+		return result, err
 	}
 	if b.scheme == nil {
 		err = errors.New("scheme is mandatory")
-		return
+		return result, err
 	}
 
 	// Create the JQ tool:
@@ -130,7 +130,7 @@ func (b *ClustersServerBuilder) Build() (result *ClustersServer, err error) {
 		SetLogger(b.logger).
 		Build()
 	if err != nil {
-		return
+		return result, err
 	}
 
 	// Create the DAOs:
@@ -140,7 +140,7 @@ func (b *ClustersServerBuilder) Build() (result *ClustersServer, err error) {
 		SetMetricsRegisterer(b.metricsRegisterer).
 		Build()
 	if err != nil {
-		return
+		return result, err
 	}
 
 	// Find the full name of the 'status' field so that we can configure the generic server to ignore it. This is
@@ -151,7 +151,7 @@ func (b *ClustersServerBuilder) Build() (result *ClustersServer, err error) {
 	statusField := objectDesc.Fields().ByName("status")
 	if statusField == nil {
 		err = fmt.Errorf("failed to find the status field of type '%s'", objectDesc.FullName())
-		return
+		return result, err
 	}
 
 	// Create the mappers:
@@ -161,14 +161,14 @@ func (b *ClustersServerBuilder) Build() (result *ClustersServer, err error) {
 		AddIgnoredFields(statusField.FullName()).
 		Build()
 	if err != nil {
-		return
+		return result, err
 	}
 	outMapper, err := NewGenericMapper[*privatev1.Cluster, *publicv1.Cluster]().
 		SetLogger(b.logger).
 		SetStrict(false).
 		Build()
 	if err != nil {
-		return
+		return result, err
 	}
 
 	// Create the private server to delegate to:
@@ -180,7 +180,7 @@ func (b *ClustersServerBuilder) Build() (result *ClustersServer, err error) {
 		SetMetricsRegisterer(b.metricsRegisterer).
 		Build()
 	if err != nil {
-		return
+		return result, err
 	}
 
 	// Create and populate the object:
@@ -195,7 +195,7 @@ func (b *ClustersServerBuilder) Build() (result *ClustersServer, err error) {
 		outMapper:       outMapper,
 		scheme:          b.scheme,
 	}
-	return
+	return result, err
 }
 
 func (s *ClustersServer) List(ctx context.Context,
@@ -235,7 +235,7 @@ func (s *ClustersServer) List(ctx context.Context,
 	response.SetSize(privateResponse.GetSize())
 	response.SetTotal(privateResponse.GetTotal())
 	response.SetItems(publicItems)
-	return
+	return response, err
 }
 
 func (s *ClustersServer) Get(ctx context.Context,
@@ -268,7 +268,7 @@ func (s *ClustersServer) Get(ctx context.Context,
 	// Create the public response:
 	response = &publicv1.ClustersGetResponse{}
 	response.SetObject(publicCluster)
-	return
+	return response, err
 }
 
 func (s *ClustersServer) Create(ctx context.Context,
@@ -277,7 +277,7 @@ func (s *ClustersServer) Create(ctx context.Context,
 	publicCluster := request.GetObject()
 	if publicCluster == nil {
 		err = grpcstatus.Errorf(grpccodes.InvalidArgument, "object is mandatory")
-		return
+		return response, err
 	}
 	privateCluster := &privatev1.Cluster{}
 	err = s.inMapper.Copy(ctx, publicCluster, privateCluster)
@@ -288,7 +288,7 @@ func (s *ClustersServer) Create(ctx context.Context,
 			slog.Any("error", err),
 		)
 		err = grpcstatus.Errorf(grpccodes.Internal, "failed to process cluster")
-		return
+		return response, err
 	}
 
 	// Delegate to the private server:
@@ -310,7 +310,7 @@ func (s *ClustersServer) Create(ctx context.Context,
 			slog.Any("error", err),
 		)
 		err = grpcstatus.Errorf(grpccodes.Internal, "failed to process cluster")
-		return
+		return response, err
 	}
 
 	redactClusterSecrets(createdPublicCluster)
@@ -318,7 +318,7 @@ func (s *ClustersServer) Create(ctx context.Context,
 	// Create the public response:
 	response = &publicv1.ClustersCreateResponse{}
 	response.SetObject(createdPublicCluster)
-	return
+	return response, err
 }
 
 func (s *ClustersServer) Update(ctx context.Context,
@@ -327,12 +327,12 @@ func (s *ClustersServer) Update(ctx context.Context,
 	publicCluster := request.GetObject()
 	if publicCluster == nil {
 		err = grpcstatus.Errorf(grpccodes.InvalidArgument, "object is mandatory")
-		return
+		return response, err
 	}
 	id := publicCluster.GetId()
 	if id == "" {
 		err = grpcstatus.Errorf(grpccodes.InvalidArgument, "object identifier is mandatory")
-		return
+		return response, err
 	}
 
 	// Check if the client sent back the redacted pull_secret sentinel ("***").
@@ -376,7 +376,7 @@ func (s *ClustersServer) Update(ctx context.Context,
 			slog.Any("error", err),
 		)
 		err = grpcstatus.Errorf(grpccodes.Internal, "failed to process cluster")
-		return
+		return response, err
 	}
 
 	// Delegate to the private server:
@@ -400,7 +400,7 @@ func (s *ClustersServer) Update(ctx context.Context,
 			slog.Any("error", err),
 		)
 		err = grpcstatus.Errorf(grpccodes.Internal, "failed to process cluster")
-		return
+		return response, err
 	}
 
 	redactClusterSecrets(updatedPublicCluster)
@@ -408,7 +408,7 @@ func (s *ClustersServer) Update(ctx context.Context,
 	// Create the public response:
 	response = &publicv1.ClustersUpdateResponse{}
 	response.SetObject(updatedPublicCluster)
-	return
+	return response, err
 }
 
 func (s *ClustersServer) Delete(ctx context.Context,
@@ -425,7 +425,7 @@ func (s *ClustersServer) Delete(ctx context.Context,
 
 	// Create the public response:
 	response = &publicv1.ClustersDeleteResponse{}
-	return
+	return response, err
 }
 
 func (s *ClustersServer) GetKubeconfig(ctx context.Context,
@@ -444,20 +444,20 @@ func (s *ClustersServer) GetKubeconfigViaHttp(ctx context.Context,
 	request *publicv1.ClustersGetKubeconfigViaHttpRequest) (response *httpbody.HttpBody, err error) {
 	kubeconfig, err := s.getKubeconfig(ctx, request.Id)
 	if err != nil {
-		return
+		return response, err
 	}
 	response = &httpbody.HttpBody{
 		ContentType: "application/yaml",
 		Data:        kubeconfig,
 	}
-	return
+	return response, err
 }
 
 func (s *ClustersServer) getKubeconfig(ctx context.Context, clusterId string) (result []byte, err error) {
 	// Validate the request:
 	if clusterId == "" {
 		err = grpcstatus.Errorf(grpccodes.InvalidArgument, "cluster identifier is mandatory")
-		return
+		return result, err
 	}
 
 	// Prepare a logger with additional information about the cluster:
@@ -481,7 +481,7 @@ func (s *ClustersServer) getKubeconfig(ctx context.Context, clusterId string) (r
 			slog.Any("error", err),
 		)
 		err = internalErr
-		return
+		return result, err
 	}
 	if secret == nil {
 		err = grpcstatus.Errorf(
@@ -489,7 +489,7 @@ func (s *ClustersServer) getKubeconfig(ctx context.Context, clusterId string) (r
 			"kubeconfig for cluster with identifier '%s' isn't yet available",
 			clusterId,
 		)
-		return
+		return result, err
 	}
 
 	// Check that the secret has the expected entry, and that it isn't empty:
@@ -497,12 +497,12 @@ func (s *ClustersServer) getKubeconfig(ctx context.Context, clusterId string) (r
 	if !ok {
 		logger.ErrorContext(ctx, "Kubeconfig secret entry doesn't exist")
 		err = internalErr
-		return
+		return result, err
 	}
 	if len(kcBytes) == 0 {
 		logger.ErrorContext(ctx, "Kubeconfig secret entry is empty")
 		err = internalErr
-		return
+		return result, err
 	}
 
 	// Done:
@@ -512,7 +512,7 @@ func (s *ClustersServer) getKubeconfig(ctx context.Context, clusterId string) (r
 		slog.Int("kc_bytes", len(kcBytes)),
 	)
 	result = kcBytes
-	return
+	return result, err
 }
 
 func (s *ClustersServer) GetPassword(ctx context.Context,
@@ -531,20 +531,20 @@ func (s *ClustersServer) GetPasswordViaHttp(ctx context.Context,
 	request *publicv1.ClustersGetPasswordViaHttpRequest) (response *httpbody.HttpBody, err error) {
 	password, err := s.getPassword(ctx, request.Id)
 	if err != nil {
-		return
+		return response, err
 	}
 	response = &httpbody.HttpBody{
 		ContentType: "text/plain",
 		Data:        []byte(password),
 	}
-	return
+	return response, err
 }
 
 func (s *ClustersServer) getPassword(ctx context.Context, clusterId string) (result string, err error) {
 	// Validate the request:
 	if clusterId == "" {
 		err = grpcstatus.Errorf(grpccodes.InvalidArgument, "cluster identifier is mandatory")
-		return
+		return result, err
 	}
 
 	// Prepare a logger with additional information about the cluster:
@@ -568,7 +568,7 @@ func (s *ClustersServer) getPassword(ctx context.Context, clusterId string) (res
 			slog.Any("error", err),
 		)
 		err = internalErr
-		return
+		return result, err
 	}
 	if secret == nil {
 		err = grpcstatus.Errorf(
@@ -576,7 +576,7 @@ func (s *ClustersServer) getPassword(ctx context.Context, clusterId string) (res
 			"password for cluster with identifier '%s' isn't available yet",
 			clusterId,
 		)
-		return
+		return result, err
 	}
 
 	// Check that the secret has the expected entry, and that it isn't empty:
@@ -584,12 +584,12 @@ func (s *ClustersServer) getPassword(ctx context.Context, clusterId string) (res
 	if !ok {
 		logger.ErrorContext(ctx, "Password secret entry doesn't exist")
 		err = internalErr
-		return
+		return result, err
 	}
 	if len(passwordBytes) == 0 {
 		logger.ErrorContext(ctx, "Password secret entry is empty")
 		err = internalErr
-		return
+		return result, err
 	}
 
 	// Done:
@@ -599,7 +599,7 @@ func (s *ClustersServer) getPassword(ctx context.Context, clusterId string) (res
 		slog.Int("password_bytes", len(passwordBytes)),
 	)
 	result = string(passwordBytes)
-	return
+	return result, err
 }
 
 func (s *ClustersServer) getHostedClusterSecret(ctx context.Context, clusterId string,
@@ -609,11 +609,11 @@ func (s *ClustersServer) getHostedClusterSecret(ctx context.Context, clusterId s
 	getRequest.SetId(clusterId)
 	getResponse, err := s.private.Get(ctx, getRequest)
 	if err != nil {
-		return
+		return result, err
 	}
 	cluster := getResponse.GetObject()
 	if cluster == nil || cluster.GetStatus().GetHub() == "" {
-		return
+		return result, err
 	}
 
 	// Get the data of the hub:
@@ -621,30 +621,30 @@ func (s *ClustersServer) getHostedClusterSecret(ctx context.Context, clusterId s
 		SetId(cluster.GetStatus().GetHub()).
 		Do(ctx)
 	if err != nil {
-		return
+		return result, err
 	}
 	hub := getHubResponse.GetObject()
 	if hub == nil {
-		return
+		return result, err
 	}
 
 	// Create a client for the hub:
 	hubClient, err := s.getKubeClient(ctx, hub)
 	if err != nil {
-		return
+		return result, err
 	}
 
 	// Get the cluster order from the hub:
 	order, err := s.getKubeClusterOrder(ctx, hubClient, hub.GetSpec().GetNamespace(), cluster.GetId())
 	if err != nil {
-		return
+		return result, err
 	}
 
 	// Extract the location of the hosted cluster:
 	clusterRef := order.Status.ClusterReference
 	if clusterRef == nil {
 		err = fmt.Errorf("cluster order for '%s' has no cluster reference", cluster.GetId())
-		return
+		return result, err
 	}
 	hcKey := clnt.ObjectKey{
 		Namespace: clusterRef.Namespace,
@@ -654,7 +654,7 @@ func (s *ClustersServer) getHostedClusterSecret(ctx context.Context, clusterId s
 	// Get the hosted cluster from the hub:
 	hc, err := s.getKubeHostedCluster(ctx, hubClient, hcKey)
 	if err != nil || hc == nil {
-		return
+		return result, err
 	}
 
 	// Extract the name of the secret from the hosted cluster:
@@ -663,12 +663,12 @@ func (s *ClustersServer) getHostedClusterSecret(ctx context.Context, clusterId s
 	}
 	err = s.jqTool.Evaluate(secretField, hc.Object, &secretKey.Name)
 	if err != nil {
-		return
+		return result, err
 	}
 
 	// Get the secret from the hub:
 	result, err = s.getKubeSecret(ctx, hubClient, secretKey)
-	return
+	return result, err
 }
 
 func (s *ClustersServer) getKubeClient(ctx context.Context, hub *privatev1.Hub) (result clnt.Client, err error) {
@@ -676,14 +676,14 @@ func (s *ClustersServer) getKubeClient(ctx context.Context, hub *privatev1.Hub) 
 	defer s.kubeClientsLock.Unlock()
 	result, ok := s.kubeClients[hub.Id]
 	if ok {
-		return
+		return result, err
 	}
 	result, err = s.createKubeClient(ctx, hub)
 	if err != nil {
-		return
+		return result, err
 	}
 	s.kubeClients[hub.Id] = result
-	return
+	return result, err
 }
 
 func (s *ClustersServer) createKubeClient(ctx context.Context, hub *privatev1.Hub) (result clnt.Client, err error) {
@@ -706,7 +706,7 @@ func (s *ClustersServer) getKubeClusterOrder(ctx context.Context, client clnt.Cl
 		},
 	)
 	if err != nil {
-		return
+		return result, err
 	}
 	items := list.Items
 	if len(items) != 1 {
@@ -714,10 +714,10 @@ func (s *ClustersServer) getKubeClusterOrder(ctx context.Context, client clnt.Cl
 			"expected exactly one cluster order with identifier '%s' but found %d",
 			id, len(items),
 		)
-		return
+		return result, err
 	}
 	result = &items[0]
-	return
+	return result, err
 }
 
 func (s *ClustersServer) getKubeHostedCluster(ctx context.Context, client clnt.Client,
@@ -727,13 +727,13 @@ func (s *ClustersServer) getKubeHostedCluster(ctx context.Context, client clnt.C
 	err = client.Get(ctx, key, object)
 	if apierrors.IsNotFound(err) {
 		err = nil
-		return
+		return result, err
 	}
 	if err != nil {
-		return
+		return result, err
 	}
 	result = object
-	return
+	return result, err
 }
 
 func (s *ClustersServer) getKubeSecret(ctx context.Context, client clnt.Client,
@@ -742,13 +742,13 @@ func (s *ClustersServer) getKubeSecret(ctx context.Context, client clnt.Client,
 	err = client.Get(ctx, key, object)
 	if apierrors.IsNotFound(err) {
 		err = nil
-		return
+		return result, err
 	}
 	if err != nil {
-		return
+		return result, err
 	}
 	result = object
-	return
+	return result, err
 }
 
 // redactClusterSecrets clears sensitive fields from a public cluster before returning it to the client.

--- a/internal/servers/compute_instance_catalog_items_server.go
+++ b/internal/servers/compute_instance_catalog_items_server.go
@@ -81,11 +81,11 @@ func (b *ComputeInstanceCatalogItemsServerBuilder) SetMetricsRegisterer(value pr
 func (b *ComputeInstanceCatalogItemsServerBuilder) Build() (result *ComputeInstanceCatalogItemsServer, err error) {
 	if b.logger == nil {
 		err = errors.New("logger is mandatory")
-		return
+		return result, err
 	}
 	if b.tenancyLogic == nil {
 		err = errors.New("tenancy logic is mandatory")
-		return
+		return result, err
 	}
 
 	inMapper, err := NewGenericMapper[*publicv1.ComputeInstanceCatalogItem, *privatev1.ComputeInstanceCatalogItem]().
@@ -93,14 +93,14 @@ func (b *ComputeInstanceCatalogItemsServerBuilder) Build() (result *ComputeInsta
 		SetStrict(true).
 		Build()
 	if err != nil {
-		return
+		return result, err
 	}
 	outMapper, err := NewGenericMapper[*privatev1.ComputeInstanceCatalogItem, *publicv1.ComputeInstanceCatalogItem]().
 		SetLogger(b.logger).
 		SetStrict(false).
 		Build()
 	if err != nil {
-		return
+		return result, err
 	}
 
 	computeInstancesDao, err := dao.NewGenericDAO[*privatev1.ComputeInstance]().
@@ -109,7 +109,7 @@ func (b *ComputeInstanceCatalogItemsServerBuilder) Build() (result *ComputeInsta
 		SetMetricsRegisterer(b.metricsRegisterer).
 		Build()
 	if err != nil {
-		return
+		return result, err
 	}
 	referenceChecker := &daoReferenceChecker[*privatev1.ComputeInstance]{resourceDao: computeInstancesDao}
 
@@ -121,7 +121,7 @@ func (b *ComputeInstanceCatalogItemsServerBuilder) Build() (result *ComputeInsta
 		SetMetricsRegisterer(b.metricsRegisterer).
 		Build()
 	if err != nil {
-		return
+		return result, err
 	}
 
 	result = &ComputeInstanceCatalogItemsServer{
@@ -131,7 +131,7 @@ func (b *ComputeInstanceCatalogItemsServerBuilder) Build() (result *ComputeInsta
 		inMapper:         inMapper,
 		outMapper:        outMapper,
 	}
-	return
+	return result, err
 }
 
 func (s *ComputeInstanceCatalogItemsServer) List(ctx context.Context,
@@ -167,7 +167,7 @@ func (s *ComputeInstanceCatalogItemsServer) List(ctx context.Context,
 	response.SetSize(privateResponse.GetSize())
 	response.SetTotal(privateResponse.GetTotal())
 	response.SetItems(publicItems)
-	return
+	return response, err
 }
 
 func (s *ComputeInstanceCatalogItemsServer) Get(ctx context.Context,
@@ -199,7 +199,7 @@ func (s *ComputeInstanceCatalogItemsServer) Get(ctx context.Context,
 
 	response = &publicv1.ComputeInstanceCatalogItemsGetResponse{}
 	response.SetObject(publicCatalogItem)
-	return
+	return response, err
 }
 
 func (s *ComputeInstanceCatalogItemsServer) Create(ctx context.Context,
@@ -207,14 +207,14 @@ func (s *ComputeInstanceCatalogItemsServer) Create(ctx context.Context,
 	publicCatalogItem := request.GetObject()
 	if publicCatalogItem == nil {
 		err = grpcstatus.Errorf(grpccodes.InvalidArgument, "object is mandatory")
-		return
+		return response, err
 	}
 	privateCatalogItem := &privatev1.ComputeInstanceCatalogItem{}
 	err = s.inMapper.Copy(ctx, publicCatalogItem, privateCatalogItem)
 	if err != nil {
 		s.logger.ErrorContext(ctx, "Failed to map public compute instance catalog item to private", slog.Any("error", err))
 		err = grpcstatus.Errorf(grpccodes.Internal, "failed to process compute instance catalog item")
-		return
+		return response, err
 	}
 
 	privateRequest := &privatev1.ComputeInstanceCatalogItemsCreateRequest{}
@@ -229,13 +229,13 @@ func (s *ComputeInstanceCatalogItemsServer) Create(ctx context.Context,
 	if err != nil {
 		s.logger.ErrorContext(ctx, "Failed to map private compute instance catalog item to public", slog.Any("error", err))
 		err = grpcstatus.Errorf(grpccodes.Internal, "failed to process compute instance catalog item")
-		return
+		return response, err
 	}
 
 	response = &publicv1.ComputeInstanceCatalogItemsCreateResponse{}
 	response.SetObject(createdPublicCatalogItem)
 	response.SetWarnings(privateResponse.GetWarnings())
-	return
+	return response, err
 }
 
 func (s *ComputeInstanceCatalogItemsServer) Update(ctx context.Context,
@@ -243,12 +243,12 @@ func (s *ComputeInstanceCatalogItemsServer) Update(ctx context.Context,
 	publicCatalogItem := request.GetObject()
 	if publicCatalogItem == nil {
 		err = grpcstatus.Errorf(grpccodes.InvalidArgument, "object is mandatory")
-		return
+		return response, err
 	}
 	id := publicCatalogItem.GetId()
 	if id == "" {
 		err = grpcstatus.Errorf(grpccodes.InvalidArgument, "object identifier is mandatory")
-		return
+		return response, err
 	}
 
 	getRequest := &privatev1.ComputeInstanceCatalogItemsGetRequest{}
@@ -263,7 +263,7 @@ func (s *ComputeInstanceCatalogItemsServer) Update(ctx context.Context,
 	if err != nil {
 		s.logger.ErrorContext(ctx, "Failed to map public compute instance catalog item to private", slog.Any("error", err))
 		err = grpcstatus.Errorf(grpccodes.Internal, "failed to process compute instance catalog item")
-		return
+		return response, err
 	}
 
 	privateRequest := &privatev1.ComputeInstanceCatalogItemsUpdateRequest{}
@@ -279,13 +279,13 @@ func (s *ComputeInstanceCatalogItemsServer) Update(ctx context.Context,
 	if err != nil {
 		s.logger.ErrorContext(ctx, "Failed to map private compute instance catalog item to public", slog.Any("error", err))
 		err = grpcstatus.Errorf(grpccodes.Internal, "failed to process compute instance catalog item")
-		return
+		return response, err
 	}
 
 	response = &publicv1.ComputeInstanceCatalogItemsUpdateResponse{}
 	response.SetObject(updatedPublicCatalogItem)
 	response.SetWarnings(privateResponse.GetWarnings())
-	return
+	return response, err
 }
 
 func (s *ComputeInstanceCatalogItemsServer) addPublishedFilter(filter string) (string, error) {
@@ -309,5 +309,5 @@ func (s *ComputeInstanceCatalogItemsServer) Delete(ctx context.Context,
 	}
 
 	response = &publicv1.ComputeInstanceCatalogItemsDeleteResponse{}
-	return
+	return response, err
 }

--- a/internal/servers/compute_instance_templates_server.go
+++ b/internal/servers/compute_instance_templates_server.go
@@ -86,11 +86,11 @@ func (b *ComputeInstanceTemplatesServerBuilder) Build() (result *ComputeInstance
 	// Check parameters:
 	if b.logger == nil {
 		err = errors.New("logger is mandatory")
-		return
+		return result, err
 	}
 	if b.tenancyLogic == nil {
 		err = errors.New("tenancy logic is mandatory")
-		return
+		return result, err
 	}
 
 	// Create the mappers:
@@ -99,14 +99,14 @@ func (b *ComputeInstanceTemplatesServerBuilder) Build() (result *ComputeInstance
 		SetStrict(true).
 		Build()
 	if err != nil {
-		return
+		return result, err
 	}
 	outMapper, err := NewGenericMapper[*privatev1.ComputeInstanceTemplate, *publicv1.ComputeInstanceTemplate]().
 		SetLogger(b.logger).
 		SetStrict(false).
 		Build()
 	if err != nil {
-		return
+		return result, err
 	}
 
 	// Create the private server to delegate to:
@@ -118,7 +118,7 @@ func (b *ComputeInstanceTemplatesServerBuilder) Build() (result *ComputeInstance
 		SetMetricsRegisterer(b.metricsRegisterer).
 		Build()
 	if err != nil {
-		return
+		return result, err
 	}
 
 	// Create and populate the object:
@@ -128,7 +128,7 @@ func (b *ComputeInstanceTemplatesServerBuilder) Build() (result *ComputeInstance
 		inMapper:  inMapper,
 		outMapper: outMapper,
 	}
-	return
+	return result, err
 }
 
 func (s *ComputeInstanceTemplatesServer) List(ctx context.Context,
@@ -167,7 +167,7 @@ func (s *ComputeInstanceTemplatesServer) List(ctx context.Context,
 	response.SetSize(privateResponse.GetSize())
 	response.SetTotal(privateResponse.GetTotal())
 	response.SetItems(publicItems)
-	return
+	return response, err
 }
 
 func (s *ComputeInstanceTemplatesServer) Get(ctx context.Context,
@@ -198,7 +198,7 @@ func (s *ComputeInstanceTemplatesServer) Get(ctx context.Context,
 	// Create the public response:
 	response = &publicv1.ComputeInstanceTemplatesGetResponse{}
 	response.SetObject(publicComputeInstanceTemplate)
-	return
+	return response, err
 }
 
 func (s *ComputeInstanceTemplatesServer) Create(ctx context.Context,
@@ -207,7 +207,7 @@ func (s *ComputeInstanceTemplatesServer) Create(ctx context.Context,
 	publicComputeInstanceTemplate := request.GetObject()
 	if publicComputeInstanceTemplate == nil {
 		err = grpcstatus.Errorf(grpccodes.InvalidArgument, "object is mandatory")
-		return
+		return response, err
 	}
 	privateComputeInstanceTemplate := &privatev1.ComputeInstanceTemplate{}
 	err = s.inMapper.Copy(ctx, publicComputeInstanceTemplate, privateComputeInstanceTemplate)
@@ -218,7 +218,7 @@ func (s *ComputeInstanceTemplatesServer) Create(ctx context.Context,
 			slog.Any("error", err),
 		)
 		err = grpcstatus.Errorf(grpccodes.Internal, "failed to process compute instance template")
-		return
+		return response, err
 	}
 
 	// Delegate to the private server:
@@ -240,14 +240,14 @@ func (s *ComputeInstanceTemplatesServer) Create(ctx context.Context,
 			slog.Any("error", err),
 		)
 		err = grpcstatus.Errorf(grpccodes.Internal, "failed to process compute instance template")
-		return
+		return response, err
 	}
 
 	// Create the public response:
 	response = &publicv1.ComputeInstanceTemplatesCreateResponse{}
 	response.SetObject(createdPublicComputeInstanceTemplate)
 	response.SetWarnings(privateResponse.GetWarnings())
-	return
+	return response, err
 }
 
 func (s *ComputeInstanceTemplatesServer) Update(ctx context.Context,
@@ -256,12 +256,12 @@ func (s *ComputeInstanceTemplatesServer) Update(ctx context.Context,
 	publicComputeInstanceTemplate := request.GetObject()
 	if publicComputeInstanceTemplate == nil {
 		err = grpcstatus.Errorf(grpccodes.InvalidArgument, "object is mandatory")
-		return
+		return response, err
 	}
 	id := publicComputeInstanceTemplate.GetId()
 	if id == "" {
 		err = grpcstatus.Errorf(grpccodes.InvalidArgument, "object identifier is mandatory")
-		return
+		return response, err
 	}
 
 	// Get the existing object from the private server:
@@ -282,7 +282,7 @@ func (s *ComputeInstanceTemplatesServer) Update(ctx context.Context,
 			slog.Any("error", err),
 		)
 		err = grpcstatus.Errorf(grpccodes.Internal, "failed to process compute instance template")
-		return
+		return response, err
 	}
 
 	// Delegate to the private server with the merged object:
@@ -305,14 +305,14 @@ func (s *ComputeInstanceTemplatesServer) Update(ctx context.Context,
 			slog.Any("error", err),
 		)
 		err = grpcstatus.Errorf(grpccodes.Internal, "failed to process compute instance template")
-		return
+		return response, err
 	}
 
 	// Create the public response:
 	response = &publicv1.ComputeInstanceTemplatesUpdateResponse{}
 	response.SetObject(updatedPublicComputeInstanceTemplate)
 	response.SetWarnings(privateResponse.GetWarnings())
-	return
+	return response, err
 }
 
 func (s *ComputeInstanceTemplatesServer) Delete(ctx context.Context,
@@ -329,5 +329,5 @@ func (s *ComputeInstanceTemplatesServer) Delete(ctx context.Context,
 
 	// Create the public response:
 	response = &publicv1.ComputeInstanceTemplatesDeleteResponse{}
-	return
+	return response, err
 }

--- a/internal/servers/compute_instances_server.go
+++ b/internal/servers/compute_instances_server.go
@@ -86,11 +86,11 @@ func (b *ComputeInstancesServerBuilder) Build() (result *ComputeInstancesServer,
 	// Check parameters:
 	if b.logger == nil {
 		err = errors.New("logger is mandatory")
-		return
+		return result, err
 	}
 	if b.tenancyLogic == nil {
 		err = errors.New("tenancy logic is mandatory")
-		return
+		return result, err
 	}
 
 	// Create the mappers:
@@ -99,14 +99,14 @@ func (b *ComputeInstancesServerBuilder) Build() (result *ComputeInstancesServer,
 		SetStrict(true).
 		Build()
 	if err != nil {
-		return
+		return result, err
 	}
 	outMapper, err := NewGenericMapper[*privatev1.ComputeInstance, *publicv1.ComputeInstance]().
 		SetLogger(b.logger).
 		SetStrict(false).
 		Build()
 	if err != nil {
-		return
+		return result, err
 	}
 
 	// Create the private server to delegate to:
@@ -118,7 +118,7 @@ func (b *ComputeInstancesServerBuilder) Build() (result *ComputeInstancesServer,
 		SetMetricsRegisterer(b.metricsRegisterer).
 		Build()
 	if err != nil {
-		return
+		return result, err
 	}
 
 	// Create and populate the object:
@@ -128,7 +128,7 @@ func (b *ComputeInstancesServerBuilder) Build() (result *ComputeInstancesServer,
 		inMapper:  inMapper,
 		outMapper: outMapper,
 	}
-	return
+	return result, err
 }
 
 func (s *ComputeInstancesServer) List(ctx context.Context,
@@ -167,7 +167,7 @@ func (s *ComputeInstancesServer) List(ctx context.Context,
 	response.SetSize(privateResponse.GetSize())
 	response.SetTotal(privateResponse.GetTotal())
 	response.SetItems(publicItems)
-	return
+	return response, err
 }
 
 func (s *ComputeInstancesServer) Get(ctx context.Context,
@@ -198,7 +198,7 @@ func (s *ComputeInstancesServer) Get(ctx context.Context,
 	// Create the public response:
 	response = &publicv1.ComputeInstancesGetResponse{}
 	response.SetObject(publicComputeInstance)
-	return
+	return response, err
 }
 
 func (s *ComputeInstancesServer) Create(ctx context.Context,
@@ -207,7 +207,7 @@ func (s *ComputeInstancesServer) Create(ctx context.Context,
 	publicComputeInstance := request.GetObject()
 	if publicComputeInstance == nil {
 		err = grpcstatus.Errorf(grpccodes.InvalidArgument, "object is mandatory")
-		return
+		return response, err
 	}
 	privateComputeInstance := &privatev1.ComputeInstance{}
 	err = s.inMapper.Copy(ctx, publicComputeInstance, privateComputeInstance)
@@ -218,7 +218,7 @@ func (s *ComputeInstancesServer) Create(ctx context.Context,
 			slog.Any("error", err),
 		)
 		err = grpcstatus.Errorf(grpccodes.Internal, "failed to process compute instance")
-		return
+		return response, err
 	}
 
 	// Delegate to the private server:
@@ -240,7 +240,7 @@ func (s *ComputeInstancesServer) Create(ctx context.Context,
 			slog.Any("error", err),
 		)
 		err = grpcstatus.Errorf(grpccodes.Internal, "failed to process compute instance")
-		return
+		return response, err
 	}
 
 	// Create the public response:
@@ -249,7 +249,7 @@ func (s *ComputeInstancesServer) Create(ctx context.Context,
 	// Propagate warnings from the private server response (deprecation notices
 	// for DEPRECATED instance types).
 	response.SetWarnings(privateResponse.GetWarnings())
-	return
+	return response, err
 }
 
 func (s *ComputeInstancesServer) Update(ctx context.Context,
@@ -258,12 +258,12 @@ func (s *ComputeInstancesServer) Update(ctx context.Context,
 	publicComputeInstance := request.GetObject()
 	if publicComputeInstance == nil {
 		err = grpcstatus.Errorf(grpccodes.InvalidArgument, "object is mandatory")
-		return
+		return response, err
 	}
 	id := publicComputeInstance.GetId()
 	if id == "" {
 		err = grpcstatus.Errorf(grpccodes.InvalidArgument, "object identifier is mandatory")
-		return
+		return response, err
 	}
 
 	// Determine how to prepare the private compute instance based on whether there's a field mask.
@@ -291,7 +291,7 @@ func (s *ComputeInstancesServer) Update(ctx context.Context,
 			slog.Any("error", err),
 		)
 		err = grpcstatus.Errorf(grpccodes.Internal, "failed to process compute instance")
-		return
+		return response, err
 	}
 
 	// Delegate to the private server:
@@ -315,13 +315,13 @@ func (s *ComputeInstancesServer) Update(ctx context.Context,
 			slog.Any("error", err),
 		)
 		err = grpcstatus.Errorf(grpccodes.Internal, "failed to process compute instance")
-		return
+		return response, err
 	}
 
 	// Create the public response:
 	response = &publicv1.ComputeInstancesUpdateResponse{}
 	response.SetObject(updatedPublicComputeInstance)
-	return
+	return response, err
 }
 
 func (s *ComputeInstancesServer) Delete(ctx context.Context,
@@ -338,5 +338,5 @@ func (s *ComputeInstancesServer) Delete(ctx context.Context,
 
 	// Create the public response:
 	response = &publicv1.ComputeInstancesDeleteResponse{}
-	return
+	return response, err
 }

--- a/internal/servers/console_server.go
+++ b/internal/servers/console_server.go
@@ -82,25 +82,25 @@ func (s *consoleSessionsServer) Create(ctx context.Context,
 
 	if resourceID == "" {
 		err = status.Errorf(codes.InvalidArgument, "field 'resource_id' is mandatory")
-		return
+		return response, err
 	}
 
 	if resourceType != publicv1.ConsoleResourceType_CONSOLE_RESOURCE_TYPE_COMPUTE_INSTANCE {
 		err = status.Errorf(codes.Unimplemented, "unsupported resource type: %s", resourceType.String())
-		return
+		return response, err
 	}
 
 	consoleType := mapConsoleType(obj.GetType())
 	if consoleType == "" {
 		err = status.Errorf(codes.InvalidArgument, "unsupported console type: %s", obj.GetType().String())
-		return
+		return response, err
 	}
 
 	clientID := obj.GetClientId()
 	if clientID != "" {
 		if _, err = uuid.Parse(clientID); err != nil {
 			err = status.Errorf(codes.InvalidArgument, "client_id must be a valid UUID or empty")
-			return
+			return response, err
 		}
 	}
 
@@ -113,7 +113,7 @@ func (s *consoleSessionsServer) Create(ctx context.Context,
 		ClientID:    clientID,
 	})
 	if err != nil {
-		return
+		return response, err
 	}
 
 	response = publicv1.ConsoleSessionsCreateResponse_builder{
@@ -126,7 +126,7 @@ func (s *consoleSessionsServer) Create(ctx context.Context,
 			ExpiresAt:    timestamppb.New(result.ExpiresAt),
 		}.Build(),
 	}.Build()
-	return
+	return response, err
 }
 
 // mapConsoleType maps proto ConsoleType to internal console type string.

--- a/internal/servers/console_target_resolver.go
+++ b/internal/servers/console_target_resolver.go
@@ -240,7 +240,7 @@ func (r *ConsoleTargetResolver) findCROnHub(ctx context.Context, config *rest.Co
 	hubClient, err := r.hubClientFactory(config)
 	if err != nil {
 		err = status.Errorf(codes.Internal, "failed to create client for hub %q: %v", hubID, err)
-		return
+		return namespace, crName, err
 	}
 
 	// Query for the ComputeInstance CR by UUID label.
@@ -254,7 +254,7 @@ func (r *ConsoleTargetResolver) findCROnHub(ctx context.Context, config *rest.Co
 	)
 	if err != nil {
 		err = status.Errorf(codes.Internal, "failed to list compute instances on hub %q: %v", hubID, err)
-		return
+		return namespace, crName, err
 	}
 
 	items := list.Items
@@ -265,12 +265,12 @@ func (r *ConsoleTargetResolver) findCROnHub(ctx context.Context, config *rest.Co
 		)
 		err = status.Errorf(codes.FailedPrecondition,
 			"compute instance %q not found on hub %q; it may still be provisioning", instanceID, hubID)
-		return
+		return namespace, crName, err
 	}
 	if len(items) > 1 {
 		err = status.Errorf(codes.Internal,
 			"expected one compute instance with ID %q on hub %q but found %d", instanceID, hubID, len(items))
-		return
+		return namespace, crName, err
 	}
 
 	obj := items[0]
@@ -289,7 +289,7 @@ func (r *ConsoleTargetResolver) findCROnHub(ctx context.Context, config *rest.Co
 			msg += "; it may still be provisioning"
 		}
 		err = status.Errorf(codes.FailedPrecondition, "%s", msg)
-		return
+		return namespace, crName, err
 	}
 	return obj.GetNamespace(), obj.GetName(), nil
 }

--- a/internal/servers/events_server.go
+++ b/internal/servers/events_server.go
@@ -94,22 +94,22 @@ func (b *EventsServerBuilder) Build() (result *EventsServer, err error) {
 	// Check parameters:
 	if b.logger == nil {
 		err = errors.New("logger is mandatory")
-		return
+		return result, err
 	}
 	if b.listener == nil {
 		err = errors.New("listener is mandatory")
-		return
+		return result, err
 	}
 	if b.tenancyLogic == nil {
 		err = errors.New("tenancy logic is mandatory")
-		return
+		return result, err
 	}
 
 	// Create  the CEL environment:
 	celEnv, err := b.createCelEnv()
 	if err != nil {
 		err = fmt.Errorf("failed to create CEL environment: %w", err)
-		return
+		return result, err
 	}
 
 	// Create the mappers:
@@ -118,13 +118,13 @@ func (b *EventsServerBuilder) Build() (result *EventsServer, err error) {
 		Build()
 	if err != nil {
 		err = fmt.Errorf("failed to create mapper: %w", err)
-		return
+		return result, err
 	}
 
 	// Look up the payload oneof and metadata field descriptors:
 	payloadOneof, err := b.findPayloadOneof()
 	if err != nil {
-		return
+		return result, err
 	}
 
 	// Create the object early so that we can use its methods as callback functions:
@@ -138,7 +138,7 @@ func (b *EventsServerBuilder) Build() (result *EventsServer, err error) {
 		tenancyLogic: b.tenancyLogic,
 		payloadOneof: payloadOneof,
 	}
-	return
+	return result, err
 }
 
 // findPayloadOneof returns the descriptor of the payload oneof field in the event message. Returns an error if the
@@ -152,10 +152,10 @@ func (b *EventsServerBuilder) findPayloadOneof() (result protoreflect.OneofDescr
 			"event message '%s' has no '%s' oneof",
 			eventDesc.FullName(), eventsServerPayloadOneofField,
 		)
-		return
+		return result, err
 	}
 	result = payloadDesc
-	return
+	return result, err
 }
 
 func (b *EventsServerBuilder) createCelEnv() (result *cel.Env, err error) {
@@ -195,7 +195,7 @@ func (b *EventsServerBuilder) createCelEnv() (result *cel.Env, err error) {
 
 	// Create the CEL environment:
 	result, err = cel.NewEnv(options...)
-	return
+	return result, err
 }
 
 // Starts starts the background components of the server, in particular the notification listener. This is a blocking
@@ -314,18 +314,18 @@ func (s *EventsServer) evalFilter(ctx context.Context, filterPrg cel.Program, ev
 		"event": event,
 	})
 	if err != nil {
-		return
+		return result, err
 	}
 	value, _, err := filterPrg.ContextEval(ctx, activation)
 	if err != nil {
-		return
+		return result, err
 	}
 	result, ok := value.Value().(bool)
 	if !ok {
 		err = fmt.Errorf("result of filter should be a boolean, but it is of type '%T'", result)
-		return
+		return result, err
 	}
-	return
+	return result, err
 }
 
 func (s *EventsServer) processPayload(ctx context.Context, payload proto.Message) error {
@@ -391,12 +391,12 @@ func (s *EventsServer) extractPayload(ctx context.Context, event *privatev1.Even
 			ctx,
 			"Event has no payload field",
 		)
-		return
+		return result, err
 	}
 	payloadValue := eventReflect.Get(payloadDesc)
 	payloadReflect := payloadValue.Message()
 	result = payloadReflect.Interface()
-	return
+	return result, err
 }
 
 func (s *EventsServer) processEvent(ctx context.Context, public *publicv1.Event, private *privatev1.Event) error {

--- a/internal/servers/events_server_test.go
+++ b/internal/servers/events_server_test.go
@@ -170,7 +170,7 @@ var _ = Describe("Events server visibility", func() {
 		// Return the collector and the context cancel function:
 		collector = watchCollector
 		cancel = watchCancel
-		return
+		return collector, cancel
 	}
 
 	It("Delivers events when tenant is visible", func() {

--- a/internal/servers/external_ip_attachments_server.go
+++ b/internal/servers/external_ip_attachments_server.go
@@ -79,15 +79,15 @@ func (b *ExternalIPAttachmentsServerBuilder) SetMetricsRegisterer(value promethe
 func (b *ExternalIPAttachmentsServerBuilder) Build() (result *ExternalIPAttachmentsServer, err error) {
 	if b.logger == nil {
 		err = errors.New("logger is mandatory")
-		return
+		return result, err
 	}
 	if b.tenancyLogic == nil {
 		err = errors.New("tenancy logic is mandatory")
-		return
+		return result, err
 	}
 	if b.attributionLogic == nil {
 		err = errors.New("attribution logic is mandatory")
-		return
+		return result, err
 	}
 
 	inMapper, err := NewGenericMapper[*publicv1.ExternalIPAttachment, *privatev1.ExternalIPAttachment]().
@@ -95,14 +95,14 @@ func (b *ExternalIPAttachmentsServerBuilder) Build() (result *ExternalIPAttachme
 		SetStrict(true).
 		Build()
 	if err != nil {
-		return
+		return result, err
 	}
 	outMapper, err := NewGenericMapper[*privatev1.ExternalIPAttachment, *publicv1.ExternalIPAttachment]().
 		SetLogger(b.logger).
 		SetStrict(false).
 		Build()
 	if err != nil {
-		return
+		return result, err
 	}
 
 	delegate, err := NewPrivateExternalIPAttachmentsServer().
@@ -113,7 +113,7 @@ func (b *ExternalIPAttachmentsServerBuilder) Build() (result *ExternalIPAttachme
 		SetMetricsRegisterer(b.metricsRegisterer).
 		Build()
 	if err != nil {
-		return
+		return result, err
 	}
 
 	result = &ExternalIPAttachmentsServer{
@@ -122,7 +122,7 @@ func (b *ExternalIPAttachmentsServerBuilder) Build() (result *ExternalIPAttachme
 		inMapper:  inMapper,
 		outMapper: outMapper,
 	}
-	return
+	return result, err
 }
 
 func (s *ExternalIPAttachmentsServer) List(ctx context.Context,

--- a/internal/servers/external_ip_pools_server.go
+++ b/internal/servers/external_ip_pools_server.go
@@ -78,15 +78,15 @@ func (b *ExternalIPPoolsServerBuilder) SetMetricsRegisterer(value prometheus.Reg
 func (b *ExternalIPPoolsServerBuilder) Build() (result *ExternalIPPoolsServer, err error) {
 	if b.logger == nil {
 		err = errors.New("logger is mandatory")
-		return
+		return result, err
 	}
 	if b.attributionLogic == nil {
 		err = errors.New("attribution logic is mandatory")
-		return
+		return result, err
 	}
 	if b.tenancyLogic == nil {
 		err = errors.New("tenancy logic is mandatory")
-		return
+		return result, err
 	}
 
 	outMapper, err := NewGenericMapper[*privatev1.ExternalIPPool, *publicv1.ExternalIPPool]().
@@ -94,7 +94,7 @@ func (b *ExternalIPPoolsServerBuilder) Build() (result *ExternalIPPoolsServer, e
 		SetStrict(false).
 		Build()
 	if err != nil {
-		return
+		return result, err
 	}
 
 	delegate, err := NewPrivateExternalIPPoolsServer().
@@ -105,7 +105,7 @@ func (b *ExternalIPPoolsServerBuilder) Build() (result *ExternalIPPoolsServer, e
 		SetMetricsRegisterer(b.metricsRegisterer).
 		Build()
 	if err != nil {
-		return
+		return result, err
 	}
 
 	result = &ExternalIPPoolsServer{
@@ -113,7 +113,7 @@ func (b *ExternalIPPoolsServerBuilder) Build() (result *ExternalIPPoolsServer, e
 		delegate:  delegate,
 		outMapper: outMapper,
 	}
-	return
+	return result, err
 }
 
 func isExternalIPPoolPubliclyVisible(p *privatev1.ExternalIPPool) bool {
@@ -167,7 +167,7 @@ func (s *ExternalIPPoolsServer) List(ctx context.Context,
 	response.SetSize(int32(len(publicItems))) // #nosec G115 -- bounded by pool size
 	response.SetTotal(total)
 	response.SetItems(publicItems)
-	return
+	return response, err
 }
 
 func (s *ExternalIPPoolsServer) Get(ctx context.Context,
@@ -197,5 +197,5 @@ func (s *ExternalIPPoolsServer) Get(ctx context.Context,
 
 	response = &publicv1.ExternalIPPoolsGetResponse{}
 	response.SetObject(publicPool)
-	return
+	return response, err
 }

--- a/internal/servers/external_ips_server.go
+++ b/internal/servers/external_ips_server.go
@@ -79,15 +79,15 @@ func (b *ExternalIPsServerBuilder) SetMetricsRegisterer(value prometheus.Registe
 func (b *ExternalIPsServerBuilder) Build() (result *ExternalIPsServer, err error) {
 	if b.logger == nil {
 		err = errors.New("logger is mandatory")
-		return
+		return result, err
 	}
 	if b.tenancyLogic == nil {
 		err = errors.New("tenancy logic is mandatory")
-		return
+		return result, err
 	}
 	if b.attributionLogic == nil {
 		err = errors.New("attribution logic is mandatory")
-		return
+		return result, err
 	}
 
 	inMapper, err := NewGenericMapper[*publicv1.ExternalIP, *privatev1.ExternalIP]().
@@ -95,14 +95,14 @@ func (b *ExternalIPsServerBuilder) Build() (result *ExternalIPsServer, err error
 		SetStrict(true).
 		Build()
 	if err != nil {
-		return
+		return result, err
 	}
 	outMapper, err := NewGenericMapper[*privatev1.ExternalIP, *publicv1.ExternalIP]().
 		SetLogger(b.logger).
 		SetStrict(false).
 		Build()
 	if err != nil {
-		return
+		return result, err
 	}
 
 	delegate, err := NewPrivateExternalIPsServer().
@@ -113,7 +113,7 @@ func (b *ExternalIPsServerBuilder) Build() (result *ExternalIPsServer, err error
 		SetMetricsRegisterer(b.metricsRegisterer).
 		Build()
 	if err != nil {
-		return
+		return result, err
 	}
 
 	result = &ExternalIPsServer{
@@ -122,7 +122,7 @@ func (b *ExternalIPsServerBuilder) Build() (result *ExternalIPsServer, err error
 		inMapper:  inMapper,
 		outMapper: outMapper,
 	}
-	return
+	return result, err
 }
 
 func (s *ExternalIPsServer) List(ctx context.Context,
@@ -158,7 +158,7 @@ func (s *ExternalIPsServer) List(ctx context.Context,
 	response.SetSize(privateResponse.GetSize())
 	response.SetTotal(privateResponse.GetTotal())
 	response.SetItems(publicItems)
-	return
+	return response, err
 }
 
 func (s *ExternalIPsServer) Get(ctx context.Context,
@@ -185,7 +185,7 @@ func (s *ExternalIPsServer) Get(ctx context.Context,
 
 	response = &publicv1.ExternalIPsGetResponse{}
 	response.SetObject(publicExternalIP)
-	return
+	return response, err
 }
 
 func (s *ExternalIPsServer) Create(ctx context.Context,
@@ -193,7 +193,7 @@ func (s *ExternalIPsServer) Create(ctx context.Context,
 	publicExternalIP := request.GetObject()
 	if publicExternalIP == nil {
 		err = grpcstatus.Errorf(grpccodes.InvalidArgument, "object is mandatory")
-		return
+		return response, err
 	}
 	privateExternalIP := &privatev1.ExternalIP{}
 	err = s.inMapper.Copy(ctx, publicExternalIP, privateExternalIP)
@@ -204,7 +204,7 @@ func (s *ExternalIPsServer) Create(ctx context.Context,
 			slog.Any("error", err),
 		)
 		err = grpcstatus.Errorf(grpccodes.Internal, "failed to process external IP")
-		return
+		return response, err
 	}
 
 	privateRequest := &privatev1.ExternalIPsCreateRequest{}
@@ -224,12 +224,12 @@ func (s *ExternalIPsServer) Create(ctx context.Context,
 			slog.Any("error", err),
 		)
 		err = grpcstatus.Errorf(grpccodes.Internal, "failed to process external IP")
-		return
+		return response, err
 	}
 
 	response = &publicv1.ExternalIPsCreateResponse{}
 	response.SetObject(createdPublicExternalIP)
-	return
+	return response, err
 }
 
 func (s *ExternalIPsServer) Update(ctx context.Context,
@@ -237,7 +237,7 @@ func (s *ExternalIPsServer) Update(ctx context.Context,
 	publicExternalIP := request.GetObject()
 	if publicExternalIP == nil {
 		err = grpcstatus.Errorf(grpccodes.InvalidArgument, "object is mandatory")
-		return
+		return response, err
 	}
 	privateExternalIP := &privatev1.ExternalIP{}
 	err = s.inMapper.Copy(ctx, publicExternalIP, privateExternalIP)
@@ -248,7 +248,7 @@ func (s *ExternalIPsServer) Update(ctx context.Context,
 			slog.Any("error", err),
 		)
 		err = grpcstatus.Errorf(grpccodes.Internal, "failed to process external IP")
-		return
+		return response, err
 	}
 
 	privateRequest := &privatev1.ExternalIPsUpdateRequest{}
@@ -270,12 +270,12 @@ func (s *ExternalIPsServer) Update(ctx context.Context,
 			slog.Any("error", err),
 		)
 		err = grpcstatus.Errorf(grpccodes.Internal, "failed to process external IP")
-		return
+		return response, err
 	}
 
 	response = &publicv1.ExternalIPsUpdateResponse{}
 	response.SetObject(updatedPublicExternalIP)
-	return
+	return response, err
 }
 
 func (s *ExternalIPsServer) Delete(ctx context.Context,
@@ -289,5 +289,5 @@ func (s *ExternalIPsServer) Delete(ctx context.Context,
 	}
 
 	response = &publicv1.ExternalIPsDeleteResponse{}
-	return
+	return response, err
 }

--- a/internal/servers/generic_mapper.go
+++ b/internal/servers/generic_mapper.go
@@ -78,7 +78,7 @@ func (b *GenericMapperBuilder[From, To]) Build() (result *GenericMapper[From, To
 	// Check parameters:
 	if b.logger == nil {
 		err = errors.New("logger is mandatory")
-		return
+		return result, err
 	}
 
 	// Create the sets of ignored fields:
@@ -102,7 +102,7 @@ func (b *GenericMapperBuilder[From, To]) Build() (result *GenericMapper[From, To
 					"of type '%T'",
 				i, ignoredField,
 			)
-			return
+			return result, err
 		}
 	}
 
@@ -113,7 +113,7 @@ func (b *GenericMapperBuilder[From, To]) Build() (result *GenericMapper[From, To
 		ignoredFieldFullNames: ignoredFieldFullNames,
 		strict:                b.strict,
 	}
-	return
+	return result, err
 }
 
 // Copy copies the data from the `from` object into the `to` object.
@@ -222,7 +222,7 @@ func (m *GenericMapper[From, To]) copyMap(from, to protoreflect.Map, field proto
 		}
 		return true
 	})
-	return
+	return err
 }
 
 // Merge merges the data from the `from` object into the `to` object.
@@ -338,7 +338,7 @@ func (m *GenericMapper[From, To]) mergeMap(from, to protoreflect.Map, field prot
 		}
 		return true
 	})
-	return
+	return err
 }
 
 func (m *GenericMapper[From, To]) shouldIgnore(field protoreflect.FieldDescriptor) bool {

--- a/internal/servers/generic_server.go
+++ b/internal/servers/generic_server.go
@@ -177,19 +177,19 @@ func (b *GenericServerBuilder[O]) Build() (result *GenericServer[O], err error) 
 	// Check parameters:
 	if b.logger == nil {
 		err = errors.New("logger is mandatory")
-		return
+		return result, err
 	}
 	if b.service == "" {
 		err = errors.New("service name is mandatory")
-		return
+		return result, err
 	}
 	if b.attributionLogic == nil {
 		err = errors.New("attribution logic is mandatory")
-		return
+		return result, err
 	}
 	if b.tenancyLogic == nil {
 		err = errors.New("tenancy logic is mandatory")
-		return
+		return result, err
 	}
 
 	// Create the path compiler:
@@ -198,14 +198,14 @@ func (b *GenericServerBuilder[O]) Build() (result *GenericServer[O], err error) 
 		Build()
 	if err != nil {
 		err = fmt.Errorf("failed to create path compiler: %w", err)
-		return
+		return result, err
 	}
 
 	// Create the protovalidate validator:
 	validator, err := protovalidate.New()
 	if err != nil {
 		err = fmt.Errorf("failed to create protovalidate validator: %w", err)
-		return
+		return result, err
 	}
 
 	// Create the object early so that we can use its methods as callbacks:
@@ -240,13 +240,13 @@ func (b *GenericServerBuilder[O]) Build() (result *GenericServer[O], err error) 
 	s.dao, err = daoBuilder.Build()
 	if err != nil {
 		err = fmt.Errorf("failed to create DAO: %w", err)
-		return
+		return result, err
 	}
 
 	// Find the descriptor:
 	service, err := b.findService()
 	if err != nil {
-		return
+		return result, err
 	}
 
 	// Prepare the template for the object:
@@ -260,44 +260,44 @@ func (b *GenericServerBuilder[O]) Build() (result *GenericServer[O], err error) 
 	s.metadataField = fields.ByName("metadata")
 	if s.metadataField == nil {
 		err = fmt.Errorf("object of type '%s' doesn't have a 'metadata' field", descriptor.FullName())
-		return
+		return result, err
 	}
 
 	// Prepare templates for the request and response types. These are empty messages that will be cloned when
 	// it is necessary to create new instances.
 	s.listRequest, s.listResponse, err = b.findRequestAndResponse(service, listMethod)
 	if err != nil {
-		return
+		return result, err
 	}
 	s.getRequest, s.getResponse, err = b.findRequestAndResponse(service, getMethod)
 	if err != nil {
-		return
+		return result, err
 	}
 	s.createRequest, s.createResponse, err = b.findRequestAndResponse(service, createMethod)
 	if err != nil {
-		return
+		return result, err
 	}
 	s.deleteRequest, s.deleteResponse, err = b.findRequestAndResponse(service, deleteMethod)
 	if err != nil {
-		return
+		return result, err
 	}
 	s.updateRequest, s.updateResponse, err = b.findRequestAndResponse(service, updateMethod)
 	if err != nil {
-		return
+		return result, err
 	}
 	s.signalRequest, s.signalResponse, err = b.findRequestAndResponse(service, signalMethod)
 	if err != nil {
-		return
+		return result, err
 	}
 
 	// Find the payload field in the event message:
 	s.payloadField, err = b.findPayloadField()
 	if err != nil {
-		return
+		return result, err
 	}
 
 	result = s
-	return
+	return result, err
 }
 
 // findService finds the service descriptor using the service name given to the builder.
@@ -315,9 +315,9 @@ func (b *GenericServerBuilder[O]) findService() (result protoreflect.ServiceDesc
 	})
 	if result == nil {
 		err = fmt.Errorf("failed to find service '%s'", b.service)
-		return
+		return result, err
 	}
-	return
+	return result, err
 }
 
 // findRequestAndResponse finds the request and response message types for the given method.
@@ -346,7 +346,7 @@ func (b *GenericServerBuilder[O]) findRequestAndResponse(service protoreflect.Se
 		}
 	}
 	err = fmt.Errorf("failed to find method '%s' in service '%s'", methodName, service.FullName())
-	return
+	return request, response, err
 }
 
 // findPayloadField finds the field in the event message that corresponds to this object type. This is used later to
@@ -360,7 +360,7 @@ func (b *GenericServerBuilder[O]) findPayloadField() (result protoreflect.FieldD
 	oneofDesc := eventDesc.Oneofs().ByName(eventPayloadField)
 	if oneofDesc == nil {
 		err = fmt.Errorf("failed to find the 'payload' field of the event type '%s'", eventDesc.FullName())
-		return
+		return result, err
 	}
 	oneofFields := oneofDesc.Fields()
 	for i := range oneofFields.Len() {
@@ -370,7 +370,7 @@ func (b *GenericServerBuilder[O]) findPayloadField() (result protoreflect.FieldD
 			break
 		}
 	}
-	return
+	return result, err
 }
 
 func (s *GenericServer[O]) List(ctx context.Context, request any, response any) error {
@@ -741,14 +741,14 @@ func (s *GenericServer[O]) compilePath(path string) (result *masks.Path[O], err 
 	defer s.pathCacheLock.Unlock()
 	result, ok := s.pathCache[path]
 	if ok {
-		return
+		return result, err
 	}
 	result, err = s.pathCompiler.Compile(path)
 	if err != nil {
-		return
+		return result, err
 	}
 	s.pathCache[path] = result
-	return
+	return result, err
 }
 
 func (s *GenericServer[O]) Delete(ctx context.Context, request any, response any) error {
@@ -1129,9 +1129,9 @@ func (s *GenericServer[O]) determineAssignedCreator(ctx context.Context) (result
 			slog.Any("error", err),
 		)
 		err = grpcstatus.Errorf(grpccodes.Internal, "failed to determine assigned creator")
-		return
+		return result, err
 	}
-	return
+	return result, err
 }
 
 // setCreator sets the creator in the object's metadata, creating the metadata if necessary. In case of error it
@@ -1159,11 +1159,11 @@ func (s *GenericServer[O]) determineAssignedTenant(ctx context.Context,
 			slog.Any("error", err),
 		)
 		err = grpcstatus.Errorf(grpccodes.Internal, "failed to determine visible tenants")
-		return
+		return result, err
 	}
 	if visibleTenants.Empty() {
 		err = grpcstatus.Errorf(grpccodes.PermissionDenied, "there are no visible tenants")
-		return
+		return result, err
 	}
 
 	// Determine the tenants that can be assigned to the object:
@@ -1175,11 +1175,11 @@ func (s *GenericServer[O]) determineAssignedTenant(ctx context.Context,
 			slog.Any("error", err),
 		)
 		err = grpcstatus.Errorf(grpccodes.Internal, "failed to determine assignable tenants")
-		return
+		return result, err
 	}
 	if assignableTenants.Empty() {
 		err = grpcstatus.Errorf(grpccodes.PermissionDenied, "there are no assignable tenants")
-		return
+		return result, err
 	}
 
 	// Determine the default tenant:
@@ -1191,11 +1191,11 @@ func (s *GenericServer[O]) determineAssignedTenant(ctx context.Context,
 			slog.Any("error", err),
 		)
 		err = grpcstatus.Errorf(grpccodes.Internal, "failed to determine default tenant")
-		return
+		return result, err
 	}
 	if defaultTenant == "" {
 		err = grpcstatus.Errorf(grpccodes.PermissionDenied, "there is no default tenant")
-		return
+		return result, err
 	}
 
 	// Get the tenant from the request and current object:
@@ -1215,7 +1215,7 @@ func (s *GenericServer[O]) determineAssignedTenant(ctx context.Context,
 				"tenant '%s' doesn't exist",
 				requestTenant,
 			)
-			return
+			return result, err
 		}
 		if !assignableTenants.Contains(requestTenant) {
 			s.logger.WarnContext(
@@ -1228,10 +1228,10 @@ func (s *GenericServer[O]) determineAssignedTenant(ctx context.Context,
 				"tenant '%s' can't be assigned",
 				requestTenant,
 			)
-			return
+			return result, err
 		}
 		result = requestTenant
-		return
+		return result, err
 	}
 
 	// Fall back to the current tenant or the default:
@@ -1240,7 +1240,7 @@ func (s *GenericServer[O]) determineAssignedTenant(ctx context.Context,
 	} else {
 		result = defaultTenant
 	}
-	return
+	return result, err
 }
 
 // getTenant extracts the tenant from an object's metadata.

--- a/internal/servers/host_types_server.go
+++ b/internal/servers/host_types_server.go
@@ -86,11 +86,11 @@ func (b *HostTypesServerBuilder) Build() (result *HostTypesServer, err error) {
 	// Check parameters:
 	if b.logger == nil {
 		err = errors.New("logger is mandatory")
-		return
+		return result, err
 	}
 	if b.tenancyLogic == nil {
 		err = errors.New("tenancy logic is mandatory")
-		return
+		return result, err
 	}
 
 	// Create the mappers:
@@ -99,14 +99,14 @@ func (b *HostTypesServerBuilder) Build() (result *HostTypesServer, err error) {
 		SetStrict(true).
 		Build()
 	if err != nil {
-		return
+		return result, err
 	}
 	outMapper, err := NewGenericMapper[*privatev1.HostType, *publicv1.HostType]().
 		SetLogger(b.logger).
 		SetStrict(false).
 		Build()
 	if err != nil {
-		return
+		return result, err
 	}
 
 	// Create the private server to delegate to:
@@ -118,7 +118,7 @@ func (b *HostTypesServerBuilder) Build() (result *HostTypesServer, err error) {
 		SetMetricsRegisterer(b.metricsRegisterer).
 		Build()
 	if err != nil {
-		return
+		return result, err
 	}
 
 	// Create and populate the object:
@@ -128,7 +128,7 @@ func (b *HostTypesServerBuilder) Build() (result *HostTypesServer, err error) {
 		inMapper:  inMapper,
 		outMapper: outMapper,
 	}
-	return
+	return result, err
 }
 
 func (s *HostTypesServer) List(ctx context.Context,
@@ -168,7 +168,7 @@ func (s *HostTypesServer) List(ctx context.Context,
 	response.SetSize(privateResponse.GetSize())
 	response.SetTotal(privateResponse.GetTotal())
 	response.SetItems(publicItems)
-	return
+	return response, err
 }
 
 func (s *HostTypesServer) Get(ctx context.Context,
@@ -199,7 +199,7 @@ func (s *HostTypesServer) Get(ctx context.Context,
 	// Create the public response:
 	response = &publicv1.HostTypesGetResponse{}
 	response.SetObject(publicHostType)
-	return
+	return response, err
 }
 
 func (s *HostTypesServer) Create(ctx context.Context,
@@ -208,7 +208,7 @@ func (s *HostTypesServer) Create(ctx context.Context,
 	publicHostType := request.GetObject()
 	if publicHostType == nil {
 		err = grpcstatus.Errorf(grpccodes.InvalidArgument, "object is mandatory")
-		return
+		return response, err
 	}
 	privateHostType := &privatev1.HostType{}
 	err = s.inMapper.Copy(ctx, publicHostType, privateHostType)
@@ -219,7 +219,7 @@ func (s *HostTypesServer) Create(ctx context.Context,
 			slog.Any("error", err),
 		)
 		err = grpcstatus.Errorf(grpccodes.Internal, "failed to process host type")
-		return
+		return response, err
 	}
 
 	// Delegate to the private server:
@@ -241,13 +241,13 @@ func (s *HostTypesServer) Create(ctx context.Context,
 			slog.Any("error", err),
 		)
 		err = grpcstatus.Errorf(grpccodes.Internal, "failed to process host type")
-		return
+		return response, err
 	}
 
 	// Create the public response:
 	response = &publicv1.HostTypesCreateResponse{}
 	response.SetObject(createdPublicHostType)
-	return
+	return response, err
 }
 
 func (s *HostTypesServer) Update(ctx context.Context,
@@ -256,12 +256,12 @@ func (s *HostTypesServer) Update(ctx context.Context,
 	publicHostType := request.GetObject()
 	if publicHostType == nil {
 		err = grpcstatus.Errorf(grpccodes.InvalidArgument, "object is mandatory")
-		return
+		return response, err
 	}
 	id := publicHostType.GetId()
 	if id == "" {
 		err = grpcstatus.Errorf(grpccodes.InvalidArgument, "object identifier is mandatory")
-		return
+		return response, err
 	}
 
 	// Get the existing object from the private server:
@@ -282,7 +282,7 @@ func (s *HostTypesServer) Update(ctx context.Context,
 			slog.Any("error", err),
 		)
 		err = grpcstatus.Errorf(grpccodes.Internal, "failed to process host type")
-		return
+		return response, err
 	}
 
 	// Delegate to the private server with the merged object:
@@ -305,13 +305,13 @@ func (s *HostTypesServer) Update(ctx context.Context,
 			slog.Any("error", err),
 		)
 		err = grpcstatus.Errorf(grpccodes.Internal, "failed to process host type")
-		return
+		return response, err
 	}
 
 	// Create the public response:
 	response = &publicv1.HostTypesUpdateResponse{}
 	response.SetObject(updatedPublicHostType)
-	return
+	return response, err
 }
 
 func (s *HostTypesServer) Delete(ctx context.Context,
@@ -328,5 +328,5 @@ func (s *HostTypesServer) Delete(ctx context.Context,
 
 	// Create the public response:
 	response = &publicv1.HostTypesDeleteResponse{}
-	return
+	return response, err
 }

--- a/internal/servers/identity_providers_server.go
+++ b/internal/servers/identity_providers_server.go
@@ -78,11 +78,11 @@ func (b *IdentityProvidersServerBuilder) Build() (result *IdentityProvidersServe
 	// Check parameters:
 	if b.logger == nil {
 		err = errors.New("logger is mandatory")
-		return
+		return result, err
 	}
 	if b.tenancyLogic == nil {
 		err = errors.New("tenancy logic is mandatory")
-		return
+		return result, err
 	}
 
 	// Create the mappers:
@@ -91,14 +91,14 @@ func (b *IdentityProvidersServerBuilder) Build() (result *IdentityProvidersServe
 		SetStrict(true).
 		Build()
 	if err != nil {
-		return
+		return result, err
 	}
 	outMapper, err := NewGenericMapper[*privatev1.IdentityProvider, *publicv1.IdentityProvider]().
 		SetLogger(b.logger).
 		SetStrict(false).
 		Build()
 	if err != nil {
-		return
+		return result, err
 	}
 
 	// Create the private server to delegate to:
@@ -110,7 +110,7 @@ func (b *IdentityProvidersServerBuilder) Build() (result *IdentityProvidersServe
 		SetMetricsRegisterer(b.metricsRegisterer).
 		Build()
 	if err != nil {
-		return
+		return result, err
 	}
 
 	// Create and populate the object:
@@ -120,7 +120,7 @@ func (b *IdentityProvidersServerBuilder) Build() (result *IdentityProvidersServe
 		inMapper:  inMapper,
 		outMapper: outMapper,
 	}
-	return
+	return result, err
 }
 
 func (s *IdentityProvidersServer) Create(ctx context.Context,
@@ -162,7 +162,7 @@ func (s *IdentityProvidersServer) Create(ctx context.Context,
 	// Build and return the response:
 	response = &publicv1.IdentityProvidersCreateResponse{}
 	response.SetObject(publicObject)
-	return
+	return response, err
 }
 
 func (s *IdentityProvidersServer) List(ctx context.Context,
@@ -201,7 +201,7 @@ func (s *IdentityProvidersServer) List(ctx context.Context,
 	response.SetSize(privateResponse.GetSize())
 	response.SetTotal(privateResponse.GetTotal())
 	response.SetItems(publicItems)
-	return
+	return response, err
 }
 
 func (s *IdentityProvidersServer) Get(ctx context.Context,
@@ -232,7 +232,7 @@ func (s *IdentityProvidersServer) Get(ctx context.Context,
 	// Create the public response:
 	response = &publicv1.IdentityProvidersGetResponse{}
 	response.SetObject(publicObject)
-	return
+	return response, err
 }
 
 func (s *IdentityProvidersServer) Update(ctx context.Context,
@@ -276,7 +276,7 @@ func (s *IdentityProvidersServer) Update(ctx context.Context,
 	// Build and return the response:
 	response = &publicv1.IdentityProvidersUpdateResponse{}
 	response.SetObject(publicObject)
-	return
+	return response, err
 }
 
 func (s *IdentityProvidersServer) Delete(ctx context.Context,
@@ -293,5 +293,5 @@ func (s *IdentityProvidersServer) Delete(ctx context.Context,
 
 	// Create the public response:
 	response = &publicv1.IdentityProvidersDeleteResponse{}
-	return
+	return response, err
 }

--- a/internal/servers/instance_types_server.go
+++ b/internal/servers/instance_types_server.go
@@ -97,15 +97,15 @@ func (b *InstanceTypesServerBuilder) Build() (result *InstanceTypesServer, err e
 	// Check parameters:
 	if b.logger == nil {
 		err = errors.New("logger is mandatory")
-		return
+		return result, err
 	}
 	if b.attributionLogic == nil {
 		err = errors.New("attribution logic is mandatory")
-		return
+		return result, err
 	}
 	if b.tenancyLogic == nil {
 		err = errors.New("tenancy logic is mandatory")
-		return
+		return result, err
 	}
 
 	// Create the mappers:
@@ -114,14 +114,14 @@ func (b *InstanceTypesServerBuilder) Build() (result *InstanceTypesServer, err e
 		SetStrict(true).
 		Build()
 	if err != nil {
-		return
+		return result, err
 	}
 	outMapper, err := NewGenericMapper[*privatev1.InstanceType, *publicv1.InstanceType]().
 		SetLogger(b.logger).
 		SetStrict(false).
 		Build()
 	if err != nil {
-		return
+		return result, err
 	}
 
 	// Create the private server to delegate to:
@@ -133,7 +133,7 @@ func (b *InstanceTypesServerBuilder) Build() (result *InstanceTypesServer, err e
 		SetMetricsRegisterer(b.metricsRegisterer).
 		Build()
 	if err != nil {
-		return
+		return result, err
 	}
 
 	// Create and populate the object:
@@ -143,7 +143,7 @@ func (b *InstanceTypesServerBuilder) Build() (result *InstanceTypesServer, err e
 		inMapper:  inMapper,
 		outMapper: outMapper,
 	}
-	return
+	return result, err
 }
 
 func (s *InstanceTypesServer) List(ctx context.Context,
@@ -187,7 +187,7 @@ func (s *InstanceTypesServer) List(ctx context.Context,
 	response.SetSize(privateResponse.GetSize())
 	response.SetTotal(privateResponse.GetTotal())
 	response.SetItems(publicItems)
-	return
+	return response, err
 }
 
 // addDefaultStateFilter composes the default state filter with the user-provided filter.
@@ -235,7 +235,7 @@ func (s *InstanceTypesServer) Get(ctx context.Context,
 	// Create the public response:
 	response = &publicv1.InstanceTypesGetResponse{}
 	response.SetObject(publicInstanceType)
-	return
+	return response, err
 }
 
 func (s *InstanceTypesServer) Create(ctx context.Context,
@@ -244,7 +244,7 @@ func (s *InstanceTypesServer) Create(ctx context.Context,
 	publicInstanceType := request.GetObject()
 	if publicInstanceType == nil {
 		err = grpcstatus.Errorf(grpccodes.InvalidArgument, "object is mandatory")
-		return
+		return response, err
 	}
 	privateInstanceType := &privatev1.InstanceType{}
 	err = s.inMapper.Copy(ctx, publicInstanceType, privateInstanceType)
@@ -255,7 +255,7 @@ func (s *InstanceTypesServer) Create(ctx context.Context,
 			slog.Any("error", err),
 		)
 		err = grpcstatus.Errorf(grpccodes.Internal, "failed to process instance type")
-		return
+		return response, err
 	}
 
 	// Delegate to the private server:
@@ -277,13 +277,13 @@ func (s *InstanceTypesServer) Create(ctx context.Context,
 			slog.Any("error", err),
 		)
 		err = grpcstatus.Errorf(grpccodes.Internal, "failed to process instance type")
-		return
+		return response, err
 	}
 
 	// Create the public response:
 	response = &publicv1.InstanceTypesCreateResponse{}
 	response.SetObject(createdPublicInstanceType)
-	return
+	return response, err
 }
 
 func (s *InstanceTypesServer) Update(ctx context.Context,
@@ -292,12 +292,12 @@ func (s *InstanceTypesServer) Update(ctx context.Context,
 	publicInstanceType := request.GetObject()
 	if publicInstanceType == nil {
 		err = grpcstatus.Errorf(grpccodes.InvalidArgument, "object is mandatory")
-		return
+		return response, err
 	}
 	id := publicInstanceType.GetId()
 	if id == "" {
 		err = grpcstatus.Errorf(grpccodes.InvalidArgument, "object identifier is mandatory")
-		return
+		return response, err
 	}
 
 	// Get the existing object from the private server:
@@ -318,7 +318,7 @@ func (s *InstanceTypesServer) Update(ctx context.Context,
 			slog.Any("error", err),
 		)
 		err = grpcstatus.Errorf(grpccodes.Internal, "failed to process instance type")
-		return
+		return response, err
 	}
 
 	// Delegate to the private server with the merged object:
@@ -341,13 +341,13 @@ func (s *InstanceTypesServer) Update(ctx context.Context,
 			slog.Any("error", err),
 		)
 		err = grpcstatus.Errorf(grpccodes.Internal, "failed to process instance type")
-		return
+		return response, err
 	}
 
 	// Create the public response:
 	response = &publicv1.InstanceTypesUpdateResponse{}
 	response.SetObject(updatedPublicInstanceType)
-	return
+	return response, err
 }
 
 func (s *InstanceTypesServer) Delete(ctx context.Context,
@@ -364,5 +364,5 @@ func (s *InstanceTypesServer) Delete(ctx context.Context,
 
 	// Create the public response:
 	response = &publicv1.InstanceTypesDeleteResponse{}
-	return
+	return response, err
 }

--- a/internal/servers/nat_gateways_server.go
+++ b/internal/servers/nat_gateways_server.go
@@ -79,15 +79,15 @@ func (b *NATGatewaysServerBuilder) SetMetricsRegisterer(value prometheus.Registe
 func (b *NATGatewaysServerBuilder) Build() (result *NATGatewaysServer, err error) {
 	if b.logger == nil {
 		err = errors.New("logger is mandatory")
-		return
+		return result, err
 	}
 	if b.tenancyLogic == nil {
 		err = errors.New("tenancy logic is mandatory")
-		return
+		return result, err
 	}
 	if b.attributionLogic == nil {
 		err = errors.New("attribution logic is mandatory")
-		return
+		return result, err
 	}
 
 	inMapper, err := NewGenericMapper[*publicv1.NATGateway, *privatev1.NATGateway]().
@@ -95,14 +95,14 @@ func (b *NATGatewaysServerBuilder) Build() (result *NATGatewaysServer, err error
 		SetStrict(true).
 		Build()
 	if err != nil {
-		return
+		return result, err
 	}
 	outMapper, err := NewGenericMapper[*privatev1.NATGateway, *publicv1.NATGateway]().
 		SetLogger(b.logger).
 		SetStrict(false).
 		Build()
 	if err != nil {
-		return
+		return result, err
 	}
 
 	delegate, err := NewPrivateNATGatewaysServer().
@@ -113,7 +113,7 @@ func (b *NATGatewaysServerBuilder) Build() (result *NATGatewaysServer, err error
 		SetMetricsRegisterer(b.metricsRegisterer).
 		Build()
 	if err != nil {
-		return
+		return result, err
 	}
 
 	result = &NATGatewaysServer{
@@ -122,7 +122,7 @@ func (b *NATGatewaysServerBuilder) Build() (result *NATGatewaysServer, err error
 		inMapper:  inMapper,
 		outMapper: outMapper,
 	}
-	return
+	return result, err
 }
 
 func (s *NATGatewaysServer) List(ctx context.Context,
@@ -158,7 +158,7 @@ func (s *NATGatewaysServer) List(ctx context.Context,
 	response.SetSize(privateResponse.GetSize())
 	response.SetTotal(privateResponse.GetTotal())
 	response.SetItems(publicItems)
-	return
+	return response, err
 }
 
 func (s *NATGatewaysServer) Get(ctx context.Context,
@@ -185,7 +185,7 @@ func (s *NATGatewaysServer) Get(ctx context.Context,
 
 	response = &publicv1.NATGatewaysGetResponse{}
 	response.SetObject(publicNATGateway)
-	return
+	return response, err
 }
 
 func (s *NATGatewaysServer) Create(ctx context.Context,
@@ -193,7 +193,7 @@ func (s *NATGatewaysServer) Create(ctx context.Context,
 	publicNATGateway := request.GetObject()
 	if publicNATGateway == nil {
 		err = grpcstatus.Errorf(grpccodes.InvalidArgument, "object is mandatory")
-		return
+		return response, err
 	}
 	privateNATGateway := &privatev1.NATGateway{}
 	err = s.inMapper.Copy(ctx, publicNATGateway, privateNATGateway)
@@ -204,7 +204,7 @@ func (s *NATGatewaysServer) Create(ctx context.Context,
 			slog.Any("error", err),
 		)
 		err = grpcstatus.Errorf(grpccodes.Internal, "failed to process NAT gateway")
-		return
+		return response, err
 	}
 
 	privateRequest := &privatev1.NATGatewaysCreateRequest{}
@@ -224,12 +224,12 @@ func (s *NATGatewaysServer) Create(ctx context.Context,
 			slog.Any("error", err),
 		)
 		err = grpcstatus.Errorf(grpccodes.Internal, "failed to process NAT gateway")
-		return
+		return response, err
 	}
 
 	response = &publicv1.NATGatewaysCreateResponse{}
 	response.SetObject(createdPublicNATGateway)
-	return
+	return response, err
 }
 
 func (s *NATGatewaysServer) Update(ctx context.Context,
@@ -237,7 +237,7 @@ func (s *NATGatewaysServer) Update(ctx context.Context,
 	publicNATGateway := request.GetObject()
 	if publicNATGateway == nil {
 		err = grpcstatus.Errorf(grpccodes.InvalidArgument, "object is mandatory")
-		return
+		return response, err
 	}
 	privateNATGateway := &privatev1.NATGateway{}
 	err = s.inMapper.Copy(ctx, publicNATGateway, privateNATGateway)
@@ -248,7 +248,7 @@ func (s *NATGatewaysServer) Update(ctx context.Context,
 			slog.Any("error", err),
 		)
 		err = grpcstatus.Errorf(grpccodes.Internal, "failed to process NAT gateway")
-		return
+		return response, err
 	}
 
 	privateRequest := &privatev1.NATGatewaysUpdateRequest{}
@@ -270,12 +270,12 @@ func (s *NATGatewaysServer) Update(ctx context.Context,
 			slog.Any("error", err),
 		)
 		err = grpcstatus.Errorf(grpccodes.Internal, "failed to process NAT gateway")
-		return
+		return response, err
 	}
 
 	response = &publicv1.NATGatewaysUpdateResponse{}
 	response.SetObject(updatedPublicNATGateway)
-	return
+	return response, err
 }
 
 func (s *NATGatewaysServer) Delete(ctx context.Context,
@@ -289,5 +289,5 @@ func (s *NATGatewaysServer) Delete(ctx context.Context,
 	}
 
 	response = &publicv1.NATGatewaysDeleteResponse{}
-	return
+	return response, err
 }

--- a/internal/servers/network_classes_server.go
+++ b/internal/servers/network_classes_server.go
@@ -87,11 +87,11 @@ func (b *NetworkClassesServerBuilder) Build() (result *NetworkClassesServer, err
 	// Check parameters:
 	if b.logger == nil {
 		err = errors.New("logger is mandatory")
-		return
+		return result, err
 	}
 	if b.tenancyLogic == nil {
 		err = errors.New("tenancy logic is mandatory")
-		return
+		return result, err
 	}
 
 	// Find OUTPUT_ONLY fields so that we can configure the inMapper to ignore them.
@@ -100,12 +100,12 @@ func (b *NetworkClassesServerBuilder) Build() (result *NetworkClassesServer, err
 	isDefaultField := ncDescriptor.Fields().ByName("is_default")
 	if isDefaultField == nil {
 		err = fmt.Errorf("failed to find the is_default field of type '%s'", ncDescriptor.FullName())
-		return
+		return result, err
 	}
 	specField := ncDescriptor.Fields().ByName("spec")
 	if specField == nil {
 		err = fmt.Errorf("failed to find the spec field of type '%s'", ncDescriptor.FullName())
-		return
+		return result, err
 	}
 
 	// Create the mappers:
@@ -115,14 +115,14 @@ func (b *NetworkClassesServerBuilder) Build() (result *NetworkClassesServer, err
 		AddIgnoredFields(isDefaultField.FullName(), specField.FullName()).
 		Build()
 	if err != nil {
-		return
+		return result, err
 	}
 	outMapper, err := NewGenericMapper[*privatev1.NetworkClass, *publicv1.NetworkClass]().
 		SetLogger(b.logger).
 		SetStrict(false).
 		Build()
 	if err != nil {
-		return
+		return result, err
 	}
 
 	// Create the private server to delegate to:
@@ -134,7 +134,7 @@ func (b *NetworkClassesServerBuilder) Build() (result *NetworkClassesServer, err
 		SetMetricsRegisterer(b.metricsRegisterer).
 		Build()
 	if err != nil {
-		return
+		return result, err
 	}
 
 	// Create and populate the object:
@@ -144,7 +144,7 @@ func (b *NetworkClassesServerBuilder) Build() (result *NetworkClassesServer, err
 		inMapper:  inMapper,
 		outMapper: outMapper,
 	}
-	return
+	return result, err
 }
 
 func (s *NetworkClassesServer) List(ctx context.Context,
@@ -184,7 +184,7 @@ func (s *NetworkClassesServer) List(ctx context.Context,
 	response.SetSize(privateResponse.GetSize())
 	response.SetTotal(privateResponse.GetTotal())
 	response.SetItems(publicItems)
-	return
+	return response, err
 }
 
 func (s *NetworkClassesServer) Get(ctx context.Context,
@@ -215,7 +215,7 @@ func (s *NetworkClassesServer) Get(ctx context.Context,
 	// Create the public response:
 	response = &publicv1.NetworkClassesGetResponse{}
 	response.SetObject(publicNetworkClass)
-	return
+	return response, err
 }
 
 func (s *NetworkClassesServer) Create(ctx context.Context,
@@ -224,7 +224,7 @@ func (s *NetworkClassesServer) Create(ctx context.Context,
 	publicNetworkClass := request.GetObject()
 	if publicNetworkClass == nil {
 		err = grpcstatus.Errorf(grpccodes.InvalidArgument, "object is mandatory")
-		return
+		return response, err
 	}
 	privateNetworkClass := &privatev1.NetworkClass{}
 	err = s.inMapper.Copy(ctx, publicNetworkClass, privateNetworkClass)
@@ -235,7 +235,7 @@ func (s *NetworkClassesServer) Create(ctx context.Context,
 			slog.Any("error", err),
 		)
 		err = grpcstatus.Errorf(grpccodes.Internal, "failed to process network class")
-		return
+		return response, err
 	}
 
 	// Delegate to the private server:
@@ -257,13 +257,13 @@ func (s *NetworkClassesServer) Create(ctx context.Context,
 			slog.Any("error", err),
 		)
 		err = grpcstatus.Errorf(grpccodes.Internal, "failed to process network class")
-		return
+		return response, err
 	}
 
 	// Create the public response:
 	response = &publicv1.NetworkClassesCreateResponse{}
 	response.SetObject(createdPublicNetworkClass)
-	return
+	return response, err
 }
 
 func (s *NetworkClassesServer) Update(ctx context.Context,
@@ -272,12 +272,12 @@ func (s *NetworkClassesServer) Update(ctx context.Context,
 	publicNetworkClass := request.GetObject()
 	if publicNetworkClass == nil {
 		err = grpcstatus.Errorf(grpccodes.InvalidArgument, "object is mandatory")
-		return
+		return response, err
 	}
 	id := publicNetworkClass.GetId()
 	if id == "" {
 		err = grpcstatus.Errorf(grpccodes.InvalidArgument, "object identifier is mandatory")
-		return
+		return response, err
 	}
 
 	// Get the existing object from the private server:
@@ -298,7 +298,7 @@ func (s *NetworkClassesServer) Update(ctx context.Context,
 			slog.Any("error", err),
 		)
 		err = grpcstatus.Errorf(grpccodes.Internal, "failed to process network class")
-		return
+		return response, err
 	}
 
 	// Delegate to the private server with the merged object:
@@ -321,13 +321,13 @@ func (s *NetworkClassesServer) Update(ctx context.Context,
 			slog.Any("error", err),
 		)
 		err = grpcstatus.Errorf(grpccodes.Internal, "failed to process network class")
-		return
+		return response, err
 	}
 
 	// Create the public response:
 	response = &publicv1.NetworkClassesUpdateResponse{}
 	response.SetObject(updatedPublicNetworkClass)
-	return
+	return response, err
 }
 
 func (s *NetworkClassesServer) Delete(ctx context.Context,
@@ -344,5 +344,5 @@ func (s *NetworkClassesServer) Delete(ctx context.Context,
 
 	// Create the public response:
 	response = &publicv1.NetworkClassesDeleteResponse{}
-	return
+	return response, err
 }

--- a/internal/servers/private_baremetal_instance_catalog_items_server.go
+++ b/internal/servers/private_baremetal_instance_catalog_items_server.go
@@ -84,15 +84,15 @@ func (b *PrivateBareMetalInstanceCatalogItemsServerBuilder) SetReferenceChecker(
 func (b *PrivateBareMetalInstanceCatalogItemsServerBuilder) Build() (result *PrivateBareMetalInstanceCatalogItemsServer, err error) {
 	if b.logger == nil {
 		err = errors.New("logger is mandatory")
-		return
+		return result, err
 	}
 	if b.tenancyLogic == nil {
 		err = errors.New("tenancy logic is mandatory")
-		return
+		return result, err
 	}
 	if b.attributionLogic == nil {
 		err = errors.New("attribution logic is mandatory")
-		return
+		return result, err
 	}
 
 	generic, err := NewGenericServer[*privatev1.BareMetalInstanceCatalogItem]().
@@ -104,7 +104,7 @@ func (b *PrivateBareMetalInstanceCatalogItemsServerBuilder) Build() (result *Pri
 		SetMetricsRegisterer(b.metricsRegisterer).
 		Build()
 	if err != nil {
-		return
+		return result, err
 	}
 
 	refChecker := b.referenceChecker
@@ -116,7 +116,7 @@ func (b *PrivateBareMetalInstanceCatalogItemsServerBuilder) Build() (result *Pri
 			Build()
 		if daoErr != nil {
 			err = daoErr
-			return
+			return result, err
 		}
 		refChecker = &daoReferenceChecker[*privatev1.BareMetalInstance]{resourceDao: bmiDao}
 	}
@@ -126,7 +126,7 @@ func (b *PrivateBareMetalInstanceCatalogItemsServerBuilder) Build() (result *Pri
 		generic:          generic,
 		referenceChecker: refChecker,
 	}
-	return
+	return result, err
 }
 
 func (s *PrivateBareMetalInstanceCatalogItemsServer) List(ctx context.Context,
@@ -167,7 +167,7 @@ func (s *PrivateBareMetalInstanceCatalogItemsServer) Delete(ctx context.Context,
 	request *privatev1.BareMetalInstanceCatalogItemsDeleteRequest) (response *privatev1.BareMetalInstanceCatalogItemsDeleteResponse, err error) {
 	hasRef, err := s.referenceChecker.hasReference(ctx, request.GetId())
 	if err != nil {
-		return
+		return response, err
 	}
 	if hasRef {
 		err = grpcstatus.Errorf(
@@ -175,10 +175,10 @@ func (s *PrivateBareMetalInstanceCatalogItemsServer) Delete(ctx context.Context,
 			"cannot delete catalog item '%s': it is still referenced by one or more bare metal instances",
 			request.GetId(),
 		)
-		return
+		return response, err
 	}
 	err = s.generic.Delete(ctx, request, &response)
-	return
+	return response, err
 }
 
 func (s *PrivateBareMetalInstanceCatalogItemsServer) Signal(ctx context.Context,

--- a/internal/servers/private_baremetal_instance_templates_server.go
+++ b/internal/servers/private_baremetal_instance_templates_server.go
@@ -73,11 +73,11 @@ func (b *PrivateBareMetalInstanceTemplatesServerBuilder) SetMetricsRegisterer(va
 func (b *PrivateBareMetalInstanceTemplatesServerBuilder) Build() (result *PrivateBareMetalInstanceTemplatesServer, err error) {
 	if b.logger == nil {
 		err = errors.New("logger is mandatory")
-		return
+		return result, err
 	}
 	if b.tenancyLogic == nil {
 		err = errors.New("tenancy logic is mandatory")
-		return
+		return result, err
 	}
 
 	generic, err := NewGenericServer[*privatev1.BareMetalInstanceTemplate]().
@@ -89,14 +89,14 @@ func (b *PrivateBareMetalInstanceTemplatesServerBuilder) Build() (result *Privat
 		SetMetricsRegisterer(b.metricsRegisterer).
 		Build()
 	if err != nil {
-		return
+		return result, err
 	}
 
 	result = &PrivateBareMetalInstanceTemplatesServer{
 		logger:  b.logger,
 		generic: generic,
 	}
-	return
+	return result, err
 }
 
 func (s *PrivateBareMetalInstanceTemplatesServer) List(ctx context.Context,

--- a/internal/servers/private_baremetal_instances_server.go
+++ b/internal/servers/private_baremetal_instances_server.go
@@ -86,15 +86,15 @@ func (b *PrivateBareMetalInstancesServerBuilder) SetMetricsRegisterer(value prom
 func (b *PrivateBareMetalInstancesServerBuilder) Build() (result *PrivateBareMetalInstancesServer, err error) {
 	if b.logger == nil {
 		err = errors.New("logger is mandatory")
-		return
+		return result, err
 	}
 	if b.tenancyLogic == nil {
 		err = errors.New("tenancy logic is mandatory")
-		return
+		return result, err
 	}
 	if b.attributionLogic == nil {
 		err = errors.New("attribution logic is mandatory")
-		return
+		return result, err
 	}
 
 	catalogItemsDao, err := dao.NewGenericDAO[*privatev1.BareMetalInstanceCatalogItem]().
@@ -103,7 +103,7 @@ func (b *PrivateBareMetalInstancesServerBuilder) Build() (result *PrivateBareMet
 		SetMetricsRegisterer(b.metricsRegisterer).
 		Build()
 	if err != nil {
-		return
+		return result, err
 	}
 
 	templatesDao, err := dao.NewGenericDAO[*privatev1.BareMetalInstanceTemplate]().
@@ -112,7 +112,7 @@ func (b *PrivateBareMetalInstancesServerBuilder) Build() (result *PrivateBareMet
 		SetMetricsRegisterer(b.metricsRegisterer).
 		Build()
 	if err != nil {
-		return
+		return result, err
 	}
 
 	generic, err := NewGenericServer[*privatev1.BareMetalInstance]().
@@ -124,7 +124,7 @@ func (b *PrivateBareMetalInstancesServerBuilder) Build() (result *PrivateBareMet
 		SetMetricsRegisterer(b.metricsRegisterer).
 		Build()
 	if err != nil {
-		return
+		return result, err
 	}
 
 	result = &PrivateBareMetalInstancesServer{
@@ -133,7 +133,7 @@ func (b *PrivateBareMetalInstancesServerBuilder) Build() (result *PrivateBareMet
 		catalogItemsDao: catalogItemsDao,
 		templatesDao:    templatesDao,
 	}
-	return
+	return result, err
 }
 
 func (s *PrivateBareMetalInstancesServer) List(ctx context.Context,

--- a/internal/servers/private_capabilities_server.go
+++ b/internal/servers/private_capabilities_server.go
@@ -62,7 +62,7 @@ func (b *PrivateCapabilitiesServerBuilder) AddAuthnTrustedTokenIssuers(
 func (b *PrivateCapabilitiesServerBuilder) Build() (result *PrivateCapabilitiesServer, err error) {
 	if b.logger == nil {
 		err = errors.New("logger is mandatory")
-		return
+		return result, err
 	}
 
 	authnTrustedTokenIssuers := slices.Clone(b.authnTrustedTokenIssuers)
@@ -73,7 +73,7 @@ func (b *PrivateCapabilitiesServerBuilder) Build() (result *PrivateCapabilitiesS
 		logger:                   b.logger,
 		authnTrustedTokenIssuers: authnTrustedTokenIssuers,
 	}
-	return
+	return result, err
 }
 
 // Get is the implementation of the method that returns the capabilities of the server.

--- a/internal/servers/private_cluster_catalog_items_server.go
+++ b/internal/servers/private_cluster_catalog_items_server.go
@@ -74,11 +74,11 @@ func (b *PrivateClusterCatalogItemsServerBuilder) SetMetricsRegisterer(value pro
 func (b *PrivateClusterCatalogItemsServerBuilder) Build() (result *PrivateClusterCatalogItemsServer, err error) {
 	if b.logger == nil {
 		err = errors.New("logger is mandatory")
-		return
+		return result, err
 	}
 	if b.tenancyLogic == nil {
 		err = errors.New("tenancy logic is mandatory")
-		return
+		return result, err
 	}
 	generic, err := NewGenericServer[*privatev1.ClusterCatalogItem]().
 		SetLogger(b.logger).
@@ -89,14 +89,14 @@ func (b *PrivateClusterCatalogItemsServerBuilder) Build() (result *PrivateCluste
 		SetMetricsRegisterer(b.metricsRegisterer).
 		Build()
 	if err != nil {
-		return
+		return result, err
 	}
 
 	result = &PrivateClusterCatalogItemsServer{
 		logger:  b.logger,
 		generic: generic,
 	}
-	return
+	return result, err
 }
 
 func (s *PrivateClusterCatalogItemsServer) List(ctx context.Context,

--- a/internal/servers/private_cluster_templates_server.go
+++ b/internal/servers/private_cluster_templates_server.go
@@ -77,11 +77,11 @@ func (b *PrivateClusterTemplatesServerBuilder) Build() (result *PrivateClusterTe
 	// Check parameters:
 	if b.logger == nil {
 		err = errors.New("logger is mandatory")
-		return
+		return result, err
 	}
 	if b.tenancyLogic == nil {
 		err = errors.New("tenancy logic is mandatory")
-		return
+		return result, err
 	}
 
 	// Create the generic server:
@@ -94,7 +94,7 @@ func (b *PrivateClusterTemplatesServerBuilder) Build() (result *PrivateClusterTe
 		SetMetricsRegisterer(b.metricsRegisterer).
 		Build()
 	if err != nil {
-		return
+		return result, err
 	}
 
 	// Create and populate the object:
@@ -102,7 +102,7 @@ func (b *PrivateClusterTemplatesServerBuilder) Build() (result *PrivateClusterTe
 		logger:  b.logger,
 		generic: generic,
 	}
-	return
+	return result, err
 }
 
 func (s *PrivateClusterTemplatesServer) List(ctx context.Context,

--- a/internal/servers/private_clusters_server.go
+++ b/internal/servers/private_clusters_server.go
@@ -93,11 +93,11 @@ func (b *PrivateClustersServerBuilder) Build() (result *PrivateClustersServer, e
 	// Check parameters:
 	if b.logger == nil {
 		err = errors.New("logger is mandatory")
-		return
+		return result, err
 	}
 	if b.tenancyLogic == nil {
 		err = errors.New("tenancy logic is mandatory")
-		return
+		return result, err
 	}
 
 	// Create the templates DAO:
@@ -107,7 +107,7 @@ func (b *PrivateClustersServerBuilder) Build() (result *PrivateClustersServer, e
 		SetMetricsRegisterer(b.metricsRegisterer).
 		Build()
 	if err != nil {
-		return
+		return result, err
 	}
 
 	// Create the catalog items DAO:
@@ -117,7 +117,7 @@ func (b *PrivateClustersServerBuilder) Build() (result *PrivateClustersServer, e
 		SetMetricsRegisterer(b.metricsRegisterer).
 		Build()
 	if err != nil {
-		return
+		return result, err
 	}
 
 	// Create the host types DAO:
@@ -127,7 +127,7 @@ func (b *PrivateClustersServerBuilder) Build() (result *PrivateClustersServer, e
 		SetMetricsRegisterer(b.metricsRegisterer).
 		Build()
 	if err != nil {
-		return
+		return result, err
 	}
 
 	// Create the generic server:
@@ -140,7 +140,7 @@ func (b *PrivateClustersServerBuilder) Build() (result *PrivateClustersServer, e
 		SetMetricsRegisterer(b.metricsRegisterer).
 		Build()
 	if err != nil {
-		return
+		return result, err
 	}
 
 	// Create and populate the object:
@@ -151,7 +151,7 @@ func (b *PrivateClustersServerBuilder) Build() (result *PrivateClustersServer, e
 		hostTypesDao:    hostTypesDao,
 		generic:         generic,
 	}
-	return
+	return result, err
 }
 
 func (s *PrivateClustersServer) List(ctx context.Context,
@@ -180,7 +180,7 @@ func (s *PrivateClustersServer) Create(ctx context.Context,
 		var hostType *privatev1.HostType
 		hostType, err = s.lookupHostType(ctx, nodeSet.GetHostType())
 		if err != nil {
-			return
+			return response, err
 		}
 		nodeSet.SetHostType(hostType.GetId())
 	}
@@ -188,7 +188,7 @@ func (s *PrivateClustersServer) Create(ctx context.Context,
 	// Validate duplicate conditions first:
 	err = s.validateNoDuplicateConditions(request.GetObject())
 	if err != nil {
-		return
+		return response, err
 	}
 
 	// Dispatch between catalog item and template paths:
@@ -197,47 +197,47 @@ func (s *PrivateClustersServer) Create(ctx context.Context,
 	if catalogItemRef != "" && templateRef != "" {
 		err = grpcstatus.Errorf(grpccodes.InvalidArgument,
 			"catalog_item and template are mutually exclusive")
-		return
+		return response, err
 	}
 	if catalogItemRef != "" {
 		err = s.validateAndTransformCatalogItem(ctx, request.GetObject())
 		if err != nil {
-			return
+			return response, err
 		}
 	} else {
 		err = s.validateAndTransformCluster(ctx, request.GetObject())
 		if err != nil {
-			return
+			return response, err
 		}
 	}
 
 	err = s.generic.Create(ctx, request, &response)
-	return
+	return response, err
 }
 
 func (s *PrivateClustersServer) Update(ctx context.Context,
 	request *privatev1.ClustersUpdateRequest) (response *privatev1.ClustersUpdateResponse, err error) {
 	err = s.validateNoDuplicateConditions(request.GetObject())
 	if err != nil {
-		return
+		return response, err
 	}
 	err = s.validateTemplateImmutability(ctx, request)
 	if err != nil {
-		return
+		return response, err
 	}
 	err = s.validateNodeSetsUpdate(ctx, request)
 	if err != nil {
-		return
+		return response, err
 	}
 	err = s.validateNetworkAttachmentImmutability(ctx, request)
 	if err != nil {
-		return
+		return response, err
 	}
 	if err = utils.ValidateClusterSpecFields(request.GetObject().GetSpec()); err != nil {
-		return
+		return response, err
 	}
 	err = s.generic.Update(ctx, request, &response)
-	return
+	return response, err
 }
 
 func (s *PrivateClustersServer) Delete(ctx context.Context,
@@ -264,7 +264,7 @@ func (s *PrivateClustersServer) setDefaults(cluster *privatev1.Cluster) {
 func (s *PrivateClustersServer) lookupTemplate(ctx context.Context,
 	key string) (result *privatev1.ClusterTemplate, err error) {
 	if key == "" {
-		return
+		return result, err
 	}
 	response, err := s.templatesDao.List().
 		SetFilter(fmt.Sprintf("this.id == %[1]s || this.metadata.name == %[1]s", strconv.Quote(key))).
@@ -275,7 +275,7 @@ func (s *PrivateClustersServer) lookupTemplate(ctx context.Context,
 		if errors.As(err, &deniedErr) {
 			err = grpcstatus.Errorf(grpccodes.PermissionDenied, "%s", deniedErr.Reason)
 		}
-		return
+		return result, err
 	}
 	switch response.GetSize() {
 	case 0:
@@ -293,13 +293,13 @@ func (s *PrivateClustersServer) lookupTemplate(ctx context.Context,
 			key,
 		)
 	}
-	return
+	return result, err
 }
 
 func (s *PrivateClustersServer) lookupHostType(ctx context.Context,
 	key string) (result *privatev1.HostType, err error) {
 	if key == "" {
-		return
+		return result, err
 	}
 	response, err := s.hostTypesDao.List().
 		SetFilter(fmt.Sprintf("this.id == %[1]s || this.metadata.name == %[1]s", strconv.Quote(key))).
@@ -310,7 +310,7 @@ func (s *PrivateClustersServer) lookupHostType(ctx context.Context,
 		if errors.As(err, &deniedErr) {
 			err = grpcstatus.Errorf(grpccodes.PermissionDenied, "%s", deniedErr.Reason)
 		}
-		return
+		return result, err
 	}
 	switch response.GetSize() {
 	case 0:
@@ -328,7 +328,7 @@ func (s *PrivateClustersServer) lookupHostType(ctx context.Context,
 			key,
 		)
 	}
-	return
+	return result, err
 }
 
 func (s *PrivateClustersServer) validateNoDuplicateConditions(object *privatev1.Cluster) error {
@@ -821,7 +821,7 @@ func (s *PrivateClustersServer) validateAndTransformCatalogItem(ctx context.Cont
 func (s *PrivateClustersServer) lookupCatalogItem(ctx context.Context,
 	key string) (result *privatev1.ClusterCatalogItem, err error) {
 	if key == "" {
-		return
+		return result, err
 	}
 	response, err := s.catalogItemsDao.List().
 		SetFilter(fmt.Sprintf("this.id == %[1]s || this.metadata.name == %[1]s", strconv.Quote(key))).
@@ -831,20 +831,20 @@ func (s *PrivateClustersServer) lookupCatalogItem(ctx context.Context,
 		var deniedErr *dao.ErrDenied
 		if errors.As(err, &deniedErr) {
 			err = grpcstatus.Errorf(grpccodes.PermissionDenied, "%s", deniedErr.Reason)
-			return
+			return result, err
 		}
 		s.logger.ErrorContext(ctx, "Failed to lookup catalog item",
 			slog.String("key", key),
 			slog.Any("error", err))
 		err = grpcstatus.Errorf(grpccodes.Internal, "failed to lookup catalog item")
-		return
+		return result, err
 	}
 	items := response.GetItems()
 	if len(items) == 0 {
 		err = grpcstatus.Errorf(grpccodes.NotFound,
 			"there is no catalog item with identifier or name '%s'", key)
-		return
+		return result, err
 	}
 	result = items[0]
-	return
+	return result, err
 }

--- a/internal/servers/private_compute_instance_catalog_items_server.go
+++ b/internal/servers/private_compute_instance_catalog_items_server.go
@@ -76,11 +76,11 @@ func (b *PrivateComputeInstanceCatalogItemsServerBuilder) SetMetricsRegisterer(v
 func (b *PrivateComputeInstanceCatalogItemsServerBuilder) Build() (result *PrivateComputeInstanceCatalogItemsServer, err error) {
 	if b.logger == nil {
 		err = errors.New("logger is mandatory")
-		return
+		return result, err
 	}
 	if b.tenancyLogic == nil {
 		err = errors.New("tenancy logic is mandatory")
-		return
+		return result, err
 	}
 	// Create the InstanceTypes DAO for field_definitions instance type validation:
 	instanceTypesDao, err := dao.NewGenericDAO[*privatev1.InstanceType]().
@@ -89,7 +89,7 @@ func (b *PrivateComputeInstanceCatalogItemsServerBuilder) Build() (result *Priva
 		SetMetricsRegisterer(b.metricsRegisterer).
 		Build()
 	if err != nil {
-		return
+		return result, err
 	}
 
 	generic, err := NewGenericServer[*privatev1.ComputeInstanceCatalogItem]().
@@ -101,7 +101,7 @@ func (b *PrivateComputeInstanceCatalogItemsServerBuilder) Build() (result *Priva
 		SetMetricsRegisterer(b.metricsRegisterer).
 		Build()
 	if err != nil {
-		return
+		return result, err
 	}
 
 	result = &PrivateComputeInstanceCatalogItemsServer{
@@ -109,7 +109,7 @@ func (b *PrivateComputeInstanceCatalogItemsServerBuilder) Build() (result *Priva
 		generic:          generic,
 		instanceTypesDao: instanceTypesDao,
 	}
-	return
+	return result, err
 }
 
 func (s *PrivateComputeInstanceCatalogItemsServer) List(ctx context.Context,
@@ -129,21 +129,21 @@ func (s *PrivateComputeInstanceCatalogItemsServer) Create(ctx context.Context,
 	var warnings []string
 	if request.GetObject() != nil {
 		if err = validateFieldDefinitions(request.GetObject().GetFieldDefinitions()); err != nil {
-			return
+			return response, err
 		}
 		warnings, err = s.validateFieldDefinitionsInstanceType(ctx, request.GetObject().GetFieldDefinitions())
 		if err != nil {
-			return
+			return response, err
 		}
 	}
 	err = s.generic.Create(ctx, request, &response)
 	if err != nil {
-		return
+		return response, err
 	}
 	if len(warnings) > 0 && response != nil {
 		response.SetWarnings(warnings)
 	}
-	return
+	return response, err
 }
 
 func (s *PrivateComputeInstanceCatalogItemsServer) Update(ctx context.Context,
@@ -151,21 +151,21 @@ func (s *PrivateComputeInstanceCatalogItemsServer) Update(ctx context.Context,
 	var warnings []string
 	if request.GetObject() != nil {
 		if err = validateFieldDefinitions(request.GetObject().GetFieldDefinitions()); err != nil {
-			return
+			return response, err
 		}
 		warnings, err = s.validateFieldDefinitionsInstanceType(ctx, request.GetObject().GetFieldDefinitions())
 		if err != nil {
-			return
+			return response, err
 		}
 	}
 	err = s.generic.Update(ctx, request, &response)
 	if err != nil {
-		return
+		return response, err
 	}
 	if len(warnings) > 0 && response != nil {
 		response.SetWarnings(warnings)
 	}
-	return
+	return response, err
 }
 
 func (s *PrivateComputeInstanceCatalogItemsServer) Delete(ctx context.Context,

--- a/internal/servers/private_compute_instance_templates_server.go
+++ b/internal/servers/private_compute_instance_templates_server.go
@@ -78,11 +78,11 @@ func (b *PrivateComputeInstanceTemplatesServerBuilder) Build() (result *PrivateC
 	// Check parameters:
 	if b.logger == nil {
 		err = errors.New("logger is mandatory")
-		return
+		return result, err
 	}
 	if b.tenancyLogic == nil {
 		err = errors.New("tenancy logic is mandatory")
-		return
+		return result, err
 	}
 
 	// Create the InstanceTypes DAO for spec_defaults instance type validation:
@@ -92,7 +92,7 @@ func (b *PrivateComputeInstanceTemplatesServerBuilder) Build() (result *PrivateC
 		SetMetricsRegisterer(b.metricsRegisterer).
 		Build()
 	if err != nil {
-		return
+		return result, err
 	}
 
 	// Create the generic server:
@@ -105,7 +105,7 @@ func (b *PrivateComputeInstanceTemplatesServerBuilder) Build() (result *PrivateC
 		SetMetricsRegisterer(b.metricsRegisterer).
 		Build()
 	if err != nil {
-		return
+		return result, err
 	}
 
 	// Create and populate the object:
@@ -114,7 +114,7 @@ func (b *PrivateComputeInstanceTemplatesServerBuilder) Build() (result *PrivateC
 		generic:          generic,
 		instanceTypesDao: instanceTypesDao,
 	}
-	return
+	return result, err
 }
 
 func (s *PrivateComputeInstanceTemplatesServer) List(ctx context.Context,
@@ -136,17 +136,17 @@ func (s *PrivateComputeInstanceTemplatesServer) Create(ctx context.Context,
 	if request.GetObject() != nil {
 		warnings, err = s.validateSpecDefaultsInstanceType(ctx, request.GetObject().GetSpecDefaults())
 		if err != nil {
-			return
+			return response, err
 		}
 	}
 	err = s.generic.Create(ctx, request, &response)
 	if err != nil {
-		return
+		return response, err
 	}
 	if len(warnings) > 0 && response != nil {
 		response.SetWarnings(warnings)
 	}
-	return
+	return response, err
 }
 
 func (s *PrivateComputeInstanceTemplatesServer) Update(ctx context.Context,
@@ -156,17 +156,17 @@ func (s *PrivateComputeInstanceTemplatesServer) Update(ctx context.Context,
 	if request.GetObject() != nil {
 		warnings, err = s.validateSpecDefaultsInstanceType(ctx, request.GetObject().GetSpecDefaults())
 		if err != nil {
-			return
+			return response, err
 		}
 	}
 	err = s.generic.Update(ctx, request, &response)
 	if err != nil {
-		return
+		return response, err
 	}
 	if len(warnings) > 0 && response != nil {
 		response.SetWarnings(warnings)
 	}
-	return
+	return response, err
 }
 
 func (s *PrivateComputeInstanceTemplatesServer) Delete(ctx context.Context,

--- a/internal/servers/private_compute_instances_server.go
+++ b/internal/servers/private_compute_instances_server.go
@@ -96,11 +96,11 @@ func (b *PrivateComputeInstancesServerBuilder) Build() (result *PrivateComputeIn
 	// Check parameters:
 	if b.logger == nil {
 		err = errors.New("logger is mandatory")
-		return
+		return result, err
 	}
 	if b.tenancyLogic == nil {
 		err = errors.New("tenancy logic is mandatory")
-		return
+		return result, err
 	}
 
 	// Create the templates DAO:
@@ -110,7 +110,7 @@ func (b *PrivateComputeInstancesServerBuilder) Build() (result *PrivateComputeIn
 		SetMetricsRegisterer(b.metricsRegisterer).
 		Build()
 	if err != nil {
-		return
+		return result, err
 	}
 
 	// Create the catalog items DAO:
@@ -120,7 +120,7 @@ func (b *PrivateComputeInstancesServerBuilder) Build() (result *PrivateComputeIn
 		SetMetricsRegisterer(b.metricsRegisterer).
 		Build()
 	if err != nil {
-		return
+		return result, err
 	}
 
 	// Create the Subnets DAO for network validation:
@@ -130,7 +130,7 @@ func (b *PrivateComputeInstancesServerBuilder) Build() (result *PrivateComputeIn
 		SetMetricsRegisterer(b.metricsRegisterer).
 		Build()
 	if err != nil {
-		return
+		return result, err
 	}
 
 	// Create the SecurityGroups DAO for network validation:
@@ -140,7 +140,7 @@ func (b *PrivateComputeInstancesServerBuilder) Build() (result *PrivateComputeIn
 		SetMetricsRegisterer(b.metricsRegisterer).
 		Build()
 	if err != nil {
-		return
+		return result, err
 	}
 
 	// Create the InstanceTypes DAO for instance type validation:
@@ -150,7 +150,7 @@ func (b *PrivateComputeInstancesServerBuilder) Build() (result *PrivateComputeIn
 		SetMetricsRegisterer(b.metricsRegisterer).
 		Build()
 	if err != nil {
-		return
+		return result, err
 	}
 
 	// Create the generic server:
@@ -163,7 +163,7 @@ func (b *PrivateComputeInstancesServerBuilder) Build() (result *PrivateComputeIn
 		SetMetricsRegisterer(b.metricsRegisterer).
 		Build()
 	if err != nil {
-		return
+		return result, err
 	}
 
 	// Create and populate the object:
@@ -176,7 +176,7 @@ func (b *PrivateComputeInstancesServerBuilder) Build() (result *PrivateComputeIn
 		securityGroupsDao: securityGroupsDao,
 		instanceTypesDao:  instanceTypesDao,
 	}
-	return
+	return result, err
 }
 
 func (s *PrivateComputeInstancesServer) List(ctx context.Context,
@@ -196,20 +196,20 @@ func (s *PrivateComputeInstancesServer) Create(ctx context.Context,
 	// Validate tenant isolation for network references:
 	err = s.validateNetworkReferencesTenancy(ctx, request.GetObject())
 	if err != nil {
-		return
+		return response, err
 	}
 
 	// Validate network references state (exists, READY):
 	err = s.validateNetworkReferencesState(ctx, request.GetObject())
 	if err != nil {
-		return
+		return response, err
 	}
 
 	// Require network_attachments for new VMs (no pod network for new VMs):
 	if len(request.GetObject().GetSpec().GetNetworkAttachments()) == 0 {
 		err = grpcstatus.Errorf(grpccodes.InvalidArgument,
 			"spec.network_attachments: at least one network attachment is required for new compute instances")
-		return
+		return response, err
 	}
 
 	// Dispatch between catalog item and template paths:
@@ -219,22 +219,22 @@ func (s *PrivateComputeInstancesServer) Create(ctx context.Context,
 	if catalogItemRef != "" && templateRef != "" {
 		err = grpcstatus.Errorf(grpccodes.InvalidArgument,
 			"catalog_item and template are mutually exclusive")
-		return
+		return response, err
 	}
 	if catalogItemRef != "" {
 		err = s.validateAndTransformCatalogItem(ctx, request.GetObject())
 		if err != nil {
-			return
+			return response, err
 		}
 	} else {
 		template, templateErr := s.fetchAndValidateTemplate(ctx, request.GetObject())
 		if templateErr != nil {
 			err = templateErr
-			return
+			return response, err
 		}
 		err = s.applySpecDefaults(request.GetObject().GetSpec(), template)
 		if err != nil {
-			return
+			return response, err
 		}
 	}
 
@@ -244,19 +244,19 @@ func (s *PrivateComputeInstancesServer) Create(ctx context.Context,
 	var warnings []string
 	warnings, err = s.validateInstanceType(ctx, request.GetObject())
 	if err != nil {
-		return
+		return response, err
 	}
 
 	err = s.generic.Create(ctx, request, &response)
 	if err != nil {
-		return
+		return response, err
 	}
 
 	// Attach warnings to the response (deprecation notices for DEPRECATED instance types).
 	if len(warnings) > 0 {
 		response.SetWarnings(warnings)
 	}
-	return
+	return response, err
 }
 
 func (s *PrivateComputeInstancesServer) Update(ctx context.Context,
@@ -271,7 +271,7 @@ func (s *PrivateComputeInstancesServer) Update(ctx context.Context,
 	if hasMaskPrefix(mask, "spec.network_attachments") {
 		err = s.validateNetworkReferencesTenancy(ctx, request.GetObject())
 		if err != nil {
-			return
+			return response, err
 		}
 	}
 
@@ -280,22 +280,22 @@ func (s *PrivateComputeInstancesServer) Update(ctx context.Context,
 	if !isBeingDeleted && hasMaskPrefix(mask, "spec.network_attachments") {
 		err = s.validateNetworkReferencesState(ctx, request.GetObject())
 		if err != nil {
-			return
+			return response, err
 		}
 	}
 
 	err = s.validateTemplateImmutability(ctx, request)
 	if err != nil {
-		return
+		return response, err
 	}
 
 	err = s.validateNetworkAttachmentsImmutability(ctx, request)
 	if err != nil {
-		return
+		return response, err
 	}
 
 	err = s.generic.Update(ctx, request, &response)
-	return
+	return response, err
 }
 
 func (s *PrivateComputeInstancesServer) Delete(ctx context.Context,
@@ -817,7 +817,7 @@ func (s *PrivateComputeInstancesServer) validateAndTransformCatalogItem(ctx cont
 func (s *PrivateComputeInstancesServer) lookupCatalogItem(ctx context.Context,
 	key string) (result *privatev1.ComputeInstanceCatalogItem, err error) {
 	if key == "" {
-		return
+		return result, err
 	}
 	response, err := s.catalogItemsDao.List().
 		SetFilter(fmt.Sprintf("this.id == %[1]s || this.metadata.name == %[1]s", strconv.Quote(key))).
@@ -827,20 +827,20 @@ func (s *PrivateComputeInstancesServer) lookupCatalogItem(ctx context.Context,
 		var deniedErr *dao.ErrDenied
 		if errors.As(err, &deniedErr) {
 			err = grpcstatus.Errorf(grpccodes.PermissionDenied, "%s", deniedErr.Reason)
-			return
+			return result, err
 		}
 		s.logger.ErrorContext(ctx, "Failed to lookup catalog item",
 			slog.String("key", key),
 			slog.Any("error", err))
 		err = grpcstatus.Errorf(grpccodes.Internal, "failed to lookup catalog item")
-		return
+		return result, err
 	}
 	items := response.GetItems()
 	if len(items) == 0 {
 		err = grpcstatus.Errorf(grpccodes.NotFound,
 			"there is no catalog item with identifier or name '%s'", key)
-		return
+		return result, err
 	}
 	result = items[0]
-	return
+	return result, err
 }

--- a/internal/servers/private_events_server.go
+++ b/internal/servers/private_events_server.go
@@ -80,18 +80,18 @@ func (b *PrivateEventsServerBuilder) Build() (result *PrivateEventsServer, err e
 	// Check parameters:
 	if b.logger == nil {
 		err = errors.New("logger is mandatory")
-		return
+		return result, err
 	}
 	if b.listener == nil {
 		err = errors.New("listener is mandatory")
-		return
+		return result, err
 	}
 
 	// Create  the CEL environment:
 	celEnv, err := b.createCelEnv()
 	if err != nil {
 		err = fmt.Errorf("failed to create CEL environment: %w", err)
-		return
+		return result, err
 	}
 
 	// Create the object:
@@ -102,7 +102,7 @@ func (b *PrivateEventsServerBuilder) Build() (result *PrivateEventsServer, err e
 		subsLock: &sync.RWMutex{},
 		celEnv:   celEnv,
 	}
-	return
+	return result, err
 }
 
 func (b *PrivateEventsServerBuilder) createCelEnv() (result *cel.Env, err error) {
@@ -142,7 +142,7 @@ func (b *PrivateEventsServerBuilder) createCelEnv() (result *cel.Env, err error)
 
 	// Create the CEL environment:
 	result, err = cel.NewEnv(options...)
-	return
+	return result, err
 }
 
 // Starts starts the background components of the server, in particular the notification listener. This is a blocking
@@ -241,18 +241,18 @@ func (s *PrivateEventsServer) evalFilter(ctx context.Context, filterPrg cel.Prog
 		"event": event,
 	})
 	if err != nil {
-		return
+		return result, err
 	}
 	value, _, err := filterPrg.ContextEval(ctx, activation)
 	if err != nil {
-		return
+		return result, err
 	}
 	result, ok := value.Value().(bool)
 	if !ok {
 		err = fmt.Errorf("result of filter should be a boolean, but it is of type '%T'", result)
-		return
+		return result, err
 	}
-	return
+	return result, err
 }
 
 func (s *PrivateEventsServer) processPayload(ctx context.Context, payload proto.Message) error {

--- a/internal/servers/private_external_ip_attachments_server.go
+++ b/internal/servers/private_external_ip_attachments_server.go
@@ -175,7 +175,7 @@ func (s *PrivateExternalIPAttachmentsServer) Create(ctx context.Context,
 
 	err = s.validateExternalIPAttachment(attachment)
 	if err != nil {
-		return
+		return response, err
 	}
 
 	spec := attachment.GetSpec()
@@ -183,18 +183,18 @@ func (s *PrivateExternalIPAttachmentsServer) Create(ctx context.Context,
 
 	err = s.validateExternalIPReference(ctx, externalIPID)
 	if err != nil {
-		return
+		return response, err
 	}
 
 	err = s.validateTargetReference(ctx, spec)
 	if err != nil {
-		return
+		return response, err
 	}
 
 	targetID := s.getTargetID(spec)
 	err = s.validateUniqueness(ctx, externalIPID, targetID)
 	if err != nil {
-		return
+		return response, err
 	}
 
 	if attachment.GetStatus() == nil {
@@ -208,15 +208,15 @@ func (s *PrivateExternalIPAttachmentsServer) Create(ctx context.Context,
 
 	err = s.generic.Create(ctx, request, &response)
 	if err != nil {
-		return
+		return response, err
 	}
 
 	err = s.updateExternalIPAttachedFlag(ctx, externalIPID, true)
 	if err != nil {
-		return
+		return response, err
 	}
 
-	return
+	return response, err
 }
 
 func (s *PrivateExternalIPAttachmentsServer) Update(ctx context.Context,
@@ -224,7 +224,7 @@ func (s *PrivateExternalIPAttachmentsServer) Update(ctx context.Context,
 	id := request.GetObject().GetId()
 	if id == "" {
 		err = grpcstatus.Errorf(grpccodes.InvalidArgument, "object identifier is mandatory")
-		return
+		return response, err
 	}
 
 	mask := request.GetUpdateMask()
@@ -236,16 +236,16 @@ func (s *PrivateExternalIPAttachmentsServer) Update(ctx context.Context,
 		var getResponse *privatev1.ExternalIPAttachmentsGetResponse
 		err = s.generic.Get(ctx, getRequest, &getResponse)
 		if err != nil {
-			return
+			return response, err
 		}
 		err = validateImmutableFieldsExternalIPAttachment(request.GetObject(), getResponse.GetObject())
 		if err != nil {
-			return
+			return response, err
 		}
 	}
 
 	err = s.generic.Update(ctx, request, &response)
-	return
+	return response, err
 }
 
 func (s *PrivateExternalIPAttachmentsServer) Delete(ctx context.Context,
@@ -253,7 +253,7 @@ func (s *PrivateExternalIPAttachmentsServer) Delete(ctx context.Context,
 	id := request.GetId()
 	if id == "" {
 		err = grpcstatus.Errorf(grpccodes.InvalidArgument, "object identifier is mandatory")
-		return
+		return response, err
 	}
 
 	getRequest := &privatev1.ExternalIPAttachmentsGetRequest{}
@@ -261,24 +261,24 @@ func (s *PrivateExternalIPAttachmentsServer) Delete(ctx context.Context,
 	var getResponse *privatev1.ExternalIPAttachmentsGetResponse
 	err = s.generic.Get(ctx, getRequest, &getResponse)
 	if err != nil {
-		return
+		return response, err
 	}
 
 	externalIPID := getResponse.GetObject().GetSpec().GetExternalIp()
 
 	err = s.generic.Delete(ctx, request, &response)
 	if err != nil {
-		return
+		return response, err
 	}
 
 	if externalIPID != "" {
 		err = s.updateExternalIPAttachedFlag(ctx, externalIPID, false)
 		if err != nil {
-			return
+			return response, err
 		}
 	}
 
-	return
+	return response, err
 }
 
 func (s *PrivateExternalIPAttachmentsServer) Signal(ctx context.Context,

--- a/internal/servers/private_external_ip_pools_server.go
+++ b/internal/servers/private_external_ip_pools_server.go
@@ -76,11 +76,11 @@ func (b *PrivateExternalIPPoolsServerBuilder) SetMetricsRegisterer(value prometh
 func (b *PrivateExternalIPPoolsServerBuilder) Build() (result *PrivateExternalIPPoolsServer, err error) {
 	if b.logger == nil {
 		err = errors.New("logger is mandatory")
-		return
+		return result, err
 	}
 	if b.tenancyLogic == nil {
 		err = errors.New("tenancy logic is mandatory")
-		return
+		return result, err
 	}
 
 	generic, err := NewGenericServer[*privatev1.ExternalIPPool]().
@@ -92,14 +92,14 @@ func (b *PrivateExternalIPPoolsServerBuilder) Build() (result *PrivateExternalIP
 		SetMetricsRegisterer(b.metricsRegisterer).
 		Build()
 	if err != nil {
-		return
+		return result, err
 	}
 
 	result = &PrivateExternalIPPoolsServer{
 		logger:  b.logger,
 		generic: generic,
 	}
-	return
+	return result, err
 }
 
 func (s *PrivateExternalIPPoolsServer) List(ctx context.Context,
@@ -120,7 +120,7 @@ func (s *PrivateExternalIPPoolsServer) Create(ctx context.Context,
 
 	err = s.validateCreate(ctx, pool)
 	if err != nil {
-		return
+		return response, err
 	}
 
 	total := calculatePoolCapacity(pool.GetSpec().GetCidrs(), pool.GetSpec().GetIpFamily())
@@ -130,7 +130,7 @@ func (s *PrivateExternalIPPoolsServer) Create(ctx context.Context,
 	}.Build())
 
 	err = s.generic.Create(ctx, request, &response)
-	return
+	return response, err
 }
 
 func (s *PrivateExternalIPPoolsServer) Update(ctx context.Context,
@@ -138,7 +138,7 @@ func (s *PrivateExternalIPPoolsServer) Update(ctx context.Context,
 	id := request.GetObject().GetId()
 	if id == "" {
 		err = grpcstatus.Errorf(grpccodes.InvalidArgument, "object identifier is mandatory")
-		return
+		return response, err
 	}
 
 	getRequest := &privatev1.ExternalIPPoolsGetRequest{}
@@ -146,16 +146,16 @@ func (s *PrivateExternalIPPoolsServer) Update(ctx context.Context,
 	var getResponse *privatev1.ExternalIPPoolsGetResponse
 	err = s.generic.Get(ctx, getRequest, &getResponse)
 	if err != nil {
-		return
+		return response, err
 	}
 
 	err = validateExternalIPPoolUpdate(request.GetObject(), getResponse.GetObject())
 	if err != nil {
-		return
+		return response, err
 	}
 
 	err = s.generic.Update(ctx, request, &response)
-	return
+	return response, err
 }
 
 func (s *PrivateExternalIPPoolsServer) validateCreate(ctx context.Context,
@@ -269,7 +269,7 @@ func (s *PrivateExternalIPPoolsServer) Delete(ctx context.Context,
 		Id: request.GetId(),
 	}.Build(), &getResponse)
 	if err != nil {
-		return
+		return response, err
 	}
 	if allocated := getResponse.GetObject().GetStatus().GetAllocated(); allocated > 0 {
 		err = grpcstatus.Errorf(
@@ -277,10 +277,10 @@ func (s *PrivateExternalIPPoolsServer) Delete(ctx context.Context,
 			"cannot delete external IP pool '%s': %d external IP(s) are still allocated from it",
 			request.GetId(), allocated,
 		)
-		return
+		return response, err
 	}
 	err = s.generic.Delete(ctx, request, &response)
-	return
+	return response, err
 }
 
 func (s *PrivateExternalIPPoolsServer) Signal(ctx context.Context,

--- a/internal/servers/private_external_ips_server.go
+++ b/internal/servers/private_external_ips_server.go
@@ -85,15 +85,15 @@ func (b *PrivateExternalIPsServerBuilder) SetMetricsRegisterer(value prometheus.
 func (b *PrivateExternalIPsServerBuilder) Build() (result *PrivateExternalIPsServer, err error) {
 	if b.logger == nil {
 		err = errors.New("logger is mandatory")
-		return
+		return result, err
 	}
 	if b.tenancyLogic == nil {
 		err = errors.New("tenancy logic is mandatory")
-		return
+		return result, err
 	}
 	if b.attributionLogic == nil {
 		err = errors.New("attribution logic is mandatory")
-		return
+		return result, err
 	}
 
 	externalIPPoolDao, err := dao.NewGenericDAO[*privatev1.ExternalIPPool]().
@@ -102,7 +102,7 @@ func (b *PrivateExternalIPsServerBuilder) Build() (result *PrivateExternalIPsSer
 		SetMetricsRegisterer(b.metricsRegisterer).
 		Build()
 	if err != nil {
-		return
+		return result, err
 	}
 
 	generic, err := NewGenericServer[*privatev1.ExternalIP]().
@@ -114,7 +114,7 @@ func (b *PrivateExternalIPsServerBuilder) Build() (result *PrivateExternalIPsSer
 		SetMetricsRegisterer(b.metricsRegisterer).
 		Build()
 	if err != nil {
-		return
+		return result, err
 	}
 
 	result = &PrivateExternalIPsServer{
@@ -122,7 +122,7 @@ func (b *PrivateExternalIPsServerBuilder) Build() (result *PrivateExternalIPsSer
 		generic:           generic,
 		externalIPPoolDao: externalIPPoolDao,
 	}
-	return
+	return result, err
 }
 
 func (s *PrivateExternalIPsServer) List(ctx context.Context,
@@ -143,13 +143,13 @@ func (s *PrivateExternalIPsServer) Create(ctx context.Context,
 
 	err = s.validateExternalIP(ctx, externalIP)
 	if err != nil {
-		return
+		return response, err
 	}
 
 	poolID := externalIP.GetSpec().GetPool()
 	err = s.validatePoolReference(ctx, poolID)
 	if err != nil {
-		return
+		return response, err
 	}
 
 	if externalIP.GetStatus() == nil {
@@ -162,15 +162,15 @@ func (s *PrivateExternalIPsServer) Create(ctx context.Context,
 
 	err = s.generic.Create(ctx, request, &response)
 	if err != nil {
-		return
+		return response, err
 	}
 
 	err = s.updatePoolCapacity(ctx, poolID, 1)
 	if err != nil {
-		return
+		return response, err
 	}
 
-	return
+	return response, err
 }
 
 func (s *PrivateExternalIPsServer) Update(ctx context.Context,
@@ -178,7 +178,7 @@ func (s *PrivateExternalIPsServer) Update(ctx context.Context,
 	id := request.GetObject().GetId()
 	if id == "" {
 		err = grpcstatus.Errorf(grpccodes.InvalidArgument, "object identifier is mandatory")
-		return
+		return response, err
 	}
 
 	getRequest := &privatev1.ExternalIPsGetRequest{}
@@ -186,7 +186,7 @@ func (s *PrivateExternalIPsServer) Update(ctx context.Context,
 	var getResponse *privatev1.ExternalIPsGetResponse
 	err = s.generic.Get(ctx, getRequest, &getResponse)
 	if err != nil {
-		return
+		return response, err
 	}
 
 	existingExternalIP := getResponse.GetObject()
@@ -194,7 +194,7 @@ func (s *PrivateExternalIPsServer) Update(ctx context.Context,
 
 	if updateIncludesField(mask, "spec.pool") {
 		if err = validateImmutableFieldsExternalIP(request.GetObject(), existingExternalIP); err != nil {
-			return
+			return response, err
 		}
 	}
 
@@ -203,13 +203,13 @@ func (s *PrivateExternalIPsServer) Update(ctx context.Context,
 		existingState := existingExternalIP.GetStatus().GetState()
 		if newState != existingState {
 			if err = validateExternalIPStateTransition(existingState, newState); err != nil {
-				return
+				return response, err
 			}
 		}
 	}
 
 	err = s.generic.Update(ctx, request, &response)
-	return
+	return response, err
 }
 
 func (s *PrivateExternalIPsServer) Delete(ctx context.Context,
@@ -217,7 +217,7 @@ func (s *PrivateExternalIPsServer) Delete(ctx context.Context,
 	id := request.GetId()
 	if id == "" {
 		err = grpcstatus.Errorf(grpccodes.InvalidArgument, "object identifier is mandatory")
-		return
+		return response, err
 	}
 
 	getRequest := &privatev1.ExternalIPsGetRequest{}
@@ -225,7 +225,7 @@ func (s *PrivateExternalIPsServer) Delete(ctx context.Context,
 	var getResponse *privatev1.ExternalIPsGetResponse
 	err = s.generic.Get(ctx, getRequest, &getResponse)
 	if err != nil {
-		return
+		return response, err
 	}
 
 	existingExternalIP := getResponse.GetObject()
@@ -234,23 +234,23 @@ func (s *PrivateExternalIPsServer) Delete(ctx context.Context,
 	if state != privatev1.ExternalIPState_EXTERNAL_IP_STATE_ALLOCATED {
 		err = grpcstatus.Errorf(grpccodes.FailedPrecondition,
 			"cannot delete ExternalIP in state %s: must be in ALLOCATED state", state)
-		return
+		return response, err
 	}
 
 	err = s.generic.Delete(ctx, request, &response)
 	if err != nil {
-		return
+		return response, err
 	}
 
 	poolID := existingExternalIP.GetSpec().GetPool()
 	if poolID != "" {
 		err = s.updatePoolCapacity(ctx, poolID, -1)
 		if err != nil {
-			return
+			return response, err
 		}
 	}
 
-	return
+	return response, err
 }
 
 func (s *PrivateExternalIPsServer) Signal(ctx context.Context,

--- a/internal/servers/private_host_types_server.go
+++ b/internal/servers/private_host_types_server.go
@@ -76,11 +76,11 @@ func (b *PrivateHostTypesServerBuilder) Build() (result *PrivateHostTypesServer,
 	// Check parameters:
 	if b.logger == nil {
 		err = errors.New("logger is mandatory")
-		return
+		return result, err
 	}
 	if b.tenancyLogic == nil {
 		err = errors.New("tenancy logic is mandatory")
-		return
+		return result, err
 	}
 
 	// Create the generic server:
@@ -93,7 +93,7 @@ func (b *PrivateHostTypesServerBuilder) Build() (result *PrivateHostTypesServer,
 		SetMetricsRegisterer(b.metricsRegisterer).
 		Build()
 	if err != nil {
-		return
+		return result, err
 	}
 
 	// Create and populate the object:
@@ -101,7 +101,7 @@ func (b *PrivateHostTypesServerBuilder) Build() (result *PrivateHostTypesServer,
 		logger:  b.logger,
 		generic: generic,
 	}
-	return
+	return result, err
 }
 
 func (s *PrivateHostTypesServer) List(ctx context.Context,

--- a/internal/servers/private_hubs_server.go
+++ b/internal/servers/private_hubs_server.go
@@ -77,11 +77,11 @@ func (b *PrivateHubsServerBuilder) Build() (result *PrivateHubsServer, err error
 	// Check parameters:
 	if b.logger == nil {
 		err = errors.New("logger is mandatory")
-		return
+		return result, err
 	}
 	if b.tenancyLogic == nil {
 		err = errors.New("tenancy logic is mandatory")
-		return
+		return result, err
 	}
 
 	// Create the server early so that we can use its functions to set up other objects:
@@ -100,12 +100,12 @@ func (b *PrivateHubsServerBuilder) Build() (result *PrivateHubsServer, err error
 		SetMetricsRegisterer(b.metricsRegisterer).
 		Build()
 	if err != nil {
-		return
+		return result, err
 	}
 
 	// Return the server:
 	result = s
-	return
+	return result, err
 }
 
 // redact clears sensitive fields from the hub before it is included in event notification payloads.

--- a/internal/servers/private_identity_providers_server.go
+++ b/internal/servers/private_identity_providers_server.go
@@ -78,11 +78,11 @@ func (b *PrivateIdentityProvidersServerBuilder) Build() (result *PrivateIdentity
 	// Check parameters:
 	if b.logger == nil {
 		err = errors.New("logger is mandatory")
-		return
+		return result, err
 	}
 	if b.tenancyLogic == nil {
 		err = errors.New("tenancy logic is mandatory")
-		return
+		return result, err
 	}
 
 	// Create the server early so that we can use its functions to set up other objects:
@@ -101,7 +101,7 @@ func (b *PrivateIdentityProvidersServerBuilder) Build() (result *PrivateIdentity
 		SetMetricsRegisterer(b.metricsRegisterer).
 		Build()
 	if err != nil {
-		return
+		return result, err
 	}
 
 	// Create the DAO:
@@ -111,12 +111,12 @@ func (b *PrivateIdentityProvidersServerBuilder) Build() (result *PrivateIdentity
 		SetMetricsRegisterer(b.metricsRegisterer).
 		Build()
 	if err != nil {
-		return
+		return result, err
 	}
 
 	// Return the server:
 	result = s
-	return
+	return result, err
 }
 
 // redact clears sensitive fields from the identity provider before it is included in event notification payloads.
@@ -145,14 +145,14 @@ func (s *PrivateIdentityProvidersServer) Create(ctx context.Context,
 				"identity provider cannot belong to '%s' tenant - must be scoped to a specific tenant",
 				tenant,
 			)
-			return
+			return response, err
 		}
 	}
 
 	// Perform the create operation:
 	err = s.generic.Create(ctx, request, &response)
 	if err != nil {
-		return
+		return response, err
 	}
 
 	// Check if the assigned tenant is 'shared' or 'system' and reject if so.
@@ -169,11 +169,11 @@ func (s *PrivateIdentityProvidersServer) Create(ctx context.Context,
 				grpccodes.InvalidArgument,
 				"identity provider must be assigned to a specific tenant - please specify metadata.tenant in the request",
 			)
-			return
+			return response, err
 		}
 	}
 
-	return
+	return response, err
 }
 
 func (s *PrivateIdentityProvidersServer) List(ctx context.Context,

--- a/internal/servers/private_instance_types_server.go
+++ b/internal/servers/private_instance_types_server.go
@@ -82,11 +82,11 @@ func (b *PrivateInstanceTypesServerBuilder) Build() (result *PrivateInstanceType
 	// Check parameters:
 	if b.logger == nil {
 		err = errors.New("logger is mandatory")
-		return
+		return result, err
 	}
 	if b.tenancyLogic == nil {
 		err = errors.New("tenancy logic is mandatory")
-		return
+		return result, err
 	}
 
 	// Create the generic server:
@@ -99,7 +99,7 @@ func (b *PrivateInstanceTypesServerBuilder) Build() (result *PrivateInstanceType
 		SetMetricsRegisterer(b.metricsRegisterer).
 		Build()
 	if err != nil {
-		return
+		return result, err
 	}
 
 	// Create and populate the object:
@@ -107,7 +107,7 @@ func (b *PrivateInstanceTypesServerBuilder) Build() (result *PrivateInstanceType
 		logger:  b.logger,
 		generic: generic,
 	}
-	return
+	return result, err
 }
 
 func (s *PrivateInstanceTypesServer) List(ctx context.Context,
@@ -126,23 +126,23 @@ func (s *PrivateInstanceTypesServer) Create(ctx context.Context,
 	request *privatev1.InstanceTypesCreateRequest) (response *privatev1.InstanceTypesCreateResponse, err error) {
 	if request.GetObject() == nil {
 		err = grpcstatus.Errorf(grpccodes.InvalidArgument, "object is mandatory")
-		return
+		return response, err
 	}
 
 	spec := request.GetObject().GetSpec()
 	if spec == nil {
 		err = grpcstatus.Errorf(grpccodes.InvalidArgument, "object spec is mandatory")
-		return
+		return response, err
 	}
 
 	// Validate required spec fields:
 	if spec.GetCores() <= 0 {
 		err = grpcstatus.Errorf(grpccodes.InvalidArgument, "field 'spec.cores' must be greater than zero")
-		return
+		return response, err
 	}
 	if spec.GetMemoryGib() <= 0 {
 		err = grpcstatus.Errorf(grpccodes.InvalidArgument, "field 'spec.memory_gib' must be greater than zero")
-		return
+		return response, err
 	}
 
 	// Set id from metadata.name (name-as-primary-key per Phase 1 D-01):
@@ -154,7 +154,7 @@ func (s *PrivateInstanceTypesServer) Create(ctx context.Context,
 	}
 
 	err = s.generic.Create(ctx, request, &response)
-	return
+	return response, err
 }
 
 func (s *PrivateInstanceTypesServer) Update(ctx context.Context,
@@ -163,7 +163,7 @@ func (s *PrivateInstanceTypesServer) Update(ctx context.Context,
 	id := request.GetObject().GetId()
 	if id == "" {
 		err = grpcstatus.Errorf(grpccodes.InvalidArgument, "object identifier is mandatory")
-		return
+		return response, err
 	}
 
 	// Fetch the existing object:
@@ -172,7 +172,7 @@ func (s *PrivateInstanceTypesServer) Update(ctx context.Context,
 	var getResponse *privatev1.InstanceTypesGetResponse
 	err = s.generic.Get(ctx, getRequest, &getResponse)
 	if err != nil {
-		return
+		return response, err
 	}
 
 	existing := getResponse.GetObject()
@@ -184,7 +184,7 @@ func (s *PrivateInstanceTypesServer) Update(ctx context.Context,
 	// Validate immutable fields:
 	err = validateInstanceTypeImmutability(merged, existing)
 	if err != nil {
-		return
+		return response, err
 	}
 
 	// Handle state transitions with timestamp auto-population:
@@ -201,7 +201,7 @@ func (s *PrivateInstanceTypesServer) Update(ctx context.Context,
 	request.GetObject().SetSpec(merged.GetSpec())
 
 	err = s.generic.Update(ctx, request, &response)
-	return
+	return response, err
 }
 
 func (s *PrivateInstanceTypesServer) Delete(ctx context.Context,

--- a/internal/servers/private_nat_gateways_server.go
+++ b/internal/servers/private_nat_gateways_server.go
@@ -78,15 +78,15 @@ func (b *PrivateNATGatewaysServerBuilder) SetMetricsRegisterer(value prometheus.
 func (b *PrivateNATGatewaysServerBuilder) Build() (result *PrivateNATGatewaysServer, err error) {
 	if b.logger == nil {
 		err = errors.New("logger is mandatory")
-		return
+		return result, err
 	}
 	if b.tenancyLogic == nil {
 		err = errors.New("tenancy logic is mandatory")
-		return
+		return result, err
 	}
 	if b.attributionLogic == nil {
 		err = errors.New("attribution logic is mandatory")
-		return
+		return result, err
 	}
 
 	externalIPDao, err := dao.NewGenericDAO[*privatev1.ExternalIP]().
@@ -95,7 +95,7 @@ func (b *PrivateNATGatewaysServerBuilder) Build() (result *PrivateNATGatewaysSer
 		SetMetricsRegisterer(b.metricsRegisterer).
 		Build()
 	if err != nil {
-		return
+		return result, err
 	}
 
 	generic, err := NewGenericServer[*privatev1.NATGateway]().
@@ -107,7 +107,7 @@ func (b *PrivateNATGatewaysServerBuilder) Build() (result *PrivateNATGatewaysSer
 		SetMetricsRegisterer(b.metricsRegisterer).
 		Build()
 	if err != nil {
-		return
+		return result, err
 	}
 
 	result = &PrivateNATGatewaysServer{
@@ -115,7 +115,7 @@ func (b *PrivateNATGatewaysServerBuilder) Build() (result *PrivateNATGatewaysSer
 		generic:       generic,
 		externalIPDao: externalIPDao,
 	}
-	return
+	return result, err
 }
 
 func (s *PrivateNATGatewaysServer) List(ctx context.Context,
@@ -136,14 +136,14 @@ func (s *PrivateNATGatewaysServer) Create(ctx context.Context,
 
 	err = s.validateNATGateway(natGateway)
 	if err != nil {
-		return
+		return response, err
 	}
 
 	externalIPID := natGateway.GetSpec().GetExternalIp()
 
 	err = s.validateExternalIPReference(ctx, externalIPID)
 	if err != nil {
-		return
+		return response, err
 	}
 
 	if natGateway.GetStatus() == nil {
@@ -156,11 +156,11 @@ func (s *PrivateNATGatewaysServer) Create(ctx context.Context,
 
 	err = s.generic.Create(ctx, request, &response)
 	if err != nil {
-		return
+		return response, err
 	}
 
 	err = s.updateExternalIPAttachedFlag(ctx, externalIPID, true)
-	return
+	return response, err
 }
 
 func (s *PrivateNATGatewaysServer) Update(ctx context.Context,
@@ -168,7 +168,7 @@ func (s *PrivateNATGatewaysServer) Update(ctx context.Context,
 	id := request.GetObject().GetId()
 	if id == "" {
 		err = grpcstatus.Errorf(grpccodes.InvalidArgument, "object identifier is mandatory")
-		return
+		return response, err
 	}
 
 	mask := request.GetUpdateMask()
@@ -178,16 +178,16 @@ func (s *PrivateNATGatewaysServer) Update(ctx context.Context,
 		var getResponse *privatev1.NATGatewaysGetResponse
 		err = s.generic.Get(ctx, getRequest, &getResponse)
 		if err != nil {
-			return
+			return response, err
 		}
 		err = validateImmutableFieldsNATGateway(request.GetObject(), getResponse.GetObject())
 		if err != nil {
-			return
+			return response, err
 		}
 	}
 
 	err = s.generic.Update(ctx, request, &response)
-	return
+	return response, err
 }
 
 func (s *PrivateNATGatewaysServer) Delete(ctx context.Context,
@@ -195,7 +195,7 @@ func (s *PrivateNATGatewaysServer) Delete(ctx context.Context,
 	id := request.GetId()
 	if id == "" {
 		err = grpcstatus.Errorf(grpccodes.InvalidArgument, "object identifier is mandatory")
-		return
+		return response, err
 	}
 
 	getRequest := &privatev1.NATGatewaysGetRequest{}
@@ -203,20 +203,20 @@ func (s *PrivateNATGatewaysServer) Delete(ctx context.Context,
 	var getResponse *privatev1.NATGatewaysGetResponse
 	err = s.generic.Get(ctx, getRequest, &getResponse)
 	if err != nil {
-		return
+		return response, err
 	}
 
 	externalIPID := getResponse.GetObject().GetSpec().GetExternalIp()
 
 	err = s.generic.Delete(ctx, request, &response)
 	if err != nil {
-		return
+		return response, err
 	}
 
 	if externalIPID != "" {
 		err = s.updateExternalIPAttachedFlag(ctx, externalIPID, false)
 	}
-	return
+	return response, err
 }
 
 func (s *PrivateNATGatewaysServer) Signal(ctx context.Context,

--- a/internal/servers/private_network_classes_server.go
+++ b/internal/servers/private_network_classes_server.go
@@ -118,11 +118,11 @@ func (b *PrivateNetworkClassesServerBuilder) Build() (result *PrivateNetworkClas
 	// Check parameters:
 	if b.logger == nil {
 		err = errors.New("logger is mandatory")
-		return
+		return result, err
 	}
 	if b.tenancyLogic == nil {
 		err = errors.New("tenancy logic is mandatory")
-		return
+		return result, err
 	}
 
 	// Create the generic server:
@@ -135,7 +135,7 @@ func (b *PrivateNetworkClassesServerBuilder) Build() (result *PrivateNetworkClas
 		SetMetricsRegisterer(b.metricsRegisterer).
 		Build()
 	if err != nil {
-		return
+		return result, err
 	}
 
 	// Create and populate the object:
@@ -143,7 +143,7 @@ func (b *PrivateNetworkClassesServerBuilder) Build() (result *PrivateNetworkClas
 		logger:  b.logger,
 		generic: generic,
 	}
-	return
+	return result, err
 }
 
 func (s *PrivateNetworkClassesServer) List(ctx context.Context,
@@ -163,7 +163,7 @@ func (s *PrivateNetworkClassesServer) Create(ctx context.Context,
 	// Validate before creating:
 	err = s.validateNetworkClass(ctx, request.GetObject(), nil)
 	if err != nil {
-		return
+		return response, err
 	}
 
 	// Set status to READY on creation since NetworkClass has no backend provisioning.
@@ -201,7 +201,7 @@ func (s *PrivateNetworkClassesServer) Create(ctx context.Context,
 			}
 		}
 	}
-	return
+	return response, err
 }
 
 func (s *PrivateNetworkClassesServer) Update(ctx context.Context,
@@ -210,7 +210,7 @@ func (s *PrivateNetworkClassesServer) Update(ctx context.Context,
 	id := request.GetObject().GetId()
 	if id == "" {
 		err = grpcstatus.Errorf(grpccodes.InvalidArgument, "object identifier is mandatory")
-		return
+		return response, err
 	}
 
 	getRequest := &privatev1.NetworkClassesGetRequest{}
@@ -218,7 +218,7 @@ func (s *PrivateNetworkClassesServer) Update(ctx context.Context,
 	var getResponse *privatev1.NetworkClassesGetResponse
 	err = s.generic.Get(ctx, getRequest, &getResponse)
 	if err != nil {
-		return
+		return response, err
 	}
 
 	existingNC := getResponse.GetObject()
@@ -231,7 +231,7 @@ func (s *PrivateNetworkClassesServer) Update(ctx context.Context,
 	// Validate the merged result against the original for immutability checks:
 	err = s.validateNetworkClass(ctx, merged, existingNC)
 	if err != nil {
-		return
+		return response, err
 	}
 
 	// Default-swap: if the update sets is_default=true AND the field is actually being applied
@@ -263,7 +263,7 @@ func (s *PrivateNetworkClassesServer) Update(ctx context.Context,
 	// normalized (no raw DB details leak), but the message is opaque. Fixing this
 	// requires GenericServer to preserve pgconn errors in the chain.
 	err = s.generic.Update(ctx, request, &response)
-	return
+	return response, err
 }
 
 func (s *PrivateNetworkClassesServer) Delete(ctx context.Context,

--- a/internal/servers/private_project_memberships_server.go
+++ b/internal/servers/private_project_memberships_server.go
@@ -84,11 +84,11 @@ func (b *PrivateProjectMembershipsServerBuilder) SetMetricsRegisterer(value prom
 func (b *PrivateProjectMembershipsServerBuilder) Build() (result *PrivateProjectMembershipsServer, err error) {
 	if b.logger == nil {
 		err = errors.New("logger is mandatory")
-		return
+		return result, err
 	}
 	if b.tenancyLogic == nil {
 		err = errors.New("tenancy logic is mandatory")
-		return
+		return result, err
 	}
 
 	generic, err := NewGenericServer[*privatev1.ProjectMembership]().
@@ -100,14 +100,14 @@ func (b *PrivateProjectMembershipsServerBuilder) Build() (result *PrivateProject
 		SetMetricsRegisterer(b.metricsRegisterer).
 		Build()
 	if err != nil {
-		return
+		return result, err
 	}
 
 	result = &PrivateProjectMembershipsServer{
 		logger:  b.logger,
 		generic: generic,
 	}
-	return
+	return result, err
 }
 
 func (s *PrivateProjectMembershipsServer) List(ctx context.Context,

--- a/internal/servers/private_projects_server.go
+++ b/internal/servers/private_projects_server.go
@@ -87,11 +87,11 @@ func (b *PrivateProjectsServerBuilder) Build() (result *PrivateProjectsServer, e
 	// Check parameters:
 	if b.logger == nil {
 		err = errors.New("logger is mandatory")
-		return
+		return result, err
 	}
 	if b.tenancyLogic == nil {
 		err = errors.New("tenancy logic is mandatory")
-		return
+		return result, err
 	}
 
 	// Create the server early, so that we can use its methods:
@@ -109,12 +109,12 @@ func (b *PrivateProjectsServerBuilder) Build() (result *PrivateProjectsServer, e
 		SetMetricsRegisterer(b.metricsRegisterer).
 		Build()
 	if err != nil {
-		return
+		return result, err
 	}
 
 	// Return the server:
 	result = s
-	return
+	return result, err
 }
 
 func (s *PrivateProjectsServer) List(ctx context.Context,
@@ -141,7 +141,7 @@ func (s *PrivateProjectsServer) Create(ctx context.Context,
 			grpccodes.InvalidArgument,
 			"field 'metadata' is mandatory",
 		)
-		return
+		return response, err
 	}
 	name := metadata.GetName()
 	path := strings.Split(name, ".")
@@ -152,7 +152,7 @@ func (s *PrivateProjectsServer) Create(ctx context.Context,
 			"field 'metadata.name' must have at most %d segments, but it has %d",
 			max, count,
 		)
-		return
+		return response, err
 	}
 
 	// When a project is created, the 'metadata.name' field must be the full name of the project, and the
@@ -170,13 +170,13 @@ func (s *PrivateProjectsServer) Create(ctx context.Context,
 				"'metadata.name', or set to '%s' to match the parent prefix, but it is '%s'",
 			project, input,
 		)
-		return
+		return response, err
 	}
 	metadata.SetProject(project)
 
 	// Call the generic server to create the project:
 	err = s.generic.Create(ctx, request, &response)
-	return
+	return response, err
 }
 
 func (s *PrivateProjectsServer) Update(ctx context.Context,

--- a/internal/servers/private_public_ip_attachments_server.go
+++ b/internal/servers/private_public_ip_attachments_server.go
@@ -156,7 +156,7 @@ func (s *PrivatePublicIPAttachmentsServer) Create(ctx context.Context,
 
 	err = s.validatePublicIPAttachment(attachment)
 	if err != nil {
-		return
+		return response, err
 	}
 
 	spec := attachment.GetSpec()
@@ -165,17 +165,17 @@ func (s *PrivatePublicIPAttachmentsServer) Create(ctx context.Context,
 
 	err = s.validatePublicIPReference(ctx, publicIPID)
 	if err != nil {
-		return
+		return response, err
 	}
 
 	err = s.validateComputeInstanceReference(ctx, computeInstanceID)
 	if err != nil {
-		return
+		return response, err
 	}
 
 	err = s.validateUniqueness(ctx, publicIPID, computeInstanceID)
 	if err != nil {
-		return
+		return response, err
 	}
 
 	if attachment.GetStatus() == nil {
@@ -189,15 +189,15 @@ func (s *PrivatePublicIPAttachmentsServer) Create(ctx context.Context,
 
 	err = s.generic.Create(ctx, request, &response)
 	if err != nil {
-		return
+		return response, err
 	}
 
 	err = s.updatePublicIPAttachedFlag(ctx, publicIPID, true)
 	if err != nil {
-		return
+		return response, err
 	}
 
-	return
+	return response, err
 }
 
 func (s *PrivatePublicIPAttachmentsServer) Update(ctx context.Context,
@@ -205,7 +205,7 @@ func (s *PrivatePublicIPAttachmentsServer) Update(ctx context.Context,
 	id := request.GetObject().GetId()
 	if id == "" {
 		err = grpcstatus.Errorf(grpccodes.InvalidArgument, "object identifier is mandatory")
-		return
+		return response, err
 	}
 
 	mask := request.GetUpdateMask()
@@ -215,16 +215,16 @@ func (s *PrivatePublicIPAttachmentsServer) Update(ctx context.Context,
 		var getResponse *privatev1.PublicIPAttachmentsGetResponse
 		err = s.generic.Get(ctx, getRequest, &getResponse)
 		if err != nil {
-			return
+			return response, err
 		}
 		err = validateImmutableFieldsPublicIPAttachment(request.GetObject(), getResponse.GetObject())
 		if err != nil {
-			return
+			return response, err
 		}
 	}
 
 	err = s.generic.Update(ctx, request, &response)
-	return
+	return response, err
 }
 
 // Delete removes the attachment and clears PublicIP.status.attached.
@@ -234,7 +234,7 @@ func (s *PrivatePublicIPAttachmentsServer) Delete(ctx context.Context,
 	id := request.GetId()
 	if id == "" {
 		err = grpcstatus.Errorf(grpccodes.InvalidArgument, "object identifier is mandatory")
-		return
+		return response, err
 	}
 
 	getRequest := &privatev1.PublicIPAttachmentsGetRequest{}
@@ -242,24 +242,24 @@ func (s *PrivatePublicIPAttachmentsServer) Delete(ctx context.Context,
 	var getResponse *privatev1.PublicIPAttachmentsGetResponse
 	err = s.generic.Get(ctx, getRequest, &getResponse)
 	if err != nil {
-		return
+		return response, err
 	}
 
 	publicIPID := getResponse.GetObject().GetSpec().GetPublicIp()
 
 	err = s.generic.Delete(ctx, request, &response)
 	if err != nil {
-		return
+		return response, err
 	}
 
 	if publicIPID != "" {
 		err = s.updatePublicIPAttachedFlag(ctx, publicIPID, false)
 		if err != nil {
-			return
+			return response, err
 		}
 	}
 
-	return
+	return response, err
 }
 
 func (s *PrivatePublicIPAttachmentsServer) Signal(ctx context.Context,

--- a/internal/servers/private_public_ip_pools_server.go
+++ b/internal/servers/private_public_ip_pools_server.go
@@ -90,11 +90,11 @@ func (b *PrivatePublicIPPoolsServerBuilder) SetMetricsRegisterer(value prometheu
 func (b *PrivatePublicIPPoolsServerBuilder) Build() (result *PrivatePublicIPPoolsServer, err error) {
 	if b.logger == nil {
 		err = errors.New("logger is mandatory")
-		return
+		return result, err
 	}
 	if b.tenancyLogic == nil {
 		err = errors.New("tenancy logic is mandatory")
-		return
+		return result, err
 	}
 
 	generic, err := NewGenericServer[*privatev1.PublicIPPool]().
@@ -106,14 +106,14 @@ func (b *PrivatePublicIPPoolsServerBuilder) Build() (result *PrivatePublicIPPool
 		SetMetricsRegisterer(b.metricsRegisterer).
 		Build()
 	if err != nil {
-		return
+		return result, err
 	}
 
 	result = &PrivatePublicIPPoolsServer{
 		logger:  b.logger,
 		generic: generic,
 	}
-	return
+	return result, err
 }
 
 func (s *PrivatePublicIPPoolsServer) List(ctx context.Context,
@@ -134,7 +134,7 @@ func (s *PrivatePublicIPPoolsServer) Create(ctx context.Context,
 
 	err = s.validateCreate(ctx, pool)
 	if err != nil {
-		return
+		return response, err
 	}
 
 	// At creation time nothing is allocated, so available == total.
@@ -145,7 +145,7 @@ func (s *PrivatePublicIPPoolsServer) Create(ctx context.Context,
 	}.Build())
 
 	err = s.generic.Create(ctx, request, &response)
-	return
+	return response, err
 }
 
 func (s *PrivatePublicIPPoolsServer) Update(ctx context.Context,
@@ -153,7 +153,7 @@ func (s *PrivatePublicIPPoolsServer) Update(ctx context.Context,
 	id := request.GetObject().GetId()
 	if id == "" {
 		err = grpcstatus.Errorf(grpccodes.InvalidArgument, "object identifier is mandatory")
-		return
+		return response, err
 	}
 
 	getRequest := &privatev1.PublicIPPoolsGetRequest{}
@@ -161,14 +161,14 @@ func (s *PrivatePublicIPPoolsServer) Update(ctx context.Context,
 	var getResponse *privatev1.PublicIPPoolsGetResponse
 	err = s.generic.Get(ctx, getRequest, &getResponse)
 	if err != nil {
-		return
+		return response, err
 	}
 
 	existing := getResponse.GetObject()
 
 	err = validateUpdate(request.GetObject(), existing)
 	if err != nil {
-		return
+		return response, err
 	}
 
 	// Preserve immutable implementation_strategy from existing object.
@@ -177,7 +177,7 @@ func (s *PrivatePublicIPPoolsServer) Update(ctx context.Context,
 	}
 
 	err = s.generic.Update(ctx, request, &response)
-	return
+	return response, err
 }
 
 // validateCreate validates a PublicIPPool creation request.
@@ -405,7 +405,7 @@ func (s *PrivatePublicIPPoolsServer) Delete(ctx context.Context,
 		Id: request.GetId(),
 	}.Build(), &getResponse)
 	if err != nil {
-		return
+		return response, err
 	}
 	if allocated := getResponse.GetObject().GetStatus().GetAllocated(); allocated > 0 {
 		err = grpcstatus.Errorf(
@@ -413,10 +413,10 @@ func (s *PrivatePublicIPPoolsServer) Delete(ctx context.Context,
 			"cannot delete public IP pool '%s': %d public IP(s) are still allocated from it",
 			request.GetId(), allocated,
 		)
-		return
+		return response, err
 	}
 	err = s.generic.Delete(ctx, request, &response)
-	return
+	return response, err
 }
 
 func (s *PrivatePublicIPPoolsServer) Signal(ctx context.Context,

--- a/internal/servers/private_public_ips_server.go
+++ b/internal/servers/private_public_ips_server.go
@@ -101,15 +101,15 @@ func (b *PrivatePublicIPsServerBuilder) Build() (result *PrivatePublicIPsServer,
 	// Check parameters:
 	if b.logger == nil {
 		err = errors.New("logger is mandatory")
-		return
+		return result, err
 	}
 	if b.tenancyLogic == nil {
 		err = errors.New("tenancy logic is mandatory")
-		return
+		return result, err
 	}
 	if b.attributionLogic == nil {
 		err = errors.New("attribution logic is mandatory")
-		return
+		return result, err
 	}
 
 	// Create the PublicIPPool DAO for pool validation and capacity tracking:
@@ -119,7 +119,7 @@ func (b *PrivatePublicIPsServerBuilder) Build() (result *PrivatePublicIPsServer,
 		SetMetricsRegisterer(b.metricsRegisterer).
 		Build()
 	if err != nil {
-		return
+		return result, err
 	}
 
 	// Create the generic server:
@@ -132,7 +132,7 @@ func (b *PrivatePublicIPsServerBuilder) Build() (result *PrivatePublicIPsServer,
 		SetMetricsRegisterer(b.metricsRegisterer).
 		Build()
 	if err != nil {
-		return
+		return result, err
 	}
 
 	// Create and populate the object:
@@ -141,7 +141,7 @@ func (b *PrivatePublicIPsServerBuilder) Build() (result *PrivatePublicIPsServer,
 		generic:         generic,
 		publicIPPoolDao: publicIPPoolDao,
 	}
-	return
+	return result, err
 }
 
 func (s *PrivatePublicIPsServer) List(ctx context.Context,
@@ -166,14 +166,14 @@ func (s *PrivatePublicIPsServer) Create(ctx context.Context,
 	// Validate before creating:
 	err = s.validatePublicIP(ctx, publicIP)
 	if err != nil {
-		return
+		return response, err
 	}
 
 	// Auto-select pool when not explicitly provided:
 	if publicIP.GetSpec().GetPool() == "" {
 		err = s.selectPool(ctx, publicIP)
 		if err != nil {
-			return
+			return response, err
 		}
 	}
 
@@ -181,7 +181,7 @@ func (s *PrivatePublicIPsServer) Create(ctx context.Context,
 	poolID := publicIP.GetSpec().GetPool()
 	err = s.validatePoolReference(ctx, poolID)
 	if err != nil {
-		return
+		return response, err
 	}
 
 	// Set initial state to PENDING
@@ -196,7 +196,7 @@ func (s *PrivatePublicIPsServer) Create(ctx context.Context,
 	// Create the PublicIP:
 	err = s.generic.Create(ctx, request, &response)
 	if err != nil {
-		return
+		return response, err
 	}
 
 	// Update pool capacity: decrement available, increment allocated.
@@ -204,10 +204,10 @@ func (s *PrivatePublicIPsServer) Create(ctx context.Context,
 	// (optimistic locking). A version conflict returns Aborted for client retry.
 	err = s.updatePoolCapacity(ctx, poolID, 1)
 	if err != nil {
-		return
+		return response, err
 	}
 
-	return
+	return response, err
 }
 
 // Update validates pool immutability and state machine transitions before persisting.
@@ -219,7 +219,7 @@ func (s *PrivatePublicIPsServer) Update(ctx context.Context,
 	id := request.GetObject().GetId()
 	if id == "" {
 		err = grpcstatus.Errorf(grpccodes.InvalidArgument, "object identifier is mandatory")
-		return
+		return response, err
 	}
 
 	getRequest := &privatev1.PublicIPsGetRequest{}
@@ -227,7 +227,7 @@ func (s *PrivatePublicIPsServer) Update(ctx context.Context,
 	var getResponse *privatev1.PublicIPsGetResponse
 	err = s.generic.Get(ctx, getRequest, &getResponse)
 	if err != nil {
-		return
+		return response, err
 	}
 
 	existingPublicIP := getResponse.GetObject()
@@ -240,7 +240,7 @@ func (s *PrivatePublicIPsServer) Update(ctx context.Context,
 			err = grpcstatus.Errorf(grpccodes.InvalidArgument,
 				"field 'spec.pool' is immutable and cannot be changed from '%s' to '%s'",
 				existingPool, newPool)
-			return
+			return response, err
 		}
 	}
 
@@ -251,7 +251,7 @@ func (s *PrivatePublicIPsServer) Update(ctx context.Context,
 			err = grpcstatus.Errorf(grpccodes.InvalidArgument,
 				"field 'spec.ip_family' is immutable and cannot be changed from '%s' to '%s'",
 				existingIPFamily.String(), newIPFamily.String())
-			return
+			return response, err
 		}
 	}
 
@@ -260,13 +260,13 @@ func (s *PrivatePublicIPsServer) Update(ctx context.Context,
 		existingState := existingPublicIP.GetStatus().GetState()
 		if newState != existingState {
 			if err = validatePublicIPStateTransition(existingState, newState); err != nil {
-				return
+				return response, err
 			}
 		}
 	}
 
 	err = s.generic.Update(ctx, request, &response)
-	return
+	return response, err
 }
 
 // Delete rejects deletion of ATTACHED PublicIPs and restores pool capacity on success.
@@ -277,7 +277,7 @@ func (s *PrivatePublicIPsServer) Delete(ctx context.Context,
 	id := request.GetId()
 	if id == "" {
 		err = grpcstatus.Errorf(grpccodes.InvalidArgument, "object identifier is mandatory")
-		return
+		return response, err
 	}
 
 	getRequest := &privatev1.PublicIPsGetRequest{}
@@ -285,7 +285,7 @@ func (s *PrivatePublicIPsServer) Delete(ctx context.Context,
 	var getResponse *privatev1.PublicIPsGetResponse
 	err = s.generic.Get(ctx, getRequest, &getResponse)
 	if err != nil {
-		return
+		return response, err
 	}
 
 	existingPublicIP := getResponse.GetObject()
@@ -294,13 +294,13 @@ func (s *PrivatePublicIPsServer) Delete(ctx context.Context,
 	if state != privatev1.PublicIPState_PUBLIC_IP_STATE_ALLOCATED {
 		err = grpcstatus.Errorf(grpccodes.FailedPrecondition,
 			"cannot delete PublicIP in state %s: must be in ALLOCATED state", state)
-		return
+		return response, err
 	}
 
 	// Delete the PublicIP:
 	err = s.generic.Delete(ctx, request, &response)
 	if err != nil {
-		return
+		return response, err
 	}
 
 	// Update pool capacity: increment available, decrement allocated:
@@ -308,11 +308,11 @@ func (s *PrivatePublicIPsServer) Delete(ctx context.Context,
 	if poolID != "" {
 		err = s.updatePoolCapacity(ctx, poolID, -1)
 		if err != nil {
-			return
+			return response, err
 		}
 	}
 
-	return
+	return response, err
 }
 
 func (s *PrivatePublicIPsServer) Signal(ctx context.Context,

--- a/internal/servers/private_role_bindings_server.go
+++ b/internal/servers/private_role_bindings_server.go
@@ -84,11 +84,11 @@ func (b *PrivateRoleBindingsServerBuilder) SetMetricsRegisterer(value prometheus
 func (b *PrivateRoleBindingsServerBuilder) Build() (result *PrivateRoleBindingsServer, err error) {
 	if b.logger == nil {
 		err = errors.New("logger is mandatory")
-		return
+		return result, err
 	}
 	if b.tenancyLogic == nil {
 		err = errors.New("tenancy logic is mandatory")
-		return
+		return result, err
 	}
 
 	generic, err := NewGenericServer[*privatev1.RoleBinding]().
@@ -100,14 +100,14 @@ func (b *PrivateRoleBindingsServerBuilder) Build() (result *PrivateRoleBindingsS
 		SetMetricsRegisterer(b.metricsRegisterer).
 		Build()
 	if err != nil {
-		return
+		return result, err
 	}
 
 	result = &PrivateRoleBindingsServer{
 		logger:  b.logger,
 		generic: generic,
 	}
-	return
+	return result, err
 }
 
 func (s *PrivateRoleBindingsServer) List(ctx context.Context,

--- a/internal/servers/private_roles_server.go
+++ b/internal/servers/private_roles_server.go
@@ -84,11 +84,11 @@ func (b *PrivateRolesServerBuilder) SetMetricsRegisterer(value prometheus.Regist
 func (b *PrivateRolesServerBuilder) Build() (result *PrivateRolesServer, err error) {
 	if b.logger == nil {
 		err = errors.New("logger is mandatory")
-		return
+		return result, err
 	}
 	if b.tenancyLogic == nil {
 		err = errors.New("tenancy logic is mandatory")
-		return
+		return result, err
 	}
 
 	generic, err := NewGenericServer[*privatev1.Role]().
@@ -100,14 +100,14 @@ func (b *PrivateRolesServerBuilder) Build() (result *PrivateRolesServer, err err
 		SetMetricsRegisterer(b.metricsRegisterer).
 		Build()
 	if err != nil {
-		return
+		return result, err
 	}
 
 	result = &PrivateRolesServer{
 		logger:  b.logger,
 		generic: generic,
 	}
-	return
+	return result, err
 }
 
 func (s *PrivateRolesServer) List(ctx context.Context,

--- a/internal/servers/private_security_groups_server.go
+++ b/internal/servers/private_security_groups_server.go
@@ -83,15 +83,15 @@ func (b *PrivateSecurityGroupsServerBuilder) Build() (result *PrivateSecurityGro
 	// Check parameters:
 	if b.logger == nil {
 		err = errors.New("logger is mandatory")
-		return
+		return result, err
 	}
 	if b.attributionLogic == nil {
 		err = errors.New("attribution logic is mandatory")
-		return
+		return result, err
 	}
 	if b.tenancyLogic == nil {
 		err = errors.New("tenancy logic is mandatory")
-		return
+		return result, err
 	}
 
 	// Create the VirtualNetwork DAO for parent validation:
@@ -101,7 +101,7 @@ func (b *PrivateSecurityGroupsServerBuilder) Build() (result *PrivateSecurityGro
 		SetMetricsRegisterer(b.metricsRegisterer).
 		Build()
 	if err != nil {
-		return
+		return result, err
 	}
 
 	// Create the generic server:
@@ -114,7 +114,7 @@ func (b *PrivateSecurityGroupsServerBuilder) Build() (result *PrivateSecurityGro
 		SetMetricsRegisterer(b.metricsRegisterer).
 		Build()
 	if err != nil {
-		return
+		return result, err
 	}
 
 	// Create and populate the object:
@@ -123,7 +123,7 @@ func (b *PrivateSecurityGroupsServerBuilder) Build() (result *PrivateSecurityGro
 		generic:           generic,
 		virtualNetworkDao: virtualNetworkDao,
 	}
-	return
+	return result, err
 }
 
 func (s *PrivateSecurityGroupsServer) List(ctx context.Context,
@@ -145,7 +145,7 @@ func (s *PrivateSecurityGroupsServer) Create(ctx context.Context,
 	// Validate before creating:
 	err = s.validateSecurityGroup(ctx, securityGroup, nil)
 	if err != nil {
-		return
+		return response, err
 	}
 
 	// Set owner reference annotation automatically
@@ -161,7 +161,7 @@ func (s *PrivateSecurityGroupsServer) Create(ctx context.Context,
 	securityGroup.GetSpec().SetImplementationStrategy(securityGroupImplementationStrategy)
 
 	err = s.generic.Create(ctx, request, &response)
-	return
+	return response, err
 }
 
 func (s *PrivateSecurityGroupsServer) Update(ctx context.Context,
@@ -170,7 +170,7 @@ func (s *PrivateSecurityGroupsServer) Update(ctx context.Context,
 	id := request.GetObject().GetId()
 	if id == "" {
 		err = grpcstatus.Errorf(grpccodes.InvalidArgument, "object identifier is mandatory")
-		return
+		return response, err
 	}
 
 	getRequest := &privatev1.SecurityGroupsGetRequest{}
@@ -178,7 +178,7 @@ func (s *PrivateSecurityGroupsServer) Update(ctx context.Context,
 	var getResponse *privatev1.SecurityGroupsGetResponse
 	err = s.generic.Get(ctx, getRequest, &getResponse)
 	if err != nil {
-		return
+		return response, err
 	}
 
 	existingSecurityGroup := getResponse.GetObject()
@@ -186,7 +186,7 @@ func (s *PrivateSecurityGroupsServer) Update(ctx context.Context,
 	// Validate with existing object context:
 	err = s.validateSecurityGroup(ctx, request.GetObject(), existingSecurityGroup)
 	if err != nil {
-		return
+		return response, err
 	}
 
 	// Preserve immutable implementation_strategy from existing object. Validation that the
@@ -196,7 +196,7 @@ func (s *PrivateSecurityGroupsServer) Update(ctx context.Context,
 	}
 
 	err = s.generic.Update(ctx, request, &response)
-	return
+	return response, err
 }
 
 func (s *PrivateSecurityGroupsServer) Delete(ctx context.Context,

--- a/internal/servers/private_storage_backends_server.go
+++ b/internal/servers/private_storage_backends_server.go
@@ -77,11 +77,11 @@ func (b *PrivateStorageBackendsServerBuilder) Build() (result *PrivateStorageBac
 	// Check parameters:
 	if b.logger == nil {
 		err = errors.New("logger is mandatory")
-		return
+		return result, err
 	}
 	if b.tenancyLogic == nil {
 		err = errors.New("tenancy logic is mandatory")
-		return
+		return result, err
 	}
 
 	// Create the server early so that we can use its functions to set up other objects:
@@ -100,12 +100,12 @@ func (b *PrivateStorageBackendsServerBuilder) Build() (result *PrivateStorageBac
 		SetMetricsRegisterer(b.metricsRegisterer).
 		Build()
 	if err != nil {
-		return
+		return result, err
 	}
 
 	// Return the server:
 	result = s
-	return
+	return result, err
 }
 
 // redact clears sensitive fields from the storage backend before it is included in event notification payloads.
@@ -138,7 +138,7 @@ func (s *PrivateStorageBackendsServer) Create(ctx context.Context,
 	request *privatev1.StorageBackendsCreateRequest) (response *privatev1.StorageBackendsCreateResponse, err error) {
 	err = s.validateStorageBackendCreate(ctx, request.GetObject())
 	if err != nil {
-		return
+		return response, err
 	}
 
 	sb := request.GetObject()
@@ -156,7 +156,7 @@ func (s *PrivateStorageBackendsServer) Create(ctx context.Context,
 	sb.GetMetadata().SetTenant(auth.SharedTenant)
 
 	err = s.generic.Create(ctx, request, &response)
-	return
+	return response, err
 }
 
 func (s *PrivateStorageBackendsServer) Update(ctx context.Context,
@@ -164,7 +164,7 @@ func (s *PrivateStorageBackendsServer) Update(ctx context.Context,
 	id := request.GetObject().GetId()
 	if id == "" {
 		err = grpcstatus.Errorf(grpccodes.InvalidArgument, "object identifier is mandatory")
-		return
+		return response, err
 	}
 
 	getRequest := &privatev1.StorageBackendsGetRequest{}
@@ -172,18 +172,18 @@ func (s *PrivateStorageBackendsServer) Update(ctx context.Context,
 	var getResponse *privatev1.StorageBackendsGetResponse
 	err = s.generic.Get(ctx, getRequest, &getResponse)
 	if err != nil {
-		return
+		return response, err
 	}
 
 	existingSB := getResponse.GetObject()
 
 	err = s.validateStorageBackendUpdate(ctx, request.GetObject(), existingSB)
 	if err != nil {
-		return
+		return response, err
 	}
 
 	err = s.generic.Update(ctx, request, &response)
-	return
+	return response, err
 }
 
 func (s *PrivateStorageBackendsServer) Delete(ctx context.Context,

--- a/internal/servers/private_storage_tiers_server.go
+++ b/internal/servers/private_storage_tiers_server.go
@@ -85,15 +85,15 @@ func (b *PrivateStorageTiersServerBuilder) SetStorageBackendsDAO(value *dao.Gene
 func (b *PrivateStorageTiersServerBuilder) Build() (result *PrivateStorageTiersServer, err error) {
 	if b.logger == nil {
 		err = errors.New("logger is mandatory")
-		return
+		return result, err
 	}
 	if b.tenancyLogic == nil {
 		err = errors.New("tenancy logic is mandatory")
-		return
+		return result, err
 	}
 	if b.storageBackendsDAO == nil {
 		err = errors.New("storage backends DAO is mandatory")
-		return
+		return result, err
 	}
 
 	generic, err := NewGenericServer[*privatev1.StorageTier]().
@@ -105,7 +105,7 @@ func (b *PrivateStorageTiersServerBuilder) Build() (result *PrivateStorageTiersS
 		SetMetricsRegisterer(b.metricsRegisterer).
 		Build()
 	if err != nil {
-		return
+		return result, err
 	}
 
 	result = &PrivateStorageTiersServer{
@@ -113,7 +113,7 @@ func (b *PrivateStorageTiersServerBuilder) Build() (result *PrivateStorageTiersS
 		generic:            generic,
 		storageBackendsDAO: b.storageBackendsDAO,
 	}
-	return
+	return result, err
 }
 
 func (s *PrivateStorageTiersServer) List(ctx context.Context,
@@ -132,7 +132,7 @@ func (s *PrivateStorageTiersServer) Create(ctx context.Context,
 	request *privatev1.StorageTiersCreateRequest) (response *privatev1.StorageTiersCreateResponse, err error) {
 	err = s.validateStorageTierCreate(ctx, request.GetObject())
 	if err != nil {
-		return
+		return response, err
 	}
 
 	st := request.GetObject()
@@ -149,7 +149,7 @@ func (s *PrivateStorageTiersServer) Create(ctx context.Context,
 	st.GetMetadata().SetTenant(auth.SharedTenant)
 
 	err = s.generic.Create(ctx, request, &response)
-	return
+	return response, err
 }
 
 func (s *PrivateStorageTiersServer) Update(ctx context.Context,
@@ -157,7 +157,7 @@ func (s *PrivateStorageTiersServer) Update(ctx context.Context,
 	id := request.GetObject().GetId()
 	if id == "" {
 		err = grpcstatus.Errorf(grpccodes.InvalidArgument, "object identifier is mandatory")
-		return
+		return response, err
 	}
 
 	getRequest := &privatev1.StorageTiersGetRequest{}
@@ -165,18 +165,18 @@ func (s *PrivateStorageTiersServer) Update(ctx context.Context,
 	var getResponse *privatev1.StorageTiersGetResponse
 	err = s.generic.Get(ctx, getRequest, &getResponse)
 	if err != nil {
-		return
+		return response, err
 	}
 
 	existingST := getResponse.GetObject()
 
 	err = s.validateStorageTierUpdate(ctx, request.GetObject(), existingST, request.GetUpdateMask())
 	if err != nil {
-		return
+		return response, err
 	}
 
 	err = s.generic.Update(ctx, request, &response)
-	return
+	return response, err
 }
 
 func (s *PrivateStorageTiersServer) Delete(ctx context.Context,

--- a/internal/servers/private_subnets_server.go
+++ b/internal/servers/private_subnets_server.go
@@ -83,11 +83,11 @@ func (b *PrivateSubnetsServerBuilder) Build() (result *PrivateSubnetsServer, err
 	// Check parameters:
 	if b.logger == nil {
 		err = errors.New("logger is mandatory")
-		return
+		return result, err
 	}
 	if b.tenancyLogic == nil {
 		err = errors.New("tenancy logic is mandatory")
-		return
+		return result, err
 	}
 
 	// Create the VirtualNetwork DAO for parent validation:
@@ -97,7 +97,7 @@ func (b *PrivateSubnetsServerBuilder) Build() (result *PrivateSubnetsServer, err
 		SetMetricsRegisterer(b.metricsRegisterer).
 		Build()
 	if err != nil {
-		return
+		return result, err
 	}
 
 	// Create the generic server:
@@ -110,7 +110,7 @@ func (b *PrivateSubnetsServerBuilder) Build() (result *PrivateSubnetsServer, err
 		SetMetricsRegisterer(b.metricsRegisterer).
 		Build()
 	if err != nil {
-		return
+		return result, err
 	}
 
 	// Create and populate the object:
@@ -119,7 +119,7 @@ func (b *PrivateSubnetsServerBuilder) Build() (result *PrivateSubnetsServer, err
 		generic:           generic,
 		virtualNetworkDao: virtualNetworkDao,
 	}
-	return
+	return result, err
 }
 
 func (s *PrivateSubnetsServer) List(ctx context.Context,
@@ -142,7 +142,7 @@ func (s *PrivateSubnetsServer) Create(ctx context.Context,
 	// Validate before creating:
 	err = s.validateSubnet(ctx, subnet, nil)
 	if err != nil {
-		return
+		return response, err
 	}
 
 	// SUB-VAL-10: Set owner reference annotation automatically
@@ -155,7 +155,7 @@ func (s *PrivateSubnetsServer) Create(ctx context.Context,
 	subnet.Metadata.Annotations["osac.openshift.io/owner-reference"] = subnet.GetSpec().GetVirtualNetwork()
 
 	err = s.generic.Create(ctx, request, &response)
-	return
+	return response, err
 }
 
 // SUB-SVC-04: Update updates an existing Subnet with validation
@@ -165,7 +165,7 @@ func (s *PrivateSubnetsServer) Update(ctx context.Context,
 	id := request.GetObject().GetId()
 	if id == "" {
 		err = grpcstatus.Errorf(grpccodes.InvalidArgument, "object identifier is mandatory")
-		return
+		return response, err
 	}
 
 	getRequest := &privatev1.SubnetsGetRequest{}
@@ -173,7 +173,7 @@ func (s *PrivateSubnetsServer) Update(ctx context.Context,
 	var getResponse *privatev1.SubnetsGetResponse
 	err = s.generic.Get(ctx, getRequest, &getResponse)
 	if err != nil {
-		return
+		return response, err
 	}
 
 	existingSubnet := getResponse.GetObject()
@@ -181,11 +181,11 @@ func (s *PrivateSubnetsServer) Update(ctx context.Context,
 	// Validate with existing object context:
 	err = s.validateSubnet(ctx, request.GetObject(), existingSubnet)
 	if err != nil {
-		return
+		return response, err
 	}
 
 	err = s.generic.Update(ctx, request, &response)
-	return
+	return response, err
 }
 
 func (s *PrivateSubnetsServer) Delete(ctx context.Context,

--- a/internal/servers/private_tenants_server.go
+++ b/internal/servers/private_tenants_server.go
@@ -80,11 +80,11 @@ func (b *PrivateTenantsServerBuilder) Build() (result *PrivateTenantsServer, err
 	// Check parameters:
 	if b.logger == nil {
 		err = errors.New("logger is mandatory")
-		return
+		return result, err
 	}
 	if b.tenancyLogic == nil {
 		err = errors.New("tenancy logic is mandatory")
-		return
+		return result, err
 	}
 
 	// Create the generic server:
@@ -98,7 +98,7 @@ func (b *PrivateTenantsServerBuilder) Build() (result *PrivateTenantsServer, err
 		SetMetricsRegisterer(b.metricsRegisterer).
 		Build()
 	if err != nil {
-		return
+		return result, err
 	}
 
 	// Create the DAO:
@@ -109,7 +109,7 @@ func (b *PrivateTenantsServerBuilder) Build() (result *PrivateTenantsServer, err
 		SetMetricsRegisterer(b.metricsRegisterer).
 		Build()
 	if err != nil {
-		return
+		return result, err
 	}
 
 	// Create and populate the object:
@@ -118,7 +118,7 @@ func (b *PrivateTenantsServerBuilder) Build() (result *PrivateTenantsServer, err
 		generic: generic,
 		dao:     dao,
 	}
-	return
+	return result, err
 }
 
 func (s *PrivateTenantsServer) List(ctx context.Context,
@@ -144,7 +144,7 @@ func (s *PrivateTenantsServer) Create(ctx context.Context,
 			grpccodes.InvalidArgument,
 			"field 'metadata.name' is mandatory",
 		)
-		return
+		return response, err
 	}
 
 	// For tenants the identifier must be empty or equal to the name. If it is empty it will be set to the name.
@@ -154,7 +154,7 @@ func (s *PrivateTenantsServer) Create(ctx context.Context,
 			grpccodes.InvalidArgument,
 			"field 'id' must be empty or equal to field 'metadata.name'",
 		)
-		return
+		return response, err
 	}
 	if id == "" {
 		object.SetId(name)
@@ -168,7 +168,7 @@ func (s *PrivateTenantsServer) Create(ctx context.Context,
 			grpccodes.InvalidArgument,
 			"field 'metadata.tenant' must be empty or equal to field 'metadata.name'",
 		)
-		return
+		return response, err
 	}
 	if tenant == "" {
 		metadata.SetTenant(name)
@@ -177,7 +177,7 @@ func (s *PrivateTenantsServer) Create(ctx context.Context,
 	// Domain validation is now handled by protovalidate in the interceptor
 	// Delegate to the generic server:
 	err = s.generic.Create(ctx, request, &response)
-	return
+	return response, err
 }
 
 func (s *PrivateTenantsServer) Update(ctx context.Context,

--- a/internal/servers/private_users_server.go
+++ b/internal/servers/private_users_server.go
@@ -76,11 +76,11 @@ func (b *PrivateUsersServerBuilder) Build() (result *PrivateUsersServer, err err
 	// Check parameters:
 	if b.logger == nil {
 		err = errors.New("logger is mandatory")
-		return
+		return result, err
 	}
 	if b.tenancyLogic == nil {
 		err = errors.New("tenancy logic is mandatory")
-		return
+		return result, err
 	}
 
 	// Create the generic server:
@@ -93,7 +93,7 @@ func (b *PrivateUsersServerBuilder) Build() (result *PrivateUsersServer, err err
 		SetMetricsRegisterer(b.metricsRegisterer).
 		Build()
 	if err != nil {
-		return
+		return result, err
 	}
 
 	// Create and populate the object:
@@ -101,7 +101,7 @@ func (b *PrivateUsersServerBuilder) Build() (result *PrivateUsersServer, err err
 		logger:  b.logger,
 		generic: generic,
 	}
-	return
+	return result, err
 }
 
 func (s *PrivateUsersServer) List(ctx context.Context,

--- a/internal/servers/private_virtual_networks_server.go
+++ b/internal/servers/private_virtual_networks_server.go
@@ -82,11 +82,11 @@ func (b *PrivateVirtualNetworksServerBuilder) Build() (result *PrivateVirtualNet
 	// Check parameters:
 	if b.logger == nil {
 		err = errors.New("logger is mandatory")
-		return
+		return result, err
 	}
 	if b.tenancyLogic == nil {
 		err = errors.New("tenancy logic is mandatory")
-		return
+		return result, err
 	}
 
 	// Create the NetworkClass DAO:
@@ -96,7 +96,7 @@ func (b *PrivateVirtualNetworksServerBuilder) Build() (result *PrivateVirtualNet
 		SetMetricsRegisterer(b.metricsRegisterer).
 		Build()
 	if err != nil {
-		return
+		return result, err
 	}
 
 	// Create the generic server:
@@ -109,7 +109,7 @@ func (b *PrivateVirtualNetworksServerBuilder) Build() (result *PrivateVirtualNet
 		SetMetricsRegisterer(b.metricsRegisterer).
 		Build()
 	if err != nil {
-		return
+		return result, err
 	}
 
 	// Create and populate the object:
@@ -118,7 +118,7 @@ func (b *PrivateVirtualNetworksServerBuilder) Build() (result *PrivateVirtualNet
 		generic:         generic,
 		networkClassDao: networkClassDao,
 	}
-	return
+	return result, err
 }
 
 func (s *PrivateVirtualNetworksServer) List(ctx context.Context,
@@ -138,7 +138,7 @@ func (s *PrivateVirtualNetworksServer) Create(ctx context.Context,
 	// Validate before creating:
 	implementationStrategy, err := s.validateVirtualNetwork(ctx, request.GetObject(), nil)
 	if err != nil {
-		return
+		return response, err
 	}
 
 	// Set the implementation_strategy from the NetworkClass
@@ -148,7 +148,7 @@ func (s *PrivateVirtualNetworksServer) Create(ctx context.Context,
 	}
 
 	err = s.generic.Create(ctx, request, &response)
-	return
+	return response, err
 }
 
 func (s *PrivateVirtualNetworksServer) Update(ctx context.Context,
@@ -157,7 +157,7 @@ func (s *PrivateVirtualNetworksServer) Update(ctx context.Context,
 	id := request.GetObject().GetId()
 	if id == "" {
 		err = grpcstatus.Errorf(grpccodes.InvalidArgument, "object identifier is mandatory")
-		return
+		return response, err
 	}
 
 	getRequest := &privatev1.VirtualNetworksGetRequest{}
@@ -165,7 +165,7 @@ func (s *PrivateVirtualNetworksServer) Update(ctx context.Context,
 	var getResponse *privatev1.VirtualNetworksGetResponse
 	err = s.generic.Get(ctx, getRequest, &getResponse)
 	if err != nil {
-		return
+		return response, err
 	}
 
 	existingVN := getResponse.GetObject()
@@ -173,7 +173,7 @@ func (s *PrivateVirtualNetworksServer) Update(ctx context.Context,
 	// Validate with existing object context:
 	_, err = s.validateVirtualNetwork(ctx, request.GetObject(), existingVN)
 	if err != nil {
-		return
+		return response, err
 	}
 
 	// Preserve immutable implementation_strategy from existing object.
@@ -182,7 +182,7 @@ func (s *PrivateVirtualNetworksServer) Update(ctx context.Context,
 	}
 
 	err = s.generic.Update(ctx, request, &response)
-	return
+	return response, err
 }
 
 func (s *PrivateVirtualNetworksServer) Delete(ctx context.Context,
@@ -204,33 +204,33 @@ func (s *PrivateVirtualNetworksServer) validateVirtualNetwork(ctx context.Contex
 
 	if newVN == nil {
 		err = grpcstatus.Errorf(grpccodes.InvalidArgument, "virtual network is mandatory")
-		return
+		return implementationStrategy, err
 	}
 
 	spec := newVN.GetSpec()
 	if spec == nil {
 		err = grpcstatus.Errorf(grpccodes.InvalidArgument, "virtual network spec is mandatory")
-		return
+		return implementationStrategy, err
 	}
 
 	// VN-VAL-08: Region is required
 	if spec.GetRegion() == "" {
 		err = grpcstatus.Errorf(grpccodes.InvalidArgument, "field 'spec.region' is required")
-		return
+		return implementationStrategy, err
 	}
 
 	// VN-VAL-09, VN-VAL-10, VN-VAL-11, VN-VAL-12: Check immutable fields (only on Update).
 	// Run before VN-VAL-03 so that explicit-empty-string attempts to clear an immutable CIDR
 	// return "field is immutable" rather than "at least one CIDR required".
 	if err = validateImmutableFields(newVN, existingVN); err != nil {
-		return
+		return implementationStrategy, err
 	}
 
 	// VN-VAL-03: At least one CIDR must be provided
 	if spec.GetIpv4Cidr() == "" && spec.GetIpv6Cidr() == "" {
 		err = grpcstatus.Errorf(grpccodes.InvalidArgument,
 			"at least one of 'spec.ipv4_cidr' or 'spec.ipv6_cidr' must be provided")
-		return
+		return implementationStrategy, err
 	}
 
 	// VN-VAL-01, VN-VAL-02: Validate and canonicalize CIDRs
@@ -238,7 +238,7 @@ func (s *PrivateVirtualNetworksServer) validateVirtualNetwork(ctx context.Contex
 		spec.GetIpv4Cidr, spec.SetIpv4Cidr,
 		spec.GetIpv6Cidr, spec.SetIpv6Cidr,
 	); err != nil {
-		return
+		return implementationStrategy, err
 	}
 
 	// VN-VAL-04, VN-VAL-05, VN-VAL-06: Validate NetworkClass
@@ -247,11 +247,11 @@ func (s *PrivateVirtualNetworksServer) validateVirtualNetwork(ctx context.Contex
 	if existingVN == nil || spec.GetNetworkClass() != existingVN.GetSpec().GetNetworkClass() {
 		implementationStrategy, err = s.validateNetworkClassReference(ctx, spec)
 		if err != nil {
-			return
+			return implementationStrategy, err
 		}
 	}
 
-	return
+	return implementationStrategy, err
 }
 
 // validateImmutableFields validates that immutable fields have not been changed.
@@ -354,12 +354,12 @@ func (s *PrivateVirtualNetworksServer) validateNetworkClassReference(ctx context
 				slog.String("network_class", networkClassRef),
 				slog.Any("error", listErr))
 			err = grpcstatus.Errorf(grpccodes.Internal, "failed to validate network_class")
-			return
+			return implementationStrategy, err
 		}
 		if len(listResponse.GetItems()) == 0 {
 			err = grpcstatus.Errorf(grpccodes.InvalidArgument,
 				"network_class '%s' does not exist", networkClassRef)
-			return
+			return implementationStrategy, err
 		}
 		networkClass = listResponse.GetItems()[0]
 	}
@@ -367,7 +367,7 @@ func (s *PrivateVirtualNetworksServer) validateNetworkClassReference(ctx context
 	if networkClass.GetMetadata().HasDeletionTimestamp() {
 		err = grpcstatus.Errorf(grpccodes.InvalidArgument,
 			"network_class '%s' does not exist", networkClassRef)
-		return
+		return implementationStrategy, err
 	}
 
 	// VN-VAL-05: Check NetworkClass is READY
@@ -375,7 +375,7 @@ func (s *PrivateVirtualNetworksServer) validateNetworkClassReference(ctx context
 		err = grpcstatus.Errorf(grpccodes.FailedPrecondition,
 			"network_class '%s' is not in READY state (current state: %s)",
 			networkClassRef, networkClass.GetStatus().GetState().String())
-		return
+		return implementationStrategy, err
 	}
 
 	// VN-VAL-06: Validate capabilities match
@@ -385,21 +385,21 @@ func (s *PrivateVirtualNetworksServer) validateNetworkClassReference(ctx context
 		if vnCaps.GetEnableIpv4() && !ncCaps.GetSupportsIpv4() {
 			err = grpcstatus.Errorf(grpccodes.InvalidArgument,
 				"network_class '%s' does not support IPv4", networkClassRef)
-			return
+			return implementationStrategy, err
 		}
 		if vnCaps.GetEnableIpv6() && !ncCaps.GetSupportsIpv6() {
 			err = grpcstatus.Errorf(grpccodes.InvalidArgument,
 				"network_class '%s' does not support IPv6", networkClassRef)
-			return
+			return implementationStrategy, err
 		}
 		if vnCaps.GetEnableDualStack() && !ncCaps.GetSupportsDualStack() {
 			err = grpcstatus.Errorf(grpccodes.InvalidArgument,
 				"network_class '%s' does not support dual-stack", networkClassRef)
-			return
+			return implementationStrategy, err
 		}
 	}
 
 	// Return the implementation_strategy for storage in VirtualNetwork spec
 	implementationStrategy = networkClass.GetImplementationStrategy()
-	return
+	return implementationStrategy, err
 }

--- a/internal/servers/project_memberships_server.go
+++ b/internal/servers/project_memberships_server.go
@@ -89,11 +89,11 @@ func (b *ProjectMembershipsServerBuilder) SetMetricsRegisterer(value prometheus.
 func (b *ProjectMembershipsServerBuilder) Build() (result *ProjectMembershipsServer, err error) {
 	if b.logger == nil {
 		err = errors.New("logger is mandatory")
-		return
+		return result, err
 	}
 	if b.tenancyLogic == nil {
 		err = errors.New("tenancy logic is mandatory")
-		return
+		return result, err
 	}
 
 	inMapper, err := NewGenericMapper[*publicv1.ProjectMembership, *privatev1.ProjectMembership]().
@@ -101,14 +101,14 @@ func (b *ProjectMembershipsServerBuilder) Build() (result *ProjectMembershipsSer
 		SetStrict(true).
 		Build()
 	if err != nil {
-		return
+		return result, err
 	}
 	outMapper, err := NewGenericMapper[*privatev1.ProjectMembership, *publicv1.ProjectMembership]().
 		SetLogger(b.logger).
 		SetStrict(false).
 		Build()
 	if err != nil {
-		return
+		return result, err
 	}
 
 	delegate, err := NewPrivateProjectMembershipsServer().
@@ -119,7 +119,7 @@ func (b *ProjectMembershipsServerBuilder) Build() (result *ProjectMembershipsSer
 		SetMetricsRegisterer(b.metricsRegisterer).
 		Build()
 	if err != nil {
-		return
+		return result, err
 	}
 
 	result = &ProjectMembershipsServer{
@@ -128,7 +128,7 @@ func (b *ProjectMembershipsServerBuilder) Build() (result *ProjectMembershipsSer
 		inMapper:  inMapper,
 		outMapper: outMapper,
 	}
-	return
+	return result, err
 }
 
 func (s *ProjectMembershipsServer) List(ctx context.Context,
@@ -164,7 +164,7 @@ func (s *ProjectMembershipsServer) List(ctx context.Context,
 	response.SetSize(privateResponse.GetSize())
 	response.SetTotal(privateResponse.GetTotal())
 	response.SetItems(publicItems)
-	return
+	return response, err
 }
 
 func (s *ProjectMembershipsServer) Get(ctx context.Context,
@@ -191,7 +191,7 @@ func (s *ProjectMembershipsServer) Get(ctx context.Context,
 
 	response = &publicv1.ProjectMembershipsGetResponse{}
 	response.SetObject(publicProjectMembership)
-	return
+	return response, err
 }
 
 func (s *ProjectMembershipsServer) Create(ctx context.Context,
@@ -199,7 +199,7 @@ func (s *ProjectMembershipsServer) Create(ctx context.Context,
 	publicProjectMembership := request.GetObject()
 	if publicProjectMembership == nil {
 		err = grpcstatus.Errorf(grpccodes.InvalidArgument, "object is mandatory")
-		return
+		return response, err
 	}
 	privateProjectMembership := &privatev1.ProjectMembership{}
 	err = s.inMapper.Copy(ctx, publicProjectMembership, privateProjectMembership)
@@ -210,7 +210,7 @@ func (s *ProjectMembershipsServer) Create(ctx context.Context,
 			slog.Any("error", err),
 		)
 		err = grpcstatus.Errorf(grpccodes.Internal, "failed to process project membership")
-		return
+		return response, err
 	}
 
 	privateRequest := &privatev1.ProjectMembershipsCreateRequest{}
@@ -230,12 +230,12 @@ func (s *ProjectMembershipsServer) Create(ctx context.Context,
 			slog.Any("error", err),
 		)
 		err = grpcstatus.Errorf(grpccodes.Internal, "failed to process project membership")
-		return
+		return response, err
 	}
 
 	response = &publicv1.ProjectMembershipsCreateResponse{}
 	response.SetObject(createdPublicProjectMembership)
-	return
+	return response, err
 }
 
 func (s *ProjectMembershipsServer) Update(ctx context.Context,
@@ -243,11 +243,11 @@ func (s *ProjectMembershipsServer) Update(ctx context.Context,
 	publicProjectMembership := request.GetObject()
 	if publicProjectMembership == nil {
 		err = grpcstatus.Errorf(grpccodes.InvalidArgument, "object is mandatory")
-		return
+		return response, err
 	}
 	if publicProjectMembership.GetId() == "" {
 		err = grpcstatus.Errorf(grpccodes.InvalidArgument, "object identifier is mandatory")
-		return
+		return response, err
 	}
 
 	privateProjectMembership := &privatev1.ProjectMembership{}
@@ -259,7 +259,7 @@ func (s *ProjectMembershipsServer) Update(ctx context.Context,
 			slog.Any("error", err),
 		)
 		err = grpcstatus.Errorf(grpccodes.Internal, "failed to process project membership")
-		return
+		return response, err
 	}
 
 	privateRequest := &privatev1.ProjectMembershipsUpdateRequest{}
@@ -281,12 +281,12 @@ func (s *ProjectMembershipsServer) Update(ctx context.Context,
 			slog.Any("error", err),
 		)
 		err = grpcstatus.Errorf(grpccodes.Internal, "failed to process project membership")
-		return
+		return response, err
 	}
 
 	response = &publicv1.ProjectMembershipsUpdateResponse{}
 	response.SetObject(updatedPublicProjectMembership)
-	return
+	return response, err
 }
 
 func (s *ProjectMembershipsServer) Delete(ctx context.Context,
@@ -300,5 +300,5 @@ func (s *ProjectMembershipsServer) Delete(ctx context.Context,
 	}
 
 	response = &publicv1.ProjectMembershipsDeleteResponse{}
-	return
+	return response, err
 }

--- a/internal/servers/projects_server.go
+++ b/internal/servers/projects_server.go
@@ -88,15 +88,15 @@ func (b *ProjectsServerBuilder) SetMetricsRegisterer(value prometheus.Registerer
 func (b *ProjectsServerBuilder) Build() (result *ProjectsServer, err error) {
 	if b.logger == nil {
 		err = errors.New("logger is mandatory")
-		return
+		return result, err
 	}
 	if b.attributionLogic == nil {
 		err = errors.New("attribution logic is mandatory")
-		return
+		return result, err
 	}
 	if b.tenancyLogic == nil {
 		err = errors.New("tenancy logic is mandatory")
-		return
+		return result, err
 	}
 
 	inMapper, err := NewGenericMapper[*publicv1.Project, *privatev1.Project]().
@@ -104,14 +104,14 @@ func (b *ProjectsServerBuilder) Build() (result *ProjectsServer, err error) {
 		SetStrict(true).
 		Build()
 	if err != nil {
-		return
+		return result, err
 	}
 	outMapper, err := NewGenericMapper[*privatev1.Project, *publicv1.Project]().
 		SetLogger(b.logger).
 		SetStrict(false).
 		Build()
 	if err != nil {
-		return
+		return result, err
 	}
 
 	delegate, err := NewPrivateProjectsServer().
@@ -122,7 +122,7 @@ func (b *ProjectsServerBuilder) Build() (result *ProjectsServer, err error) {
 		SetMetricsRegisterer(b.metricsRegisterer).
 		Build()
 	if err != nil {
-		return
+		return result, err
 	}
 
 	result = &ProjectsServer{
@@ -131,7 +131,7 @@ func (b *ProjectsServerBuilder) Build() (result *ProjectsServer, err error) {
 		inMapper:  inMapper,
 		outMapper: outMapper,
 	}
-	return
+	return result, err
 }
 
 func (s *ProjectsServer) List(ctx context.Context,
@@ -162,7 +162,7 @@ func (s *ProjectsServer) List(ctx context.Context,
 	response.SetSize(privateResponse.GetSize())
 	response.SetTotal(privateResponse.GetTotal())
 	response.SetItems(publicItems)
-	return
+	return response, err
 }
 
 func (s *ProjectsServer) Get(ctx context.Context,
@@ -184,7 +184,7 @@ func (s *ProjectsServer) Get(ctx context.Context,
 
 	response = &publicv1.ProjectsGetResponse{}
 	response.SetObject(publicObject)
-	return
+	return response, err
 }
 
 func (s *ProjectsServer) Create(ctx context.Context,
@@ -213,7 +213,7 @@ func (s *ProjectsServer) Create(ctx context.Context,
 
 	response = &publicv1.ProjectsCreateResponse{}
 	response.SetObject(publicObject)
-	return
+	return response, err
 }
 
 func (s *ProjectsServer) Update(ctx context.Context,
@@ -243,7 +243,7 @@ func (s *ProjectsServer) Update(ctx context.Context,
 
 	response = &publicv1.ProjectsUpdateResponse{}
 	response.SetObject(publicObject)
-	return
+	return response, err
 }
 
 func (s *ProjectsServer) Delete(ctx context.Context,
@@ -257,5 +257,5 @@ func (s *ProjectsServer) Delete(ctx context.Context,
 	}
 
 	response = &publicv1.ProjectsDeleteResponse{}
-	return
+	return response, err
 }

--- a/internal/servers/public_ip_attachments_server.go
+++ b/internal/servers/public_ip_attachments_server.go
@@ -85,15 +85,15 @@ func (b *PublicIPAttachmentsServerBuilder) SetMetricsRegisterer(value prometheus
 func (b *PublicIPAttachmentsServerBuilder) Build() (result *PublicIPAttachmentsServer, err error) {
 	if b.logger == nil {
 		err = errors.New("logger is mandatory")
-		return
+		return result, err
 	}
 	if b.tenancyLogic == nil {
 		err = errors.New("tenancy logic is mandatory")
-		return
+		return result, err
 	}
 	if b.attributionLogic == nil {
 		err = errors.New("attribution logic is mandatory")
-		return
+		return result, err
 	}
 
 	inMapper, err := NewGenericMapper[*publicv1.PublicIPAttachment, *privatev1.PublicIPAttachment]().
@@ -101,14 +101,14 @@ func (b *PublicIPAttachmentsServerBuilder) Build() (result *PublicIPAttachmentsS
 		SetStrict(true).
 		Build()
 	if err != nil {
-		return
+		return result, err
 	}
 	outMapper, err := NewGenericMapper[*privatev1.PublicIPAttachment, *publicv1.PublicIPAttachment]().
 		SetLogger(b.logger).
 		SetStrict(false).
 		Build()
 	if err != nil {
-		return
+		return result, err
 	}
 
 	delegate, err := NewPrivatePublicIPAttachmentsServer().
@@ -119,7 +119,7 @@ func (b *PublicIPAttachmentsServerBuilder) Build() (result *PublicIPAttachmentsS
 		SetMetricsRegisterer(b.metricsRegisterer).
 		Build()
 	if err != nil {
-		return
+		return result, err
 	}
 
 	result = &PublicIPAttachmentsServer{
@@ -128,7 +128,7 @@ func (b *PublicIPAttachmentsServerBuilder) Build() (result *PublicIPAttachmentsS
 		inMapper:  inMapper,
 		outMapper: outMapper,
 	}
-	return
+	return result, err
 }
 
 func (s *PublicIPAttachmentsServer) List(ctx context.Context,

--- a/internal/servers/public_ip_pools_server.go
+++ b/internal/servers/public_ip_pools_server.go
@@ -88,15 +88,15 @@ func (b *PublicIPPoolsServerBuilder) SetMetricsRegisterer(value prometheus.Regis
 func (b *PublicIPPoolsServerBuilder) Build() (result *PublicIPPoolsServer, err error) {
 	if b.logger == nil {
 		err = errors.New("logger is mandatory")
-		return
+		return result, err
 	}
 	if b.attributionLogic == nil {
 		err = errors.New("attribution logic is mandatory")
-		return
+		return result, err
 	}
 	if b.tenancyLogic == nil {
 		err = errors.New("tenancy logic is mandatory")
-		return
+		return result, err
 	}
 
 	// SetStrict(false): private type has extra fields (spec.cidrs, spec.implementation_strategy, status.*) not in public type.
@@ -105,7 +105,7 @@ func (b *PublicIPPoolsServerBuilder) Build() (result *PublicIPPoolsServer, err e
 		SetStrict(false).
 		Build()
 	if err != nil {
-		return
+		return result, err
 	}
 
 	delegate, err := NewPrivatePublicIPPoolsServer().
@@ -116,7 +116,7 @@ func (b *PublicIPPoolsServerBuilder) Build() (result *PublicIPPoolsServer, err e
 		SetMetricsRegisterer(b.metricsRegisterer).
 		Build()
 	if err != nil {
-		return
+		return result, err
 	}
 
 	result = &PublicIPPoolsServer{
@@ -124,7 +124,7 @@ func (b *PublicIPPoolsServerBuilder) Build() (result *PublicIPPoolsServer, err e
 		delegate:  delegate,
 		outMapper: outMapper,
 	}
-	return
+	return result, err
 }
 
 // isPoolPubliclyVisible returns true when a pool should be exposed via the public API.
@@ -186,7 +186,7 @@ func (s *PublicIPPoolsServer) List(ctx context.Context,
 	response.SetSize(int32(len(publicItems))) // #nosec G115 -- bounded by pool size
 	response.SetTotal(total)
 	response.SetItems(publicItems)
-	return
+	return response, err
 }
 
 func (s *PublicIPPoolsServer) Get(ctx context.Context,
@@ -216,5 +216,5 @@ func (s *PublicIPPoolsServer) Get(ctx context.Context,
 
 	response = &publicv1.PublicIPPoolsGetResponse{}
 	response.SetObject(publicPool)
-	return
+	return response, err
 }

--- a/internal/servers/public_ips_server.go
+++ b/internal/servers/public_ips_server.go
@@ -86,15 +86,15 @@ func (b *PublicIPsServerBuilder) Build() (result *PublicIPsServer, err error) {
 	// Check parameters:
 	if b.logger == nil {
 		err = errors.New("logger is mandatory")
-		return
+		return result, err
 	}
 	if b.tenancyLogic == nil {
 		err = errors.New("tenancy logic is mandatory")
-		return
+		return result, err
 	}
 	if b.attributionLogic == nil {
 		err = errors.New("attribution logic is mandatory")
-		return
+		return result, err
 	}
 
 	// Create the mappers:
@@ -103,14 +103,14 @@ func (b *PublicIPsServerBuilder) Build() (result *PublicIPsServer, err error) {
 		SetStrict(true).
 		Build()
 	if err != nil {
-		return
+		return result, err
 	}
 	outMapper, err := NewGenericMapper[*privatev1.PublicIP, *publicv1.PublicIP]().
 		SetLogger(b.logger).
 		SetStrict(false).
 		Build()
 	if err != nil {
-		return
+		return result, err
 	}
 
 	// Create the private server to delegate to:
@@ -122,7 +122,7 @@ func (b *PublicIPsServerBuilder) Build() (result *PublicIPsServer, err error) {
 		SetMetricsRegisterer(b.metricsRegisterer).
 		Build()
 	if err != nil {
-		return
+		return result, err
 	}
 
 	// Create and populate the object:
@@ -132,7 +132,7 @@ func (b *PublicIPsServerBuilder) Build() (result *PublicIPsServer, err error) {
 		inMapper:  inMapper,
 		outMapper: outMapper,
 	}
-	return
+	return result, err
 }
 
 func (s *PublicIPsServer) List(ctx context.Context,
@@ -172,7 +172,7 @@ func (s *PublicIPsServer) List(ctx context.Context,
 	response.SetSize(privateResponse.GetSize())
 	response.SetTotal(privateResponse.GetTotal())
 	response.SetItems(publicItems)
-	return
+	return response, err
 }
 
 func (s *PublicIPsServer) Get(ctx context.Context,
@@ -203,7 +203,7 @@ func (s *PublicIPsServer) Get(ctx context.Context,
 	// Create the public response:
 	response = &publicv1.PublicIPsGetResponse{}
 	response.SetObject(publicPublicIP)
-	return
+	return response, err
 }
 
 func (s *PublicIPsServer) Create(ctx context.Context,
@@ -212,7 +212,7 @@ func (s *PublicIPsServer) Create(ctx context.Context,
 	publicPublicIP := request.GetObject()
 	if publicPublicIP == nil {
 		err = grpcstatus.Errorf(grpccodes.InvalidArgument, "object is mandatory")
-		return
+		return response, err
 	}
 	privatePublicIP := &privatev1.PublicIP{}
 	err = s.inMapper.Copy(ctx, publicPublicIP, privatePublicIP)
@@ -223,7 +223,7 @@ func (s *PublicIPsServer) Create(ctx context.Context,
 			slog.Any("error", err),
 		)
 		err = grpcstatus.Errorf(grpccodes.Internal, "failed to process public IP")
-		return
+		return response, err
 	}
 
 	// Delegate to the private server:
@@ -245,13 +245,13 @@ func (s *PublicIPsServer) Create(ctx context.Context,
 			slog.Any("error", err),
 		)
 		err = grpcstatus.Errorf(grpccodes.Internal, "failed to process public IP")
-		return
+		return response, err
 	}
 
 	// Create the public response:
 	response = &publicv1.PublicIPsCreateResponse{}
 	response.SetObject(createdPublicPublicIP)
-	return
+	return response, err
 }
 
 func (s *PublicIPsServer) Update(ctx context.Context,
@@ -260,7 +260,7 @@ func (s *PublicIPsServer) Update(ctx context.Context,
 	publicPublicIP := request.GetObject()
 	if publicPublicIP == nil {
 		err = grpcstatus.Errorf(grpccodes.InvalidArgument, "object is mandatory")
-		return
+		return response, err
 	}
 	privatePublicIP := &privatev1.PublicIP{}
 	err = s.inMapper.Copy(ctx, publicPublicIP, privatePublicIP)
@@ -271,7 +271,7 @@ func (s *PublicIPsServer) Update(ctx context.Context,
 			slog.Any("error", err),
 		)
 		err = grpcstatus.Errorf(grpccodes.Internal, "failed to process public IP")
-		return
+		return response, err
 	}
 
 	// Delegate to the private server:
@@ -295,13 +295,13 @@ func (s *PublicIPsServer) Update(ctx context.Context,
 			slog.Any("error", err),
 		)
 		err = grpcstatus.Errorf(grpccodes.Internal, "failed to process public IP")
-		return
+		return response, err
 	}
 
 	// Create the public response:
 	response = &publicv1.PublicIPsUpdateResponse{}
 	response.SetObject(updatedPublicPublicIP)
-	return
+	return response, err
 }
 
 func (s *PublicIPsServer) Delete(ctx context.Context,
@@ -318,5 +318,5 @@ func (s *PublicIPsServer) Delete(ctx context.Context,
 
 	// Create the public response:
 	response = &publicv1.PublicIPsDeleteResponse{}
-	return
+	return response, err
 }

--- a/internal/servers/role_bindings_server.go
+++ b/internal/servers/role_bindings_server.go
@@ -89,11 +89,11 @@ func (b *RoleBindingsServerBuilder) SetMetricsRegisterer(value prometheus.Regist
 func (b *RoleBindingsServerBuilder) Build() (result *RoleBindingsServer, err error) {
 	if b.logger == nil {
 		err = errors.New("logger is mandatory")
-		return
+		return result, err
 	}
 	if b.tenancyLogic == nil {
 		err = errors.New("tenancy logic is mandatory")
-		return
+		return result, err
 	}
 
 	inMapper, err := NewGenericMapper[*publicv1.RoleBinding, *privatev1.RoleBinding]().
@@ -101,14 +101,14 @@ func (b *RoleBindingsServerBuilder) Build() (result *RoleBindingsServer, err err
 		SetStrict(true).
 		Build()
 	if err != nil {
-		return
+		return result, err
 	}
 	outMapper, err := NewGenericMapper[*privatev1.RoleBinding, *publicv1.RoleBinding]().
 		SetLogger(b.logger).
 		SetStrict(false).
 		Build()
 	if err != nil {
-		return
+		return result, err
 	}
 
 	delegate, err := NewPrivateRoleBindingsServer().
@@ -119,7 +119,7 @@ func (b *RoleBindingsServerBuilder) Build() (result *RoleBindingsServer, err err
 		SetMetricsRegisterer(b.metricsRegisterer).
 		Build()
 	if err != nil {
-		return
+		return result, err
 	}
 
 	result = &RoleBindingsServer{
@@ -128,7 +128,7 @@ func (b *RoleBindingsServerBuilder) Build() (result *RoleBindingsServer, err err
 		inMapper:  inMapper,
 		outMapper: outMapper,
 	}
-	return
+	return result, err
 }
 
 func (s *RoleBindingsServer) List(ctx context.Context,
@@ -164,7 +164,7 @@ func (s *RoleBindingsServer) List(ctx context.Context,
 	response.SetSize(privateResponse.GetSize())
 	response.SetTotal(privateResponse.GetTotal())
 	response.SetItems(publicItems)
-	return
+	return response, err
 }
 
 func (s *RoleBindingsServer) Get(ctx context.Context,
@@ -191,7 +191,7 @@ func (s *RoleBindingsServer) Get(ctx context.Context,
 
 	response = &publicv1.RoleBindingsGetResponse{}
 	response.SetObject(publicRoleBinding)
-	return
+	return response, err
 }
 
 func (s *RoleBindingsServer) Create(ctx context.Context,
@@ -199,7 +199,7 @@ func (s *RoleBindingsServer) Create(ctx context.Context,
 	publicRoleBinding := request.GetObject()
 	if publicRoleBinding == nil {
 		err = grpcstatus.Errorf(grpccodes.InvalidArgument, "object is mandatory")
-		return
+		return response, err
 	}
 	privateRoleBinding := &privatev1.RoleBinding{}
 	err = s.inMapper.Copy(ctx, publicRoleBinding, privateRoleBinding)
@@ -210,7 +210,7 @@ func (s *RoleBindingsServer) Create(ctx context.Context,
 			slog.Any("error", err),
 		)
 		err = grpcstatus.Errorf(grpccodes.Internal, "failed to process role binding")
-		return
+		return response, err
 	}
 
 	privateRequest := &privatev1.RoleBindingsCreateRequest{}
@@ -230,12 +230,12 @@ func (s *RoleBindingsServer) Create(ctx context.Context,
 			slog.Any("error", err),
 		)
 		err = grpcstatus.Errorf(grpccodes.Internal, "failed to process role binding")
-		return
+		return response, err
 	}
 
 	response = &publicv1.RoleBindingsCreateResponse{}
 	response.SetObject(createdPublicRoleBinding)
-	return
+	return response, err
 }
 
 func (s *RoleBindingsServer) Update(ctx context.Context,
@@ -243,11 +243,11 @@ func (s *RoleBindingsServer) Update(ctx context.Context,
 	publicRoleBinding := request.GetObject()
 	if publicRoleBinding == nil {
 		err = grpcstatus.Errorf(grpccodes.InvalidArgument, "object is mandatory")
-		return
+		return response, err
 	}
 	if publicRoleBinding.GetId() == "" {
 		err = grpcstatus.Errorf(grpccodes.InvalidArgument, "object identifier is mandatory")
-		return
+		return response, err
 	}
 
 	privateRoleBinding := &privatev1.RoleBinding{}
@@ -259,7 +259,7 @@ func (s *RoleBindingsServer) Update(ctx context.Context,
 			slog.Any("error", err),
 		)
 		err = grpcstatus.Errorf(grpccodes.Internal, "failed to process role binding")
-		return
+		return response, err
 	}
 
 	privateRequest := &privatev1.RoleBindingsUpdateRequest{}
@@ -281,12 +281,12 @@ func (s *RoleBindingsServer) Update(ctx context.Context,
 			slog.Any("error", err),
 		)
 		err = grpcstatus.Errorf(grpccodes.Internal, "failed to process role binding")
-		return
+		return response, err
 	}
 
 	response = &publicv1.RoleBindingsUpdateResponse{}
 	response.SetObject(updatedPublicRoleBinding)
-	return
+	return response, err
 }
 
 func (s *RoleBindingsServer) Delete(ctx context.Context,
@@ -300,5 +300,5 @@ func (s *RoleBindingsServer) Delete(ctx context.Context,
 	}
 
 	response = &publicv1.RoleBindingsDeleteResponse{}
-	return
+	return response, err
 }

--- a/internal/servers/roles_server.go
+++ b/internal/servers/roles_server.go
@@ -89,11 +89,11 @@ func (b *RolesServerBuilder) SetMetricsRegisterer(value prometheus.Registerer) *
 func (b *RolesServerBuilder) Build() (result *RolesServer, err error) {
 	if b.logger == nil {
 		err = errors.New("logger is mandatory")
-		return
+		return result, err
 	}
 	if b.tenancyLogic == nil {
 		err = errors.New("tenancy logic is mandatory")
-		return
+		return result, err
 	}
 
 	inMapper, err := NewGenericMapper[*publicv1.Role, *privatev1.Role]().
@@ -101,14 +101,14 @@ func (b *RolesServerBuilder) Build() (result *RolesServer, err error) {
 		SetStrict(true).
 		Build()
 	if err != nil {
-		return
+		return result, err
 	}
 	outMapper, err := NewGenericMapper[*privatev1.Role, *publicv1.Role]().
 		SetLogger(b.logger).
 		SetStrict(false).
 		Build()
 	if err != nil {
-		return
+		return result, err
 	}
 
 	delegate, err := NewPrivateRolesServer().
@@ -119,7 +119,7 @@ func (b *RolesServerBuilder) Build() (result *RolesServer, err error) {
 		SetMetricsRegisterer(b.metricsRegisterer).
 		Build()
 	if err != nil {
-		return
+		return result, err
 	}
 
 	result = &RolesServer{
@@ -128,7 +128,7 @@ func (b *RolesServerBuilder) Build() (result *RolesServer, err error) {
 		inMapper:  inMapper,
 		outMapper: outMapper,
 	}
-	return
+	return result, err
 }
 
 func (s *RolesServer) List(ctx context.Context,
@@ -164,7 +164,7 @@ func (s *RolesServer) List(ctx context.Context,
 	response.SetSize(privateResponse.GetSize())
 	response.SetTotal(privateResponse.GetTotal())
 	response.SetItems(publicItems)
-	return
+	return response, err
 }
 
 func (s *RolesServer) Get(ctx context.Context,
@@ -191,7 +191,7 @@ func (s *RolesServer) Get(ctx context.Context,
 
 	response = &publicv1.RolesGetResponse{}
 	response.SetObject(publicRole)
-	return
+	return response, err
 }
 
 func (s *RolesServer) Create(ctx context.Context,
@@ -199,7 +199,7 @@ func (s *RolesServer) Create(ctx context.Context,
 	publicRole := request.GetObject()
 	if publicRole == nil {
 		err = grpcstatus.Errorf(grpccodes.InvalidArgument, "object is mandatory")
-		return
+		return response, err
 	}
 	privateRole := &privatev1.Role{}
 	err = s.inMapper.Copy(ctx, publicRole, privateRole)
@@ -210,7 +210,7 @@ func (s *RolesServer) Create(ctx context.Context,
 			slog.Any("error", err),
 		)
 		err = grpcstatus.Errorf(grpccodes.Internal, "failed to process role")
-		return
+		return response, err
 	}
 
 	privateRequest := &privatev1.RolesCreateRequest{}
@@ -230,12 +230,12 @@ func (s *RolesServer) Create(ctx context.Context,
 			slog.Any("error", err),
 		)
 		err = grpcstatus.Errorf(grpccodes.Internal, "failed to process role")
-		return
+		return response, err
 	}
 
 	response = &publicv1.RolesCreateResponse{}
 	response.SetObject(createdPublicRole)
-	return
+	return response, err
 }
 
 func (s *RolesServer) Update(ctx context.Context,
@@ -243,11 +243,11 @@ func (s *RolesServer) Update(ctx context.Context,
 	publicRole := request.GetObject()
 	if publicRole == nil {
 		err = grpcstatus.Errorf(grpccodes.InvalidArgument, "object is mandatory")
-		return
+		return response, err
 	}
 	if publicRole.GetId() == "" {
 		err = grpcstatus.Errorf(grpccodes.InvalidArgument, "object identifier is mandatory")
-		return
+		return response, err
 	}
 
 	privateRole := &privatev1.Role{}
@@ -259,7 +259,7 @@ func (s *RolesServer) Update(ctx context.Context,
 			slog.Any("error", err),
 		)
 		err = grpcstatus.Errorf(grpccodes.Internal, "failed to process role")
-		return
+		return response, err
 	}
 
 	privateRequest := &privatev1.RolesUpdateRequest{}
@@ -281,12 +281,12 @@ func (s *RolesServer) Update(ctx context.Context,
 			slog.Any("error", err),
 		)
 		err = grpcstatus.Errorf(grpccodes.Internal, "failed to process role")
-		return
+		return response, err
 	}
 
 	response = &publicv1.RolesUpdateResponse{}
 	response.SetObject(updatedPublicRole)
-	return
+	return response, err
 }
 
 func (s *RolesServer) Delete(ctx context.Context,
@@ -300,5 +300,5 @@ func (s *RolesServer) Delete(ctx context.Context,
 	}
 
 	response = &publicv1.RolesDeleteResponse{}
-	return
+	return response, err
 }

--- a/internal/servers/security_groups_server.go
+++ b/internal/servers/security_groups_server.go
@@ -86,11 +86,11 @@ func (b *SecurityGroupsServerBuilder) Build() (result *SecurityGroupsServer, err
 	// Check parameters:
 	if b.logger == nil {
 		err = errors.New("logger is mandatory")
-		return
+		return result, err
 	}
 	if b.tenancyLogic == nil {
 		err = errors.New("tenancy logic is mandatory")
-		return
+		return result, err
 	}
 
 	// Create the mappers:
@@ -99,14 +99,14 @@ func (b *SecurityGroupsServerBuilder) Build() (result *SecurityGroupsServer, err
 		SetStrict(true).
 		Build()
 	if err != nil {
-		return
+		return result, err
 	}
 	outMapper, err := NewGenericMapper[*privatev1.SecurityGroup, *publicv1.SecurityGroup]().
 		SetLogger(b.logger).
 		SetStrict(false).
 		Build()
 	if err != nil {
-		return
+		return result, err
 	}
 
 	// Create the private server to delegate to:
@@ -118,7 +118,7 @@ func (b *SecurityGroupsServerBuilder) Build() (result *SecurityGroupsServer, err
 		SetMetricsRegisterer(b.metricsRegisterer).
 		Build()
 	if err != nil {
-		return
+		return result, err
 	}
 
 	// Create and populate the object:
@@ -128,7 +128,7 @@ func (b *SecurityGroupsServerBuilder) Build() (result *SecurityGroupsServer, err
 		inMapper:  inMapper,
 		outMapper: outMapper,
 	}
-	return
+	return result, err
 }
 
 func (s *SecurityGroupsServer) List(ctx context.Context,
@@ -168,7 +168,7 @@ func (s *SecurityGroupsServer) List(ctx context.Context,
 	response.SetSize(privateResponse.GetSize())
 	response.SetTotal(privateResponse.GetTotal())
 	response.SetItems(publicItems)
-	return
+	return response, err
 }
 
 func (s *SecurityGroupsServer) Get(ctx context.Context,
@@ -199,7 +199,7 @@ func (s *SecurityGroupsServer) Get(ctx context.Context,
 	// Create the public response:
 	response = &publicv1.SecurityGroupsGetResponse{}
 	response.SetObject(publicSecurityGroup)
-	return
+	return response, err
 }
 
 func (s *SecurityGroupsServer) Create(ctx context.Context,
@@ -208,7 +208,7 @@ func (s *SecurityGroupsServer) Create(ctx context.Context,
 	publicSecurityGroup := request.GetObject()
 	if publicSecurityGroup == nil {
 		err = grpcstatus.Errorf(grpccodes.InvalidArgument, "object is mandatory")
-		return
+		return response, err
 	}
 	privateSecurityGroup := &privatev1.SecurityGroup{}
 	err = s.inMapper.Copy(ctx, publicSecurityGroup, privateSecurityGroup)
@@ -219,7 +219,7 @@ func (s *SecurityGroupsServer) Create(ctx context.Context,
 			slog.Any("error", err),
 		)
 		err = grpcstatus.Errorf(grpccodes.Internal, "failed to process security group")
-		return
+		return response, err
 	}
 
 	// Delegate to the private server:
@@ -241,13 +241,13 @@ func (s *SecurityGroupsServer) Create(ctx context.Context,
 			slog.Any("error", err),
 		)
 		err = grpcstatus.Errorf(grpccodes.Internal, "failed to process security group")
-		return
+		return response, err
 	}
 
 	// Create the public response:
 	response = &publicv1.SecurityGroupsCreateResponse{}
 	response.SetObject(createdPublicSecurityGroup)
-	return
+	return response, err
 }
 
 func (s *SecurityGroupsServer) Update(ctx context.Context,
@@ -256,12 +256,12 @@ func (s *SecurityGroupsServer) Update(ctx context.Context,
 	publicSecurityGroup := request.GetObject()
 	if publicSecurityGroup == nil {
 		err = grpcstatus.Errorf(grpccodes.InvalidArgument, "object is mandatory")
-		return
+		return response, err
 	}
 	id := publicSecurityGroup.GetId()
 	if id == "" {
 		err = grpcstatus.Errorf(grpccodes.InvalidArgument, "object identifier is mandatory")
-		return
+		return response, err
 	}
 
 	// Get the existing object from the private server:
@@ -282,7 +282,7 @@ func (s *SecurityGroupsServer) Update(ctx context.Context,
 			slog.Any("error", err),
 		)
 		err = grpcstatus.Errorf(grpccodes.Internal, "failed to process security group")
-		return
+		return response, err
 	}
 
 	// Delegate to the private server with the merged object:
@@ -305,13 +305,13 @@ func (s *SecurityGroupsServer) Update(ctx context.Context,
 			slog.Any("error", err),
 		)
 		err = grpcstatus.Errorf(grpccodes.Internal, "failed to process security group")
-		return
+		return response, err
 	}
 
 	// Create the public response:
 	response = &publicv1.SecurityGroupsUpdateResponse{}
 	response.SetObject(updatedPublicSecurityGroup)
-	return
+	return response, err
 }
 
 func (s *SecurityGroupsServer) Delete(ctx context.Context,
@@ -328,5 +328,5 @@ func (s *SecurityGroupsServer) Delete(ctx context.Context,
 
 	// Create the public response:
 	response = &publicv1.SecurityGroupsDeleteResponse{}
-	return
+	return response, err
 }

--- a/internal/servers/subnets_server.go
+++ b/internal/servers/subnets_server.go
@@ -86,11 +86,11 @@ func (b *SubnetsServerBuilder) Build() (result *SubnetsServer, err error) {
 	// Check parameters:
 	if b.logger == nil {
 		err = errors.New("logger is mandatory")
-		return
+		return result, err
 	}
 	if b.tenancyLogic == nil {
 		err = errors.New("tenancy logic is mandatory")
-		return
+		return result, err
 	}
 
 	// Create the mappers:
@@ -99,14 +99,14 @@ func (b *SubnetsServerBuilder) Build() (result *SubnetsServer, err error) {
 		SetStrict(true).
 		Build()
 	if err != nil {
-		return
+		return result, err
 	}
 	outMapper, err := NewGenericMapper[*privatev1.Subnet, *publicv1.Subnet]().
 		SetLogger(b.logger).
 		SetStrict(false).
 		Build()
 	if err != nil {
-		return
+		return result, err
 	}
 
 	// Create the private server to delegate to:
@@ -118,7 +118,7 @@ func (b *SubnetsServerBuilder) Build() (result *SubnetsServer, err error) {
 		SetMetricsRegisterer(b.metricsRegisterer).
 		Build()
 	if err != nil {
-		return
+		return result, err
 	}
 
 	// Create and populate the object:
@@ -128,7 +128,7 @@ func (b *SubnetsServerBuilder) Build() (result *SubnetsServer, err error) {
 		inMapper:  inMapper,
 		outMapper: outMapper,
 	}
-	return
+	return result, err
 }
 
 func (s *SubnetsServer) List(ctx context.Context,
@@ -168,7 +168,7 @@ func (s *SubnetsServer) List(ctx context.Context,
 	response.SetSize(privateResponse.GetSize())
 	response.SetTotal(privateResponse.GetTotal())
 	response.SetItems(publicItems)
-	return
+	return response, err
 }
 
 func (s *SubnetsServer) Get(ctx context.Context,
@@ -199,7 +199,7 @@ func (s *SubnetsServer) Get(ctx context.Context,
 	// Create the public response:
 	response = &publicv1.SubnetsGetResponse{}
 	response.SetObject(publicSubnet)
-	return
+	return response, err
 }
 
 func (s *SubnetsServer) Create(ctx context.Context,
@@ -208,7 +208,7 @@ func (s *SubnetsServer) Create(ctx context.Context,
 	publicSubnet := request.GetObject()
 	if publicSubnet == nil {
 		err = grpcstatus.Errorf(grpccodes.InvalidArgument, "object is mandatory")
-		return
+		return response, err
 	}
 	privateSubnet := &privatev1.Subnet{}
 	err = s.inMapper.Copy(ctx, publicSubnet, privateSubnet)
@@ -219,7 +219,7 @@ func (s *SubnetsServer) Create(ctx context.Context,
 			slog.Any("error", err),
 		)
 		err = grpcstatus.Errorf(grpccodes.Internal, "failed to process subnet")
-		return
+		return response, err
 	}
 
 	// Delegate to the private server:
@@ -241,13 +241,13 @@ func (s *SubnetsServer) Create(ctx context.Context,
 			slog.Any("error", err),
 		)
 		err = grpcstatus.Errorf(grpccodes.Internal, "failed to process subnet")
-		return
+		return response, err
 	}
 
 	// Create the public response:
 	response = &publicv1.SubnetsCreateResponse{}
 	response.SetObject(createdPublicSubnet)
-	return
+	return response, err
 }
 
 func (s *SubnetsServer) Update(ctx context.Context,
@@ -256,12 +256,12 @@ func (s *SubnetsServer) Update(ctx context.Context,
 	publicSubnet := request.GetObject()
 	if publicSubnet == nil {
 		err = grpcstatus.Errorf(grpccodes.InvalidArgument, "object is mandatory")
-		return
+		return response, err
 	}
 	id := publicSubnet.GetId()
 	if id == "" {
 		err = grpcstatus.Errorf(grpccodes.InvalidArgument, "object identifier is mandatory")
-		return
+		return response, err
 	}
 
 	// Get the existing object from the private server:
@@ -282,7 +282,7 @@ func (s *SubnetsServer) Update(ctx context.Context,
 			slog.Any("error", err),
 		)
 		err = grpcstatus.Errorf(grpccodes.Internal, "failed to process subnet")
-		return
+		return response, err
 	}
 
 	// Delegate to the private server with the merged object:
@@ -305,13 +305,13 @@ func (s *SubnetsServer) Update(ctx context.Context,
 			slog.Any("error", err),
 		)
 		err = grpcstatus.Errorf(grpccodes.Internal, "failed to process subnet")
-		return
+		return response, err
 	}
 
 	// Create the public response:
 	response = &publicv1.SubnetsUpdateResponse{}
 	response.SetObject(updatedPublicSubnet)
-	return
+	return response, err
 }
 
 func (s *SubnetsServer) Delete(ctx context.Context,
@@ -328,5 +328,5 @@ func (s *SubnetsServer) Delete(ctx context.Context,
 
 	// Create the public response:
 	response = &publicv1.SubnetsDeleteResponse{}
-	return
+	return response, err
 }

--- a/internal/servers/tenants_server.go
+++ b/internal/servers/tenants_server.go
@@ -80,11 +80,11 @@ func (b *TenantsServerBuilder) Build() (result *TenantsServer, err error) {
 	// Check parameters:
 	if b.logger == nil {
 		err = errors.New("logger is mandatory")
-		return
+		return result, err
 	}
 	if b.tenancyLogic == nil {
 		err = errors.New("tenancy logic is mandatory")
-		return
+		return result, err
 	}
 
 	// Create the mappers:
@@ -93,14 +93,14 @@ func (b *TenantsServerBuilder) Build() (result *TenantsServer, err error) {
 		SetStrict(true).
 		Build()
 	if err != nil {
-		return
+		return result, err
 	}
 	outMapper, err := NewGenericMapper[*privatev1.Tenant, *publicv1.Tenant]().
 		SetLogger(b.logger).
 		SetStrict(false).
 		Build()
 	if err != nil {
-		return
+		return result, err
 	}
 
 	// Create the private server to delegate to:
@@ -112,7 +112,7 @@ func (b *TenantsServerBuilder) Build() (result *TenantsServer, err error) {
 		SetMetricsRegisterer(b.metricsRegisterer).
 		Build()
 	if err != nil {
-		return
+		return result, err
 	}
 
 	// Create and populate the object:
@@ -122,7 +122,7 @@ func (b *TenantsServerBuilder) Build() (result *TenantsServer, err error) {
 		inMapper:  inMapper,
 		outMapper: outMapper,
 	}
-	return
+	return result, err
 }
 
 func (s *TenantsServer) List(ctx context.Context,
@@ -162,7 +162,7 @@ func (s *TenantsServer) List(ctx context.Context,
 	response.SetSize(privateResponse.GetSize())
 	response.SetTotal(privateResponse.GetTotal())
 	response.SetItems(publicItems)
-	return
+	return response, err
 }
 
 func (s *TenantsServer) Get(ctx context.Context,
@@ -192,5 +192,5 @@ func (s *TenantsServer) Get(ctx context.Context,
 	// Build and return the response:
 	response = &publicv1.TenantsGetResponse{}
 	response.SetObject(publicObject)
-	return
+	return response, err
 }

--- a/internal/servers/users_server.go
+++ b/internal/servers/users_server.go
@@ -80,15 +80,15 @@ func (b *UsersServerBuilder) Build() (result *UsersServer, err error) {
 	// Check parameters:
 	if b.logger == nil {
 		err = errors.New("logger is mandatory")
-		return
+		return result, err
 	}
 	if b.attributionLogic == nil {
 		err = errors.New("attribution logic is mandatory")
-		return
+		return result, err
 	}
 	if b.tenancyLogic == nil {
 		err = errors.New("tenancy logic is mandatory")
-		return
+		return result, err
 	}
 
 	// Create the mappers:
@@ -97,14 +97,14 @@ func (b *UsersServerBuilder) Build() (result *UsersServer, err error) {
 		SetStrict(true).
 		Build()
 	if err != nil {
-		return
+		return result, err
 	}
 	outMapper, err := NewGenericMapper[*privatev1.User, *publicv1.User]().
 		SetLogger(b.logger).
 		SetStrict(false).
 		Build()
 	if err != nil {
-		return
+		return result, err
 	}
 
 	// Create the private server to delegate to:
@@ -116,7 +116,7 @@ func (b *UsersServerBuilder) Build() (result *UsersServer, err error) {
 		SetMetricsRegisterer(b.metricsRegisterer).
 		Build()
 	if err != nil {
-		return
+		return result, err
 	}
 
 	// Create and populate the object:
@@ -126,7 +126,7 @@ func (b *UsersServerBuilder) Build() (result *UsersServer, err error) {
 		inMapper:  inMapper,
 		outMapper: outMapper,
 	}
-	return
+	return result, err
 }
 
 func (s *UsersServer) List(ctx context.Context,
@@ -168,7 +168,7 @@ func (s *UsersServer) List(ctx context.Context,
 	response.SetSize(privateResponse.GetSize())
 	response.SetTotal(privateResponse.GetTotal())
 	response.SetItems(publicItems)
-	return
+	return response, err
 }
 
 func (s *UsersServer) Get(ctx context.Context,
@@ -199,7 +199,7 @@ func (s *UsersServer) Get(ctx context.Context,
 	s.pruneCredentials(publicObject)
 	response = &publicv1.UsersGetResponse{}
 	response.SetObject(publicObject)
-	return
+	return response, err
 }
 
 func (s *UsersServer) Create(ctx context.Context,
@@ -242,7 +242,7 @@ func (s *UsersServer) Create(ctx context.Context,
 	s.pruneCredentials(publicObject)
 	response = &publicv1.UsersCreateResponse{}
 	response.SetObject(publicObject)
-	return
+	return response, err
 }
 
 func (s *UsersServer) Update(ctx context.Context,
@@ -286,7 +286,7 @@ func (s *UsersServer) Update(ctx context.Context,
 	s.pruneCredentials(publicObject)
 	response = &publicv1.UsersUpdateResponse{}
 	response.SetObject(publicObject)
-	return
+	return response, err
 }
 
 func (s *UsersServer) Delete(ctx context.Context,
@@ -303,7 +303,7 @@ func (s *UsersServer) Delete(ctx context.Context,
 
 	// Build and return the response:
 	response = &publicv1.UsersDeleteResponse{}
-	return
+	return response, err
 }
 
 // pruneCredentials removes credential data from a user object so that sensitive information like passwords is never

--- a/internal/servers/virtual_networks_server.go
+++ b/internal/servers/virtual_networks_server.go
@@ -87,11 +87,11 @@ func (b *VirtualNetworksServerBuilder) Build() (result *VirtualNetworksServer, e
 	// Check parameters:
 	if b.logger == nil {
 		err = errors.New("logger is mandatory")
-		return
+		return result, err
 	}
 	if b.tenancyLogic == nil {
 		err = errors.New("tenancy logic is mandatory")
-		return
+		return result, err
 	}
 
 	// Find the network_class field in VirtualNetworkSpec so that we can configure the inMapper to ignore it.
@@ -100,7 +100,7 @@ func (b *VirtualNetworksServerBuilder) Build() (result *VirtualNetworksServer, e
 	ncField := new(publicv1.VirtualNetworkSpec).ProtoReflect().Descriptor().Fields().ByName("network_class")
 	if ncField == nil {
 		err = fmt.Errorf("failed to find the network_class field of type '%s'", new(publicv1.VirtualNetworkSpec).ProtoReflect().Descriptor().FullName())
-		return
+		return result, err
 	}
 
 	// Create the mappers:
@@ -110,14 +110,14 @@ func (b *VirtualNetworksServerBuilder) Build() (result *VirtualNetworksServer, e
 		AddIgnoredFields(ncField.FullName()).
 		Build()
 	if err != nil {
-		return
+		return result, err
 	}
 	outMapper, err := NewGenericMapper[*privatev1.VirtualNetwork, *publicv1.VirtualNetwork]().
 		SetLogger(b.logger).
 		SetStrict(false).
 		Build()
 	if err != nil {
-		return
+		return result, err
 	}
 
 	// Create the private server to delegate to:
@@ -129,7 +129,7 @@ func (b *VirtualNetworksServerBuilder) Build() (result *VirtualNetworksServer, e
 		SetMetricsRegisterer(b.metricsRegisterer).
 		Build()
 	if err != nil {
-		return
+		return result, err
 	}
 
 	// Create and populate the object:
@@ -139,7 +139,7 @@ func (b *VirtualNetworksServerBuilder) Build() (result *VirtualNetworksServer, e
 		inMapper:  inMapper,
 		outMapper: outMapper,
 	}
-	return
+	return result, err
 }
 
 func (s *VirtualNetworksServer) List(ctx context.Context,
@@ -179,7 +179,7 @@ func (s *VirtualNetworksServer) List(ctx context.Context,
 	response.SetSize(privateResponse.GetSize())
 	response.SetTotal(privateResponse.GetTotal())
 	response.SetItems(publicItems)
-	return
+	return response, err
 }
 
 func (s *VirtualNetworksServer) Get(ctx context.Context,
@@ -210,7 +210,7 @@ func (s *VirtualNetworksServer) Get(ctx context.Context,
 	// Create the public response:
 	response = &publicv1.VirtualNetworksGetResponse{}
 	response.SetObject(publicVirtualNetwork)
-	return
+	return response, err
 }
 
 func (s *VirtualNetworksServer) Create(ctx context.Context,
@@ -219,7 +219,7 @@ func (s *VirtualNetworksServer) Create(ctx context.Context,
 	publicVirtualNetwork := request.GetObject()
 	if publicVirtualNetwork == nil {
 		err = grpcstatus.Errorf(grpccodes.InvalidArgument, "object is mandatory")
-		return
+		return response, err
 	}
 	privateVirtualNetwork := &privatev1.VirtualNetwork{}
 	err = s.inMapper.Copy(ctx, publicVirtualNetwork, privateVirtualNetwork)
@@ -230,7 +230,7 @@ func (s *VirtualNetworksServer) Create(ctx context.Context,
 			slog.Any("error", err),
 		)
 		err = grpcstatus.Errorf(grpccodes.Internal, "failed to process virtual network")
-		return
+		return response, err
 	}
 
 	// Restore network_class from the public request. AddIgnoredFields drops it during Copy
@@ -264,13 +264,13 @@ func (s *VirtualNetworksServer) Create(ctx context.Context,
 			slog.Any("error", err),
 		)
 		err = grpcstatus.Errorf(grpccodes.Internal, "failed to process virtual network")
-		return
+		return response, err
 	}
 
 	// Create the public response:
 	response = &publicv1.VirtualNetworksCreateResponse{}
 	response.SetObject(createdPublicVirtualNetwork)
-	return
+	return response, err
 }
 
 func (s *VirtualNetworksServer) Update(ctx context.Context,
@@ -279,12 +279,12 @@ func (s *VirtualNetworksServer) Update(ctx context.Context,
 	publicVirtualNetwork := request.GetObject()
 	if publicVirtualNetwork == nil {
 		err = grpcstatus.Errorf(grpccodes.InvalidArgument, "object is mandatory")
-		return
+		return response, err
 	}
 	id := publicVirtualNetwork.GetId()
 	if id == "" {
 		err = grpcstatus.Errorf(grpccodes.InvalidArgument, "object identifier is mandatory")
-		return
+		return response, err
 	}
 
 	// Get the existing object from the private server:
@@ -316,7 +316,7 @@ func (s *VirtualNetworksServer) Update(ctx context.Context,
 			slog.Any("error", err),
 		)
 		err = grpcstatus.Errorf(grpccodes.Internal, "failed to process virtual network")
-		return
+		return response, err
 	}
 
 	// Delegate to the private server with the merged object:
@@ -339,13 +339,13 @@ func (s *VirtualNetworksServer) Update(ctx context.Context,
 			slog.Any("error", err),
 		)
 		err = grpcstatus.Errorf(grpccodes.Internal, "failed to process virtual network")
-		return
+		return response, err
 	}
 
 	// Create the public response:
 	response = &publicv1.VirtualNetworksUpdateResponse{}
 	response.SetObject(updatedPublicVirtualNetwork)
-	return
+	return response, err
 }
 
 func (s *VirtualNetworksServer) Delete(ctx context.Context,
@@ -362,5 +362,5 @@ func (s *VirtualNetworksServer) Delete(ctx context.Context,
 
 	// Create the public response:
 	response = &publicv1.VirtualNetworksDeleteResponse{}
-	return
+	return response, err
 }

--- a/internal/shutdown/shutdown_sequence.go
+++ b/internal/shutdown/shutdown_sequence.go
@@ -318,25 +318,25 @@ func (b *SequenceBuilder) Build() (result *Sequence, err error) {
 	// Check parameters:
 	if b.logger == nil {
 		err = errors.New("logger is mandatory")
-		return
+		return result, err
 	}
 	if b.delay < 0 {
 		err = fmt.Errorf(
 			"delay must be greater than or equal to zero, but it is %s",
 			b.delay,
 		)
-		return
+		return result, err
 	}
 	if b.timeout < 0 {
 		err = fmt.Errorf(
 			"timeout must be greater than or equal to zero, but it is %s",
 			b.timeout,
 		)
-		return
+		return result, err
 	}
 	if b.exit == nil {
 		err = errors.New("exit function is mandatory")
-		return
+		return result, err
 	}
 
 	// Set the default delay if needed:
@@ -391,7 +391,7 @@ func (b *SequenceBuilder) Build() (result *Sequence, err error) {
 		result.Start(0)
 	}()
 
-	return
+	return result, err
 }
 
 // AddFunction adds a function that will be executed as a shutdown action. The is used to identify the function in the

--- a/internal/templating/templating_engine.go
+++ b/internal/templating/templating_engine.go
@@ -104,7 +104,7 @@ func (b *EngineBuilder) Build() (result *Engine, err error) {
 	// Check parameters:
 	if b.logger == nil {
 		err = errors.New("logger is mandatory")
-		return
+		return result, err
 	}
 
 	// We need to create the engine early because the some of the functions need the pointer:
@@ -141,18 +141,18 @@ func (b *EngineBuilder) Build() (result *Engine, err error) {
 		if b.dir != "" {
 			fsys, err = fs.Sub(filesystem, b.dir)
 			if err != nil {
-				return
+				return result, err
 			}
 		}
 		err = e.discoverTemplates(fsys)
 		if err != nil {
-			return
+			return result, err
 		}
 	}
 
 	// Return the object:
 	result = e
-	return
+	return result, err
 }
 
 func (e *Engine) discoverTemplates(fsys fs.FS) error {
@@ -276,11 +276,11 @@ func (e *Engine) base64Func(value any) (result string, err error) {
 			value,
 		)
 		if err != nil {
-			return
+			return result, err
 		}
 	}
 	result = base64.StdEncoding.EncodeToString(data)
-	return
+	return result, err
 }
 
 // evaluateFunc is a template function that parses and executes an arbitrary string as a template, returning the
@@ -292,19 +292,19 @@ func (e *Engine) base64Func(value any) (result string, err error) {
 func (e *Engine) evaluateFunc(text string, data any) (result string, err error) {
 	template, err := e.template.Clone()
 	if err != nil {
-		return
+		return result, err
 	}
 	template, err = template.New("").Parse(text)
 	if err != nil {
-		return
+		return result, err
 	}
 	buffer := &bytes.Buffer{}
 	err = template.Execute(buffer, data)
 	if err != nil {
-		return
+		return result, err
 	}
 	result = buffer.String()
-	return
+	return result, err
 }
 
 // executeFunc is a template function similar to template.ExecuteTemplate but it returns the result instead of writing
@@ -315,16 +315,16 @@ func (e *Engine) evaluateFunc(text string, data any) (result string, err error) 
 func (e *Engine) executeFunc(name string, data any) (result string, err error) {
 	err = e.ensureLoaded(name)
 	if err != nil {
-		return
+		return result, err
 	}
 	buffer := &bytes.Buffer{}
 	executed := e.template.Lookup(name)
 	err = executed.Execute(buffer, data)
 	if err != nil {
-		return
+		return result, err
 	}
 	result = buffer.String()
-	return
+	return result, err
 }
 
 // jsonFunc is a template function that encodes the given data as JSON. This can be used, for example, to encode as a
@@ -395,7 +395,7 @@ func (e *Engine) dataFunc(args ...any) (result map[string]any, err error) {
 			"number of arguments should be even, but it is %d",
 			len(args),
 		)
-		return
+		return result, err
 	}
 	result = map[string]any{}
 	for i := 0; i < len(args)/2; i++ {
@@ -406,10 +406,10 @@ func (e *Engine) dataFunc(args ...any) (result map[string]any, err error) {
 				"argument %d should be a string, but it is of type %T",
 				i, key,
 			)
-			return
+			return result, err
 		}
 		value := args[2*i+1]
 		result[name] = value
 	}
-	return
+	return result, err
 }

--- a/internal/terminal/terminal_console.go
+++ b/internal/terminal/terminal_console.go
@@ -93,7 +93,7 @@ func (b *ConsoleBuilder) Build() (result *Console, err error) {
 	// Check parameters:
 	if b.logger == nil {
 		err = errors.New("logger is mandatory")
-		return
+		return result, err
 	}
 
 	// Set the default writers if needed:
@@ -122,12 +122,12 @@ func (b *ConsoleBuilder) Build() (result *Console, err error) {
 		Build()
 	if err != nil {
 		err = fmt.Errorf("failed to create templating engine: %w", err)
-		return
+		return result, err
 	}
 
 	// Return the console object:
 	result = console
-	return
+	return result, err
 }
 
 // AddTemplates adds one temlate file system containing templates, including only the templates that are in the given
@@ -335,7 +335,7 @@ func (c *Console) Write(p []byte) (n int, err error) {
 func (c *Console) tableFunc(objects any) (result string, err error) {
 	if c.helper == nil {
 		err = fmt.Errorf("the 'table' function requires the reflection helper, but it isn't set")
-		return
+		return result, err
 	}
 	var buffer bytes.Buffer
 	renderer, err := rendering.NewTableRenderer().
@@ -345,15 +345,15 @@ func (c *Console) tableFunc(objects any) (result string, err error) {
 		Build()
 	if err != nil {
 		err = fmt.Errorf("failed to create table renderer: %w", err)
-		return
+		return result, err
 	}
 	err = renderer.Render(context.Background(), objects)
 	if err != nil {
 		err = fmt.Errorf("failed to render table: %w", err)
-		return
+		return result, err
 	}
 	result = buffer.String()
-	return
+	return result, err
 }
 
 // binaryFunc is a template function that returns the name of the binary.

--- a/internal/testing/command.go
+++ b/internal/testing/command.go
@@ -108,11 +108,11 @@ func (b *CommandBuilder) Build() (result *Command, err error) {
 	// Check parameters:
 	if b.logger == nil {
 		err = fmt.Errorf("logger is mandatory")
-		return
+		return result, err
 	}
 	if b.name == "" {
 		err = fmt.Errorf("name is mandatory")
-		return
+		return result, err
 	}
 
 	// Use the current working directory if no directory is set
@@ -120,7 +120,7 @@ func (b *CommandBuilder) Build() (result *Command, err error) {
 	if dir == "" {
 		dir, err = os.Getwd()
 		if err != nil {
-			return
+			return result, err
 		}
 	}
 
@@ -148,7 +148,7 @@ func (b *CommandBuilder) Build() (result *Command, err error) {
 		dir:    dir,
 		quiet:  b.quiet,
 	}
-	return
+	return result, err
 }
 
 // Execute executes the commands. It returns an error if the command fails.
@@ -202,7 +202,7 @@ func (c *Command) Evaluate(ctx context.Context) (stdoutBytes, stderrBytes []byte
 	if !c.quiet {
 		err = c.setupLogging(ctx, cmd)
 		if err != nil {
-			return
+			return stdoutBytes, stderrBytes, err
 		}
 	}
 	logger.DebugContext(ctx, "Evaluating command")
@@ -221,7 +221,7 @@ func (c *Command) Evaluate(ctx context.Context) (stdoutBytes, stderrBytes []byte
 	} else if logger.Enabled(ctx, slog.LevelDebug) {
 		logger.LogAttrs(ctx, slog.LevelDebug, "Command succeeded", attrs...)
 	}
-	return
+	return stdoutBytes, stderrBytes, err
 }
 
 func (c *Command) setupLogging(ctx context.Context, cmd *exec.Cmd) error {

--- a/internal/testing/fs.go
+++ b/internal/testing/fs.go
@@ -69,5 +69,5 @@ func TmpFS(args ...any) (dir string, fsys fs.FS) {
 		Expect(err).ToNot(HaveOccurred())
 	}
 	fsys = os.DirFS(dir)
-	return
+	return dir, fsys
 }

--- a/internal/testing/kind.go
+++ b/internal/testing/kind.go
@@ -152,15 +152,15 @@ func (b *KindBuilder) Build() (result *Kind, err error) {
 	// Check parameters:
 	if b.logger == nil {
 		err = fmt.Errorf("logger is mandatory")
-		return
+		return result, err
 	}
 	if b.name == "" {
 		err = fmt.Errorf("name is mandatory")
-		return
+		return result, err
 	}
 	if (b.caKeyFile == "") != (b.caCrtFile == "") {
 		err = fmt.Errorf("key file and certificate file must both be provided or both be omitted")
-		return
+		return result, err
 	}
 
 	// If a custom CA key pair is provided, verify that it is valid:
@@ -169,17 +169,17 @@ func (b *KindBuilder) Build() (result *Kind, err error) {
 		caKeyData, err = os.ReadFile(b.caKeyFile)
 		if err != nil {
 			err = fmt.Errorf("failed to load key file '%s': %w", b.caKeyFile, err)
-			return
+			return result, err
 		}
 		caCrtData, err = os.ReadFile(b.caCrtFile)
 		if err != nil {
 			err = fmt.Errorf("failed to load certificate file '%s': %w", b.caCrtFile, err)
-			return
+			return result, err
 		}
 		_, err = tls.X509KeyPair(caCrtData, caKeyData)
 		if err != nil {
 			err = fmt.Errorf("key and certificate files don't contain a valid key pair: %w", err)
-			return
+			return result, err
 		}
 	}
 
@@ -193,17 +193,17 @@ func (b *KindBuilder) Build() (result *Kind, err error) {
 	_, err = exec.LookPath(helmCmd)
 	if err != nil {
 		err = fmt.Errorf("command line tool '%s' isn't available: %w", helmCmd, err)
-		return
+		return result, err
 	}
 	_, err = exec.LookPath(kindCmd)
 	if err != nil {
 		err = fmt.Errorf("command line tool '%s' isn't available: %w", kindCmd, err)
-		return
+		return result, err
 	}
 	_, err = exec.LookPath(kubectlCmd)
 	if err != nil {
 		err = fmt.Errorf("command line tool '%s' isn't available: %w", kubectlCmd, err)
-		return
+		return result, err
 	}
 
 	// Create and populate the object:
@@ -217,7 +217,7 @@ func (b *KindBuilder) Build() (result *Kind, err error) {
 		crdFiles:     slices.Clone(b.crdFiles),
 		portMappings: slices.Clone(b.portMappings),
 	}
-	return
+	return result, err
 }
 
 // Exists checks whether the cluster already exists.
@@ -486,7 +486,7 @@ func (k *Kind) getClusters(ctx context.Context) (result []string, err error) {
 			"failed to create command to get existing kind clusters: %w",
 			err,
 		)
-		return
+		return result, err
 	}
 	getOut, _, err := getCmd.Evaluate(ctx)
 	if err != nil {
@@ -494,14 +494,14 @@ func (k *Kind) getClusters(ctx context.Context) (result []string, err error) {
 			"failed to get existing kind clusters: %w",
 			err,
 		)
-		return
+		return result, err
 	}
 	names := strings.Split(string(getOut), "\n")
 	for len(names) > 0 && names[len(names)-1] == "" {
 		names = names[:len(names)-1]
 	}
 	result = names
-	return
+	return result, err
 }
 
 func (k *Kind) createCluster(ctx context.Context) error {

--- a/internal/testing/servers.go
+++ b/internal/testing/servers.go
@@ -61,7 +61,7 @@ func MakeTCPTLSServer() (server *ghttp.Server, ca string) {
 	Expect(err).ToNot(HaveOccurred())
 	ca = fetchCACertificate("tcp", address.Host)
 
-	return
+	return server, ca
 }
 
 // fetchCACertificates connects to the given network address and extracts the CA certificate from the TLS handshake. It
@@ -227,7 +227,7 @@ func LocalhostCertificateFiles() (certFile, keyFile, caFile string) {
 	Expect(err).ToNot(HaveOccurred())
 	caFile = caTmp.Name()
 
-	return
+	return certFile, keyFile, caFile
 }
 
 // localhostCertificate contains the TLS certificate returned by the LocalhostCertificate function.

--- a/internal/validation/protovalidate_interceptor.go
+++ b/internal/validation/protovalidate_interceptor.go
@@ -57,13 +57,13 @@ func (b *ProtovalidateInterceptorBuilder) Build() (result *ProtovalidateIntercep
 	// Check parameters:
 	if b.logger == nil {
 		err = errors.New("logger is mandatory")
-		return
+		return result, err
 	}
 
 	// Create the protovalidate validator:
 	validator, err := protovalidate.New()
 	if err != nil {
-		return
+		return result, err
 	}
 
 	// Create the interceptor:
@@ -71,7 +71,7 @@ func (b *ProtovalidateInterceptorBuilder) Build() (result *ProtovalidateIntercep
 		logger:    b.logger,
 		validator: validator,
 	}
-	return
+	return result, err
 }
 
 // UnaryServer is the unary server interceptor function.

--- a/internal/version/version_interceptor.go
+++ b/internal/version/version_interceptor.go
@@ -110,7 +110,7 @@ func (b *InterceptorBuilder) Build() (result *Interceptor, err error) {
 	// Check parameters:
 	if b.logger == nil {
 		err = errors.New("logger is mandatory")
-		return
+		return result, err
 	}
 
 	// Use provided values or defaults:
@@ -129,7 +129,7 @@ func (b *InterceptorBuilder) Build() (result *Interceptor, err error) {
 		product: product,
 		version: version,
 	}
-	return
+	return result, err
 }
 
 // userAgent calculates the value for the `User-Agent` header.

--- a/internal/work/work_loop.go
+++ b/internal/work/work_loop.go
@@ -110,19 +110,19 @@ func (b *LoopBuilder) Build() (result *Loop, err error) {
 	// Check parameters:
 	if b.logger == nil {
 		err = errors.New("logger is mandatory")
-		return
+		return result, err
 	}
 	if b.workFunc == nil {
 		err = errors.New("function is mandatory")
-		return
+		return result, err
 	}
 	if b.interval <= 0 {
 		err = fmt.Errorf("interval should be positive, but it is %s", b.interval)
-		return
+		return result, err
 	}
 	if b.name == "" {
 		err = errors.New("name is mandatory")
-		return
+		return result, err
 	}
 
 	// Create a logger with the name of the loop:
@@ -137,7 +137,7 @@ func (b *LoopBuilder) Build() (result *Loop, err error) {
 		interval: b.interval,
 		kick:     make(chan struct{}, 1),
 	}
-	return
+	return result, err
 }
 
 // Run runs the loop until the context is cancelled.

--- a/it/it_tool.go
+++ b/it/it_tool.go
@@ -198,11 +198,11 @@ func (b *ToolBuilder) Build() (result *Tool, err error) {
 	// Check parameters:
 	if b.logger == nil {
 		err = errors.New("logger is mandatory")
-		return
+		return result, err
 	}
 	if (b.caKeyFile == "") != (b.caCrtFile == "") {
 		err = errors.New("key file and certificate file must both be provided or both be omitted")
-		return
+		return result, err
 	}
 
 	// Find the project directory if not specified:
@@ -210,7 +210,7 @@ func (b *ToolBuilder) Build() (result *Tool, err error) {
 	if projectDir == "" {
 		projectDir, err = b.findProjectDir()
 		if err != nil {
-			return
+			return result, err
 		}
 	}
 
@@ -220,7 +220,7 @@ func (b *ToolBuilder) Build() (result *Tool, err error) {
 		Build()
 	if err != nil {
 		err = fmt.Errorf("failed to create JQ tool: %w", err)
-		return
+		return result, err
 	}
 
 	// Create and populate the object:
@@ -236,7 +236,7 @@ func (b *ToolBuilder) Build() (result *Tool, err error) {
 		secret:      b.secret,
 		jqTool:      jqTool,
 	}
-	return
+	return result, err
 }
 
 // findProjectDir finds the project directory by searching for the go.mod file starting from the current directory.
@@ -244,23 +244,23 @@ func (b *ToolBuilder) findProjectDir() (result string, err error) {
 	currentDir, err := os.Getwd()
 	if err != nil {
 		err = fmt.Errorf("failed to get current directory: %w", err)
-		return
+		return result, err
 	}
 	for {
 		modFile := filepath.Join(currentDir, "go.mod")
 		_, statErr := os.Stat(modFile)
 		if statErr == nil {
 			result = currentDir
-			return
+			return result, err
 		}
 		if !errors.Is(statErr, os.ErrNotExist) {
 			err = fmt.Errorf("failed to stat '%s': %w", modFile, statErr)
-			return
+			return result, err
 		}
 		parentDir := filepath.Dir(currentDir)
 		if parentDir == currentDir {
 			err = fmt.Errorf("failed to find 'go.mod' file starting from '%s'", currentDir)
-			return
+			return result, err
 		}
 		currentDir = parentDir
 	}
@@ -501,15 +501,15 @@ func (t *Tool) buildImage(ctx context.Context) (result string, err error) {
 		Build()
 	if err != nil {
 		err = fmt.Errorf("failed to create command to build image: %w", err)
-		return
+		return result, err
 	}
 	err = buildCmd.Execute(ctx)
 	if err != nil {
 		err = fmt.Errorf("failed to build image: %w", err)
-		return
+		return result, err
 	}
 	result = imageRef
-	return
+	return result, err
 }
 
 // saveImage saves the given container image to a tar file and returns the path to that tar file.
@@ -529,15 +529,15 @@ func (t *Tool) saveImage(ctx context.Context, imageRef string) (result string, e
 		Build()
 	if err != nil {
 		err = fmt.Errorf("failed to create command to save image: %w", err)
-		return
+		return result, err
 	}
 	err = saveCmd.Execute(ctx)
 	if err != nil {
 		err = fmt.Errorf("failed to save container image: %w", err)
-		return
+		return result, err
 	}
 	result = imageTar
-	return
+	return result, err
 }
 
 func (t *Tool) startCluster(ctx context.Context) error {
@@ -1166,7 +1166,7 @@ func (t *Tool) deployKeycloak(ctx context.Context) error {
 			data, err = json.Marshal(input)
 			if err != nil {
 				err = fmt.Errorf("failed to marshal request body: %w", err)
-				return
+				return code, output, err
 			}
 			body = bytes.NewReader(data)
 		}
@@ -1174,7 +1174,7 @@ func (t *Tool) deployKeycloak(ctx context.Context) error {
 		request, err := http.NewRequestWithContext(ctx, method, url, body)
 		if err != nil {
 			err = fmt.Errorf("failed to create request: %w", err)
-			return
+			return code, output, err
 		}
 		if input != nil {
 			request.Header.Set("Content-Type", "application/json")
@@ -1183,22 +1183,22 @@ func (t *Tool) deployKeycloak(ctx context.Context) error {
 		token, err = tokenSource.Token(ctx)
 		if err != nil {
 			err = fmt.Errorf("failed to get token: %w", err)
-			return
+			return code, output, err
 		}
 		request.Header.Set("Authorization", fmt.Sprintf("Bearer %s", token.Access))
 		response, err := httpClient.Do(request)
 		if err != nil {
 			err = fmt.Errorf("failed to send request: %w", err)
-			return
+			return code, output, err
 		}
 		defer response.Body.Close()
 		output, err = io.ReadAll(response.Body)
 		if err != nil {
 			err = fmt.Errorf("failed to read response body: %w", err)
-			return
+			return code, output, err
 		}
 		code = response.StatusCode
-		return
+		return code, output, err
 	}
 
 	// Create the 'admin' client in the master realm:
@@ -1904,7 +1904,7 @@ func (t *Tool) makeKubernetesTokenSource(ctx context.Context, sa, namespace stri
 	)
 	if err != nil {
 		err = fmt.Errorf("failed to create token for service account '%s': %w", sa, err)
-		return
+		return result, err
 	}
 	token := &auth.Token{
 		Access: response.Status.Token,
@@ -1913,7 +1913,7 @@ func (t *Tool) makeKubernetesTokenSource(ctx context.Context, sa, namespace stri
 		SetLogger(t.logger).
 		SetToken(token).
 		Build()
-	return
+	return result, err
 }
 
 func (t *Tool) makeKeycloakTokenSource(ctx context.Context, username, password string) (result auth.TokenSource, err error) {
@@ -1921,7 +1921,7 @@ func (t *Tool) makeKeycloakTokenSource(ctx context.Context, username, password s
 		SetLogger(t.logger).
 		Build()
 	if err != nil {
-		return
+		return result, err
 	}
 	result, err = oauth.NewTokenSource().
 		SetLogger(t.logger).
@@ -1934,7 +1934,7 @@ func (t *Tool) makeKeycloakTokenSource(ctx context.Context, username, password s
 		SetPassword(password).
 		SetScopes("openid", "organization").
 		Build()
-	return
+	return result, err
 }
 
 // KeycloakAdminRequest makes an authenticated request to the Keycloak admin API for the 'osac' realm.
@@ -1947,7 +1947,7 @@ func (t *Tool) KeycloakAdminRequest(ctx context.Context, method, path string, in
 		Build()
 	if err != nil {
 		err = fmt.Errorf("failed to create Keycloak admin token store: %w", err)
-		return
+		return code, output, err
 	}
 	tokenSource, err := oauth.NewTokenSource().
 		SetLogger(t.logger).
@@ -1962,7 +1962,7 @@ func (t *Tool) KeycloakAdminRequest(ctx context.Context, method, path string, in
 		Build()
 	if err != nil {
 		err = fmt.Errorf("failed to create Keycloak admin token source: %w", err)
-		return
+		return code, output, err
 	}
 	httpClient := &http.Client{
 		Transport: &http.Transport{
@@ -1978,7 +1978,7 @@ func (t *Tool) KeycloakAdminRequest(ctx context.Context, method, path string, in
 		data, err = json.Marshal(input)
 		if err != nil {
 			err = fmt.Errorf("failed to marshal request body: %w", err)
-			return
+			return code, output, err
 		}
 		body = bytes.NewReader(data)
 	}
@@ -1986,7 +1986,7 @@ func (t *Tool) KeycloakAdminRequest(ctx context.Context, method, path string, in
 	request, err := http.NewRequestWithContext(ctx, method, url, body)
 	if err != nil {
 		err = fmt.Errorf("failed to create request: %w", err)
-		return
+		return code, output, err
 	}
 	if input != nil {
 		request.Header.Set("Content-Type", "application/json")
@@ -1994,22 +1994,22 @@ func (t *Tool) KeycloakAdminRequest(ctx context.Context, method, path string, in
 	token, err := tokenSource.Token(ctx)
 	if err != nil {
 		err = fmt.Errorf("failed to get token: %w", err)
-		return
+		return code, output, err
 	}
 	request.Header.Set("Authorization", fmt.Sprintf("Bearer %s", token.Access))
 	response, err := httpClient.Do(request)
 	if err != nil {
 		err = fmt.Errorf("failed to send request: %w", err)
-		return
+		return code, output, err
 	}
 	defer response.Body.Close()
 	output, err = io.ReadAll(response.Body)
 	if err != nil {
 		err = fmt.Errorf("failed to read response body: %w", err)
-		return
+		return code, output, err
 	}
 	code = response.StatusCode
-	return
+	return code, output, err
 }
 
 // makeGrpcConn creates a gRPC connection that automatically adds the token to the request.
@@ -2053,7 +2053,7 @@ func (t *Tool) makeHttpClient(addr string, tokenSource auth.TokenSource) *http.C
 
 			// Forward the request:
 			response, err = transport.RoundTrip(request)
-			return
+			return response, err
 		},
 	)
 	return &http.Client{


### PR DESCRIPTION
## Summary
- Added `nakedret` linter rule to `.golangci.yml` with `max-func-lines: 10`
- Resolved all ~1,920 naked returns across 180 files via `nakedret -l 10 -fix ./...`

## Test plan
- [x] `uv run dev.py lint` passes with 0 issues
- [x] `ginkgo run -r internal` — all 83 test suites pass
- [x] `go build ./cmd/fulfillment-service && go build ./cmd/osac` — both binaries compile

Assisted-by: Claude <noreply@anthropic.com>