### PR TITLE
NO-ISSUE: Verify release assets after goreleaser publish

### DIFF
--- a/.github/workflows/publish-binaries.yaml
+++ b/.github/workflows/publish-binaries.yaml
@@ -37,3 +37,24 @@ jobs:
         args: release --clean
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    # goreleaser has been observed silently shipping a broken release when the
+    # GitHub API errors mid-publish: it can't find the release it's supposed to
+    # update, creates a second orphaned "untagged-*" release with the real
+    # assets attached, then fails to rename it onto the real tag -- leaving the
+    # tag's actual release empty. Every consumer that resolves "latest" (e.g.
+    # osac-test-infra's e2e image build) then 404s on the binary download.
+    # Fail loudly here instead of finding out from a downstream repo days later.
+    - name: Verify release assets were published
+      run: |
+        tag="${GITHUB_REF_NAME}"
+        count=$(gh release view "${tag}" --json assets --jq '.assets | length')
+        echo "Release ${tag} has ${count} asset(s)."
+        # 2 builds (osac, fulfillment-service) x 3 os x 2 arch + 1 checksums file = 13
+        # today; use a conservative floor so small build-matrix changes don't
+        # make this flaky.
+        if [ "${count}" -lt 10 ]; then
+          echo "::error::Release ${tag} has only ${count} asset(s) -- goreleaser likely failed to attach binaries (see comment above). Check for a stray 'untagged-*' release holding the real assets."
+          exit 1
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

- goreleaser silently shipped a broken `v0.0.78` release on 2026-07-16: a GitHub API error mid-publish made it create an orphaned `untagged-*` release with the real binaries attached, then fail to rename it onto the `v0.0.78` tag, leaving that tag's actual release with zero assets.
- Every consumer resolving "latest" (e.g. `osac-test-infra`'s e2e image build, which downloads `osac_Linux_x86_64`) started 404ing on the binary download, and nobody noticed until an unrelated CI job broke days later.
- Adds a post-publish check to `publish-binaries.yaml` that fails the workflow loudly if the tagged release doesn't have a sane number of assets, instead of silently shipping a broken release.

## Test plan

- [ ] Next tagged release: confirm the new "Verify release assets were published" step runs and passes with the full asset set
- [ ] Sanity check: manually run `gh release view <tag> --json assets --jq '.assets | length'` against a healthy past release to confirm the threshold (10) is reasonable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added release verification to detect incomplete binary releases.
  * Publishing now fails with a clear error when too few release assets are uploaded, helping prevent empty releases from being distributed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->