### PR TITLE
OSAC-1494: Add CLI commands, table rendering, and integration tests for NATGateway

### DIFF
--- a/internal/cmd/cli/create/create_cmd.go
+++ b/internal/cmd/cli/create/create_cmd.go
@@ -38,6 +38,7 @@ import (
 	"github.com/osac-project/fulfillment-service/internal/cmd/cli/create/externalipattachment"
 	"github.com/osac-project/fulfillment-service/internal/cmd/cli/create/hub"
 	"github.com/osac-project/fulfillment-service/internal/cmd/cli/create/instancetype"
+	"github.com/osac-project/fulfillment-service/internal/cmd/cli/create/natgateway"
 	"github.com/osac-project/fulfillment-service/internal/cmd/cli/create/publicip"
 	"github.com/osac-project/fulfillment-service/internal/cmd/cli/create/publicipattachment"
 	"github.com/osac-project/fulfillment-service/internal/cmd/cli/create/securitygroup"
@@ -70,6 +71,7 @@ func Cmd() *cobra.Command {
 	result.AddCommand(externalipattachment.Cmd())
 	result.AddCommand(hub.Cmd())
 	result.AddCommand(instancetype.Cmd())
+	result.AddCommand(natgateway.Cmd())
 	result.AddCommand(publicip.Cmd())
 	result.AddCommand(publicipattachment.Cmd())
 	result.AddCommand(virtualnetwork.Cmd())

--- a/internal/cmd/cli/create/natgateway/create_natgateway_cmd.go
+++ b/internal/cmd/cli/create/natgateway/create_natgateway_cmd.go
@@ -1,0 +1,180 @@
+/*
+Copyright (c) 2026 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package natgateway
+
+import (
+	"fmt"
+	"log/slog"
+
+	"github.com/spf13/cobra"
+	"google.golang.org/protobuf/proto"
+
+	publicv1 "github.com/osac-project/fulfillment-service/internal/api/osac/public/v1"
+	"github.com/osac-project/fulfillment-service/internal/cmd/cli/lookup"
+	"github.com/osac-project/fulfillment-service/internal/config"
+	"github.com/osac-project/fulfillment-service/internal/logging"
+	"github.com/osac-project/fulfillment-service/internal/terminal"
+)
+
+func Cmd() *cobra.Command {
+	runner := &runnerContext{}
+	result := &cobra.Command{
+		Use:                   "natgateway [FLAG...]",
+		Aliases:               []string{string(proto.MessageName((*publicv1.NATGateway)(nil)))},
+		Short:                 shortHelp,
+		Long:                  longHelp,
+		DisableFlagsInUseLine: true,
+		Args:                  cobra.NoArgs,
+		RunE:                  runner.run,
+	}
+	flags := result.Flags()
+	flags.StringVarP(
+		&runner.args.name,
+		"name",
+		"n",
+		"",
+		nameFlagHelp,
+	)
+	flags.StringVar(
+		&runner.args.virtualNetwork,
+		"virtual-network",
+		"",
+		virtualNetworkFlagHelp,
+	)
+	flags.StringVar(
+		&runner.args.externalIP,
+		"externalip",
+		"",
+		externalIPFlagHelp,
+	)
+	result.MarkFlagRequired("virtual-network") //nolint:errcheck
+	result.MarkFlagRequired("externalip")      //nolint:errcheck
+	return result
+}
+
+type runnerContext struct {
+	args struct {
+		name           string
+		virtualNetwork string
+		externalIP     string
+	}
+	logger   *slog.Logger
+	console  *terminal.Console
+	settings *config.Settings
+}
+
+func (c *runnerContext) run(cmd *cobra.Command, args []string) error {
+	ctx := cmd.Context()
+
+	c.logger = logging.LoggerFromContext(ctx)
+	c.console = terminal.ConsoleFromContext(ctx)
+
+	c.settings = config.SettingsFromContext(ctx)
+	if !c.settings.Armed() {
+		return fmt.Errorf("there is no configuration, run the 'login' command")
+	}
+
+	conn, err := c.settings.Connect(ctx, cmd.Flags())
+	if err != nil {
+		return fmt.Errorf("failed to create gRPC connection: %w", err)
+	}
+	defer conn.Close()
+
+	vnClient := publicv1.NewVirtualNetworksClient(conn)
+	vn, err := lookup.Find(c.args.virtualNetwork, "virtual network", func(filter string, limit int32) ([]*publicv1.VirtualNetwork, error) {
+		resp, err := vnClient.List(ctx, publicv1.VirtualNetworksListRequest_builder{
+			Filter: proto.String(filter),
+			Limit:  proto.Int32(limit),
+		}.Build())
+		if err != nil {
+			return nil, fmt.Errorf("failed to resolve virtual network %q: %w", c.args.virtualNetwork, err)
+		}
+		return resp.GetItems(), nil
+	})
+	if err != nil {
+		return err
+	}
+
+	eipClient := publicv1.NewExternalIPsClient(conn)
+	eip, err := lookup.Find(c.args.externalIP, "external IP", func(filter string, limit int32) ([]*publicv1.ExternalIP, error) {
+		resp, err := eipClient.List(ctx, publicv1.ExternalIPsListRequest_builder{
+			Filter: proto.String(filter),
+			Limit:  proto.Int32(limit),
+		}.Build())
+		if err != nil {
+			return nil, fmt.Errorf("failed to resolve external IP %q: %w", c.args.externalIP, err)
+		}
+		return resp.GetItems(), nil
+	})
+	if err != nil {
+		return err
+	}
+
+	client := publicv1.NewNATGatewaysClient(conn)
+
+	natGateway := publicv1.NATGateway_builder{
+		Metadata: publicv1.Metadata_builder{
+			Name:   c.args.name,
+			Tenant: c.settings.Tenant(),
+		}.Build(),
+		Spec: publicv1.NATGatewaySpec_builder{
+			VirtualNetwork: vn.GetId(),
+			ExternalIp:     eip.GetId(),
+		}.Build(),
+	}.Build()
+
+	response, err := client.Create(ctx, publicv1.NATGatewaysCreateRequest_builder{Object: natGateway}.Build())
+	if err != nil {
+		return fmt.Errorf("failed to create NAT gateway: %w", err)
+	}
+
+	c.console.Infof(ctx, "Created NAT gateway '%s' (ID: %s).\n", response.Object.GetMetadata().GetName(), response.Object.GetId())
+
+	return nil
+}
+
+const shortHelp = `Create a NAT gateway.`
+
+const longHelp = `
+Create a NAT gateway for outbound traffic (SNAT) from a virtual network.
+
+The NAT gateway provides a dedicated egress identity for all resources within a virtual network.
+All outbound traffic from the virtual network's CIDR is source-NATted to the associated external
+IP address.
+
+Both {{ bt }}--virtual-network{{ bt }} and {{ bt }}--externalip{{ bt }} are required. Only one NAT
+gateway is allowed per virtual network.
+
+Examples:
+
+{{ bt 3 }}shell
+# Create a NAT gateway
+{{ binary }} create natgateway --name my-natgw --virtual-network vnet-abc123 --externalip eip-xyz789
+
+# Create using resource names
+{{ binary }} create natgateway --name my-natgw --virtual-network my-vnet --externalip my-ip
+{{ bt 3 }}
+`
+
+const nameFlagHelp = `
+_NAME_ - Name of the NAT gateway.
+`
+
+const virtualNetworkFlagHelp = `
+_ID|NAME_ - ID or name of the parent virtual network. Required.
+`
+
+const externalIPFlagHelp = `
+_ID|NAME_ - ID or name of the external IP to use for SNAT. Required.
+`

--- a/internal/cmd/cli/describe/describe_cmd.go
+++ b/internal/cmd/cli/describe/describe_cmd.go
@@ -22,6 +22,7 @@ import (
 	"github.com/osac-project/fulfillment-service/internal/cmd/cli/describe/externalip"
 	"github.com/osac-project/fulfillment-service/internal/cmd/cli/describe/externalipattachment"
 	"github.com/osac-project/fulfillment-service/internal/cmd/cli/describe/instancetype"
+	"github.com/osac-project/fulfillment-service/internal/cmd/cli/describe/natgateway"
 	"github.com/osac-project/fulfillment-service/internal/cmd/cli/describe/networkclass"
 	"github.com/osac-project/fulfillment-service/internal/cmd/cli/describe/publicip"
 	"github.com/osac-project/fulfillment-service/internal/cmd/cli/describe/publicipattachment"
@@ -44,6 +45,7 @@ func Cmd() *cobra.Command {
 	result.AddCommand(externalip.Cmd())
 	result.AddCommand(externalipattachment.Cmd())
 	result.AddCommand(instancetype.Cmd())
+	result.AddCommand(natgateway.Cmd())
 	result.AddCommand(networkclass.Cmd())
 	result.AddCommand(publicip.Cmd())
 	result.AddCommand(publicipattachment.Cmd())

--- a/internal/cmd/cli/describe/natgateway/describe_natgateway_cmd.go
+++ b/internal/cmd/cli/describe/natgateway/describe_natgateway_cmd.go
@@ -1,0 +1,133 @@
+/*
+Copyright (c) 2026 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package natgateway
+
+import (
+	"fmt"
+	"io"
+	"log/slog"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/spf13/cobra"
+	"google.golang.org/protobuf/proto"
+
+	publicv1 "github.com/osac-project/fulfillment-service/internal/api/osac/public/v1"
+	"github.com/osac-project/fulfillment-service/internal/cmd/cli/lookup"
+	"github.com/osac-project/fulfillment-service/internal/config"
+	"github.com/osac-project/fulfillment-service/internal/logging"
+	"github.com/osac-project/fulfillment-service/internal/terminal"
+)
+
+func Cmd() *cobra.Command {
+	runner := &runnerContext{}
+	result := &cobra.Command{
+		Use:                   "natgateway [FLAG...] ID|NAME",
+		Aliases:               []string{"natgateways"},
+		Short:                 shortHelp,
+		Long:                  longHelp,
+		DisableFlagsInUseLine: true,
+		Args:                  cobra.ExactArgs(1),
+		RunE:                  runner.run,
+	}
+	return result
+}
+
+type runnerContext struct {
+	logger  *slog.Logger
+	console *terminal.Console
+}
+
+func (c *runnerContext) run(cmd *cobra.Command, args []string) error {
+	ref := args[0]
+
+	ctx := cmd.Context()
+
+	c.logger = logging.LoggerFromContext(ctx)
+	c.console = terminal.ConsoleFromContext(ctx)
+
+	cfg := config.SettingsFromContext(ctx)
+	if !cfg.Armed() {
+		return fmt.Errorf("there is no configuration, run the 'login' command")
+	}
+
+	conn, err := cfg.Connect(ctx, cmd.Flags())
+	if err != nil {
+		return fmt.Errorf("failed to create gRPC connection: %w", err)
+	}
+	defer conn.Close()
+
+	client := publicv1.NewNATGatewaysClient(conn)
+
+	matched, err := lookup.Find(ref, "NAT gateway", func(filter string, limit int32) ([]*publicv1.NATGateway, error) {
+		resp, err := client.List(ctx, publicv1.NATGatewaysListRequest_builder{
+			Filter: proto.String(filter),
+			Limit:  proto.Int32(limit),
+		}.Build())
+		if err != nil {
+			return nil, fmt.Errorf("failed to describe NAT gateway: %w", err)
+		}
+		return resp.GetItems(), nil
+	})
+	if err != nil {
+		return err
+	}
+
+	RenderNATGateway(c.console, matched)
+
+	return nil
+}
+
+// RenderNATGateway writes a formatted description of ng to w.
+func RenderNATGateway(w io.Writer, ng *publicv1.NATGateway) {
+	writer := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
+
+	name := "-"
+	if v := ng.GetMetadata().GetName(); v != "" {
+		name = v
+	}
+
+	state := "-"
+	message := "-"
+	if ng.GetStatus() != nil {
+		state = strings.TrimPrefix(ng.GetStatus().GetState().String(), "NAT_GATEWAY_STATE_")
+		if v := ng.GetStatus().GetMessage(); v != "" {
+			message = v
+		}
+	}
+
+	fmt.Fprintf(writer, "ID:\t%s\n", ng.GetId())
+	fmt.Fprintf(writer, "Name:\t%s\n", name)
+	fmt.Fprintf(writer, "Virtual Network:\t%s\n", ng.GetSpec().GetVirtualNetwork())
+	fmt.Fprintf(writer, "External IP:\t%s\n", ng.GetSpec().GetExternalIp())
+	fmt.Fprintf(writer, "State:\t%s\n", state)
+	fmt.Fprintf(writer, "Message:\t%s\n", message)
+	writer.Flush()
+}
+
+const shortHelp = "Describe a NAT gateway"
+
+const longHelp = `
+Display detailed information about a NAT gateway, referenced by identifier or name.
+
+Examples:
+
+{{ bt 3 }}shell
+# Describe a NAT gateway by identifier:
+{{ binary }} describe natgateway 019e5ff0-6266-7310-acf3-94e99a3786c9
+
+# Describe a NAT gateway by name:
+{{ binary }} describe natgateway my-natgw
+{{ bt 3 }}
+`

--- a/internal/rendering/tables/osac.private.v1.NATGateway.yaml
+++ b/internal/rendering/tables/osac.private.v1.NATGateway.yaml
@@ -1,0 +1,42 @@
+#
+# Copyright (c) 2025 Red Hat Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+# the License. You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+columns:
+
+- header: PROJECT
+  value: "has(this.metadata.project)? this.metadata.project: '-'"
+
+- header: ID
+  value: this.id
+
+- header: NAME
+  value: "has(this.metadata.name)? this.metadata.name: '-'"
+
+- header: VIRTUAL-NETWORK
+  value: this.spec.virtual_network
+  type: osac.private.v1.VirtualNetwork
+  lookup: true
+
+- header: EXTERNAL-IP
+  value: this.spec.external_ip
+  type: osac.private.v1.ExternalIP
+  lookup: true
+
+- header: STATE
+  value: this.status.state
+  type: osac.private.v1.NATGatewayState
+
+- header: HUB
+  value: this.status.hub
+  type: osac.private.v1.Hub
+  lookup: true

--- a/internal/rendering/tables/osac.public.v1.NATGateway.yaml
+++ b/internal/rendering/tables/osac.public.v1.NATGateway.yaml
@@ -1,0 +1,37 @@
+#
+# Copyright (c) 2025 Red Hat Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+# the License. You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+columns:
+
+- header: PROJECT
+  value: "has(this.metadata.project)? this.metadata.project: '-'"
+
+- header: ID
+  value: this.id
+
+- header: NAME
+  value: "has(this.metadata.name)? this.metadata.name: '-'"
+
+- header: VIRTUAL-NETWORK
+  value: this.spec.virtual_network
+  type: osac.public.v1.VirtualNetwork
+  lookup: true
+
+- header: EXTERNAL-IP
+  value: this.spec.external_ip
+  type: osac.public.v1.ExternalIP
+  lookup: true
+
+- header: STATE
+  value: this.status.state
+  type: osac.public.v1.NATGatewayState

--- a/it/it_nat_gateway_test.go
+++ b/it/it_nat_gateway_test.go
@@ -1,0 +1,483 @@
+/*
+Copyright (c) 2026 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package it
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2/dsl/core"
+	. "github.com/onsi/gomega"
+	grpccodes "google.golang.org/grpc/codes"
+	grpcstatus "google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/fieldmaskpb"
+
+	privatev1 "github.com/osac-project/fulfillment-service/internal/api/osac/private/v1"
+	publicv1 "github.com/osac-project/fulfillment-service/internal/api/osac/public/v1"
+	"github.com/osac-project/fulfillment-service/internal/uuid"
+)
+
+var _ = Describe("NATGateway lifecycle", func() {
+	var (
+		ctx context.Context
+
+		natGatewaysClient        publicv1.NATGatewaysClient
+		privateExternalIPsClient privatev1.ExternalIPsClient
+		externalIPsClient        publicv1.ExternalIPsClient
+		poolsClient              privatev1.ExternalIPPoolsClient
+		virtualNetworksClient    privatev1.VirtualNetworksClient
+		networkClassesClient     privatev1.NetworkClassesClient
+
+		networkClassId   string
+		virtualNetworkId string
+		poolId           string
+		externalIPId     string
+	)
+
+	BeforeEach(func() {
+		ctx = context.Background()
+
+		natGatewaysClient = publicv1.NewNATGatewaysClient(tool.ExternalView().UserConn())
+		privateExternalIPsClient = privatev1.NewExternalIPsClient(tool.InternalView().AdminConn())
+		externalIPsClient = publicv1.NewExternalIPsClient(tool.ExternalView().UserConn())
+		poolsClient = privatev1.NewExternalIPPoolsClient(tool.InternalView().AdminConn())
+		virtualNetworksClient = privatev1.NewVirtualNetworksClient(tool.InternalView().AdminConn())
+		networkClassesClient = privatev1.NewNetworkClassesClient(tool.InternalView().AdminConn())
+
+		// Create NetworkClass
+		ncResp, err := networkClassesClient.Create(ctx, privatev1.NetworkClassesCreateRequest_builder{
+			Object: privatev1.NetworkClass_builder{
+				Title:                  "Test CUDN Network Class",
+				ImplementationStrategy: "cudn",
+				FabricManager:          "netris",
+			}.Build(),
+		}.Build())
+		Expect(err).ToNot(HaveOccurred())
+		networkClassId = ncResp.GetObject().GetId()
+
+		// Create VirtualNetwork
+		virtualNetworkId = fmt.Sprintf("test-vnet-%s", uuid.New())
+		_, err = virtualNetworksClient.Create(ctx, privatev1.VirtualNetworksCreateRequest_builder{
+			Object: privatev1.VirtualNetwork_builder{
+				Id: virtualNetworkId,
+				Spec: privatev1.VirtualNetworkSpec_builder{
+					NetworkClass: networkClassId,
+					Region:       "us-east-1",
+					Ipv4Cidr:     new("10.100.0.0/16"),
+				}.Build(),
+			}.Build(),
+		}.Build())
+		Expect(err).ToNot(HaveOccurred())
+
+		Eventually(func(g Gomega) {
+			resp, err := virtualNetworksClient.Get(ctx, privatev1.VirtualNetworksGetRequest_builder{
+				Id: virtualNetworkId,
+			}.Build())
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(resp.GetObject().GetStatus().GetState()).To(
+				Equal(privatev1.VirtualNetworkState_VIRTUAL_NETWORK_STATE_PENDING))
+		}, time.Minute, time.Second).Should(Succeed())
+
+		vnGetResp, err := virtualNetworksClient.Get(ctx, privatev1.VirtualNetworksGetRequest_builder{
+			Id: virtualNetworkId,
+		}.Build())
+		Expect(err).ToNot(HaveOccurred())
+		vn := vnGetResp.GetObject()
+		vn.SetStatus(privatev1.VirtualNetworkStatus_builder{
+			State: privatev1.VirtualNetworkState_VIRTUAL_NETWORK_STATE_READY,
+		}.Build())
+		_, err = virtualNetworksClient.Update(ctx, privatev1.VirtualNetworksUpdateRequest_builder{
+			Object:     vn,
+			UpdateMask: &fieldmaskpb.FieldMask{Paths: []string{"status.state"}},
+		}.Build())
+		Expect(err).ToNot(HaveOccurred())
+
+		// Create ExternalIPPool
+		poolId = fmt.Sprintf("test-pool-%s", uuid.New())
+		_, err = poolsClient.Create(ctx, privatev1.ExternalIPPoolsCreateRequest_builder{
+			Object: privatev1.ExternalIPPool_builder{
+				Id: poolId,
+				Spec: privatev1.ExternalIPPoolSpec_builder{
+					Cidrs:    []string{uniqueCIDR()},
+					IpFamily: privatev1.IPFamily_IP_FAMILY_IPV4,
+				}.Build(),
+			}.Build(),
+		}.Build())
+		Expect(err).ToNot(HaveOccurred())
+
+		Eventually(func(g Gomega) {
+			resp, err := poolsClient.Get(ctx, privatev1.ExternalIPPoolsGetRequest_builder{
+				Id: poolId,
+			}.Build())
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(resp.GetObject().GetStatus().GetState()).To(
+				Equal(privatev1.ExternalIPPoolState_EXTERNAL_IP_POOL_STATE_PENDING))
+		}, time.Minute, time.Second).Should(Succeed())
+
+		poolGetResp, err := poolsClient.Get(ctx, privatev1.ExternalIPPoolsGetRequest_builder{
+			Id: poolId,
+		}.Build())
+		Expect(err).ToNot(HaveOccurred())
+		pool := poolGetResp.GetObject()
+		pool.SetStatus(privatev1.ExternalIPPoolStatus_builder{
+			State:     privatev1.ExternalIPPoolState_EXTERNAL_IP_POOL_STATE_READY,
+			Total:     pool.GetStatus().GetTotal(),
+			Available: pool.GetStatus().GetAvailable(),
+			Allocated: pool.GetStatus().GetAllocated(),
+		}.Build())
+		_, err = poolsClient.Update(ctx, privatev1.ExternalIPPoolsUpdateRequest_builder{
+			Object:     pool,
+			UpdateMask: &fieldmaskpb.FieldMask{Paths: []string{"status.state"}},
+		}.Build())
+		Expect(err).ToNot(HaveOccurred())
+
+		// Create ExternalIP
+		externalIPId = fmt.Sprintf("test-ip-%s", uuid.New())
+		_, err = externalIPsClient.Create(ctx, publicv1.ExternalIPsCreateRequest_builder{
+			Object: publicv1.ExternalIP_builder{
+				Id: externalIPId,
+				Spec: publicv1.ExternalIPSpec_builder{
+					Pool: poolId,
+				}.Build(),
+			}.Build(),
+		}.Build())
+		Expect(err).ToNot(HaveOccurred())
+
+		// Promote ExternalIP to ALLOCATED
+		ipGetResp, err := privateExternalIPsClient.Get(ctx, privatev1.ExternalIPsGetRequest_builder{
+			Id: externalIPId,
+		}.Build())
+		Expect(err).ToNot(HaveOccurred())
+		ip := ipGetResp.GetObject()
+		ip.SetStatus(privatev1.ExternalIPStatus_builder{
+			State: privatev1.ExternalIPState_EXTERNAL_IP_STATE_ALLOCATED,
+		}.Build())
+		_, err = privateExternalIPsClient.Update(ctx, privatev1.ExternalIPsUpdateRequest_builder{
+			Object:     ip,
+			UpdateMask: &fieldmaskpb.FieldMask{Paths: []string{"status.state"}},
+		}.Build())
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	AfterEach(func() {
+		if externalIPId != "" {
+			_, _ = externalIPsClient.Delete(ctx, publicv1.ExternalIPsDeleteRequest_builder{
+				Id: externalIPId,
+			}.Build())
+		}
+		if poolId != "" {
+			_, _ = poolsClient.Delete(ctx, privatev1.ExternalIPPoolsDeleteRequest_builder{
+				Id: poolId,
+			}.Build())
+		}
+		if virtualNetworkId != "" {
+			_, _ = virtualNetworksClient.Delete(ctx, privatev1.VirtualNetworksDeleteRequest_builder{
+				Id: virtualNetworkId,
+			}.Build())
+		}
+		if networkClassId != "" {
+			_, _ = networkClassesClient.Delete(ctx, privatev1.NetworkClassesDeleteRequest_builder{
+				Id: networkClassId,
+			}.Build())
+		}
+	})
+
+	It("Can create, get, and list a NATGateway", func() {
+		ngId := fmt.Sprintf("test-ng-%s", uuid.New())
+		response, err := natGatewaysClient.Create(ctx, publicv1.NATGatewaysCreateRequest_builder{
+			Object: publicv1.NATGateway_builder{
+				Id: ngId,
+				Spec: publicv1.NATGatewaySpec_builder{
+					VirtualNetwork: virtualNetworkId,
+					ExternalIp:     externalIPId,
+				}.Build(),
+			}.Build(),
+		}.Build())
+		Expect(err).ToNot(HaveOccurred())
+		Expect(response).ToNot(BeNil())
+		DeferCleanup(func() {
+			natGatewaysClient.Delete(ctx, publicv1.NATGatewaysDeleteRequest_builder{
+				Id: ngId,
+			}.Build())
+		})
+
+		ng := response.GetObject()
+		Expect(ng.GetId()).To(Equal(ngId))
+		Expect(ng.GetSpec().GetVirtualNetwork()).To(Equal(virtualNetworkId))
+		Expect(ng.GetSpec().GetExternalIp()).To(Equal(externalIPId))
+		Expect(ng.GetStatus().GetState()).To(Equal(publicv1.NATGatewayState_NAT_GATEWAY_STATE_PENDING))
+
+		// Verify ExternalIP attached flag is set
+		ipResp, err := privateExternalIPsClient.Get(ctx, privatev1.ExternalIPsGetRequest_builder{
+			Id: externalIPId,
+		}.Build())
+		Expect(err).ToNot(HaveOccurred())
+		Expect(ipResp.GetObject().GetStatus().GetAttached()).To(BeTrue())
+
+		// Get
+		getResponse, err := natGatewaysClient.Get(ctx, publicv1.NATGatewaysGetRequest_builder{
+			Id: ngId,
+		}.Build())
+		Expect(err).ToNot(HaveOccurred())
+		Expect(getResponse.GetObject().GetId()).To(Equal(ngId))
+		Expect(getResponse.GetObject().GetSpec().GetVirtualNetwork()).To(Equal(virtualNetworkId))
+		Expect(getResponse.GetObject().GetSpec().GetExternalIp()).To(Equal(externalIPId))
+
+		// List
+		listResponse, err := natGatewaysClient.List(ctx, publicv1.NATGatewaysListRequest_builder{}.Build())
+		Expect(err).ToNot(HaveOccurred())
+		Expect(listResponse.GetItems()).ToNot(BeEmpty())
+	})
+
+	It("Rejects create with non-existent ExternalIP", func() {
+		ngId := fmt.Sprintf("test-ng-%s", uuid.New())
+		_, err := natGatewaysClient.Create(ctx, publicv1.NATGatewaysCreateRequest_builder{
+			Object: publicv1.NATGateway_builder{
+				Id: ngId,
+				Spec: publicv1.NATGatewaySpec_builder{
+					VirtualNetwork: virtualNetworkId,
+					ExternalIp:     "nonexistent-ip",
+				}.Build(),
+			}.Build(),
+		}.Build())
+		Expect(err).To(HaveOccurred())
+		Expect(grpcstatus.Code(err)).To(Equal(grpccodes.InvalidArgument))
+	})
+
+	It("Rejects create with non-ALLOCATED ExternalIP", func() {
+		pendingIPId := fmt.Sprintf("test-ip-%s", uuid.New())
+		_, err := externalIPsClient.Create(ctx, publicv1.ExternalIPsCreateRequest_builder{
+			Object: publicv1.ExternalIP_builder{
+				Id: pendingIPId,
+				Spec: publicv1.ExternalIPSpec_builder{
+					Pool: poolId,
+				}.Build(),
+			}.Build(),
+		}.Build())
+		Expect(err).ToNot(HaveOccurred())
+		DeferCleanup(func() {
+			// Promote to ALLOCATED so delete succeeds
+			ipGetResp, err := privateExternalIPsClient.Get(ctx, privatev1.ExternalIPsGetRequest_builder{
+				Id: pendingIPId,
+			}.Build())
+			if err == nil {
+				ip := ipGetResp.GetObject()
+				ip.SetStatus(privatev1.ExternalIPStatus_builder{
+					State: privatev1.ExternalIPState_EXTERNAL_IP_STATE_ALLOCATED,
+				}.Build())
+				_, _ = privateExternalIPsClient.Update(ctx, privatev1.ExternalIPsUpdateRequest_builder{
+					Object:     ip,
+					UpdateMask: &fieldmaskpb.FieldMask{Paths: []string{"status.state"}},
+				}.Build())
+			}
+			_, _ = externalIPsClient.Delete(ctx, publicv1.ExternalIPsDeleteRequest_builder{
+				Id: pendingIPId,
+			}.Build())
+		})
+
+		ngId := fmt.Sprintf("test-ng-%s", uuid.New())
+		_, err = natGatewaysClient.Create(ctx, publicv1.NATGatewaysCreateRequest_builder{
+			Object: publicv1.NATGateway_builder{
+				Id: ngId,
+				Spec: publicv1.NATGatewaySpec_builder{
+					VirtualNetwork: virtualNetworkId,
+					ExternalIp:     pendingIPId,
+				}.Build(),
+			}.Build(),
+		}.Build())
+		Expect(err).To(HaveOccurred())
+		Expect(grpcstatus.Code(err)).To(Equal(grpccodes.FailedPrecondition))
+	})
+
+	It("Rejects create with already-attached ExternalIP", func() {
+		ngId1 := fmt.Sprintf("test-ng-%s", uuid.New())
+		_, err := natGatewaysClient.Create(ctx, publicv1.NATGatewaysCreateRequest_builder{
+			Object: publicv1.NATGateway_builder{
+				Id: ngId1,
+				Spec: publicv1.NATGatewaySpec_builder{
+					VirtualNetwork: virtualNetworkId,
+					ExternalIp:     externalIPId,
+				}.Build(),
+			}.Build(),
+		}.Build())
+		Expect(err).ToNot(HaveOccurred())
+		DeferCleanup(func() {
+			natGatewaysClient.Delete(ctx, publicv1.NATGatewaysDeleteRequest_builder{
+				Id: ngId1,
+			}.Build())
+		})
+
+		// Create a second VirtualNetwork for the second NATGateway attempt
+		vn2Id := fmt.Sprintf("test-vnet-%s", uuid.New())
+		_, err = virtualNetworksClient.Create(ctx, privatev1.VirtualNetworksCreateRequest_builder{
+			Object: privatev1.VirtualNetwork_builder{
+				Id: vn2Id,
+				Spec: privatev1.VirtualNetworkSpec_builder{
+					NetworkClass: networkClassId,
+					Region:       "us-east-1",
+					Ipv4Cidr:     new("10.200.0.0/16"),
+				}.Build(),
+			}.Build(),
+		}.Build())
+		Expect(err).ToNot(HaveOccurred())
+		DeferCleanup(func() {
+			virtualNetworksClient.Delete(ctx, privatev1.VirtualNetworksDeleteRequest_builder{
+				Id: vn2Id,
+			}.Build())
+		})
+
+		ngId2 := fmt.Sprintf("test-ng-%s", uuid.New())
+		_, err = natGatewaysClient.Create(ctx, publicv1.NATGatewaysCreateRequest_builder{
+			Object: publicv1.NATGateway_builder{
+				Id: ngId2,
+				Spec: publicv1.NATGatewaySpec_builder{
+					VirtualNetwork: vn2Id,
+					ExternalIp:     externalIPId,
+				}.Build(),
+			}.Build(),
+		}.Build())
+		Expect(err).To(HaveOccurred())
+		Expect(grpcstatus.Code(err)).To(Equal(grpccodes.FailedPrecondition))
+	})
+
+	It("Rejects update of immutable spec.virtual_network", func() {
+		ngId := fmt.Sprintf("test-ng-%s", uuid.New())
+		_, err := natGatewaysClient.Create(ctx, publicv1.NATGatewaysCreateRequest_builder{
+			Object: publicv1.NATGateway_builder{
+				Id: ngId,
+				Spec: publicv1.NATGatewaySpec_builder{
+					VirtualNetwork: virtualNetworkId,
+					ExternalIp:     externalIPId,
+				}.Build(),
+			}.Build(),
+		}.Build())
+		Expect(err).ToNot(HaveOccurred())
+		DeferCleanup(func() {
+			natGatewaysClient.Delete(ctx, publicv1.NATGatewaysDeleteRequest_builder{
+				Id: ngId,
+			}.Build())
+		})
+
+		_, err = natGatewaysClient.Update(ctx, publicv1.NATGatewaysUpdateRequest_builder{
+			Object: publicv1.NATGateway_builder{
+				Id: ngId,
+				Spec: publicv1.NATGatewaySpec_builder{
+					VirtualNetwork: "different-vnet",
+				}.Build(),
+			}.Build(),
+			UpdateMask: &fieldmaskpb.FieldMask{Paths: []string{"spec.virtual_network"}},
+		}.Build())
+		Expect(err).To(HaveOccurred())
+		Expect(grpcstatus.Code(err)).To(Equal(grpccodes.InvalidArgument))
+	})
+
+	It("Rejects update of immutable spec.external_ip", func() {
+		ngId := fmt.Sprintf("test-ng-%s", uuid.New())
+		_, err := natGatewaysClient.Create(ctx, publicv1.NATGatewaysCreateRequest_builder{
+			Object: publicv1.NATGateway_builder{
+				Id: ngId,
+				Spec: publicv1.NATGatewaySpec_builder{
+					VirtualNetwork: virtualNetworkId,
+					ExternalIp:     externalIPId,
+				}.Build(),
+			}.Build(),
+		}.Build())
+		Expect(err).ToNot(HaveOccurred())
+		DeferCleanup(func() {
+			natGatewaysClient.Delete(ctx, publicv1.NATGatewaysDeleteRequest_builder{
+				Id: ngId,
+			}.Build())
+		})
+
+		_, err = natGatewaysClient.Update(ctx, publicv1.NATGatewaysUpdateRequest_builder{
+			Object: publicv1.NATGateway_builder{
+				Id: ngId,
+				Spec: publicv1.NATGatewaySpec_builder{
+					ExternalIp: "different-ip",
+				}.Build(),
+			}.Build(),
+			UpdateMask: &fieldmaskpb.FieldMask{Paths: []string{"spec.external_ip"}},
+		}.Build())
+		Expect(err).To(HaveOccurred())
+		Expect(grpcstatus.Code(err)).To(Equal(grpccodes.InvalidArgument))
+	})
+
+	It("Deleting NATGateway resets ExternalIP attached flag", func() {
+		ngId := fmt.Sprintf("test-ng-%s", uuid.New())
+		_, err := natGatewaysClient.Create(ctx, publicv1.NATGatewaysCreateRequest_builder{
+			Object: publicv1.NATGateway_builder{
+				Id: ngId,
+				Spec: publicv1.NATGatewaySpec_builder{
+					VirtualNetwork: virtualNetworkId,
+					ExternalIp:     externalIPId,
+				}.Build(),
+			}.Build(),
+		}.Build())
+		Expect(err).ToNot(HaveOccurred())
+
+		ipResp, err := privateExternalIPsClient.Get(ctx, privatev1.ExternalIPsGetRequest_builder{
+			Id: externalIPId,
+		}.Build())
+		Expect(err).ToNot(HaveOccurred())
+		Expect(ipResp.GetObject().GetStatus().GetAttached()).To(BeTrue())
+
+		_, err = natGatewaysClient.Delete(ctx, publicv1.NATGatewaysDeleteRequest_builder{
+			Id: ngId,
+		}.Build())
+		Expect(err).ToNot(HaveOccurred())
+
+		ipResp, err = privateExternalIPsClient.Get(ctx, privatev1.ExternalIPsGetRequest_builder{
+			Id: externalIPId,
+		}.Build())
+		Expect(err).ToNot(HaveOccurred())
+		Expect(ipResp.GetObject().GetStatus().GetAttached()).To(BeFalse())
+	})
+
+	It("Can update metadata labels", func() {
+		ngId := fmt.Sprintf("test-ng-%s", uuid.New())
+		_, err := natGatewaysClient.Create(ctx, publicv1.NATGatewaysCreateRequest_builder{
+			Object: publicv1.NATGateway_builder{
+				Id: ngId,
+				Spec: publicv1.NATGatewaySpec_builder{
+					VirtualNetwork: virtualNetworkId,
+					ExternalIp:     externalIPId,
+				}.Build(),
+			}.Build(),
+		}.Build())
+		Expect(err).ToNot(HaveOccurred())
+		DeferCleanup(func() {
+			natGatewaysClient.Delete(ctx, publicv1.NATGatewaysDeleteRequest_builder{
+				Id: ngId,
+			}.Build())
+		})
+
+		_, err = natGatewaysClient.Update(ctx, publicv1.NATGatewaysUpdateRequest_builder{
+			Object: publicv1.NATGateway_builder{
+				Id: ngId,
+				Metadata: publicv1.Metadata_builder{
+					Labels: map[string]string{"env": "test"},
+				}.Build(),
+			}.Build(),
+			UpdateMask: &fieldmaskpb.FieldMask{Paths: []string{"metadata.labels"}},
+		}.Build())
+		Expect(err).ToNot(HaveOccurred())
+
+		getResp, err := natGatewaysClient.Get(ctx, publicv1.NATGatewaysGetRequest_builder{
+			Id: ngId,
+		}.Build())
+		Expect(err).ToNot(HaveOccurred())
+		Expect(getResp.GetObject().GetMetadata().GetLabels()).To(HaveKeyWithValue("env", "test"))
+	})
+})


### PR DESCRIPTION


Add create/describe CLI subcommands, public and private table rendering YAML files, and integration tests covering full CRUD lifecycle, immutable field rejection, ExternalIP attached flag behavior, and metadata updates.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added CLI support for creating NAT gateways with a virtual network and external IP.
  * Added CLI support for describing NAT gateways by ID or name.
  * Added NAT gateway table views with network, external IP, state, and status details.

* **Bug Fixes**
  * Improved validation for invalid, unavailable, or already-attached external IPs.
  * Ensured external IPs are detached when NAT gateways are deleted.

* **Tests**
  * Added coverage for NAT gateway lifecycle operations, metadata updates, and immutable fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->