### PR TITLE
OSAC-2835: Validate mandatory spec fields on catalog-item ComputeInstance creation

### DIFF
--- a/internal/servers/private_compute_instances_server.go
+++ b/internal/servers/private_compute_instances_server.go
@@ -221,21 +221,25 @@ func (s *PrivateComputeInstancesServer) Create(ctx context.Context,
 			"catalog_item and template are mutually exclusive")
 		return
 	}
+	var template *privatev1.ComputeInstanceTemplate
 	if catalogItemRef != "" {
 		err = s.validateAndTransformCatalogItem(ctx, request.GetObject())
 		if err != nil {
 			return
 		}
+		template, err = s.fetchTemplate(ctx, spec.GetTemplate())
 	} else {
-		template, templateErr := s.fetchAndValidateTemplate(ctx, request.GetObject())
-		if templateErr != nil {
-			err = templateErr
-			return
-		}
-		err = s.applySpecDefaults(request.GetObject().GetSpec(), template)
-		if err != nil {
-			return
-		}
+		template, err = s.fetchAndValidateTemplate(ctx, request.GetObject())
+	}
+	if err != nil {
+		return
+	}
+
+	// Apply the template's spec defaults and validate required fields, regardless
+	// of whether the template was referenced directly or resolved via a catalog item.
+	err = s.applySpecDefaults(spec, template)
+	if err != nil {
+		return
 	}
 
 	// Validate instance type existence and state (D-02: validate-only, no resolution).
@@ -784,7 +788,15 @@ func (s *PrivateComputeInstancesServer) validateNetworkReferencesState(
 	return nil
 }
 
-func (s *PrivateComputeInstancesServer) validateAndTransformCatalogItem(ctx context.Context, ci *privatev1.ComputeInstance) error {
+// validateAndTransformCatalogItem validates a catalog item reference, ensures it references
+// a template, and applies its field definitions to the compute instance spec. Every catalog
+// item must reference a template — it's the only source of the spec defaults (image,
+// boot_disk, run_strategy, instance_type) that provisioning requires; a catalog item without
+// one can never produce a valid compute instance. Callers fetch the template separately once
+// this succeeds, using the template reference now set on the spec.
+func (s *PrivateComputeInstancesServer) validateAndTransformCatalogItem(
+	ctx context.Context, ci *privatev1.ComputeInstance,
+) error {
 	if ci == nil {
 		return grpcstatus.Errorf(grpccodes.InvalidArgument, "object is mandatory")
 	}
@@ -803,15 +815,13 @@ func (s *PrivateComputeInstancesServer) validateAndTransformCatalogItem(ctx cont
 	}
 
 	templateRef := catalogItem.GetTemplate()
-	if templateRef != "" {
-		ci.GetSpec().SetTemplate(templateRef)
+	if templateRef == "" {
+		return grpcstatus.Errorf(grpccodes.InvalidArgument,
+			"catalog item '%s' does not reference a template", catalogItemRef)
 	}
+	ci.GetSpec().SetTemplate(templateRef)
 
-	if err := applyFieldDefinitions(ci.GetSpec(), catalogItem.GetFieldDefinitions()); err != nil {
-		return err
-	}
-
-	return nil
+	return applyFieldDefinitions(ci.GetSpec(), catalogItem.GetFieldDefinitions())
 }
 
 func (s *PrivateComputeInstancesServer) lookupCatalogItem(ctx context.Context,

--- a/internal/servers/private_compute_instances_server_test.go
+++ b/internal/servers/private_compute_instances_server_test.go
@@ -1009,6 +1009,12 @@ var _ = Describe("Private compute instances server", func() {
 					SetTenancyLogic(tenancy).
 					Build()
 				Expect(err).ToNot(HaveOccurred())
+
+				// Backing template for the catalog items created below, with full
+				// spec_defaults so catalog-item creation succeeds for the right
+				// reason (defaults resolved from the template), not because
+				// required-field validation was skipped.
+				createTemplate("ci-template-id")
 			})
 
 			createCICatalogItem := func(id string, published bool, fieldDefs []*privatev1.FieldDefinition) {
@@ -1117,6 +1123,41 @@ var _ = Describe("Private compute instances server", func() {
 				Expect(status.Code()).To(Equal(grpccodes.NotFound))
 				Expect(status.Message()).To(Equal(
 					"catalog item 'ci-cat-unpub' is not published",
+				))
+			})
+
+			It("Fails when catalog item does not reference a template", func() {
+				_, err := catalogItemsDao.Create().SetObject(
+					privatev1.ComputeInstanceCatalogItem_builder{
+						Id: "ci-cat-no-template",
+						Metadata: privatev1.Metadata_builder{
+							Name:   "ci-cat-no-template-name",
+							Tenant: "shared",
+						}.Build(),
+						Title:     "Catalog Item without template",
+						Published: true,
+					}.Build(),
+				).Do(ctx)
+				Expect(err).ToNot(HaveOccurred())
+
+				_, err = server.Create(ctx, privatev1.ComputeInstancesCreateRequest_builder{
+					Object: privatev1.ComputeInstance_builder{
+						Spec: privatev1.ComputeInstanceSpec_builder{
+							CatalogItem: "ci-cat-no-template",
+							NetworkAttachments: []*privatev1.NetworkAttachment{
+								privatev1.NetworkAttachment_builder{
+									Subnet: "test-subnet",
+								}.Build(),
+							},
+						}.Build(),
+					}.Build(),
+				}.Build())
+				Expect(err).To(HaveOccurred())
+				status, ok := grpcstatus.FromError(err)
+				Expect(ok).To(BeTrue())
+				Expect(status.Code()).To(Equal(grpccodes.InvalidArgument))
+				Expect(status.Message()).To(Equal(
+					"catalog item 'ci-cat-no-template' does not reference a template",
 				))
 			})
 
@@ -1282,6 +1323,60 @@ var _ = Describe("Private compute instances server", func() {
 				Expect(status.Message()).To(Equal(
 					"cannot change spec.catalog_item from 'ci-cat-immut' to 'different-catalog-item': catalog item is immutable",
 				))
+			})
+
+			It("Rejects creation via catalog item when template has no spec defaults", func() {
+				templatesDao, err := dao.NewGenericDAO[*privatev1.ComputeInstanceTemplate]().
+					SetLogger(logger).
+					SetTenancyLogic(tenancy).
+					Build()
+				Expect(err).ToNot(HaveOccurred())
+
+				_, err = templatesDao.Create().SetObject(
+					privatev1.ComputeInstanceTemplate_builder{
+						Id:    "ci-template-no-defaults",
+						Title: "Template without spec defaults",
+						Metadata: privatev1.Metadata_builder{
+							Tenant: auth.SharedTenant,
+						}.Build(),
+					}.Build(),
+				).Do(ctx)
+				Expect(err).ToNot(HaveOccurred())
+
+				_, err = catalogItemsDao.Create().SetObject(
+					privatev1.ComputeInstanceCatalogItem_builder{
+						Id: "ci-cat-no-defaults",
+						Metadata: privatev1.Metadata_builder{
+							Name:   "ci-cat-no-defaults-name",
+							Tenant: "shared",
+						}.Build(),
+						Title:     "Catalog Item without defaults",
+						Published: true,
+						Template:  "ci-template-no-defaults",
+					}.Build(),
+				).Do(ctx)
+				Expect(err).ToNot(HaveOccurred())
+
+				_, err = server.Create(ctx, privatev1.ComputeInstancesCreateRequest_builder{
+					Object: privatev1.ComputeInstance_builder{
+						Spec: privatev1.ComputeInstanceSpec_builder{
+							CatalogItem: "ci-cat-no-defaults",
+							NetworkAttachments: []*privatev1.NetworkAttachment{
+								privatev1.NetworkAttachment_builder{
+									Subnet: "test-subnet",
+								}.Build(),
+							},
+						}.Build(),
+					}.Build(),
+				}.Build())
+				Expect(err).To(HaveOccurred())
+				status, ok := grpcstatus.FromError(err)
+				Expect(ok).To(BeTrue())
+				Expect(status.Code()).To(Equal(grpccodes.InvalidArgument))
+				Expect(status.Message()).To(ContainSubstring("instance_type"))
+				Expect(status.Message()).To(ContainSubstring("image"))
+				Expect(status.Message()).To(ContainSubstring("boot_disk"))
+				Expect(status.Message()).To(ContainSubstring("run_strategy"))
 			})
 
 			It("Validates instance_type from template spec_defaults via catalog item", func() {


### PR DESCRIPTION
## Summary

- The catalog-item `Create()` path never merged the referenced template's `spec_defaults` or ran `ValidateRequiredSpecFields`, unlike the template-direct path — so a `ComputeInstance` created via a catalog item could end up with no `instance_type` (or `image`/`boot_disk`/`run_strategy`), and that would only fail much later, either deep in the `ocp_virt_vm` Ansible role or asynchronously in fulfillment-service's own reconciler.
- `Create()` now resolves and applies the template's spec defaults uniformly for both the catalog-item and template-direct paths, rejecting the request synchronously with `InvalidArgument` if any mandatory field is still missing.
- Catalog items are now required to reference a template (enforced in `validateAndTransformCatalogItem`), since that template is the only source of these defaults — a catalog item without one could never produce a valid compute instance.

## Jira

[OSAC-2835](https://redhat.atlassian.net/browse/OSAC-2835)

## Test plan

- [x] Added `"Fails when catalog item does not reference a template"` covering the new mandatory-template check
- [x] Added `"Rejects creation via catalog item when template has no spec defaults"` covering the reported bug
- [x] Fixed existing catalog-item tests that were passing only because their referenced template didn't actually exist in the test DB
- [x] `gofmt -s -w .`, `buf generate`, `go build ./...` clean
- [x] `ginkgo run -r internal` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Compute instances created from catalog items now consistently inherit defaults from their referenced templates.
  * Catalog items without a template reference now return a clear validation error.
  * Creation correctly reports missing required fields when the referenced template lacks default values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->