### PR TITLE
NO-ISSUE: Pin buf CLI version in publish-proto workflow

### DIFF
--- a/.github/workflows/publish-proto.yaml
+++ b/.github/workflows/publish-proto.yaml
@@ -30,9 +30,14 @@ jobs:
     - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
       with:
         persist-credentials: false
+    # Pinned so setup doesn't depend on a live "resolve latest buf CLI
+    # release from github.com" call on every run -- that call returned a
+    # raw github.com 404 page (not the JSON api.github.com error) on
+    # 2026-07-16, failing this step in under a second with no retry.
     - uses: bufbuild/buf-action@fd21066df7214747548607aaa45548ba2b9bc1ff  # v1
       with:
         setup_only: true
         token: ${{ secrets.BUF_TOKEN }}
+        version: 1.71.0
     - run: |
         buf push --label "${{ github.ref_name }}"

--- a/.github/workflows/publish-proto.yaml
+++ b/.github/workflows/publish-proto.yaml
@@ -30,10 +30,6 @@ jobs:
     - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
       with:
         persist-credentials: false
-    # Pinned so setup doesn't depend on a live "resolve latest buf CLI
-    # release from github.com" call on every run -- that call returned a
-    # raw github.com 404 page (not the JSON api.github.com error) on
-    # 2026-07-16, failing this step in under a second with no retry.
     - uses: bufbuild/buf-action@fd21066df7214747548607aaa45548ba2b9bc1ff  # v1
       with:
         setup_only: true


### PR DESCRIPTION
## Summary

- `buf-action`'s setup step (`setup_only: true`) resolves the "latest" Buf CLI release from github.com on every run when `version` isn't pinned.
- On 2026-07-16, that resolution call returned a raw `github.com` 404 HTML page (not the JSON `api.github.com` error) instead of a valid response, failing "Publish proto" for the `v0.0.78` tag in under a second, no retry.
- This happened in the same push, within ~4 minutes of the goreleaser 503-storm that broke "Publish binaries" (see #925) — likely the same transient GitHub-API blip affecting multiple independent jobs.
- Pins `version: 1.71.0` (current latest stable) so this step no longer depends on a live version-resolution call succeeding.

## Test plan

- [ ] Next tagged release: confirm "Publish proto" runs `buf-action` setup successfully without a version-resolution network call
- [ ] Periodically bump the pinned version as new Buf CLI releases come out