### PR TITLE
OSAC-2855: Delete users from Keycloak if they're deleted in OSAC

### DIFF
--- a/internal/controllers/user/user_reconciler_function.go
+++ b/internal/controllers/user/user_reconciler_function.go
@@ -16,12 +16,15 @@ package user
 import (
 	"context"
 	"errors"
+	"fmt"
 	"log/slog"
+	"slices"
 
 	"google.golang.org/grpc"
 	"google.golang.org/protobuf/proto"
 
 	privatev1 "github.com/osac-project/fulfillment-service/internal/api/osac/private/v1"
+	"github.com/osac-project/fulfillment-service/internal/controllers/finalizers"
 	"github.com/osac-project/fulfillment-service/internal/idp"
 	"github.com/osac-project/fulfillment-service/internal/masks"
 )
@@ -97,7 +100,12 @@ func (r *function) Run(ctx context.Context, user *privatev1.User) error {
 		user: user,
 	}
 
-	err := task.reconcile(ctx)
+	var err error
+	if user.HasMetadata() && user.GetMetadata().HasDeletionTimestamp() {
+		err = task.delete(ctx)
+	} else {
+		err = task.reconcile(ctx)
+	}
 	if err != nil {
 		return err
 	}
@@ -122,8 +130,7 @@ type task struct {
 
 // reconcile performs the reconciliation logic for a user.
 func (t *task) reconcile(ctx context.Context) error {
-	// Skip if user is being deleted
-	if t.user.HasMetadata() && t.user.GetMetadata().HasDeletionTimestamp() {
+	if t.addFinalizer() {
 		return nil
 	}
 
@@ -189,4 +196,68 @@ func (t *task) reconcile(ctx context.Context) error {
 	)
 
 	return nil
+}
+
+// delete performs the deletion cleanup for a user.
+func (t *task) delete(ctx context.Context) error {
+	keycloakUserID := t.user.GetStatus().GetKeycloakUserId()
+	tenant := t.user.GetMetadata().GetTenant()
+	username := t.user.GetSpec().GetUsername()
+
+	if tenant != "" {
+		if keycloakUserID == "" && username != "" {
+			keycloakUser, err := t.r.idpClient.GetUserByUsername(ctx, tenant, username)
+			if err != nil {
+				return fmt.Errorf("failed to look up user in IDP for deletion: %w", err)
+			}
+			if keycloakUser != nil {
+				keycloakUserID = keycloakUser.ID
+			}
+		}
+
+		if keycloakUserID != "" {
+			err := t.r.idpClient.DeleteUser(ctx, tenant, keycloakUserID)
+			if err != nil {
+				return fmt.Errorf("failed to delete user from IDP: %w", err)
+			}
+
+			t.r.logger.DebugContext(ctx, "Deleted user from IDP",
+				slog.String("!user_id", t.user.GetId()),
+				slog.String("!keycloak_user_id", keycloakUserID),
+				slog.String("!tenant", tenant),
+			)
+		}
+	}
+
+	t.removeFinalizer()
+	return nil
+}
+
+// addFinalizer adds the controller finalizer to the user if not already present.
+// Returns true if the finalizer was added (indicating the update should be saved immediately).
+func (t *task) addFinalizer() bool {
+	if !t.user.HasMetadata() {
+		t.user.SetMetadata(&privatev1.Metadata{})
+	}
+	list := t.user.GetMetadata().GetFinalizers()
+	if !slices.Contains(list, finalizers.Controller) {
+		list = append(list, finalizers.Controller)
+		t.user.GetMetadata().SetFinalizers(list)
+		return true
+	}
+	return false
+}
+
+// removeFinalizer removes the controller finalizer from the user.
+func (t *task) removeFinalizer() {
+	if !t.user.HasMetadata() {
+		return
+	}
+	list := t.user.GetMetadata().GetFinalizers()
+	if slices.Contains(list, finalizers.Controller) {
+		list = slices.DeleteFunc(list, func(item string) bool {
+			return item == finalizers.Controller
+		})
+		t.user.GetMetadata().SetFinalizers(list)
+	}
 }

--- a/internal/controllers/user/user_reconciler_function_test.go
+++ b/internal/controllers/user/user_reconciler_function_test.go
@@ -26,6 +26,7 @@ import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	privatev1 "github.com/osac-project/fulfillment-service/internal/api/osac/private/v1"
+	"github.com/osac-project/fulfillment-service/internal/controllers/finalizers"
 	"github.com/osac-project/fulfillment-service/internal/idp"
 )
 
@@ -95,8 +96,9 @@ var _ = Describe("User Reconciler", func() {
 				user := privatev1.User_builder{
 					Id: "user-123",
 					Metadata: privatev1.Metadata_builder{
-						Name:   "testuser",
-						Tenant: "test-tenant",
+						Name:       "testuser",
+						Tenant:     "test-tenant",
+						Finalizers: []string{finalizers.Controller},
 					}.Build(),
 					Spec: privatev1.UserSpec_builder{
 						Username: "testuser",
@@ -128,8 +130,9 @@ var _ = Describe("User Reconciler", func() {
 				user := privatev1.User_builder{
 					Id: "user-123",
 					Metadata: privatev1.Metadata_builder{
-						Name:   "testuser",
-						Tenant: "test-tenant",
+						Name:       "testuser",
+						Tenant:     "test-tenant",
+						Finalizers: []string{finalizers.Controller},
 					}.Build(),
 					Spec: privatev1.UserSpec_builder{
 						Username: "testuser",
@@ -163,8 +166,9 @@ var _ = Describe("User Reconciler", func() {
 				user := privatev1.User_builder{
 					Id: "user-123",
 					Metadata: privatev1.Metadata_builder{
-						Name:   "testuser",
-						Tenant: "test-tenant",
+						Name:       "testuser",
+						Tenant:     "test-tenant",
+						Finalizers: []string{finalizers.Controller},
 					}.Build(),
 					Spec: privatev1.UserSpec_builder{
 						Username: "testuser",
@@ -194,8 +198,9 @@ var _ = Describe("User Reconciler", func() {
 				user := privatev1.User_builder{
 					Id: "user-123",
 					Metadata: privatev1.Metadata_builder{
-						Name:   "testuser",
-						Tenant: "test-tenant",
+						Name:       "testuser",
+						Tenant:     "test-tenant",
+						Finalizers: []string{finalizers.Controller},
 					}.Build(),
 					Spec: privatev1.UserSpec_builder{
 						Username: "testuser",
@@ -225,8 +230,9 @@ var _ = Describe("User Reconciler", func() {
 				user := privatev1.User_builder{
 					Id: "user-123",
 					Metadata: privatev1.Metadata_builder{
-						Name:   "testuser",
-						Tenant: "test-tenant",
+						Name:       "testuser",
+						Tenant:     "test-tenant",
+						Finalizers: []string{finalizers.Controller},
 					}.Build(),
 					Spec: privatev1.UserSpec_builder{
 						Username: "testuser",
@@ -254,15 +260,13 @@ var _ = Describe("User Reconciler", func() {
 			})
 		})
 
-		Context("when user is being deleted", func() {
-			It("should skip reconciliation", func() {
-				now := timestamppb.New(time.Now())
+		Context("when user has no finalizer", func() {
+			It("should add the finalizer and return early", func() {
 				user := privatev1.User_builder{
 					Id: "user-123",
 					Metadata: privatev1.Metadata_builder{
-						Name:              "testuser",
-						Tenant:            "test-tenant",
-						DeletionTimestamp: now,
+						Name:   "testuser",
+						Tenant: "test-tenant",
 					}.Build(),
 					Spec: privatev1.UserSpec_builder{
 						Username: "testuser",
@@ -271,9 +275,6 @@ var _ = Describe("User Reconciler", func() {
 					Status: privatev1.UserStatus_builder{}.Build(),
 				}.Build()
 
-				// Should not call GetUserByUsername since user is being deleted
-				// No mock expectations set
-
 				task := &task{
 					r:    function,
 					user: user,
@@ -281,6 +282,7 @@ var _ = Describe("User Reconciler", func() {
 
 				err := task.reconcile(ctx)
 				Expect(err).ToNot(HaveOccurred())
+				Expect(user.GetMetadata().GetFinalizers()).To(ContainElement(finalizers.Controller))
 				Expect(user.GetStatus().GetKeycloakUserId()).To(BeEmpty())
 			})
 		})
@@ -290,8 +292,9 @@ var _ = Describe("User Reconciler", func() {
 				user := privatev1.User_builder{
 					Id: "user-123",
 					Metadata: privatev1.Metadata_builder{
-						Name:   "testuser",
-						Tenant: "test-tenant",
+						Name:       "testuser",
+						Tenant:     "test-tenant",
+						Finalizers: []string{finalizers.Controller},
 					}.Build(),
 					Spec: privatev1.UserSpec_builder{
 						// No username
@@ -319,7 +322,8 @@ var _ = Describe("User Reconciler", func() {
 				user := privatev1.User_builder{
 					Id: "user-123",
 					Metadata: privatev1.Metadata_builder{
-						Name: "testuser",
+						Name:       "testuser",
+						Finalizers: []string{finalizers.Controller},
 						// No tenant
 					}.Build(),
 					Spec: privatev1.UserSpec_builder{
@@ -344,7 +348,7 @@ var _ = Describe("User Reconciler", func() {
 		})
 
 		Context("when user has no metadata", func() {
-			It("should skip reconciliation for deletion check", func() {
+			It("should add metadata with finalizer", func() {
 				user := privatev1.User_builder{
 					Id: "user-123",
 					// No metadata
@@ -355,9 +359,6 @@ var _ = Describe("User Reconciler", func() {
 					Status: privatev1.UserStatus_builder{}.Build(),
 				}.Build()
 
-				// Should not call GetUserByUsername
-				// No mock expectations set
-
 				task := &task{
 					r:    function,
 					user: user,
@@ -365,6 +366,213 @@ var _ = Describe("User Reconciler", func() {
 
 				err := task.reconcile(ctx)
 				Expect(err).ToNot(HaveOccurred())
+				Expect(user.HasMetadata()).To(BeTrue())
+				Expect(user.GetMetadata().GetFinalizers()).To(ContainElement(finalizers.Controller))
+			})
+		})
+	})
+
+	Describe("Delete logic", func() {
+		Context("when user has keycloak_user_id", func() {
+			It("should delete user from IDP and remove finalizer", func() {
+				now := timestamppb.New(time.Now())
+				user := privatev1.User_builder{
+					Id: "user-123",
+					Metadata: privatev1.Metadata_builder{
+						Name:              "testuser",
+						Tenant:            "test-tenant",
+						DeletionTimestamp: now,
+						Finalizers:        []string{finalizers.Controller},
+					}.Build(),
+					Spec: privatev1.UserSpec_builder{
+						Username: "testuser",
+						Email:    "test@example.com",
+					}.Build(),
+					Status: privatev1.UserStatus_builder{
+						KeycloakUserId: "keycloak-user-id-456",
+					}.Build(),
+				}.Build()
+
+				mockClient.EXPECT().
+					DeleteUser(ctx, "test-tenant", "keycloak-user-id-456").
+					Return(nil)
+
+				task := &task{
+					r:    function,
+					user: user,
+				}
+
+				err := task.delete(ctx)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(user.GetMetadata().GetFinalizers()).ToNot(ContainElement(finalizers.Controller))
+			})
+		})
+
+		Context("when IDP deletion fails", func() {
+			It("should return error and keep finalizer", func() {
+				now := timestamppb.New(time.Now())
+				user := privatev1.User_builder{
+					Id: "user-123",
+					Metadata: privatev1.Metadata_builder{
+						Name:              "testuser",
+						Tenant:            "test-tenant",
+						DeletionTimestamp: now,
+						Finalizers:        []string{finalizers.Controller},
+					}.Build(),
+					Spec: privatev1.UserSpec_builder{
+						Username: "testuser",
+						Email:    "test@example.com",
+					}.Build(),
+					Status: privatev1.UserStatus_builder{
+						KeycloakUserId: "keycloak-user-id-456",
+					}.Build(),
+				}.Build()
+
+				mockClient.EXPECT().
+					DeleteUser(ctx, "test-tenant", "keycloak-user-id-456").
+					Return(errors.New("IDP connection failed"))
+
+				task := &task{
+					r:    function,
+					user: user,
+				}
+
+				err := task.delete(ctx)
+				Expect(err).To(HaveOccurred())
+				Expect(user.GetMetadata().GetFinalizers()).To(ContainElement(finalizers.Controller))
+			})
+		})
+
+		Context("when user has no keycloak_user_id", func() {
+			It("should look up user by username and delete from IDP", func() {
+				now := timestamppb.New(time.Now())
+				user := privatev1.User_builder{
+					Id: "user-123",
+					Metadata: privatev1.Metadata_builder{
+						Name:              "testuser",
+						Tenant:            "test-tenant",
+						DeletionTimestamp: now,
+						Finalizers:        []string{finalizers.Controller},
+					}.Build(),
+					Spec: privatev1.UserSpec_builder{
+						Username: "testuser",
+						Email:    "test@example.com",
+					}.Build(),
+					Status: privatev1.UserStatus_builder{}.Build(),
+				}.Build()
+
+				gomock.InOrder(
+					mockClient.EXPECT().
+						GetUserByUsername(ctx, "test-tenant", "testuser").
+						Return(&idp.User{
+							ID:       "resolved-keycloak-id",
+							Username: "testuser",
+						}, nil),
+					mockClient.EXPECT().
+						DeleteUser(ctx, "test-tenant", "resolved-keycloak-id").
+						Return(nil),
+				)
+
+				task := &task{
+					r:    function,
+					user: user,
+				}
+
+				err := task.delete(ctx)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(user.GetMetadata().GetFinalizers()).ToNot(ContainElement(finalizers.Controller))
+			})
+
+			It("should remove finalizer when user not found in IDP", func() {
+				now := timestamppb.New(time.Now())
+				user := privatev1.User_builder{
+					Id: "user-123",
+					Metadata: privatev1.Metadata_builder{
+						Name:              "testuser",
+						Tenant:            "test-tenant",
+						DeletionTimestamp: now,
+						Finalizers:        []string{finalizers.Controller},
+					}.Build(),
+					Spec: privatev1.UserSpec_builder{
+						Username: "testuser",
+						Email:    "test@example.com",
+					}.Build(),
+					Status: privatev1.UserStatus_builder{}.Build(),
+				}.Build()
+
+				mockClient.EXPECT().
+					GetUserByUsername(ctx, "test-tenant", "testuser").
+					Return(nil, nil)
+
+				task := &task{
+					r:    function,
+					user: user,
+				}
+
+				err := task.delete(ctx)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(user.GetMetadata().GetFinalizers()).ToNot(ContainElement(finalizers.Controller))
+			})
+
+			It("should return error when IDP lookup fails", func() {
+				now := timestamppb.New(time.Now())
+				user := privatev1.User_builder{
+					Id: "user-123",
+					Metadata: privatev1.Metadata_builder{
+						Name:              "testuser",
+						Tenant:            "test-tenant",
+						DeletionTimestamp: now,
+						Finalizers:        []string{finalizers.Controller},
+					}.Build(),
+					Spec: privatev1.UserSpec_builder{
+						Username: "testuser",
+						Email:    "test@example.com",
+					}.Build(),
+					Status: privatev1.UserStatus_builder{}.Build(),
+				}.Build()
+
+				mockClient.EXPECT().
+					GetUserByUsername(ctx, "test-tenant", "testuser").
+					Return(nil, errors.New("IDP connection failed"))
+
+				task := &task{
+					r:    function,
+					user: user,
+				}
+
+				err := task.delete(ctx)
+				Expect(err).To(HaveOccurred())
+				Expect(user.GetMetadata().GetFinalizers()).To(ContainElement(finalizers.Controller))
+			})
+		})
+
+		Context("when user has no tenant", func() {
+			It("should skip IDP deletion and remove finalizer", func() {
+				now := timestamppb.New(time.Now())
+				user := privatev1.User_builder{
+					Id: "user-123",
+					Metadata: privatev1.Metadata_builder{
+						Name:              "testuser",
+						DeletionTimestamp: now,
+						Finalizers:        []string{finalizers.Controller},
+					}.Build(),
+					Spec: privatev1.UserSpec_builder{
+						Username: "testuser",
+						Email:    "test@example.com",
+					}.Build(),
+					Status: privatev1.UserStatus_builder{
+						KeycloakUserId: "keycloak-user-id-456",
+					}.Build(),
+				}.Build()
+
+				task := &task{
+					r:    function,
+					user: user,
+				}
+
+				err := task.delete(ctx)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(user.GetMetadata().GetFinalizers()).ToNot(ContainElement(finalizers.Controller))
 			})
 		})
 	})


### PR DESCRIPTION
# Description

When a user is deleted in OSAC, they weren't actually removed in Keycloak which left persistent user data that OSAC viewed as no longer existing.

This can cause issues such as when a user is reimported later, Keycloak will complain that there is a duplicate user.

We should delete the user from Keycloak if they are removed from OSAC.

# Testing

1. Deployed integration environment, logged in as cloud provider admin and created tenant
2. Created IdP attached to tenant and logged in as tenant user from IdP
3. Logged in as cloud provider admin and verified get users returned tenant user, and the tenant user existed on keycloak console
4. Deleted user from CLI, verified osac get user didn't return it and the Keycloak user was removed on the console
5. Logged in as the same IdP user and verified had to register again and registration succeeded

Assisted-by: Claude Code <noreply@anthropic.com>

/cc @jhernand 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved user deletion handling by removing users from the identity provider when eligible.
  * Added cleanup safeguards to ensure controller finalizers are removed after successful deletion.
  * Preserved resources and finalizers when required deletion details are missing or deletion fails.
  * Automatically initializes missing metadata and adds the required controller finalizer during reconciliation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->