### PR TITLE
NO-ISSUE: Add -o yaml|json flag to create command

### DIFF
--- a/internal/cmd/cli/create/create_cmd.go
+++ b/internal/cmd/cli/create/create_cmd.go
@@ -14,6 +14,7 @@ language governing permissions and limitations under the License.
 package create
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -52,8 +53,18 @@ import (
 	"github.com/osac-project/fulfillment-service/internal/terminal"
 )
 
+// Possible output formats:
+const (
+	outputFormatJson = "json"
+	outputFormatYaml = "yaml"
+)
+
 func Cmd() *cobra.Command {
-	runner := &runnerContext{}
+	runner := &runnerContext{
+		marshalOptions: protojson.MarshalOptions{
+			UseProtoNames: true,
+		},
+	}
 	result := &cobra.Command{
 		Use:                   "create [FLAG...] -f FILE",
 		DisableFlagsInUseLine: true,
@@ -86,17 +97,26 @@ func Cmd() *cobra.Command {
 		"",
 		filenameFlagHelp,
 	)
+	flags.StringVarP(
+		&runner.args.format,
+		"output",
+		"o",
+		"",
+		outputFlagHelp,
+	)
 	return result
 }
 
 type runnerContext struct {
 	args struct {
-		file string
+		file   string
+		format string
 	}
-	logger   *slog.Logger
-	console  *terminal.Console
-	settings *config.Settings
-	conn     *grpc.ClientConn
+	logger         *slog.Logger
+	console        *terminal.Console
+	settings       *config.Settings
+	conn           *grpc.ClientConn
+	marshalOptions protojson.MarshalOptions
 }
 
 func (c *runnerContext) run(cmd *cobra.Command, args []string) error {
@@ -136,6 +156,12 @@ func (c *runnerContext) run(cmd *cobra.Command, args []string) error {
 	if c.args.file == "" {
 		return fmt.Errorf("it is mandatory to specify the input file with the '--filename' or '-f' options")
 	}
+	if c.args.format != "" && c.args.format != outputFormatJson && c.args.format != outputFormatYaml {
+		return fmt.Errorf(
+			"unknown output format '%s', should be '%s' or '%s'",
+			c.args.format, outputFormatJson, outputFormatYaml,
+		)
+	}
 
 	// Open the input:
 	var reader io.ReadCloser
@@ -165,6 +191,7 @@ func (c *runnerContext) run(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
+	created := make([]proto.Message, 0, len(objects))
 	tenant := config.TenantFromContext(ctx)
 	for i, object := range objects {
 		objectDesc := object.ProtoReflect().Descriptor()
@@ -179,6 +206,10 @@ func (c *runnerContext) run(cmd *cobra.Command, args []string) error {
 		object, err = objectHelper.Create(ctx, object)
 		if err != nil {
 			return fmt.Errorf("failed to create object at index %d: %w", i, err)
+		}
+		created = append(created, object)
+		if c.args.format != "" {
+			continue
 		}
 		objectSingular := objectHelper.Singular()
 		objectId := objectHelper.GetId(object)
@@ -209,7 +240,67 @@ func (c *runnerContext) run(cmd *cobra.Command, args []string) error {
 		}
 	}
 
+	// When an output format was requested, write the created objects instead of the human-readable messages.
+	switch c.args.format {
+	case outputFormatJson:
+		return c.renderJson(ctx, created)
+	case outputFormatYaml:
+		return c.renderYaml(ctx, created)
+	default:
+		return nil
+	}
+}
+
+func (c *runnerContext) renderJson(ctx context.Context, objects []proto.Message) error {
+	values, err := c.encodeObjects(objects)
+	if err != nil {
+		return err
+	}
+	if len(values) == 1 {
+		c.console.RenderJson(ctx, values[0])
+	} else {
+		c.console.RenderJson(ctx, values)
+	}
 	return nil
+}
+
+func (c *runnerContext) renderYaml(ctx context.Context, objects []proto.Message) error {
+	values, err := c.encodeObjects(objects)
+	if err != nil {
+		return err
+	}
+	if len(values) == 1 {
+		c.console.RenderYaml(ctx, values[0])
+	} else {
+		c.console.RenderYaml(ctx, values)
+	}
+	return nil
+}
+
+func (c *runnerContext) encodeObjects(objects []proto.Message) (result []any, err error) {
+	values := make([]any, len(objects))
+	for i, object := range objects {
+		values[i], err = c.encodeObject(object)
+		if err != nil {
+			return
+		}
+	}
+	result = values
+	return
+}
+
+func (c *runnerContext) encodeObject(object proto.Message) (result any, err error) {
+	wrapper, err := anypb.New(object)
+	if err != nil {
+		return
+	}
+	var data []byte
+	data, err = c.marshalOptions.Marshal(wrapper)
+	if err != nil {
+		return
+	}
+	err = json.Unmarshal(data, &result)
+	return
 }
 
 // decode reads the given input, which may contain multiple YAML or JSON documents, each of them being a single object
@@ -298,10 +389,22 @@ cat my-cluster.yaml | {{ binary }} create -f -
 The input file can contain multiple documents separated by {{ bt }}---{{ bt }}, and each document can be a single object
 or a list of objects. All objects are created in order.
 
+By default the command prints a short confirmation message for each created object. Use the {{ bt }}--output{{ bt }}
+flag to write the created objects as {{ bt }}json{{ bt }} or {{ bt }}yaml{{ bt }} instead:
+
+{{ bt 3 }}shell
+{{ binary }} create -f my-cluster.yaml -o yaml
+{{ bt 3 }}
+
 There are also subcommands for creating specific types of objects with dedicated flags instead of a file. Use {{ bt
 }}--help{{ bt }} on any subcommand for details.
 `
 
 const filenameFlagHelp = `
 _FILE_ - Name of the file containing the object to create. Use {{ bt }}-{{ bt }} to read from standard input.
+`
+
+const outputFlagHelp = `
+_FORMAT_ - Output format for the created objects. Must be {{ bt }}json{{ bt }} or {{ bt }}yaml{{ bt }}. When omitted
+the command prints a short confirmation message instead.
 `

--- a/internal/cmd/cli/create/create_cmd_test.go
+++ b/internal/cmd/cli/create/create_cmd_test.go
@@ -14,11 +14,13 @@ language governing permissions and limitations under the License.
 package create
 
 import (
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/proto"
+
 	. "github.com/onsi/ginkgo/v2/dsl/core"
 	. "github.com/onsi/ginkgo/v2/dsl/table"
 	. "github.com/onsi/gomega"
 	"github.com/spf13/cobra"
-	"google.golang.org/protobuf/proto"
 
 	privatev1 "github.com/osac-project/fulfillment-service/internal/api/osac/private/v1"
 	publicv1 "github.com/osac-project/fulfillment-service/internal/api/osac/public/v1"
@@ -64,6 +66,35 @@ var _ = Describe("Create command", func() {
 			}
 
 			Expect(subcommandNames).To(ContainElements("baremetalinstancecatalogitem", "cluster", "clustercatalogitem", "computeinstance", "computeinstancecatalogitem", "hub", "publicip", "publicipattachment", "virtualnetwork", "subnet", "securitygroup"))
+		})
+	})
+
+	Describe("Output flag", func() {
+		It("registers the -o/--output flag", func() {
+			cmd := Cmd()
+			flag := cmd.Flags().Lookup("output")
+			Expect(flag).ToNot(BeNil())
+			Expect(flag.Shorthand).To(Equal("o"))
+			Expect(flag.DefValue).To(Equal(""))
+		})
+
+		It("encodes created objects with @type for JSON/YAML output", func() {
+			runner := &runnerContext{
+				marshalOptions: protojson.MarshalOptions{
+					UseProtoNames: true,
+				},
+			}
+			object := publicv1.Cluster_builder{
+				Id: "123",
+				Metadata: publicv1.Metadata_builder{
+					Name: "my-cluster",
+				}.Build(),
+			}.Build()
+
+			encoded, err := runner.encodeObject(object)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(encoded).To(HaveKeyWithValue("@type", "type.googleapis.com/osac.public.v1.Cluster"))
+			Expect(encoded).To(HaveKeyWithValue("id", "123"))
 		})
 	})
 })


### PR DESCRIPTION
## Summary
- Add `-o` / `--output` to the file-based `create` command so callers can write created objects as YAML or JSON.
- Match the `get` command encoding (`@type` wrappers, single object vs list).
- Keep the existing confirmation messages when no output format is set.

## Test plan
- [x] `ginkgo run internal/cmd/cli/create`
- [x] `osac create -f <file>` still prints confirmation messages
- [x] `osac create -f <file> -o yaml` prints the created object as YAML
- [x] `osac create -f <file> -o json` prints the created object as JSON
- [x] Creating multiple objects with `-o yaml` prints a list
- [x] Invalid `-o` values are rejected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--output`/`-o` support to the `create` command.
  * Export created objects as JSON or YAML for machine-readable workflows.
  * Output includes object details and type information.
  * Added validation for supported output formats and updated command help text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->