### PR TITLE
OSAC-2819: Restrict public list filters to public object fields

### DIFF
--- a/internal/database/dao/filter_translator.go
+++ b/internal/database/dao/filter_translator.go
@@ -28,27 +28,29 @@ import (
 	"github.com/google/cel-go/common/ast"
 	"github.com/google/cel-go/common/operators"
 	"github.com/google/cel-go/common/types/ref"
-	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/reflect/protoreflect"
+	"google.golang.org/protobuf/types/dynamicpb"
 	"google.golang.org/protobuf/types/known/structpb"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	privatev1 "github.com/osac-project/fulfillment-service/internal/api/osac/private/v1"
+	publicv1 "github.com/osac-project/fulfillment-service/internal/api/osac/public/v1"
 )
 
 // FilterTranslatorBuilder contains the data and logic needed to create a filter translator. Don't create instances of
-// this type directly, use the NewTranslationBuilder function instead.
-type FilterTranslatorBuilder[O proto.Message] struct {
-	logger *slog.Logger
+// this type directly, use the NewFilterTranslator function instead.
+type FilterTranslatorBuilder struct {
+	logger   *slog.Logger
+	thisDesc protoreflect.MessageDescriptor
 }
 
 // FilterTranslator knows how to translate filter expressions into SQL where clauses.
-type FilterTranslator[O proto.Message] struct {
-	logger      *slog.Logger
-	tsDesc      protoreflect.MessageDescriptor
-	thisDesc    protoreflect.MessageDescriptor
-	projectDesc protoreflect.MessageDescriptor
-	celEnv      *cel.Env
+type FilterTranslator struct {
+	logger    *slog.Logger
+	tsDesc    protoreflect.MessageDescriptor
+	thisDesc  protoreflect.MessageDescriptor
+	isProject bool
+	celEnv    *cel.Env
 }
 
 // filterTranslatorResultKind is the type of the result inferred during the translation process.
@@ -173,21 +175,34 @@ var binaryOps = map[string]binaryOpInfo{
 }
 
 // NewFilterTranslator creates a object that knows how to translate filter expressions into SQL where statements.
-func NewFilterTranslator[O proto.Message]() *FilterTranslatorBuilder[O] {
-	return &FilterTranslatorBuilder[O]{}
+func NewFilterTranslator() *FilterTranslatorBuilder {
+	return &FilterTranslatorBuilder{}
 }
 
 // SetLogger sets the logger that will be used by the translator. This is mandatory.
-func (b *FilterTranslatorBuilder[O]) SetLogger(value *slog.Logger) *FilterTranslatorBuilder[O] {
+func (b *FilterTranslatorBuilder) SetLogger(value *slog.Logger) *FilterTranslatorBuilder {
 	b.logger = value
 	return b
 }
 
+// SetDescriptor sets the protobuf message descriptor of the object type that will be filtered. This is mandatory. The
+// descriptor defines the CEL type of the 'this' variable, so only fields present on that message (and its nested
+// messages) can appear in filter expressions. Callers that expose a public API over private storage should pass the
+// public message descriptor here so that private-only fields are rejected at compile time.
+func (b *FilterTranslatorBuilder) SetDescriptor(value protoreflect.MessageDescriptor) *FilterTranslatorBuilder {
+	b.thisDesc = value
+	return b
+}
+
 // Build uses the data stored in the builder to create and configure a new filter translator.
-func (b *FilterTranslatorBuilder[O]) Build() (result *FilterTranslator[O], err error) {
+func (b *FilterTranslatorBuilder) Build() (result *FilterTranslator, err error) {
 	// Check parameters:
 	if b.logger == nil {
 		err = errors.New("logger is mandatory")
+		return
+	}
+	if b.thisDesc == nil {
+		err = errors.New("descriptor is mandatory")
 		return
 	}
 
@@ -195,41 +210,38 @@ func (b *FilterTranslatorBuilder[O]) Build() (result *FilterTranslator[O], err e
 	var tsTempl *timestamppb.Timestamp
 	tsDesc := tsTempl.ProtoReflect().Descriptor()
 
-	// Get the object descriptor:
-	var thisTempl O
-	thisDesc := thisTempl.ProtoReflect().Descriptor()
-
-	var projectTempl *privatev1.Project
-	projectDesc := projectTempl.ProtoReflect().Descriptor()
+	// Check if the type is a project, as that affects the type of the 'metadata.name' field: it will be a 'text'
+	// for projects and a 'ltree' for project templates.
+	publicProjectDesc := (*publicv1.Project)(nil).ProtoReflect().Descriptor()
+	privateProjectDesc := (*privatev1.Project)(nil).ProtoReflect().Descriptor()
+	isProject := b.thisDesc == publicProjectDesc || b.thisDesc == privateProjectDesc
 
 	// Create the CEL environment:
 	celEnv, err := b.createCelEnv()
 	if err != nil {
-		err = fmt.Errorf("failed to create CEL environment")
+		err = fmt.Errorf("failed to create CEL environment: %w", err)
 		return
 	}
 
 	// Create and populate the object:
-	result = &FilterTranslator[O]{
-		logger:      b.logger,
-		tsDesc:      tsDesc,
-		thisDesc:    thisDesc,
-		projectDesc: projectDesc,
-		celEnv:      celEnv,
+	result = &FilterTranslator{
+		logger:    b.logger,
+		tsDesc:    tsDesc,
+		thisDesc:  b.thisDesc,
+		isProject: isProject,
+		celEnv:    celEnv,
 	}
 	return
 }
 
-func (b *FilterTranslatorBuilder[O]) createCelEnv() (result *cel.Env, err error) {
+func (b *FilterTranslatorBuilder) createCelEnv() (result *cel.Env, err error) {
 	var options []cel.EnvOption
 
 	// Declare the object type:
-	var thisTemplate O
-	options = append(options, cel.Types(thisTemplate))
+	options = append(options, cel.Types(dynamicpb.NewMessage(b.thisDesc)))
 
 	// Declare the object variable:
-	thisDesc := thisTemplate.ProtoReflect().Descriptor()
-	thisType := cel.ObjectType(string(thisDesc.FullName()))
+	thisType := cel.ObjectType(string(b.thisDesc.FullName()))
 	options = append(options, cel.Variable("this", thisType))
 
 	// Declare the current date:
@@ -241,7 +253,7 @@ func (b *FilterTranslatorBuilder[O]) createCelEnv() (result *cel.Env, err error)
 }
 
 // Translate translate the given filter expression into a SQL where statement.
-func (t *FilterTranslator[O]) Translate(ctx context.Context, filter string) (sql string, err error) {
+func (t *FilterTranslator) Translate(ctx context.Context, filter string) (sql string, err error) {
 	ast, issues := t.celEnv.Compile(filter)
 	if issues != nil {
 		err = issues.Err()
@@ -257,7 +269,7 @@ func (t *FilterTranslator[O]) Translate(ctx context.Context, filter string) (sql
 	return
 }
 
-func (t *FilterTranslator[O]) translate(expr ast.Expr) (result filterTranslatorResult, err error) {
+func (t *FilterTranslator) translate(expr ast.Expr) (result filterTranslatorResult, err error) {
 	switch expr.Kind() {
 	case ast.CallKind:
 		result, err = t.translateCall(expr.AsCall())
@@ -274,7 +286,7 @@ func (t *FilterTranslator[O]) translate(expr ast.Expr) (result filterTranslatorR
 	return
 }
 
-func (t *FilterTranslator[O]) translateCall(expr ast.CallExpr) (result filterTranslatorResult, err error) {
+func (t *FilterTranslator) translateCall(expr ast.CallExpr) (result filterTranslatorResult, err error) {
 	funcName := expr.FunctionName()
 	funcArgs := expr.Args()
 	switch funcName {
@@ -339,7 +351,7 @@ func (t *FilterTranslator[O]) translateCall(expr ast.CallExpr) (result filterTra
 	return
 }
 
-func (t *FilterTranslator[O]) translateBinary(name string, left, right ast.Expr) (result filterTranslatorResult, err error) {
+func (t *FilterTranslator) translateBinary(name string, left, right ast.Expr) (result filterTranslatorResult, err error) {
 	leftTr, err := t.translate(left)
 	if err != nil {
 		return
@@ -368,7 +380,7 @@ func (t *FilterTranslator[O]) translateBinary(name string, left, right ast.Expr)
 }
 
 // translateEquals handles the CEL == operator, including null-swap and map-index equality.
-func (t *FilterTranslator[O]) translateEquals(leftTr, rightTr filterTranslatorResult) (result filterTranslatorResult, err error) {
+func (t *FilterTranslator) translateEquals(leftTr, rightTr filterTranslatorResult) (result filterTranslatorResult, err error) {
 	// If one of the sides is a null expression then we swap sides so that the null is always on the right,
 	// as that way we can convert it to 'is null'.
 	if leftTr.kind == filterTranslatorNullType {
@@ -403,7 +415,7 @@ func (t *FilterTranslator[O]) translateEquals(leftTr, rightTr filterTranslatorRe
 }
 
 // translateNotEquals handles the CEL != operator, including null-swap and map-index inequality.
-func (t *FilterTranslator[O]) translateNotEquals(leftTr, rightTr filterTranslatorResult) (result filterTranslatorResult, err error) {
+func (t *FilterTranslator) translateNotEquals(leftTr, rightTr filterTranslatorResult) (result filterTranslatorResult, err error) {
 	// If one of the sides is a null expression then we swap sides so that the null is always on the right,
 	// as that way we can convert it to 'is not null'.
 	if leftTr.kind == filterTranslatorNullType {
@@ -465,7 +477,7 @@ func assembleBinarySQL(leftTr, rightTr filterTranslatorResult, operatorSQL strin
 	}
 }
 
-func (t *FilterTranslator[O]) translateNot(value ast.Expr) (result filterTranslatorResult, err error) {
+func (t *FilterTranslator) translateNot(value ast.Expr) (result filterTranslatorResult, err error) {
 	valueTr, err := t.translate(value)
 	if err != nil {
 		return
@@ -485,7 +497,7 @@ func (t *FilterTranslator[O]) translateNot(value ast.Expr) (result filterTransla
 	return
 }
 
-func (t *FilterTranslator[O]) translateIdent(name string) (result filterTranslatorResult, err error) {
+func (t *FilterTranslator) translateIdent(name string) (result filterTranslatorResult, err error) {
 	switch name {
 	case "this":
 		result.sql = ""
@@ -501,7 +513,7 @@ func (t *FilterTranslator[O]) translateIdent(name string) (result filterTranslat
 	return
 }
 
-func (t *FilterTranslator[O]) translateLiteral(value ref.Val) (result filterTranslatorResult, err error) {
+func (t *FilterTranslator) translateLiteral(value ref.Val) (result filterTranslatorResult, err error) {
 	switch value := value.Value().(type) {
 	case structpb.NullValue:
 		result.sql = "null"
@@ -535,7 +547,7 @@ func (t *FilterTranslator[O]) translateLiteral(value ref.Val) (result filterTran
 // special characters that need to be escaped. This is intended for the creation of patterns for the 'like' operator,
 // where it is necessary to escape the '%' and '_' characters. It returns the translated text, and a flag indicating if
 // that text contains escape sequences that require the 'e' prefix.
-func (t *FilterTranslator[O]) translateString(value, special string) (text string, escaped bool) {
+func (t *FilterTranslator) translateString(value, special string) (text string, escaped bool) {
 	var buffer bytes.Buffer
 	buffer.Grow(len(value))
 	for _, r := range value {
@@ -565,7 +577,7 @@ func (t *FilterTranslator[O]) translateString(value, special string) (text strin
 	return
 }
 
-func (t *FilterTranslator[O]) translateIn(args []ast.Expr) (result filterTranslatorResult, err error) {
+func (t *FilterTranslator) translateIn(args []ast.Expr) (result filterTranslatorResult, err error) {
 	key := args[0]
 	values := args[1]
 	switch values.Kind() {
@@ -580,7 +592,7 @@ func (t *FilterTranslator[O]) translateIn(args []ast.Expr) (result filterTransla
 	return
 }
 
-func (t *FilterTranslator[O]) translateIndex(args []ast.Expr) (result filterTranslatorResult, err error) {
+func (t *FilterTranslator) translateIndex(args []ast.Expr) (result filterTranslatorResult, err error) {
 	if len(args) != 2 {
 		err = fmt.Errorf("expected exactly two arguments for index but got %d", len(args))
 		return
@@ -619,7 +631,7 @@ func (t *FilterTranslator[O]) translateIndex(args []ast.Expr) (result filterTran
 	return
 }
 
-func (t *FilterTranslator[O]) translateMapEquals(operand, key, value string) (string, error) {
+func (t *FilterTranslator) translateMapEquals(operand, key, value string) (string, error) {
 	data, err := json.Marshal(map[string]string{
 		key: value,
 	})
@@ -633,7 +645,7 @@ func (t *FilterTranslator[O]) translateMapEquals(operand, key, value string) (st
 	return fmt.Sprintf("%s @> '%s'", operand, text), nil
 }
 
-func (t *FilterTranslator[O]) translateMapNotEquals(operand, key, value string) (string, error) {
+func (t *FilterTranslator) translateMapNotEquals(operand, key, value string) (string, error) {
 	existsSql, err := t.translateMapEquals(operand, key, value)
 	if err != nil {
 		return "", err
@@ -641,7 +653,7 @@ func (t *FilterTranslator[O]) translateMapNotEquals(operand, key, value string) 
 	return fmt.Sprintf("not (%s)", existsSql), nil
 }
 
-func (t *FilterTranslator[O]) resolveEnumName(enumDesc protoreflect.EnumDescriptor, value int64) (string, bool) {
+func (t *FilterTranslator) resolveEnumName(enumDesc protoreflect.EnumDescriptor, value int64) (string, bool) {
 	if value < math.MinInt32 || value > math.MaxInt32 {
 		return "", false
 	}
@@ -652,7 +664,7 @@ func (t *FilterTranslator[O]) resolveEnumName(enumDesc protoreflect.EnumDescript
 	return string(enumValue.Name()), true
 }
 
-func (t *FilterTranslator[O]) translateEnumEquals(leftTr, rightTr filterTranslatorResult) (result filterTranslatorResult, err error) {
+func (t *FilterTranslator) translateEnumEquals(leftTr, rightTr filterTranslatorResult) (result filterTranslatorResult, err error) {
 	enumDesc, intVal, fieldSql, ok := t.extractEnumComparison(leftTr, rightTr)
 	if !ok {
 		err = t.checkUnsupportedEnumComparison(leftTr, rightTr)
@@ -674,7 +686,7 @@ func (t *FilterTranslator[O]) translateEnumEquals(leftTr, rightTr filterTranslat
 	return
 }
 
-func (t *FilterTranslator[O]) translateEnumNotEquals(leftTr, rightTr filterTranslatorResult) (result filterTranslatorResult, err error) {
+func (t *FilterTranslator) translateEnumNotEquals(leftTr, rightTr filterTranslatorResult) (result filterTranslatorResult, err error) {
 	enumDesc, intVal, fieldSql, ok := t.extractEnumComparison(leftTr, rightTr)
 	if !ok {
 		err = t.checkUnsupportedEnumComparison(leftTr, rightTr)
@@ -696,7 +708,7 @@ func (t *FilterTranslator[O]) translateEnumNotEquals(leftTr, rightTr filterTrans
 	return
 }
 
-func (t *FilterTranslator[O]) checkUnsupportedEnumComparison(leftTr, rightTr filterTranslatorResult) error {
+func (t *FilterTranslator) checkUnsupportedEnumComparison(leftTr, rightTr filterTranslatorResult) error {
 	if leftTr.enumDesc != nil && rightTr.kind == filterTranslatorNumericKind {
 		return fmt.Errorf(
 			"comparison of enum '%s' requires a literal integer value",
@@ -712,7 +724,7 @@ func (t *FilterTranslator[O]) checkUnsupportedEnumComparison(leftTr, rightTr fil
 	return nil
 }
 
-func (t *FilterTranslator[O]) extractEnumComparison(leftTr, rightTr filterTranslatorResult) (
+func (t *FilterTranslator) extractEnumComparison(leftTr, rightTr filterTranslatorResult) (
 	enumDesc protoreflect.EnumDescriptor, intVal int64, fieldSql string, ok bool,
 ) {
 	if leftTr.enumDesc != nil && rightTr.hasIntValue {
@@ -724,7 +736,7 @@ func (t *FilterTranslator[O]) extractEnumComparison(leftTr, rightTr filterTransl
 	return nil, 0, "", false
 }
 
-func (t *FilterTranslator[O]) translateInList(key ast.Expr, list ast.ListExpr) (result filterTranslatorResult, err error) {
+func (t *FilterTranslator) translateInList(key ast.Expr, list ast.ListExpr) (result filterTranslatorResult, err error) {
 	values := list.Elements()
 	if len(values) == 0 {
 		result.sql = "false"
@@ -766,7 +778,7 @@ func (t *FilterTranslator[O]) translateInList(key ast.Expr, list ast.ListExpr) (
 	return
 }
 
-func (t *FilterTranslator[O]) translateInField(key ast.Expr, value ast.SelectExpr) (result filterTranslatorResult, err error) {
+func (t *FilterTranslator) translateInField(key ast.Expr, value ast.SelectExpr) (result filterTranslatorResult, err error) {
 	keyTr, err := t.translate(key)
 	if err != nil {
 		return
@@ -793,7 +805,7 @@ func (t *FilterTranslator[O]) translateInField(key ast.Expr, value ast.SelectExp
 	return
 }
 
-func (t *FilterTranslator[O]) translateToLike(funcName string, target ast.Expr, pattern ast.Expr,
+func (t *FilterTranslator) translateToLike(funcName string, target ast.Expr, pattern ast.Expr,
 	patternPrefix, patternSuffix string) (result filterTranslatorResult,
 	err error) {
 	var buffer bytes.Buffer
@@ -838,7 +850,7 @@ func (t *FilterTranslator[O]) translateToLike(funcName string, target ast.Expr, 
 	return
 }
 
-func (t *FilterTranslator[O]) translateSelectField(expr ast.SelectExpr) (result filterTranslatorResult, err error) {
+func (t *FilterTranslator) translateSelectField(expr ast.SelectExpr) (result filterTranslatorResult, err error) {
 	operandTr, err := t.translate(expr.Operand())
 	if err != nil {
 		return
@@ -860,7 +872,7 @@ func (t *FilterTranslator[O]) translateSelectField(expr ast.SelectExpr) (result 
 	return
 }
 
-func (t *FilterTranslator[O]) translateSelectThisField(fieldName string, testOnly bool) (result filterTranslatorResult,
+func (t *FilterTranslator) translateSelectThisField(fieldName string, testOnly bool) (result filterTranslatorResult,
 	err error) {
 	switch fieldName {
 	case "id":
@@ -889,7 +901,7 @@ func (t *FilterTranslator[O]) translateSelectThisField(fieldName string, testOnl
 	return
 }
 
-func (t *FilterTranslator[O]) translateSelectThisMdField(fieldName string,
+func (t *FilterTranslator) translateSelectThisMdField(fieldName string,
 	testOnly bool) (result filterTranslatorResult, err error) {
 	switch fieldName {
 	case "name":
@@ -899,7 +911,7 @@ func (t *FilterTranslator[O]) translateSelectThisMdField(fieldName string,
 			result.precedence = filterTranslatorMaxPrecedence
 		} else {
 			result.sql = fieldName
-			if t.thisDesc == t.projectDesc {
+			if t.isProject {
 				result.kind = filterTranslatorLtreeKind
 			} else {
 				result.kind = filterTranslatorStringKind
@@ -979,7 +991,7 @@ func (t *FilterTranslator[O]) translateSelectThisMdField(fieldName string,
 	return
 }
 
-func (t *FilterTranslator[O]) translateSelectJsonField(operandSql string, msgDesc protoreflect.MessageDescriptor,
+func (t *FilterTranslator) translateSelectJsonField(operandSql string, msgDesc protoreflect.MessageDescriptor,
 	fieldName string, testOnly bool) (result filterTranslatorResult, err error) {
 	if testOnly {
 		result.sql = fmt.Sprintf("%s ? '%s'", operandSql, fieldName)
@@ -1034,7 +1046,7 @@ func (t *FilterTranslator[O]) translateSelectJsonField(operandSql string, msgDes
 	return
 }
 
-func (t *FilterTranslator[O]) castToString(input filterTranslatorResult) (result filterTranslatorResult, err error) {
+func (t *FilterTranslator) castToString(input filterTranslatorResult) (result filterTranslatorResult, err error) {
 	switch input.kind {
 	case filterTranslatorStringKind:
 		result = input

--- a/internal/database/dao/filter_translator_test.go
+++ b/internal/database/dao/filter_translator_test.go
@@ -19,20 +19,24 @@ import (
 	. "github.com/onsi/ginkgo/v2/dsl/core"
 	. "github.com/onsi/ginkgo/v2/dsl/table"
 	. "github.com/onsi/gomega"
+	"google.golang.org/protobuf/reflect/protoreflect"
 
 	privatev1 "github.com/osac-project/fulfillment-service/internal/api/osac/private/v1"
+	publicv1 "github.com/osac-project/fulfillment-service/internal/api/osac/public/v1"
 	testsv1 "github.com/osac-project/fulfillment-service/internal/api/osac/tests/v1"
 )
 
 var _ = Describe("Filter translator", func() {
 	Describe("Object translation", func() {
-		var translator *FilterTranslator[*testsv1.Object]
+		var translator *FilterTranslator
 
 		BeforeEach(func() {
 			var err error
+			var object *testsv1.Object
 
-			translator, err = NewFilterTranslator[*testsv1.Object]().
+			translator, err = NewFilterTranslator().
 				SetLogger(logger).
+				SetDescriptor(object.ProtoReflect().Descriptor()).
 				Build()
 			Expect(err).ToNot(HaveOccurred())
 		})
@@ -375,44 +379,44 @@ var _ = Describe("Filter translator", func() {
 	// Projects need special translation because the type of the 'name' column is 'ltree', and that can't be
 	// compared directly to strings using the 'like' operator.
 	Describe("Project translation", func() {
-		var translator *FilterTranslator[*privatev1.Project]
-
-		BeforeEach(func() {
-			var err error
-
-			translator, err = NewFilterTranslator[*privatev1.Project]().
-				SetLogger(logger).
-				Build()
-			Expect(err).ToNot(HaveOccurred())
-		})
-
-		DescribeTable(
-			"Project translation",
-			func(ctx context.Context, filter, expected string) {
-				actual, err := translator.Translate(ctx, filter)
-				Expect(err).ToNot(HaveOccurred())
-				Expect(actual).To(Equal(expected))
-			},
-			Entry(
-				"Compare name to string",
-				`this.metadata.name == 'my_project'`,
-				`name = 'my_project'`,
-			),
-			Entry(
-				"Name starts with string",
-				`this.metadata.name.startsWith('my_project.')`,
-				`cast(name as text) like 'my\_project.%'`,
-			),
-			Entry(
-				"Name ends with string",
-				`this.metadata.name.endsWith('.my_project')`,
-				`cast(name as text) like '%.my\_project'`,
-			),
-			Entry(
-				"Name contains string",
-				`this.metadata.name.contains('my')`,
-				`cast(name as text) like '%my%'`,
-			),
-		)
+		projectDescs := []protoreflect.MessageDescriptor{
+			(*publicv1.Project)(nil).ProtoReflect().Descriptor(),
+			(*privatev1.Project)(nil).ProtoReflect().Descriptor(),
+		}
+		for _, projectDesc := range projectDescs {
+			DescribeTable(
+				"Project translation",
+				func(ctx context.Context, filter, expected string) {
+					translator, err := NewFilterTranslator().
+						SetLogger(logger).
+						SetDescriptor(projectDesc).
+						Build()
+					Expect(err).ToNot(HaveOccurred())
+					actual, err := translator.Translate(ctx, filter)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(actual).To(Equal(expected))
+				},
+				Entry(
+					"Compare name to string",
+					`this.metadata.name == 'my_project'`,
+					`name = 'my_project'`,
+				),
+				Entry(
+					"Name starts with string",
+					`this.metadata.name.startsWith('my_project.')`,
+					`cast(name as text) like 'my\_project.%'`,
+				),
+				Entry(
+					"Name ends with string",
+					`this.metadata.name.endsWith('.my_project')`,
+					`cast(name as text) like '%.my\_project'`,
+				),
+				Entry(
+					"Name contains string",
+					`this.metadata.name.contains('my')`,
+					`cast(name as text) like '%my%'`,
+				),
+			)
+		}
 	})
 })

--- a/internal/database/dao/generic_dao.go
+++ b/internal/database/dao/generic_dao.go
@@ -46,6 +46,7 @@ type GenericDAOBuilder[O Object] struct {
 	eventCallbacks    []EventCallback
 	tenancyLogic      auth.TenancyLogic
 	metricsRegisterer prometheus.Registerer
+	filterDesc        protoreflect.MessageDescriptor
 }
 
 // GenericDAO provides generic data access operations for protocol buffers messages. It assumes that objects will be
@@ -79,7 +80,7 @@ type GenericDAO[O Object] struct {
 	jsonEncoder      *json.Encoder
 	marshalOptions   protojson.MarshalOptions
 	unmarshalOptions protojson.UnmarshalOptions
-	filterTranslator *FilterTranslator[O]
+	filterTranslator *FilterTranslator
 	tenancyLogic     auth.TenancyLogic
 
 	// Metrics:
@@ -121,6 +122,17 @@ func NewGenericDAO[O Object]() *GenericDAOBuilder[O] {
 // SetLogger sets the logger. This is mandatory.
 func (b *GenericDAOBuilder[O]) SetLogger(value *slog.Logger) *GenericDAOBuilder[O] {
 	b.logger = value
+	return b
+}
+
+// SetFilterDesc sets the protobuf message descriptor used to validate and translate CEL filter expressions. This is
+// optional. When unset, the descriptor of the O generic parameter is used.
+//
+// Pass a different descriptor to restrict which fields clients may reference in filters. Public servers that store
+// private objects typically pass the public message descriptor so that private-only fields (for example `status.hub` on
+// clusters) are rejected during CEL compilation.
+func (b *GenericDAOBuilder[O]) SetFilterDesc(value protoreflect.MessageDescriptor) *GenericDAOBuilder[O] {
+	b.filterDesc = value
 	return b
 }
 
@@ -272,8 +284,13 @@ func (b *GenericDAOBuilder[O]) Build() (result *GenericDAO[O], err error) {
 	}
 
 	// Create the filter translator:
-	filterTranslator, err := NewFilterTranslator[O]().
+	filterDesc := b.filterDesc
+	if filterDesc == nil {
+		filterDesc = objectDesc
+	}
+	filterTranslator, err := NewFilterTranslator().
 		SetLogger(b.logger).
+		SetDescriptor(filterDesc).
 		Build()
 	if err != nil {
 		err = fmt.Errorf("failed to create filter translator: %w", err)

--- a/internal/servers/baremetal_instance_catalog_items_server.go
+++ b/internal/servers/baremetal_instance_catalog_items_server.go
@@ -126,6 +126,7 @@ func (b *BareMetalInstanceCatalogItemsServerBuilder) Build() (result *BareMetalI
 		SetTenancyLogic(b.tenancyLogic).
 		SetMetricsRegisterer(b.metricsRegisterer).
 		SetReferenceChecker(referenceChecker).
+		SetFilterDesc((*publicv1.BareMetalInstanceCatalogItem)(nil).ProtoReflect().Descriptor()).
 		Build()
 	if err != nil {
 		return

--- a/internal/servers/baremetal_instance_templates_server.go
+++ b/internal/servers/baremetal_instance_templates_server.go
@@ -105,6 +105,7 @@ func (b *BareMetalInstanceTemplatesServerBuilder) Build() (result *BareMetalInst
 		SetAttributionLogic(b.attributionLogic).
 		SetTenancyLogic(b.tenancyLogic).
 		SetMetricsRegisterer(b.metricsRegisterer).
+		SetFilterDesc((*publicv1.BareMetalInstanceTemplate)(nil).ProtoReflect().Descriptor()).
 		Build()
 	if err != nil {
 		return

--- a/internal/servers/baremetal_instances_server.go
+++ b/internal/servers/baremetal_instances_server.go
@@ -113,6 +113,7 @@ func (b *BareMetalInstancesServerBuilder) Build() (result *BareMetalInstancesSer
 		SetAttributionLogic(b.attributionLogic).
 		SetTenancyLogic(b.tenancyLogic).
 		SetMetricsRegisterer(b.metricsRegisterer).
+		SetFilterDesc((*publicv1.BareMetalInstance)(nil).ProtoReflect().Descriptor()).
 		Build()
 	if err != nil {
 		return

--- a/internal/servers/cluster_catalog_items_server.go
+++ b/internal/servers/cluster_catalog_items_server.go
@@ -119,6 +119,7 @@ func (b *ClusterCatalogItemsServerBuilder) Build() (result *ClusterCatalogItemsS
 		SetAttributionLogic(b.attributionLogic).
 		SetTenancyLogic(b.tenancyLogic).
 		SetMetricsRegisterer(b.metricsRegisterer).
+		SetFilterDesc((*publicv1.ClusterCatalogItem)(nil).ProtoReflect().Descriptor()).
 		Build()
 	if err != nil {
 		return

--- a/internal/servers/cluster_templates_server.go
+++ b/internal/servers/cluster_templates_server.go
@@ -116,6 +116,7 @@ func (b *ClusterTemplatesServerBuilder) Build() (result *ClusterTemplatesServer,
 		SetAttributionLogic(b.attributionLogic).
 		SetTenancyLogic(b.tenancyLogic).
 		SetMetricsRegisterer(b.metricsRegisterer).
+		SetFilterDesc((*publicv1.ClusterTemplate)(nil).ProtoReflect().Descriptor()).
 		Build()
 	if err != nil {
 		return

--- a/internal/servers/clusters_server.go
+++ b/internal/servers/clusters_server.go
@@ -178,6 +178,7 @@ func (b *ClustersServerBuilder) Build() (result *ClustersServer, err error) {
 		SetAttributionLogic(b.attributionLogic).
 		SetTenancyLogic(b.tenancyLogic).
 		SetMetricsRegisterer(b.metricsRegisterer).
+		SetFilterDesc((*publicv1.Cluster)(nil).ProtoReflect().Descriptor()).
 		Build()
 	if err != nil {
 		return

--- a/internal/servers/clusters_server_test.go
+++ b/internal/servers/clusters_server_test.go
@@ -721,6 +721,26 @@ var _ = Describe("Clusters server", func() {
 			}
 		})
 
+		It("Rejects filters that reference private-only fields", func() {
+			// The 'status.hub' field exists on the private cluster message but not on the public one. The public server
+			// configures the filter translator with the public descriptor so this must fail.
+			_, err := server.List(ctx, publicv1.ClustersListRequest_builder{
+				Filter: new("this.status.hub == 'my-hub'"),
+			}.Build())
+			Expect(err).To(HaveOccurred())
+			status, ok := grpcstatus.FromError(err)
+			Expect(ok).To(BeTrue())
+			Expect(status.Code()).To(Equal(grpccodes.Internal))
+			Expect(status.Message()).To(Equal("failed to list"))
+		})
+
+		It("Accepts filters that reference public fields", func() {
+			_, err := server.List(ctx, publicv1.ClustersListRequest_builder{
+				Filter: new("this.status.api_url == 'https://api.example.com'"),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+		})
+
 		It("Get object", func() {
 			// Create the object:
 			createResponse, err := server.Create(ctx, publicv1.ClustersCreateRequest_builder{

--- a/internal/servers/compute_instance_catalog_items_server.go
+++ b/internal/servers/compute_instance_catalog_items_server.go
@@ -119,6 +119,7 @@ func (b *ComputeInstanceCatalogItemsServerBuilder) Build() (result *ComputeInsta
 		SetAttributionLogic(b.attributionLogic).
 		SetTenancyLogic(b.tenancyLogic).
 		SetMetricsRegisterer(b.metricsRegisterer).
+		SetFilterDesc((*publicv1.ComputeInstanceCatalogItem)(nil).ProtoReflect().Descriptor()).
 		Build()
 	if err != nil {
 		return

--- a/internal/servers/compute_instance_templates_server.go
+++ b/internal/servers/compute_instance_templates_server.go
@@ -116,6 +116,7 @@ func (b *ComputeInstanceTemplatesServerBuilder) Build() (result *ComputeInstance
 		SetAttributionLogic(b.attributionLogic).
 		SetTenancyLogic(b.tenancyLogic).
 		SetMetricsRegisterer(b.metricsRegisterer).
+		SetFilterDesc((*publicv1.ComputeInstanceTemplate)(nil).ProtoReflect().Descriptor()).
 		Build()
 	if err != nil {
 		return

--- a/internal/servers/compute_instances_server.go
+++ b/internal/servers/compute_instances_server.go
@@ -116,6 +116,7 @@ func (b *ComputeInstancesServerBuilder) Build() (result *ComputeInstancesServer,
 		SetAttributionLogic(b.attributionLogic).
 		SetTenancyLogic(b.tenancyLogic).
 		SetMetricsRegisterer(b.metricsRegisterer).
+		SetFilterDesc((*publicv1.ComputeInstance)(nil).ProtoReflect().Descriptor()).
 		Build()
 	if err != nil {
 		return

--- a/internal/servers/external_ip_attachments_server.go
+++ b/internal/servers/external_ip_attachments_server.go
@@ -111,6 +111,7 @@ func (b *ExternalIPAttachmentsServerBuilder) Build() (result *ExternalIPAttachme
 		SetAttributionLogic(b.attributionLogic).
 		SetTenancyLogic(b.tenancyLogic).
 		SetMetricsRegisterer(b.metricsRegisterer).
+		SetFilterDesc((*publicv1.ExternalIPAttachment)(nil).ProtoReflect().Descriptor()).
 		Build()
 	if err != nil {
 		return

--- a/internal/servers/external_ip_pools_server.go
+++ b/internal/servers/external_ip_pools_server.go
@@ -103,6 +103,7 @@ func (b *ExternalIPPoolsServerBuilder) Build() (result *ExternalIPPoolsServer, e
 		SetAttributionLogic(b.attributionLogic).
 		SetTenancyLogic(b.tenancyLogic).
 		SetMetricsRegisterer(b.metricsRegisterer).
+		SetFilterDesc((*publicv1.ExternalIPPool)(nil).ProtoReflect().Descriptor()).
 		Build()
 	if err != nil {
 		return

--- a/internal/servers/external_ips_server.go
+++ b/internal/servers/external_ips_server.go
@@ -111,6 +111,7 @@ func (b *ExternalIPsServerBuilder) Build() (result *ExternalIPsServer, err error
 		SetAttributionLogic(b.attributionLogic).
 		SetTenancyLogic(b.tenancyLogic).
 		SetMetricsRegisterer(b.metricsRegisterer).
+		SetFilterDesc((*publicv1.ExternalIP)(nil).ProtoReflect().Descriptor()).
 		Build()
 	if err != nil {
 		return

--- a/internal/servers/generic_server.go
+++ b/internal/servers/generic_server.go
@@ -51,6 +51,7 @@ type GenericServerBuilder[O dao.Object] struct {
 	attributionLogic  auth.AttributionLogic
 	tenancyLogic      auth.TenancyLogic
 	metricsRegisterer prometheus.Registerer
+	filterDesc        protoreflect.MessageDescriptor
 }
 
 // GenericServer is a gRPC server that knows how to implement the List, Get, Create, Update and Delete operators for
@@ -172,6 +173,17 @@ func (b *GenericServerBuilder[O]) SetMetricsRegisterer(value prometheus.Register
 	return b
 }
 
+// SetFilterDesc sets the protobuf message descriptor used to validate and translate CEL filter expressions. This is
+// optional. When unset, the descriptor of the O generic parameter is used.
+//
+// Pass a different descriptor to restrict which fields clients may reference in filters. Public servers that store
+// private objects typically pass the public message descriptor so that private-only fields are rejected during CEL
+// compilation. The value is forwarded to the underlying DAO via [dao.GenericDAOBuilder.SetFilterDesc].
+func (b *GenericServerBuilder[O]) SetFilterDesc(value protoreflect.MessageDescriptor) *GenericServerBuilder[O] {
+	b.filterDesc = value
+	return b
+}
+
 // Build uses the configuration stored in the builder to create and configure a new generic server.
 func (b *GenericServerBuilder[O]) Build() (result *GenericServer[O], err error) {
 	// Check parameters:
@@ -236,6 +248,9 @@ func (b *GenericServerBuilder[O]) Build() (result *GenericServer[O], err error) 
 	}
 	if b.metricsRegisterer != nil {
 		daoBuilder.SetMetricsRegisterer(b.metricsRegisterer)
+	}
+	if b.filterDesc != nil {
+		daoBuilder.SetFilterDesc(b.filterDesc)
 	}
 	s.dao, err = daoBuilder.Build()
 	if err != nil {

--- a/internal/servers/host_types_server.go
+++ b/internal/servers/host_types_server.go
@@ -116,6 +116,7 @@ func (b *HostTypesServerBuilder) Build() (result *HostTypesServer, err error) {
 		SetAttributionLogic(b.attributionLogic).
 		SetTenancyLogic(b.tenancyLogic).
 		SetMetricsRegisterer(b.metricsRegisterer).
+		SetFilterDesc((*publicv1.HostType)(nil).ProtoReflect().Descriptor()).
 		Build()
 	if err != nil {
 		return

--- a/internal/servers/identity_providers_server.go
+++ b/internal/servers/identity_providers_server.go
@@ -108,6 +108,7 @@ func (b *IdentityProvidersServerBuilder) Build() (result *IdentityProvidersServe
 		SetAttributionLogic(b.attributionLogic).
 		SetTenancyLogic(b.tenancyLogic).
 		SetMetricsRegisterer(b.metricsRegisterer).
+		SetFilterDesc((*publicv1.IdentityProvider)(nil).ProtoReflect().Descriptor()).
 		Build()
 	if err != nil {
 		return

--- a/internal/servers/instance_types_server.go
+++ b/internal/servers/instance_types_server.go
@@ -131,6 +131,7 @@ func (b *InstanceTypesServerBuilder) Build() (result *InstanceTypesServer, err e
 		SetAttributionLogic(b.attributionLogic).
 		SetTenancyLogic(b.tenancyLogic).
 		SetMetricsRegisterer(b.metricsRegisterer).
+		SetFilterDesc((*publicv1.InstanceType)(nil).ProtoReflect().Descriptor()).
 		Build()
 	if err != nil {
 		return

--- a/internal/servers/nat_gateways_server.go
+++ b/internal/servers/nat_gateways_server.go
@@ -111,6 +111,7 @@ func (b *NATGatewaysServerBuilder) Build() (result *NATGatewaysServer, err error
 		SetAttributionLogic(b.attributionLogic).
 		SetTenancyLogic(b.tenancyLogic).
 		SetMetricsRegisterer(b.metricsRegisterer).
+		SetFilterDesc((*publicv1.NATGateway)(nil).ProtoReflect().Descriptor()).
 		Build()
 	if err != nil {
 		return

--- a/internal/servers/network_classes_server.go
+++ b/internal/servers/network_classes_server.go
@@ -96,7 +96,7 @@ func (b *NetworkClassesServerBuilder) Build() (result *NetworkClassesServer, err
 
 	// Find OUTPUT_ONLY fields so that we can configure the inMapper to ignore them.
 	// This prevents public API callers from directly setting these fields.
-	ncDescriptor := new(publicv1.NetworkClass).ProtoReflect().Descriptor()
+	ncDescriptor := (*publicv1.NetworkClass)(nil).ProtoReflect().Descriptor()
 	isDefaultField := ncDescriptor.Fields().ByName("is_default")
 	if isDefaultField == nil {
 		err = fmt.Errorf("failed to find the is_default field of type '%s'", ncDescriptor.FullName())
@@ -132,6 +132,7 @@ func (b *NetworkClassesServerBuilder) Build() (result *NetworkClassesServer, err
 		SetAttributionLogic(b.attributionLogic).
 		SetTenancyLogic(b.tenancyLogic).
 		SetMetricsRegisterer(b.metricsRegisterer).
+		SetFilterDesc(ncDescriptor).
 		Build()
 	if err != nil {
 		return

--- a/internal/servers/private_baremetal_instance_catalog_items_server.go
+++ b/internal/servers/private_baremetal_instance_catalog_items_server.go
@@ -22,6 +22,7 @@ import (
 
 	grpccodes "google.golang.org/grpc/codes"
 	grpcstatus "google.golang.org/grpc/status"
+	"google.golang.org/protobuf/reflect/protoreflect"
 
 	privatev1 "github.com/osac-project/fulfillment-service/internal/api/osac/private/v1"
 	"github.com/osac-project/fulfillment-service/internal/auth"
@@ -36,6 +37,7 @@ type PrivateBareMetalInstanceCatalogItemsServerBuilder struct {
 	tenancyLogic      auth.TenancyLogic
 	metricsRegisterer prometheus.Registerer
 	referenceChecker  catalogItemReferenceChecker
+	filterDesc        protoreflect.MessageDescriptor
 }
 
 var _ privatev1.BareMetalInstanceCatalogItemsServer = (*PrivateBareMetalInstanceCatalogItemsServer)(nil)
@@ -81,6 +83,14 @@ func (b *PrivateBareMetalInstanceCatalogItemsServerBuilder) SetReferenceChecker(
 	return b
 }
 
+// SetFilterDesc sets the protobuf message descriptor used to validate and translate CEL filter expressions. This is
+// optional. When unset, the private object type is used. Public servers that wrap this private server should pass the
+// corresponding public object descriptor so that clients cannot filter on private-only fields.
+func (b *PrivateBareMetalInstanceCatalogItemsServerBuilder) SetFilterDesc(value protoreflect.MessageDescriptor) *PrivateBareMetalInstanceCatalogItemsServerBuilder {
+	b.filterDesc = value
+	return b
+}
+
 func (b *PrivateBareMetalInstanceCatalogItemsServerBuilder) Build() (result *PrivateBareMetalInstanceCatalogItemsServer, err error) {
 	if b.logger == nil {
 		err = errors.New("logger is mandatory")
@@ -102,6 +112,7 @@ func (b *PrivateBareMetalInstanceCatalogItemsServerBuilder) Build() (result *Pri
 		SetAttributionLogic(b.attributionLogic).
 		SetTenancyLogic(b.tenancyLogic).
 		SetMetricsRegisterer(b.metricsRegisterer).
+		SetFilterDesc(b.filterDesc).
 		Build()
 	if err != nil {
 		return

--- a/internal/servers/private_baremetal_instance_templates_server.go
+++ b/internal/servers/private_baremetal_instance_templates_server.go
@@ -19,6 +19,7 @@ import (
 	"log/slog"
 
 	"github.com/prometheus/client_golang/prometheus"
+	"google.golang.org/protobuf/reflect/protoreflect"
 
 	privatev1 "github.com/osac-project/fulfillment-service/internal/api/osac/private/v1"
 	"github.com/osac-project/fulfillment-service/internal/auth"
@@ -31,6 +32,7 @@ type PrivateBareMetalInstanceTemplatesServerBuilder struct {
 	attributionLogic  auth.AttributionLogic
 	tenancyLogic      auth.TenancyLogic
 	metricsRegisterer prometheus.Registerer
+	filterDesc        protoreflect.MessageDescriptor
 }
 
 var _ privatev1.BareMetalInstanceTemplatesServer = (*PrivateBareMetalInstanceTemplatesServer)(nil)
@@ -70,6 +72,14 @@ func (b *PrivateBareMetalInstanceTemplatesServerBuilder) SetMetricsRegisterer(va
 	return b
 }
 
+// SetFilterDesc sets the protobuf message descriptor used to validate and translate CEL filter expressions. This is
+// optional. When unset, the private object type is used. Public servers that wrap this private server should pass the
+// corresponding public object descriptor so that clients cannot filter on private-only fields.
+func (b *PrivateBareMetalInstanceTemplatesServerBuilder) SetFilterDesc(value protoreflect.MessageDescriptor) *PrivateBareMetalInstanceTemplatesServerBuilder {
+	b.filterDesc = value
+	return b
+}
+
 func (b *PrivateBareMetalInstanceTemplatesServerBuilder) Build() (result *PrivateBareMetalInstanceTemplatesServer, err error) {
 	if b.logger == nil {
 		err = errors.New("logger is mandatory")
@@ -87,6 +97,7 @@ func (b *PrivateBareMetalInstanceTemplatesServerBuilder) Build() (result *Privat
 		SetAttributionLogic(b.attributionLogic).
 		SetTenancyLogic(b.tenancyLogic).
 		SetMetricsRegisterer(b.metricsRegisterer).
+		SetFilterDesc(b.filterDesc).
 		Build()
 	if err != nil {
 		return

--- a/internal/servers/private_baremetal_instances_server.go
+++ b/internal/servers/private_baremetal_instances_server.go
@@ -25,6 +25,7 @@ import (
 	grpccodes "google.golang.org/grpc/codes"
 	grpcstatus "google.golang.org/grpc/status"
 	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/reflect/protoreflect"
 	"google.golang.org/protobuf/types/known/anypb"
 
 	privatev1 "github.com/osac-project/fulfillment-service/internal/api/osac/private/v1"
@@ -42,6 +43,7 @@ type PrivateBareMetalInstancesServerBuilder struct {
 	attributionLogic  auth.AttributionLogic
 	tenancyLogic      auth.TenancyLogic
 	metricsRegisterer prometheus.Registerer
+	filterDesc        protoreflect.MessageDescriptor
 }
 
 var _ privatev1.BareMetalInstancesServer = (*PrivateBareMetalInstancesServer)(nil)
@@ -80,6 +82,14 @@ func (b *PrivateBareMetalInstancesServerBuilder) SetTenancyLogic(value auth.Tena
 
 func (b *PrivateBareMetalInstancesServerBuilder) SetMetricsRegisterer(value prometheus.Registerer) *PrivateBareMetalInstancesServerBuilder {
 	b.metricsRegisterer = value
+	return b
+}
+
+// SetFilterDesc sets the protobuf message descriptor used to validate and translate CEL filter expressions. This is
+// optional. When unset, the private object type is used. Public servers that wrap this private server should pass the
+// corresponding public object descriptor so that clients cannot filter on private-only fields.
+func (b *PrivateBareMetalInstancesServerBuilder) SetFilterDesc(value protoreflect.MessageDescriptor) *PrivateBareMetalInstancesServerBuilder {
+	b.filterDesc = value
 	return b
 }
 
@@ -122,6 +132,7 @@ func (b *PrivateBareMetalInstancesServerBuilder) Build() (result *PrivateBareMet
 		SetAttributionLogic(b.attributionLogic).
 		SetTenancyLogic(b.tenancyLogic).
 		SetMetricsRegisterer(b.metricsRegisterer).
+		SetFilterDesc(b.filterDesc).
 		Build()
 	if err != nil {
 		return

--- a/internal/servers/private_cluster_catalog_items_server.go
+++ b/internal/servers/private_cluster_catalog_items_server.go
@@ -19,6 +19,7 @@ import (
 	"log/slog"
 
 	"github.com/prometheus/client_golang/prometheus"
+	"google.golang.org/protobuf/reflect/protoreflect"
 
 	privatev1 "github.com/osac-project/fulfillment-service/internal/api/osac/private/v1"
 	"github.com/osac-project/fulfillment-service/internal/auth"
@@ -31,6 +32,7 @@ type PrivateClusterCatalogItemsServerBuilder struct {
 	attributionLogic  auth.AttributionLogic
 	tenancyLogic      auth.TenancyLogic
 	metricsRegisterer prometheus.Registerer
+	filterDesc        protoreflect.MessageDescriptor
 }
 
 var _ privatev1.ClusterCatalogItemsServer = (*PrivateClusterCatalogItemsServer)(nil)
@@ -71,6 +73,14 @@ func (b *PrivateClusterCatalogItemsServerBuilder) SetMetricsRegisterer(value pro
 	return b
 }
 
+// SetFilterDesc sets the protobuf message descriptor used to validate and translate CEL filter expressions. This is
+// optional. When unset, the private object type is used. Public servers that wrap this private server should pass the
+// corresponding public object descriptor so that clients cannot filter on private-only fields.
+func (b *PrivateClusterCatalogItemsServerBuilder) SetFilterDesc(value protoreflect.MessageDescriptor) *PrivateClusterCatalogItemsServerBuilder {
+	b.filterDesc = value
+	return b
+}
+
 func (b *PrivateClusterCatalogItemsServerBuilder) Build() (result *PrivateClusterCatalogItemsServer, err error) {
 	if b.logger == nil {
 		err = errors.New("logger is mandatory")
@@ -87,6 +97,7 @@ func (b *PrivateClusterCatalogItemsServerBuilder) Build() (result *PrivateCluste
 		SetAttributionLogic(b.attributionLogic).
 		SetTenancyLogic(b.tenancyLogic).
 		SetMetricsRegisterer(b.metricsRegisterer).
+		SetFilterDesc(b.filterDesc).
 		Build()
 	if err != nil {
 		return

--- a/internal/servers/private_cluster_templates_server.go
+++ b/internal/servers/private_cluster_templates_server.go
@@ -19,6 +19,7 @@ import (
 	"log/slog"
 
 	"github.com/prometheus/client_golang/prometheus"
+	"google.golang.org/protobuf/reflect/protoreflect"
 
 	privatev1 "github.com/osac-project/fulfillment-service/internal/api/osac/private/v1"
 	"github.com/osac-project/fulfillment-service/internal/auth"
@@ -31,6 +32,7 @@ type PrivateClusterTemplatesServerBuilder struct {
 	attributionLogic  auth.AttributionLogic
 	tenancyLogic      auth.TenancyLogic
 	metricsRegisterer prometheus.Registerer
+	filterDesc        protoreflect.MessageDescriptor
 }
 
 var _ privatev1.ClusterTemplatesServer = (*PrivateClusterTemplatesServer)(nil)
@@ -73,6 +75,14 @@ func (b *PrivateClusterTemplatesServerBuilder) SetMetricsRegisterer(value promet
 	return b
 }
 
+// SetFilterDesc sets the protobuf message descriptor used to validate and translate CEL filter expressions. This is
+// optional. When unset, the private object type is used. Public servers that wrap this private server should pass the
+// corresponding public object descriptor so that clients cannot filter on private-only fields.
+func (b *PrivateClusterTemplatesServerBuilder) SetFilterDesc(value protoreflect.MessageDescriptor) *PrivateClusterTemplatesServerBuilder {
+	b.filterDesc = value
+	return b
+}
+
 func (b *PrivateClusterTemplatesServerBuilder) Build() (result *PrivateClusterTemplatesServer, err error) {
 	// Check parameters:
 	if b.logger == nil {
@@ -92,6 +102,7 @@ func (b *PrivateClusterTemplatesServerBuilder) Build() (result *PrivateClusterTe
 		SetAttributionLogic(b.attributionLogic).
 		SetTenancyLogic(b.tenancyLogic).
 		SetMetricsRegisterer(b.metricsRegisterer).
+		SetFilterDesc(b.filterDesc).
 		Build()
 	if err != nil {
 		return

--- a/internal/servers/private_clusters_server.go
+++ b/internal/servers/private_clusters_server.go
@@ -29,6 +29,7 @@ import (
 	grpccodes "google.golang.org/grpc/codes"
 	grpcstatus "google.golang.org/grpc/status"
 	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/reflect/protoreflect"
 	"google.golang.org/protobuf/types/known/anypb"
 	"google.golang.org/protobuf/types/known/fieldmaskpb"
 
@@ -45,6 +46,7 @@ type PrivateClustersServerBuilder struct {
 	attributionLogic  auth.AttributionLogic
 	tenancyLogic      auth.TenancyLogic
 	metricsRegisterer prometheus.Registerer
+	filterDesc        protoreflect.MessageDescriptor
 }
 
 var _ privatev1.ClustersServer = (*PrivateClustersServer)(nil)
@@ -79,6 +81,14 @@ func (b *PrivateClustersServerBuilder) SetAttributionLogic(value auth.Attributio
 
 func (b *PrivateClustersServerBuilder) SetTenancyLogic(value auth.TenancyLogic) *PrivateClustersServerBuilder {
 	b.tenancyLogic = value
+	return b
+}
+
+// SetFilterDesc sets the protobuf message descriptor used to validate and translate CEL filter expressions. This is
+// optional. When unset, the private object type is used. Public servers that wrap this private server should pass the
+// corresponding public object descriptor so that clients cannot filter on private-only fields.
+func (b *PrivateClustersServerBuilder) SetFilterDesc(value protoreflect.MessageDescriptor) *PrivateClustersServerBuilder {
+	b.filterDesc = value
 	return b
 }
 
@@ -138,6 +148,7 @@ func (b *PrivateClustersServerBuilder) Build() (result *PrivateClustersServer, e
 		SetAttributionLogic(b.attributionLogic).
 		SetTenancyLogic(b.tenancyLogic).
 		SetMetricsRegisterer(b.metricsRegisterer).
+		SetFilterDesc(b.filterDesc).
 		Build()
 	if err != nil {
 		return

--- a/internal/servers/private_clusters_server_test.go
+++ b/internal/servers/private_clusters_server_test.go
@@ -554,6 +554,28 @@ var _ = Describe("Private clusters server", func() {
 			}
 		})
 
+		It("Accepts filters that reference private-only fields", func() {
+			// The private server does not set a public filter descriptor, so private-only fields such as 'status.hub' are valid
+			// in CEL filters.
+			_, err := server.Create(ctx, privatev1.ClustersCreateRequest_builder{
+				Object: privatev1.Cluster_builder{
+					Spec: privatev1.ClusterSpec_builder{
+						Template: "my-template-id",
+					}.Build(),
+					Status: privatev1.ClusterStatus_builder{
+						Hub: "my-hub",
+					}.Build(),
+				}.Build(),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+			response, err := server.List(ctx, privatev1.ClustersListRequest_builder{
+				Filter: new("this.status.hub == 'my-hub'"),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+			Expect(response.GetSize()).To(BeNumerically("==", 1))
+			Expect(response.GetItems()[0].GetStatus().GetHub()).To(Equal("my-hub"))
+		})
+
 		It("Get object", func() {
 			// Create the object:
 			createResponse, err := server.Create(ctx, privatev1.ClustersCreateRequest_builder{

--- a/internal/servers/private_compute_instance_catalog_items_server.go
+++ b/internal/servers/private_compute_instance_catalog_items_server.go
@@ -19,6 +19,7 @@ import (
 	"log/slog"
 
 	"github.com/prometheus/client_golang/prometheus"
+	"google.golang.org/protobuf/reflect/protoreflect"
 
 	privatev1 "github.com/osac-project/fulfillment-service/internal/api/osac/private/v1"
 	"github.com/osac-project/fulfillment-service/internal/auth"
@@ -32,6 +33,7 @@ type PrivateComputeInstanceCatalogItemsServerBuilder struct {
 	attributionLogic  auth.AttributionLogic
 	tenancyLogic      auth.TenancyLogic
 	metricsRegisterer prometheus.Registerer
+	filterDesc        protoreflect.MessageDescriptor
 }
 
 var _ privatev1.ComputeInstanceCatalogItemsServer = (*PrivateComputeInstanceCatalogItemsServer)(nil)
@@ -73,6 +75,14 @@ func (b *PrivateComputeInstanceCatalogItemsServerBuilder) SetMetricsRegisterer(v
 	return b
 }
 
+// SetFilterDesc sets the protobuf message descriptor used to validate and translate CEL filter expressions. This is
+// optional. When unset, the private object type is used. Public servers that wrap this private server should pass the
+// corresponding public object descriptor so that clients cannot filter on private-only fields.
+func (b *PrivateComputeInstanceCatalogItemsServerBuilder) SetFilterDesc(value protoreflect.MessageDescriptor) *PrivateComputeInstanceCatalogItemsServerBuilder {
+	b.filterDesc = value
+	return b
+}
+
 func (b *PrivateComputeInstanceCatalogItemsServerBuilder) Build() (result *PrivateComputeInstanceCatalogItemsServer, err error) {
 	if b.logger == nil {
 		err = errors.New("logger is mandatory")
@@ -99,6 +109,7 @@ func (b *PrivateComputeInstanceCatalogItemsServerBuilder) Build() (result *Priva
 		SetAttributionLogic(b.attributionLogic).
 		SetTenancyLogic(b.tenancyLogic).
 		SetMetricsRegisterer(b.metricsRegisterer).
+		SetFilterDesc(b.filterDesc).
 		Build()
 	if err != nil {
 		return

--- a/internal/servers/private_compute_instance_templates_server.go
+++ b/internal/servers/private_compute_instance_templates_server.go
@@ -19,6 +19,7 @@ import (
 	"log/slog"
 
 	"github.com/prometheus/client_golang/prometheus"
+	"google.golang.org/protobuf/reflect/protoreflect"
 
 	privatev1 "github.com/osac-project/fulfillment-service/internal/api/osac/private/v1"
 	"github.com/osac-project/fulfillment-service/internal/auth"
@@ -32,6 +33,7 @@ type PrivateComputeInstanceTemplatesServerBuilder struct {
 	attributionLogic  auth.AttributionLogic
 	tenancyLogic      auth.TenancyLogic
 	metricsRegisterer prometheus.Registerer
+	filterDesc        protoreflect.MessageDescriptor
 }
 
 var _ privatev1.ComputeInstanceTemplatesServer = (*PrivateComputeInstanceTemplatesServer)(nil)
@@ -74,6 +76,14 @@ func (b *PrivateComputeInstanceTemplatesServerBuilder) SetMetricsRegisterer(valu
 	return b
 }
 
+// SetFilterDesc sets the protobuf message descriptor used to validate and translate CEL filter expressions. This is
+// optional. When unset, the private object type is used. Public servers that wrap this private server should pass the
+// corresponding public object descriptor so that clients cannot filter on private-only fields.
+func (b *PrivateComputeInstanceTemplatesServerBuilder) SetFilterDesc(value protoreflect.MessageDescriptor) *PrivateComputeInstanceTemplatesServerBuilder {
+	b.filterDesc = value
+	return b
+}
+
 func (b *PrivateComputeInstanceTemplatesServerBuilder) Build() (result *PrivateComputeInstanceTemplatesServer, err error) {
 	// Check parameters:
 	if b.logger == nil {
@@ -103,6 +113,7 @@ func (b *PrivateComputeInstanceTemplatesServerBuilder) Build() (result *PrivateC
 		SetAttributionLogic(b.attributionLogic).
 		SetTenancyLogic(b.tenancyLogic).
 		SetMetricsRegisterer(b.metricsRegisterer).
+		SetFilterDesc(b.filterDesc).
 		Build()
 	if err != nil {
 		return

--- a/internal/servers/private_compute_instances_server.go
+++ b/internal/servers/private_compute_instances_server.go
@@ -28,6 +28,7 @@ import (
 	grpccodes "google.golang.org/grpc/codes"
 	grpcstatus "google.golang.org/grpc/status"
 	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/reflect/protoreflect"
 	"google.golang.org/protobuf/types/known/anypb"
 	"google.golang.org/protobuf/types/known/fieldmaskpb"
 
@@ -45,6 +46,7 @@ type PrivateComputeInstancesServerBuilder struct {
 	attributionLogic  auth.AttributionLogic
 	tenancyLogic      auth.TenancyLogic
 	metricsRegisterer prometheus.Registerer
+	filterDesc        protoreflect.MessageDescriptor
 }
 
 var _ privatev1.ComputeInstancesServer = (*PrivateComputeInstancesServer)(nil)
@@ -89,6 +91,14 @@ func (b *PrivateComputeInstancesServerBuilder) SetTenancyLogic(value auth.Tenanc
 // access objects. This is optional. If not set, no metrics will be recorded.
 func (b *PrivateComputeInstancesServerBuilder) SetMetricsRegisterer(value prometheus.Registerer) *PrivateComputeInstancesServerBuilder {
 	b.metricsRegisterer = value
+	return b
+}
+
+// SetFilterDesc sets the protobuf message descriptor used to validate and translate CEL filter expressions. This is
+// optional. When unset, the private object type is used. Public servers that wrap this private server should pass the
+// corresponding public object descriptor so that clients cannot filter on private-only fields.
+func (b *PrivateComputeInstancesServerBuilder) SetFilterDesc(value protoreflect.MessageDescriptor) *PrivateComputeInstancesServerBuilder {
+	b.filterDesc = value
 	return b
 }
 
@@ -161,6 +171,7 @@ func (b *PrivateComputeInstancesServerBuilder) Build() (result *PrivateComputeIn
 		SetAttributionLogic(b.attributionLogic).
 		SetTenancyLogic(b.tenancyLogic).
 		SetMetricsRegisterer(b.metricsRegisterer).
+		SetFilterDesc(b.filterDesc).
 		Build()
 	if err != nil {
 		return

--- a/internal/servers/private_external_ip_attachments_server.go
+++ b/internal/servers/private_external_ip_attachments_server.go
@@ -22,6 +22,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	grpccodes "google.golang.org/grpc/codes"
 	grpcstatus "google.golang.org/grpc/status"
+	"google.golang.org/protobuf/reflect/protoreflect"
 
 	privatev1 "github.com/osac-project/fulfillment-service/internal/api/osac/private/v1"
 	"github.com/osac-project/fulfillment-service/internal/auth"
@@ -35,6 +36,7 @@ type PrivateExternalIPAttachmentsServerBuilder struct {
 	attributionLogic  auth.AttributionLogic
 	tenancyLogic      auth.TenancyLogic
 	metricsRegisterer prometheus.Registerer
+	filterDesc        protoreflect.MessageDescriptor
 }
 
 var _ privatev1.ExternalIPAttachmentsServer = (*PrivateExternalIPAttachmentsServer)(nil)
@@ -77,6 +79,14 @@ func (b *PrivateExternalIPAttachmentsServerBuilder) SetTenancyLogic(value auth.T
 
 func (b *PrivateExternalIPAttachmentsServerBuilder) SetMetricsRegisterer(value prometheus.Registerer) *PrivateExternalIPAttachmentsServerBuilder {
 	b.metricsRegisterer = value
+	return b
+}
+
+// SetFilterDesc sets the protobuf message descriptor used to validate and translate CEL filter expressions. This is
+// optional. When unset, the private object type is used. Public servers that wrap this private server should pass the
+// corresponding public object descriptor so that clients cannot filter on private-only fields.
+func (b *PrivateExternalIPAttachmentsServerBuilder) SetFilterDesc(value protoreflect.MessageDescriptor) *PrivateExternalIPAttachmentsServerBuilder {
+	b.filterDesc = value
 	return b
 }
 
@@ -140,6 +150,7 @@ func (b *PrivateExternalIPAttachmentsServerBuilder) Build() (*PrivateExternalIPA
 		SetAttributionLogic(b.attributionLogic).
 		SetTenancyLogic(b.tenancyLogic).
 		SetMetricsRegisterer(b.metricsRegisterer).
+		SetFilterDesc(b.filterDesc).
 		Build()
 	if err != nil {
 		return nil, err

--- a/internal/servers/private_external_ip_pools_server.go
+++ b/internal/servers/private_external_ip_pools_server.go
@@ -21,6 +21,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	grpccodes "google.golang.org/grpc/codes"
 	grpcstatus "google.golang.org/grpc/status"
+	"google.golang.org/protobuf/reflect/protoreflect"
 
 	privatev1 "github.com/osac-project/fulfillment-service/internal/api/osac/private/v1"
 	"github.com/osac-project/fulfillment-service/internal/auth"
@@ -33,6 +34,7 @@ type PrivateExternalIPPoolsServerBuilder struct {
 	attributionLogic  auth.AttributionLogic
 	tenancyLogic      auth.TenancyLogic
 	metricsRegisterer prometheus.Registerer
+	filterDesc        protoreflect.MessageDescriptor
 }
 
 var _ privatev1.ExternalIPPoolsServer = (*PrivateExternalIPPoolsServer)(nil)
@@ -73,6 +75,14 @@ func (b *PrivateExternalIPPoolsServerBuilder) SetMetricsRegisterer(value prometh
 	return b
 }
 
+// SetFilterDesc sets the protobuf message descriptor used to validate and translate CEL filter expressions. This is
+// optional. When unset, the private object type is used. Public servers that wrap this private server should pass the
+// corresponding public object descriptor so that clients cannot filter on private-only fields.
+func (b *PrivateExternalIPPoolsServerBuilder) SetFilterDesc(value protoreflect.MessageDescriptor) *PrivateExternalIPPoolsServerBuilder {
+	b.filterDesc = value
+	return b
+}
+
 func (b *PrivateExternalIPPoolsServerBuilder) Build() (result *PrivateExternalIPPoolsServer, err error) {
 	if b.logger == nil {
 		err = errors.New("logger is mandatory")
@@ -90,6 +100,7 @@ func (b *PrivateExternalIPPoolsServerBuilder) Build() (result *PrivateExternalIP
 		SetAttributionLogic(b.attributionLogic).
 		SetTenancyLogic(b.tenancyLogic).
 		SetMetricsRegisterer(b.metricsRegisterer).
+		SetFilterDesc(b.filterDesc).
 		Build()
 	if err != nil {
 		return

--- a/internal/servers/private_external_ips_server.go
+++ b/internal/servers/private_external_ips_server.go
@@ -22,6 +22,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	grpccodes "google.golang.org/grpc/codes"
 	grpcstatus "google.golang.org/grpc/status"
+	"google.golang.org/protobuf/reflect/protoreflect"
 
 	privatev1 "github.com/osac-project/fulfillment-service/internal/api/osac/private/v1"
 	"github.com/osac-project/fulfillment-service/internal/auth"
@@ -41,6 +42,7 @@ type PrivateExternalIPsServerBuilder struct {
 	attributionLogic  auth.AttributionLogic
 	tenancyLogic      auth.TenancyLogic
 	metricsRegisterer prometheus.Registerer
+	filterDesc        protoreflect.MessageDescriptor
 }
 
 var _ privatev1.ExternalIPsServer = (*PrivateExternalIPsServer)(nil)
@@ -82,6 +84,14 @@ func (b *PrivateExternalIPsServerBuilder) SetMetricsRegisterer(value prometheus.
 	return b
 }
 
+// SetFilterDesc sets the protobuf message descriptor used to validate and translate CEL filter expressions. This is
+// optional. When unset, the private object type is used. Public servers that wrap this private server should pass the
+// corresponding public object descriptor so that clients cannot filter on private-only fields.
+func (b *PrivateExternalIPsServerBuilder) SetFilterDesc(value protoreflect.MessageDescriptor) *PrivateExternalIPsServerBuilder {
+	b.filterDesc = value
+	return b
+}
+
 func (b *PrivateExternalIPsServerBuilder) Build() (result *PrivateExternalIPsServer, err error) {
 	if b.logger == nil {
 		err = errors.New("logger is mandatory")
@@ -112,6 +122,7 @@ func (b *PrivateExternalIPsServerBuilder) Build() (result *PrivateExternalIPsSer
 		SetAttributionLogic(b.attributionLogic).
 		SetTenancyLogic(b.tenancyLogic).
 		SetMetricsRegisterer(b.metricsRegisterer).
+		SetFilterDesc(b.filterDesc).
 		Build()
 	if err != nil {
 		return

--- a/internal/servers/private_host_types_server.go
+++ b/internal/servers/private_host_types_server.go
@@ -19,6 +19,7 @@ import (
 	"log/slog"
 
 	"github.com/prometheus/client_golang/prometheus"
+	"google.golang.org/protobuf/reflect/protoreflect"
 
 	privatev1 "github.com/osac-project/fulfillment-service/internal/api/osac/private/v1"
 	"github.com/osac-project/fulfillment-service/internal/auth"
@@ -31,6 +32,7 @@ type PrivateHostTypesServerBuilder struct {
 	attributionLogic  auth.AttributionLogic
 	tenancyLogic      auth.TenancyLogic
 	metricsRegisterer prometheus.Registerer
+	filterDesc        protoreflect.MessageDescriptor
 }
 
 var _ privatev1.HostTypesServer = (*PrivateHostTypesServer)(nil)
@@ -72,6 +74,14 @@ func (b *PrivateHostTypesServerBuilder) SetMetricsRegisterer(value prometheus.Re
 	return b
 }
 
+// SetFilterDesc sets the protobuf message descriptor used to validate and translate CEL filter expressions. This is
+// optional. When unset, the private object type is used. Public servers that wrap this private server should pass the
+// corresponding public object descriptor so that clients cannot filter on private-only fields.
+func (b *PrivateHostTypesServerBuilder) SetFilterDesc(value protoreflect.MessageDescriptor) *PrivateHostTypesServerBuilder {
+	b.filterDesc = value
+	return b
+}
+
 func (b *PrivateHostTypesServerBuilder) Build() (result *PrivateHostTypesServer, err error) {
 	// Check parameters:
 	if b.logger == nil {
@@ -91,6 +101,7 @@ func (b *PrivateHostTypesServerBuilder) Build() (result *PrivateHostTypesServer,
 		SetAttributionLogic(b.attributionLogic).
 		SetTenancyLogic(b.tenancyLogic).
 		SetMetricsRegisterer(b.metricsRegisterer).
+		SetFilterDesc(b.filterDesc).
 		Build()
 	if err != nil {
 		return

--- a/internal/servers/private_hubs_server.go
+++ b/internal/servers/private_hubs_server.go
@@ -19,6 +19,7 @@ import (
 	"log/slog"
 
 	"github.com/prometheus/client_golang/prometheus"
+	"google.golang.org/protobuf/reflect/protoreflect"
 
 	privatev1 "github.com/osac-project/fulfillment-service/internal/api/osac/private/v1"
 	"github.com/osac-project/fulfillment-service/internal/auth"
@@ -31,6 +32,7 @@ type PrivateHubsServerBuilder struct {
 	attributionLogic  auth.AttributionLogic
 	tenancyLogic      auth.TenancyLogic
 	metricsRegisterer prometheus.Registerer
+	filterDesc        protoreflect.MessageDescriptor
 }
 
 var _ privatev1.HubsServer = (*PrivateHubsServer)(nil)
@@ -73,6 +75,14 @@ func (b *PrivateHubsServerBuilder) SetMetricsRegisterer(value prometheus.Registe
 	return b
 }
 
+// SetFilterDesc sets the protobuf message descriptor used to validate and translate CEL filter expressions. This is
+// optional. When unset, the private object type is used. Public servers that wrap this private server should pass the
+// corresponding public object descriptor so that clients cannot filter on private-only fields.
+func (b *PrivateHubsServerBuilder) SetFilterDesc(value protoreflect.MessageDescriptor) *PrivateHubsServerBuilder {
+	b.filterDesc = value
+	return b
+}
+
 func (b *PrivateHubsServerBuilder) Build() (result *PrivateHubsServer, err error) {
 	// Check parameters:
 	if b.logger == nil {
@@ -98,6 +108,7 @@ func (b *PrivateHubsServerBuilder) Build() (result *PrivateHubsServer, err error
 		SetAttributionLogic(b.attributionLogic).
 		SetTenancyLogic(b.tenancyLogic).
 		SetMetricsRegisterer(b.metricsRegisterer).
+		SetFilterDesc(b.filterDesc).
 		Build()
 	if err != nil {
 		return

--- a/internal/servers/private_identity_providers_server.go
+++ b/internal/servers/private_identity_providers_server.go
@@ -21,6 +21,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	grpccodes "google.golang.org/grpc/codes"
 	grpcstatus "google.golang.org/grpc/status"
+	"google.golang.org/protobuf/reflect/protoreflect"
 
 	privatev1 "github.com/osac-project/fulfillment-service/internal/api/osac/private/v1"
 	"github.com/osac-project/fulfillment-service/internal/auth"
@@ -34,6 +35,7 @@ type PrivateIdentityProvidersServerBuilder struct {
 	attributionLogic  auth.AttributionLogic
 	tenancyLogic      auth.TenancyLogic
 	metricsRegisterer prometheus.Registerer
+	filterDesc        protoreflect.MessageDescriptor
 }
 
 var _ privatev1.IdentityProvidersServer = (*PrivateIdentityProvidersServer)(nil)
@@ -74,6 +76,14 @@ func (b *PrivateIdentityProvidersServerBuilder) SetMetricsRegisterer(value prome
 	return b
 }
 
+// SetFilterDesc sets the protobuf message descriptor used to validate and translate CEL filter expressions. This is
+// optional. When unset, the private object type is used. Public servers that wrap this private server should pass the
+// corresponding public object descriptor so that clients cannot filter on private-only fields.
+func (b *PrivateIdentityProvidersServerBuilder) SetFilterDesc(value protoreflect.MessageDescriptor) *PrivateIdentityProvidersServerBuilder {
+	b.filterDesc = value
+	return b
+}
+
 func (b *PrivateIdentityProvidersServerBuilder) Build() (result *PrivateIdentityProvidersServer, err error) {
 	// Check parameters:
 	if b.logger == nil {
@@ -99,6 +109,7 @@ func (b *PrivateIdentityProvidersServerBuilder) Build() (result *PrivateIdentity
 		SetAttributionLogic(b.attributionLogic).
 		SetTenancyLogic(b.tenancyLogic).
 		SetMetricsRegisterer(b.metricsRegisterer).
+		SetFilterDesc(b.filterDesc).
 		Build()
 	if err != nil {
 		return

--- a/internal/servers/private_instance_types_server.go
+++ b/internal/servers/private_instance_types_server.go
@@ -22,6 +22,7 @@ import (
 	grpccodes "google.golang.org/grpc/codes"
 	grpcstatus "google.golang.org/grpc/status"
 	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/reflect/protoreflect"
 	"google.golang.org/protobuf/types/known/fieldmaskpb"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
@@ -36,6 +37,7 @@ type PrivateInstanceTypesServerBuilder struct {
 	attributionLogic  auth.AttributionLogic
 	tenancyLogic      auth.TenancyLogic
 	metricsRegisterer prometheus.Registerer
+	filterDesc        protoreflect.MessageDescriptor
 }
 
 var _ privatev1.InstanceTypesServer = (*PrivateInstanceTypesServer)(nil)
@@ -78,6 +80,14 @@ func (b *PrivateInstanceTypesServerBuilder) SetMetricsRegisterer(value prometheu
 	return b
 }
 
+// SetFilterDesc sets the protobuf message descriptor used to validate and translate CEL filter expressions. This is
+// optional. When unset, the private object type is used. Public servers that wrap this private server should pass the
+// corresponding public object descriptor so that clients cannot filter on private-only fields.
+func (b *PrivateInstanceTypesServerBuilder) SetFilterDesc(value protoreflect.MessageDescriptor) *PrivateInstanceTypesServerBuilder {
+	b.filterDesc = value
+	return b
+}
+
 func (b *PrivateInstanceTypesServerBuilder) Build() (result *PrivateInstanceTypesServer, err error) {
 	// Check parameters:
 	if b.logger == nil {
@@ -97,6 +107,7 @@ func (b *PrivateInstanceTypesServerBuilder) Build() (result *PrivateInstanceType
 		SetAttributionLogic(b.attributionLogic).
 		SetTenancyLogic(b.tenancyLogic).
 		SetMetricsRegisterer(b.metricsRegisterer).
+		SetFilterDesc(b.filterDesc).
 		Build()
 	if err != nil {
 		return

--- a/internal/servers/private_nat_gateways_server.go
+++ b/internal/servers/private_nat_gateways_server.go
@@ -21,6 +21,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	grpccodes "google.golang.org/grpc/codes"
 	grpcstatus "google.golang.org/grpc/status"
+	"google.golang.org/protobuf/reflect/protoreflect"
 
 	privatev1 "github.com/osac-project/fulfillment-service/internal/api/osac/private/v1"
 	"github.com/osac-project/fulfillment-service/internal/auth"
@@ -34,6 +35,7 @@ type PrivateNATGatewaysServerBuilder struct {
 	attributionLogic  auth.AttributionLogic
 	tenancyLogic      auth.TenancyLogic
 	metricsRegisterer prometheus.Registerer
+	filterDesc        protoreflect.MessageDescriptor
 }
 
 var _ privatev1.NATGatewaysServer = (*PrivateNATGatewaysServer)(nil)
@@ -75,6 +77,14 @@ func (b *PrivateNATGatewaysServerBuilder) SetMetricsRegisterer(value prometheus.
 	return b
 }
 
+// SetFilterDesc sets the protobuf message descriptor used to validate and translate CEL filter expressions. This is
+// optional. When unset, the private object type is used. Public servers that wrap this private server should pass the
+// corresponding public object descriptor so that clients cannot filter on private-only fields.
+func (b *PrivateNATGatewaysServerBuilder) SetFilterDesc(value protoreflect.MessageDescriptor) *PrivateNATGatewaysServerBuilder {
+	b.filterDesc = value
+	return b
+}
+
 func (b *PrivateNATGatewaysServerBuilder) Build() (result *PrivateNATGatewaysServer, err error) {
 	if b.logger == nil {
 		err = errors.New("logger is mandatory")
@@ -105,6 +115,7 @@ func (b *PrivateNATGatewaysServerBuilder) Build() (result *PrivateNATGatewaysSer
 		SetAttributionLogic(b.attributionLogic).
 		SetTenancyLogic(b.tenancyLogic).
 		SetMetricsRegisterer(b.metricsRegisterer).
+		SetFilterDesc(b.filterDesc).
 		Build()
 	if err != nil {
 		return

--- a/internal/servers/private_network_classes_server.go
+++ b/internal/servers/private_network_classes_server.go
@@ -24,6 +24,7 @@ import (
 	grpccodes "google.golang.org/grpc/codes"
 	grpcstatus "google.golang.org/grpc/status"
 	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/reflect/protoreflect"
 	"google.golang.org/protobuf/types/known/fieldmaskpb"
 
 	privatev1 "github.com/osac-project/fulfillment-service/internal/api/osac/private/v1"
@@ -72,6 +73,7 @@ type PrivateNetworkClassesServerBuilder struct {
 	attributionLogic  auth.AttributionLogic
 	tenancyLogic      auth.TenancyLogic
 	metricsRegisterer prometheus.Registerer
+	filterDesc        protoreflect.MessageDescriptor
 }
 
 var _ privatev1.NetworkClassesServer = (*PrivateNetworkClassesServer)(nil)
@@ -114,6 +116,14 @@ func (b *PrivateNetworkClassesServerBuilder) SetMetricsRegisterer(value promethe
 	return b
 }
 
+// SetFilterDesc sets the protobuf message descriptor used to validate and translate CEL filter expressions. This is
+// optional. When unset, the private object type is used. Public servers that wrap this private server should pass the
+// corresponding public object descriptor so that clients cannot filter on private-only fields.
+func (b *PrivateNetworkClassesServerBuilder) SetFilterDesc(value protoreflect.MessageDescriptor) *PrivateNetworkClassesServerBuilder {
+	b.filterDesc = value
+	return b
+}
+
 func (b *PrivateNetworkClassesServerBuilder) Build() (result *PrivateNetworkClassesServer, err error) {
 	// Check parameters:
 	if b.logger == nil {
@@ -133,6 +143,7 @@ func (b *PrivateNetworkClassesServerBuilder) Build() (result *PrivateNetworkClas
 		SetAttributionLogic(b.attributionLogic).
 		SetTenancyLogic(b.tenancyLogic).
 		SetMetricsRegisterer(b.metricsRegisterer).
+		SetFilterDesc(b.filterDesc).
 		Build()
 	if err != nil {
 		return

--- a/internal/servers/private_project_memberships_server.go
+++ b/internal/servers/private_project_memberships_server.go
@@ -19,6 +19,7 @@ import (
 	"log/slog"
 
 	"github.com/prometheus/client_golang/prometheus"
+	"google.golang.org/protobuf/reflect/protoreflect"
 
 	privatev1 "github.com/osac-project/fulfillment-service/internal/api/osac/private/v1"
 	"github.com/osac-project/fulfillment-service/internal/auth"
@@ -32,6 +33,7 @@ type PrivateProjectMembershipsServerBuilder struct {
 	attributionLogic  auth.AttributionLogic
 	tenancyLogic      auth.TenancyLogic
 	metricsRegisterer prometheus.Registerer
+	filterDesc        protoreflect.MessageDescriptor
 }
 
 var _ privatev1.ProjectMembershipsServer = (*PrivateProjectMembershipsServer)(nil)
@@ -80,6 +82,14 @@ func (b *PrivateProjectMembershipsServerBuilder) SetMetricsRegisterer(value prom
 	return b
 }
 
+// SetFilterDesc sets the protobuf message descriptor used to validate and translate CEL filter expressions. This is
+// optional. When unset, the private object type is used. Public servers that wrap this private server should pass the
+// corresponding public object descriptor so that clients cannot filter on private-only fields.
+func (b *PrivateProjectMembershipsServerBuilder) SetFilterDesc(value protoreflect.MessageDescriptor) *PrivateProjectMembershipsServerBuilder {
+	b.filterDesc = value
+	return b
+}
+
 // Build creates the private project memberships server from the builder configuration.
 func (b *PrivateProjectMembershipsServerBuilder) Build() (result *PrivateProjectMembershipsServer, err error) {
 	if b.logger == nil {
@@ -98,6 +108,7 @@ func (b *PrivateProjectMembershipsServerBuilder) Build() (result *PrivateProject
 		SetAttributionLogic(b.attributionLogic).
 		SetTenancyLogic(b.tenancyLogic).
 		SetMetricsRegisterer(b.metricsRegisterer).
+		SetFilterDesc(b.filterDesc).
 		Build()
 	if err != nil {
 		return

--- a/internal/servers/private_projects_server.go
+++ b/internal/servers/private_projects_server.go
@@ -22,6 +22,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	grpccodes "google.golang.org/grpc/codes"
 	grpcstatus "google.golang.org/grpc/status"
+	"google.golang.org/protobuf/reflect/protoreflect"
 
 	privatev1 "github.com/osac-project/fulfillment-service/internal/api/osac/private/v1"
 	"github.com/osac-project/fulfillment-service/internal/auth"
@@ -35,6 +36,7 @@ type PrivateProjectsServerBuilder struct {
 	attributionLogic  auth.AttributionLogic
 	tenancyLogic      auth.TenancyLogic
 	metricsRegisterer prometheus.Registerer
+	filterDesc        protoreflect.MessageDescriptor
 }
 
 var _ privatev1.ProjectsServer = (*PrivateProjectsServer)(nil)
@@ -82,6 +84,14 @@ func (b *PrivateProjectsServerBuilder) SetMetricsRegisterer(value prometheus.Reg
 	return b
 }
 
+// SetFilterDesc sets the protobuf message descriptor used to validate and translate CEL filter expressions. This is
+// optional. When unset, the private object type is used. Public servers that wrap this private server should pass the
+// corresponding public object descriptor so that clients cannot filter on private-only fields.
+func (b *PrivateProjectsServerBuilder) SetFilterDesc(value protoreflect.MessageDescriptor) *PrivateProjectsServerBuilder {
+	b.filterDesc = value
+	return b
+}
+
 // Build creates the private projects server.
 func (b *PrivateProjectsServerBuilder) Build() (result *PrivateProjectsServer, err error) {
 	// Check parameters:
@@ -107,6 +117,7 @@ func (b *PrivateProjectsServerBuilder) Build() (result *PrivateProjectsServer, e
 		SetAttributionLogic(b.attributionLogic).
 		SetTenancyLogic(b.tenancyLogic).
 		SetMetricsRegisterer(b.metricsRegisterer).
+		SetFilterDesc(b.filterDesc).
 		Build()
 	if err != nil {
 		return

--- a/internal/servers/private_public_ip_attachments_server.go
+++ b/internal/servers/private_public_ip_attachments_server.go
@@ -22,6 +22,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	grpccodes "google.golang.org/grpc/codes"
 	grpcstatus "google.golang.org/grpc/status"
+	"google.golang.org/protobuf/reflect/protoreflect"
 
 	privatev1 "github.com/osac-project/fulfillment-service/internal/api/osac/private/v1"
 	"github.com/osac-project/fulfillment-service/internal/auth"
@@ -35,6 +36,7 @@ type PrivatePublicIPAttachmentsServerBuilder struct {
 	attributionLogic  auth.AttributionLogic
 	tenancyLogic      auth.TenancyLogic
 	metricsRegisterer prometheus.Registerer
+	filterDesc        protoreflect.MessageDescriptor
 }
 
 var _ privatev1.PublicIPAttachmentsServer = (*PrivatePublicIPAttachmentsServer)(nil)
@@ -75,6 +77,14 @@ func (b *PrivatePublicIPAttachmentsServerBuilder) SetTenancyLogic(value auth.Ten
 
 func (b *PrivatePublicIPAttachmentsServerBuilder) SetMetricsRegisterer(value prometheus.Registerer) *PrivatePublicIPAttachmentsServerBuilder {
 	b.metricsRegisterer = value
+	return b
+}
+
+// SetFilterDesc sets the protobuf message descriptor used to validate and translate CEL filter expressions. This is
+// optional. When unset, the private object type is used. Public servers that wrap this private server should pass the
+// corresponding public object descriptor so that clients cannot filter on private-only fields.
+func (b *PrivatePublicIPAttachmentsServerBuilder) SetFilterDesc(value protoreflect.MessageDescriptor) *PrivatePublicIPAttachmentsServerBuilder {
+	b.filterDesc = value
 	return b
 }
 
@@ -120,6 +130,7 @@ func (b *PrivatePublicIPAttachmentsServerBuilder) Build() (*PrivatePublicIPAttac
 		SetAttributionLogic(b.attributionLogic).
 		SetTenancyLogic(b.tenancyLogic).
 		SetMetricsRegisterer(b.metricsRegisterer).
+		SetFilterDesc(b.filterDesc).
 		Build()
 	if err != nil {
 		return nil, err

--- a/internal/servers/private_public_ip_pools_server.go
+++ b/internal/servers/private_public_ip_pools_server.go
@@ -24,6 +24,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	grpccodes "google.golang.org/grpc/codes"
 	grpcstatus "google.golang.org/grpc/status"
+	"google.golang.org/protobuf/reflect/protoreflect"
 
 	privatev1 "github.com/osac-project/fulfillment-service/internal/api/osac/private/v1"
 	"github.com/osac-project/fulfillment-service/internal/auth"
@@ -37,6 +38,7 @@ type PrivatePublicIPPoolsServerBuilder struct {
 	attributionLogic  auth.AttributionLogic
 	tenancyLogic      auth.TenancyLogic
 	metricsRegisterer prometheus.Registerer
+	filterDesc        protoreflect.MessageDescriptor
 }
 
 var _ privatev1.PublicIPPoolsServer = (*PrivatePublicIPPoolsServer)(nil)
@@ -86,6 +88,14 @@ func (b *PrivatePublicIPPoolsServerBuilder) SetMetricsRegisterer(value prometheu
 	return b
 }
 
+// SetFilterDesc sets the protobuf message descriptor used to validate and translate CEL filter expressions. This is
+// optional. When unset, the private object type is used. Public servers that wrap this private server should pass the
+// corresponding public object descriptor so that clients cannot filter on private-only fields.
+func (b *PrivatePublicIPPoolsServerBuilder) SetFilterDesc(value protoreflect.MessageDescriptor) *PrivatePublicIPPoolsServerBuilder {
+	b.filterDesc = value
+	return b
+}
+
 // Build uses the data stored in the builder to create a new private public IP pools server.
 func (b *PrivatePublicIPPoolsServerBuilder) Build() (result *PrivatePublicIPPoolsServer, err error) {
 	if b.logger == nil {
@@ -104,6 +114,7 @@ func (b *PrivatePublicIPPoolsServerBuilder) Build() (result *PrivatePublicIPPool
 		SetAttributionLogic(b.attributionLogic).
 		SetTenancyLogic(b.tenancyLogic).
 		SetMetricsRegisterer(b.metricsRegisterer).
+		SetFilterDesc(b.filterDesc).
 		Build()
 	if err != nil {
 		return

--- a/internal/servers/private_public_ips_server.go
+++ b/internal/servers/private_public_ips_server.go
@@ -23,6 +23,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	grpccodes "google.golang.org/grpc/codes"
 	grpcstatus "google.golang.org/grpc/status"
+	"google.golang.org/protobuf/reflect/protoreflect"
 
 	privatev1 "github.com/osac-project/fulfillment-service/internal/api/osac/private/v1"
 	"github.com/osac-project/fulfillment-service/internal/auth"
@@ -45,6 +46,7 @@ type PrivatePublicIPsServerBuilder struct {
 	attributionLogic  auth.AttributionLogic
 	tenancyLogic      auth.TenancyLogic
 	metricsRegisterer prometheus.Registerer
+	filterDesc        protoreflect.MessageDescriptor
 }
 
 var _ privatev1.PublicIPsServer = (*PrivatePublicIPsServer)(nil)
@@ -96,6 +98,14 @@ func (b *PrivatePublicIPsServerBuilder) SetMetricsRegisterer(value prometheus.Re
 	return b
 }
 
+// SetFilterDesc sets the protobuf message descriptor used to validate and translate CEL filter expressions. This is
+// optional. When unset, the private object type is used. Public servers that wrap this private server should pass the
+// corresponding public object descriptor so that clients cannot filter on private-only fields.
+func (b *PrivatePublicIPsServerBuilder) SetFilterDesc(value protoreflect.MessageDescriptor) *PrivatePublicIPsServerBuilder {
+	b.filterDesc = value
+	return b
+}
+
 // Build uses the configuration stored in the builder to create a new PrivatePublicIPsServer.
 func (b *PrivatePublicIPsServerBuilder) Build() (result *PrivatePublicIPsServer, err error) {
 	// Check parameters:
@@ -130,6 +140,7 @@ func (b *PrivatePublicIPsServerBuilder) Build() (result *PrivatePublicIPsServer,
 		SetAttributionLogic(b.attributionLogic).
 		SetTenancyLogic(b.tenancyLogic).
 		SetMetricsRegisterer(b.metricsRegisterer).
+		SetFilterDesc(b.filterDesc).
 		Build()
 	if err != nil {
 		return

--- a/internal/servers/private_role_bindings_server.go
+++ b/internal/servers/private_role_bindings_server.go
@@ -19,6 +19,7 @@ import (
 	"log/slog"
 
 	"github.com/prometheus/client_golang/prometheus"
+	"google.golang.org/protobuf/reflect/protoreflect"
 
 	privatev1 "github.com/osac-project/fulfillment-service/internal/api/osac/private/v1"
 	"github.com/osac-project/fulfillment-service/internal/auth"
@@ -32,6 +33,7 @@ type PrivateRoleBindingsServerBuilder struct {
 	attributionLogic  auth.AttributionLogic
 	tenancyLogic      auth.TenancyLogic
 	metricsRegisterer prometheus.Registerer
+	filterDesc        protoreflect.MessageDescriptor
 }
 
 var _ privatev1.RoleBindingsServer = (*PrivateRoleBindingsServer)(nil)
@@ -80,6 +82,14 @@ func (b *PrivateRoleBindingsServerBuilder) SetMetricsRegisterer(value prometheus
 	return b
 }
 
+// SetFilterDesc sets the protobuf message descriptor used to validate and translate CEL filter expressions. This is
+// optional. When unset, the private object type is used. Public servers that wrap this private server should pass the
+// corresponding public object descriptor so that clients cannot filter on private-only fields.
+func (b *PrivateRoleBindingsServerBuilder) SetFilterDesc(value protoreflect.MessageDescriptor) *PrivateRoleBindingsServerBuilder {
+	b.filterDesc = value
+	return b
+}
+
 // Build creates the private role bindings server from the builder configuration.
 func (b *PrivateRoleBindingsServerBuilder) Build() (result *PrivateRoleBindingsServer, err error) {
 	if b.logger == nil {
@@ -98,6 +108,7 @@ func (b *PrivateRoleBindingsServerBuilder) Build() (result *PrivateRoleBindingsS
 		SetAttributionLogic(b.attributionLogic).
 		SetTenancyLogic(b.tenancyLogic).
 		SetMetricsRegisterer(b.metricsRegisterer).
+		SetFilterDesc(b.filterDesc).
 		Build()
 	if err != nil {
 		return

--- a/internal/servers/private_roles_server.go
+++ b/internal/servers/private_roles_server.go
@@ -19,6 +19,7 @@ import (
 	"log/slog"
 
 	"github.com/prometheus/client_golang/prometheus"
+	"google.golang.org/protobuf/reflect/protoreflect"
 
 	privatev1 "github.com/osac-project/fulfillment-service/internal/api/osac/private/v1"
 	"github.com/osac-project/fulfillment-service/internal/auth"
@@ -32,6 +33,7 @@ type PrivateRolesServerBuilder struct {
 	attributionLogic  auth.AttributionLogic
 	tenancyLogic      auth.TenancyLogic
 	metricsRegisterer prometheus.Registerer
+	filterDesc        protoreflect.MessageDescriptor
 }
 
 var _ privatev1.RolesServer = (*PrivateRolesServer)(nil)
@@ -80,6 +82,14 @@ func (b *PrivateRolesServerBuilder) SetMetricsRegisterer(value prometheus.Regist
 	return b
 }
 
+// SetFilterDesc sets the protobuf message descriptor used to validate and translate CEL filter expressions. This is
+// optional. When unset, the private object type is used. Public servers that wrap this private server should pass the
+// corresponding public object descriptor so that clients cannot filter on private-only fields.
+func (b *PrivateRolesServerBuilder) SetFilterDesc(value protoreflect.MessageDescriptor) *PrivateRolesServerBuilder {
+	b.filterDesc = value
+	return b
+}
+
 // Build creates the private roles server from the builder configuration.
 func (b *PrivateRolesServerBuilder) Build() (result *PrivateRolesServer, err error) {
 	if b.logger == nil {
@@ -98,6 +108,7 @@ func (b *PrivateRolesServerBuilder) Build() (result *PrivateRolesServer, err err
 		SetAttributionLogic(b.attributionLogic).
 		SetTenancyLogic(b.tenancyLogic).
 		SetMetricsRegisterer(b.metricsRegisterer).
+		SetFilterDesc(b.filterDesc).
 		Build()
 	if err != nil {
 		return

--- a/internal/servers/private_security_groups_server.go
+++ b/internal/servers/private_security_groups_server.go
@@ -21,6 +21,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	grpccodes "google.golang.org/grpc/codes"
 	grpcstatus "google.golang.org/grpc/status"
+	"google.golang.org/protobuf/reflect/protoreflect"
 
 	privatev1 "github.com/osac-project/fulfillment-service/internal/api/osac/private/v1"
 	"github.com/osac-project/fulfillment-service/internal/auth"
@@ -36,6 +37,7 @@ type PrivateSecurityGroupsServerBuilder struct {
 	attributionLogic  auth.AttributionLogic
 	tenancyLogic      auth.TenancyLogic
 	metricsRegisterer prometheus.Registerer
+	filterDesc        protoreflect.MessageDescriptor
 }
 
 var _ privatev1.SecurityGroupsServer = (*PrivateSecurityGroupsServer)(nil)
@@ -79,6 +81,14 @@ func (b *PrivateSecurityGroupsServerBuilder) SetMetricsRegisterer(value promethe
 	return b
 }
 
+// SetFilterDesc sets the protobuf message descriptor used to validate and translate CEL filter expressions. This is
+// optional. When unset, the private object type is used. Public servers that wrap this private server should pass the
+// corresponding public object descriptor so that clients cannot filter on private-only fields.
+func (b *PrivateSecurityGroupsServerBuilder) SetFilterDesc(value protoreflect.MessageDescriptor) *PrivateSecurityGroupsServerBuilder {
+	b.filterDesc = value
+	return b
+}
+
 func (b *PrivateSecurityGroupsServerBuilder) Build() (result *PrivateSecurityGroupsServer, err error) {
 	// Check parameters:
 	if b.logger == nil {
@@ -112,6 +122,7 @@ func (b *PrivateSecurityGroupsServerBuilder) Build() (result *PrivateSecurityGro
 		SetAttributionLogic(b.attributionLogic).
 		SetTenancyLogic(b.tenancyLogic).
 		SetMetricsRegisterer(b.metricsRegisterer).
+		SetFilterDesc(b.filterDesc).
 		Build()
 	if err != nil {
 		return

--- a/internal/servers/private_storage_backends_server.go
+++ b/internal/servers/private_storage_backends_server.go
@@ -21,6 +21,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	grpccodes "google.golang.org/grpc/codes"
 	grpcstatus "google.golang.org/grpc/status"
+	"google.golang.org/protobuf/reflect/protoreflect"
 
 	privatev1 "github.com/osac-project/fulfillment-service/internal/api/osac/private/v1"
 	"github.com/osac-project/fulfillment-service/internal/auth"
@@ -33,6 +34,7 @@ type PrivateStorageBackendsServerBuilder struct {
 	attributionLogic  auth.AttributionLogic
 	tenancyLogic      auth.TenancyLogic
 	metricsRegisterer prometheus.Registerer
+	filterDesc        protoreflect.MessageDescriptor
 }
 
 var _ privatev1.StorageBackendsServer = (*PrivateStorageBackendsServer)(nil)
@@ -73,6 +75,14 @@ func (b *PrivateStorageBackendsServerBuilder) SetMetricsRegisterer(value prometh
 	return b
 }
 
+// SetFilterDesc sets the protobuf message descriptor used to validate and translate CEL filter expressions. This is
+// optional. When unset, the private object type is used. Public servers that wrap this private server should pass the
+// corresponding public object descriptor so that clients cannot filter on private-only fields.
+func (b *PrivateStorageBackendsServerBuilder) SetFilterDesc(value protoreflect.MessageDescriptor) *PrivateStorageBackendsServerBuilder {
+	b.filterDesc = value
+	return b
+}
+
 func (b *PrivateStorageBackendsServerBuilder) Build() (result *PrivateStorageBackendsServer, err error) {
 	// Check parameters:
 	if b.logger == nil {
@@ -98,6 +108,7 @@ func (b *PrivateStorageBackendsServerBuilder) Build() (result *PrivateStorageBac
 		SetAttributionLogic(b.attributionLogic).
 		SetTenancyLogic(b.tenancyLogic).
 		SetMetricsRegisterer(b.metricsRegisterer).
+		SetFilterDesc(b.filterDesc).
 		Build()
 	if err != nil {
 		return

--- a/internal/servers/private_storage_tiers_server.go
+++ b/internal/servers/private_storage_tiers_server.go
@@ -21,6 +21,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	grpccodes "google.golang.org/grpc/codes"
 	grpcstatus "google.golang.org/grpc/status"
+	"google.golang.org/protobuf/reflect/protoreflect"
 	"google.golang.org/protobuf/types/known/fieldmaskpb"
 
 	privatev1 "github.com/osac-project/fulfillment-service/internal/api/osac/private/v1"
@@ -36,6 +37,7 @@ type PrivateStorageTiersServerBuilder struct {
 	tenancyLogic       auth.TenancyLogic
 	metricsRegisterer  prometheus.Registerer
 	storageBackendsDAO *dao.GenericDAO[*privatev1.StorageBackend]
+	filterDesc         protoreflect.MessageDescriptor
 }
 
 var _ privatev1.StorageTiersServer = (*PrivateStorageTiersServer)(nil)
@@ -82,6 +84,14 @@ func (b *PrivateStorageTiersServerBuilder) SetStorageBackendsDAO(value *dao.Gene
 	return b
 }
 
+// SetFilterDesc sets the protobuf message descriptor used to validate and translate CEL filter expressions. This is
+// optional. When unset, the private object type is used. Public servers that wrap this private server should pass the
+// corresponding public object descriptor so that clients cannot filter on private-only fields.
+func (b *PrivateStorageTiersServerBuilder) SetFilterDesc(value protoreflect.MessageDescriptor) *PrivateStorageTiersServerBuilder {
+	b.filterDesc = value
+	return b
+}
+
 func (b *PrivateStorageTiersServerBuilder) Build() (result *PrivateStorageTiersServer, err error) {
 	if b.logger == nil {
 		err = errors.New("logger is mandatory")
@@ -103,6 +113,7 @@ func (b *PrivateStorageTiersServerBuilder) Build() (result *PrivateStorageTiersS
 		SetAttributionLogic(b.attributionLogic).
 		SetTenancyLogic(b.tenancyLogic).
 		SetMetricsRegisterer(b.metricsRegisterer).
+		SetFilterDesc(b.filterDesc).
 		Build()
 	if err != nil {
 		return

--- a/internal/servers/private_subnets_server.go
+++ b/internal/servers/private_subnets_server.go
@@ -23,6 +23,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	grpccodes "google.golang.org/grpc/codes"
 	grpcstatus "google.golang.org/grpc/status"
+	"google.golang.org/protobuf/reflect/protoreflect"
 
 	privatev1 "github.com/osac-project/fulfillment-service/internal/api/osac/private/v1"
 	"github.com/osac-project/fulfillment-service/internal/auth"
@@ -36,6 +37,7 @@ type PrivateSubnetsServerBuilder struct {
 	attributionLogic  auth.AttributionLogic
 	tenancyLogic      auth.TenancyLogic
 	metricsRegisterer prometheus.Registerer
+	filterDesc        protoreflect.MessageDescriptor
 }
 
 var _ privatev1.SubnetsServer = (*PrivateSubnetsServer)(nil)
@@ -79,6 +81,14 @@ func (b *PrivateSubnetsServerBuilder) SetMetricsRegisterer(value prometheus.Regi
 	return b
 }
 
+// SetFilterDesc sets the protobuf message descriptor used to validate and translate CEL filter expressions. This is
+// optional. When unset, the private object type is used. Public servers that wrap this private server should pass the
+// corresponding public object descriptor so that clients cannot filter on private-only fields.
+func (b *PrivateSubnetsServerBuilder) SetFilterDesc(value protoreflect.MessageDescriptor) *PrivateSubnetsServerBuilder {
+	b.filterDesc = value
+	return b
+}
+
 func (b *PrivateSubnetsServerBuilder) Build() (result *PrivateSubnetsServer, err error) {
 	// Check parameters:
 	if b.logger == nil {
@@ -108,6 +118,7 @@ func (b *PrivateSubnetsServerBuilder) Build() (result *PrivateSubnetsServer, err
 		SetAttributionLogic(b.attributionLogic).
 		SetTenancyLogic(b.tenancyLogic).
 		SetMetricsRegisterer(b.metricsRegisterer).
+		SetFilterDesc(b.filterDesc).
 		Build()
 	if err != nil {
 		return

--- a/internal/servers/private_tenants_server.go
+++ b/internal/servers/private_tenants_server.go
@@ -21,6 +21,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	grpccodes "google.golang.org/grpc/codes"
 	grpcstatus "google.golang.org/grpc/status"
+	"google.golang.org/protobuf/reflect/protoreflect"
 
 	privatev1 "github.com/osac-project/fulfillment-service/internal/api/osac/private/v1"
 	"github.com/osac-project/fulfillment-service/internal/auth"
@@ -34,6 +35,7 @@ type PrivateTenantsServerBuilder struct {
 	attributionLogic  auth.AttributionLogic
 	tenancyLogic      auth.TenancyLogic
 	metricsRegisterer prometheus.Registerer
+	filterDesc        protoreflect.MessageDescriptor
 }
 
 var _ privatev1.TenantsServer = (*PrivateTenantsServer)(nil)
@@ -69,6 +71,14 @@ func (b *PrivateTenantsServerBuilder) SetTenancyLogic(value auth.TenancyLogic) *
 	return b
 }
 
+// SetFilterDesc sets the protobuf message descriptor used to validate and translate CEL filter expressions. This is
+// optional. When unset, the private object type is used. Public servers that wrap this private server should pass the
+// corresponding public object descriptor so that clients cannot filter on private-only fields.
+func (b *PrivateTenantsServerBuilder) SetFilterDesc(value protoreflect.MessageDescriptor) *PrivateTenantsServerBuilder {
+	b.filterDesc = value
+	return b
+}
+
 // SetMetricsRegisterer sets the Prometheus registerer used to register the metrics for the underlying database
 // access objects. This is optional. If not set, no metrics will be recorded.
 func (b *PrivateTenantsServerBuilder) SetMetricsRegisterer(value prometheus.Registerer) *PrivateTenantsServerBuilder {
@@ -96,6 +106,7 @@ func (b *PrivateTenantsServerBuilder) Build() (result *PrivateTenantsServer, err
 		SetAttributionLogic(b.attributionLogic).
 		SetTenancyLogic(b.tenancyLogic).
 		SetMetricsRegisterer(b.metricsRegisterer).
+		SetFilterDesc(b.filterDesc).
 		Build()
 	if err != nil {
 		return

--- a/internal/servers/private_users_server.go
+++ b/internal/servers/private_users_server.go
@@ -19,6 +19,7 @@ import (
 	"log/slog"
 
 	"github.com/prometheus/client_golang/prometheus"
+	"google.golang.org/protobuf/reflect/protoreflect"
 
 	privatev1 "github.com/osac-project/fulfillment-service/internal/api/osac/private/v1"
 	"github.com/osac-project/fulfillment-service/internal/auth"
@@ -31,6 +32,7 @@ type PrivateUsersServerBuilder struct {
 	attributionLogic  auth.AttributionLogic
 	tenancyLogic      auth.TenancyLogic
 	metricsRegisterer prometheus.Registerer
+	filterDesc        protoreflect.MessageDescriptor
 }
 
 var _ privatev1.UsersServer = (*PrivateUsersServer)(nil)
@@ -72,6 +74,14 @@ func (b *PrivateUsersServerBuilder) SetMetricsRegisterer(value prometheus.Regist
 	return b
 }
 
+// SetFilterDesc sets the protobuf message descriptor used to validate and translate CEL filter expressions. This is
+// optional. When unset, the private object type is used. Public servers that wrap this private server should pass the
+// corresponding public object descriptor so that clients cannot filter on private-only fields.
+func (b *PrivateUsersServerBuilder) SetFilterDesc(value protoreflect.MessageDescriptor) *PrivateUsersServerBuilder {
+	b.filterDesc = value
+	return b
+}
+
 func (b *PrivateUsersServerBuilder) Build() (result *PrivateUsersServer, err error) {
 	// Check parameters:
 	if b.logger == nil {
@@ -91,6 +101,7 @@ func (b *PrivateUsersServerBuilder) Build() (result *PrivateUsersServer, err err
 		SetAttributionLogic(b.attributionLogic).
 		SetTenancyLogic(b.tenancyLogic).
 		SetMetricsRegisterer(b.metricsRegisterer).
+		SetFilterDesc(b.filterDesc).
 		Build()
 	if err != nil {
 		return

--- a/internal/servers/private_virtual_networks_server.go
+++ b/internal/servers/private_virtual_networks_server.go
@@ -22,6 +22,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	grpccodes "google.golang.org/grpc/codes"
 	grpcstatus "google.golang.org/grpc/status"
+	"google.golang.org/protobuf/reflect/protoreflect"
 
 	privatev1 "github.com/osac-project/fulfillment-service/internal/api/osac/private/v1"
 	"github.com/osac-project/fulfillment-service/internal/auth"
@@ -35,6 +36,7 @@ type PrivateVirtualNetworksServerBuilder struct {
 	attributionLogic  auth.AttributionLogic
 	tenancyLogic      auth.TenancyLogic
 	metricsRegisterer prometheus.Registerer
+	filterDesc        protoreflect.MessageDescriptor
 }
 
 var _ privatev1.VirtualNetworksServer = (*PrivateVirtualNetworksServer)(nil)
@@ -78,6 +80,14 @@ func (b *PrivateVirtualNetworksServerBuilder) SetMetricsRegisterer(value prometh
 	return b
 }
 
+// SetFilterDesc sets the protobuf message descriptor used to validate and translate CEL filter expressions. This is
+// optional. When unset, the private object type is used. Public servers that wrap this private server should pass the
+// corresponding public object descriptor so that clients cannot filter on private-only fields.
+func (b *PrivateVirtualNetworksServerBuilder) SetFilterDesc(value protoreflect.MessageDescriptor) *PrivateVirtualNetworksServerBuilder {
+	b.filterDesc = value
+	return b
+}
+
 func (b *PrivateVirtualNetworksServerBuilder) Build() (result *PrivateVirtualNetworksServer, err error) {
 	// Check parameters:
 	if b.logger == nil {
@@ -107,6 +117,7 @@ func (b *PrivateVirtualNetworksServerBuilder) Build() (result *PrivateVirtualNet
 		SetAttributionLogic(b.attributionLogic).
 		SetTenancyLogic(b.tenancyLogic).
 		SetMetricsRegisterer(b.metricsRegisterer).
+		SetFilterDesc(b.filterDesc).
 		Build()
 	if err != nil {
 		return

--- a/internal/servers/project_memberships_server.go
+++ b/internal/servers/project_memberships_server.go
@@ -117,6 +117,7 @@ func (b *ProjectMembershipsServerBuilder) Build() (result *ProjectMembershipsSer
 		SetAttributionLogic(b.attributionLogic).
 		SetTenancyLogic(b.tenancyLogic).
 		SetMetricsRegisterer(b.metricsRegisterer).
+		SetFilterDesc((*publicv1.ProjectMembership)(nil).ProtoReflect().Descriptor()).
 		Build()
 	if err != nil {
 		return

--- a/internal/servers/projects_server.go
+++ b/internal/servers/projects_server.go
@@ -120,6 +120,7 @@ func (b *ProjectsServerBuilder) Build() (result *ProjectsServer, err error) {
 		SetAttributionLogic(b.attributionLogic).
 		SetTenancyLogic(b.tenancyLogic).
 		SetMetricsRegisterer(b.metricsRegisterer).
+		SetFilterDesc((*publicv1.Project)(nil).ProtoReflect().Descriptor()).
 		Build()
 	if err != nil {
 		return

--- a/internal/servers/public_ip_attachments_server.go
+++ b/internal/servers/public_ip_attachments_server.go
@@ -117,6 +117,7 @@ func (b *PublicIPAttachmentsServerBuilder) Build() (result *PublicIPAttachmentsS
 		SetAttributionLogic(b.attributionLogic).
 		SetTenancyLogic(b.tenancyLogic).
 		SetMetricsRegisterer(b.metricsRegisterer).
+		SetFilterDesc((*publicv1.PublicIPAttachment)(nil).ProtoReflect().Descriptor()).
 		Build()
 	if err != nil {
 		return

--- a/internal/servers/public_ip_pools_server.go
+++ b/internal/servers/public_ip_pools_server.go
@@ -114,6 +114,7 @@ func (b *PublicIPPoolsServerBuilder) Build() (result *PublicIPPoolsServer, err e
 		SetAttributionLogic(b.attributionLogic).
 		SetTenancyLogic(b.tenancyLogic).
 		SetMetricsRegisterer(b.metricsRegisterer).
+		SetFilterDesc((*publicv1.PublicIPPool)(nil).ProtoReflect().Descriptor()).
 		Build()
 	if err != nil {
 		return

--- a/internal/servers/public_ips_server.go
+++ b/internal/servers/public_ips_server.go
@@ -120,6 +120,7 @@ func (b *PublicIPsServerBuilder) Build() (result *PublicIPsServer, err error) {
 		SetAttributionLogic(b.attributionLogic).
 		SetTenancyLogic(b.tenancyLogic).
 		SetMetricsRegisterer(b.metricsRegisterer).
+		SetFilterDesc((*publicv1.PublicIP)(nil).ProtoReflect().Descriptor()).
 		Build()
 	if err != nil {
 		return

--- a/internal/servers/role_bindings_server.go
+++ b/internal/servers/role_bindings_server.go
@@ -117,6 +117,7 @@ func (b *RoleBindingsServerBuilder) Build() (result *RoleBindingsServer, err err
 		SetAttributionLogic(b.attributionLogic).
 		SetTenancyLogic(b.tenancyLogic).
 		SetMetricsRegisterer(b.metricsRegisterer).
+		SetFilterDesc((*publicv1.RoleBinding)(nil).ProtoReflect().Descriptor()).
 		Build()
 	if err != nil {
 		return

--- a/internal/servers/roles_server.go
+++ b/internal/servers/roles_server.go
@@ -117,6 +117,7 @@ func (b *RolesServerBuilder) Build() (result *RolesServer, err error) {
 		SetAttributionLogic(b.attributionLogic).
 		SetTenancyLogic(b.tenancyLogic).
 		SetMetricsRegisterer(b.metricsRegisterer).
+		SetFilterDesc((*publicv1.Role)(nil).ProtoReflect().Descriptor()).
 		Build()
 	if err != nil {
 		return

--- a/internal/servers/security_groups_server.go
+++ b/internal/servers/security_groups_server.go
@@ -116,6 +116,7 @@ func (b *SecurityGroupsServerBuilder) Build() (result *SecurityGroupsServer, err
 		SetAttributionLogic(b.attributionLogic).
 		SetTenancyLogic(b.tenancyLogic).
 		SetMetricsRegisterer(b.metricsRegisterer).
+		SetFilterDesc((*publicv1.SecurityGroup)(nil).ProtoReflect().Descriptor()).
 		Build()
 	if err != nil {
 		return

--- a/internal/servers/subnets_server.go
+++ b/internal/servers/subnets_server.go
@@ -116,6 +116,7 @@ func (b *SubnetsServerBuilder) Build() (result *SubnetsServer, err error) {
 		SetAttributionLogic(b.attributionLogic).
 		SetTenancyLogic(b.tenancyLogic).
 		SetMetricsRegisterer(b.metricsRegisterer).
+		SetFilterDesc((*publicv1.Subnet)(nil).ProtoReflect().Descriptor()).
 		Build()
 	if err != nil {
 		return

--- a/internal/servers/tenants_server.go
+++ b/internal/servers/tenants_server.go
@@ -110,6 +110,7 @@ func (b *TenantsServerBuilder) Build() (result *TenantsServer, err error) {
 		SetAttributionLogic(b.attributionLogic).
 		SetTenancyLogic(b.tenancyLogic).
 		SetMetricsRegisterer(b.metricsRegisterer).
+		SetFilterDesc((*publicv1.Tenant)(nil).ProtoReflect().Descriptor()).
 		Build()
 	if err != nil {
 		return

--- a/internal/servers/tenants_server_test.go
+++ b/internal/servers/tenants_server_test.go
@@ -102,6 +102,26 @@ var _ = Describe("Public tenants server", func() {
 			Expect(listResponse.Items[0].Metadata.Name).To(Equal("my-tenant"))
 		})
 
+		It("Rejects filters that reference private-only fields", func() {
+			// The 'status.state' field exists on the private tenant message but not on the public one. The public server
+			// configures the filter translator with the public descriptor so this must fail.
+			_, err := publicServer.List(ctx, publicv1.TenantsListRequest_builder{
+				Filter: new("this.status.state == 1"),
+			}.Build())
+			Expect(err).To(HaveOccurred())
+			status, ok := grpcstatus.FromError(err)
+			Expect(ok).To(BeTrue())
+			Expect(status.Code()).To(Equal(grpccodes.Internal))
+			Expect(status.Message()).To(Equal("failed to list"))
+		})
+
+		It("Allows the private server to filter on private-only fields", func() {
+			_, err := privateServer.List(ctx, privatev1.TenantsListRequest_builder{
+				Filter: new("this.status.state == 1"),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+		})
+
 		It("Gets a tenant by identifier", func() {
 			// Create the tenant using the private server, as that isn't implemented for the public server:
 			createResponse, err := privateServer.Create(ctx, privatev1.TenantsCreateRequest_builder{

--- a/internal/servers/users_server.go
+++ b/internal/servers/users_server.go
@@ -114,6 +114,7 @@ func (b *UsersServerBuilder) Build() (result *UsersServer, err error) {
 		SetAttributionLogic(b.attributionLogic).
 		SetTenancyLogic(b.tenancyLogic).
 		SetMetricsRegisterer(b.metricsRegisterer).
+		SetFilterDesc((*publicv1.User)(nil).ProtoReflect().Descriptor()).
 		Build()
 	if err != nil {
 		return

--- a/internal/servers/virtual_networks_server.go
+++ b/internal/servers/virtual_networks_server.go
@@ -127,6 +127,7 @@ func (b *VirtualNetworksServerBuilder) Build() (result *VirtualNetworksServer, e
 		SetAttributionLogic(b.attributionLogic).
 		SetTenancyLogic(b.tenancyLogic).
 		SetMetricsRegisterer(b.metricsRegisterer).
+		SetFilterDesc((*publicv1.VirtualNetwork)(nil).ProtoReflect().Descriptor()).
 		Build()
 	if err != nil {
 		return


### PR DESCRIPTION
## Summary

- Make the CEL filter translator take an explicit protobuf message descriptor instead of inferring it from the private storage type.
- Have public servers pass the public object descriptor through `SetFilterDesc`, so list filters cannot reference private-only fields (for example `status.hub` on clusters).
- Keep private APIs on the private descriptor by default, and add unit tests covering both the translator and public/private server list paths.

Related: https://redhat.atlassian.net/browse/OSAC-2819

## Test plan

- [x] `ginkgo run internal/database/dao --focus="Public versus private descriptors"`
- [x] `ginkgo run internal/servers --focus="Rejects filters that reference private-only fields|Accepts filters that reference public fields|Accepts filters that reference private-only fields|Allows the private server to filter on private-only fields"`
- [x] `ginkgo run -r internal`
- [x] Manually confirm a public `List` with a private-only field in the filter fails, while the same filter succeeds on the private API

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added descriptor-based CEL filter configuration across resource and server builders, aligning filter validation/translation with each service’s exposed protobuf schema.
* **Bug Fixes**
  * Improved filter enforcement so public list endpoints reject filters that reference private-only fields, while private endpoints can still accept private fields when appropriate.
* **Tests**
  * Added behavior coverage for filter field visibility, including new/updated cases for clusters and tenants list filtering acceptance/rejection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->