### PR TITLE
OSAC-2873: Add authz for ProjectMembership

### DIFF
--- a/internal/auth/grpc_authz_interceptor.go
+++ b/internal/auth/grpc_authz_interceptor.go
@@ -40,19 +40,52 @@ import (
 //go:embed policies/authz.rego
 var authzPolicy string
 
-// MetadataFetcher fetches object metadata (tenant and project name) for authorization. Returns empty strings if object
-// not found or on error.
-type MetadataFetcher func(ctx context.Context, id string) (tenant, project string)
+// ObjectMetadata contains the metadata fields fetched from the database for authorization decisions.
+type ObjectMetadata struct {
+	Tenant  string
+	Name    string
+	Project string
+}
+
+// MetadataFetcher fetches object metadata for authorization. Returns nil if the object is not found or on error.
+type MetadataFetcher func(ctx context.Context, id string) *ObjectMetadata
+
+// ContextExtensions holds the typed fields passed to OPA as input.context.context_extensions.
+type ContextExtensions struct {
+	ID      string
+	Tenant  string
+	Name    string
+	Project string
+}
+
+// ToMap converts the extensions to the untyped map OPA expects, omitting empty fields.
+func (e *ContextExtensions) ToMap() map[string]any {
+	m := map[string]any{}
+	if e.ID != "" {
+		m["id"] = e.ID
+	}
+	if e.Tenant != "" {
+		m["tenant"] = e.Tenant
+	}
+	if e.Name != "" {
+		m["name"] = e.Name
+	}
+	if e.Project != "" {
+		m["project"] = e.Project
+	}
+	return m
+}
 
 // GrpcAuthzInterceptorBuilder contains the data and logic needed to build an interceptor that checks authorization
 // using an embedded Rego policy evaluated with the OPA library. Don't create instances of this type directly, use the
 // NewGrpcAuthzInterceptor function instead.
 type GrpcAuthzInterceptorBuilder struct {
-	logger                   *slog.Logger
-	anonymousMethods         []string
-	inputCallback            func(ctx context.Context, input map[string]any) error
-	metadataFetcher          MetadataFetcher
-	emergencyServiceAccounts []string
+	logger                           *slog.Logger
+	anonymousMethods                 []string
+	inputCallback                    func(ctx context.Context, input map[string]any) error
+	metadataFetcher                  MetadataFetcher
+	projectMembershipMetadataFetcher MetadataFetcher
+	emergencyServiceAccounts         []string
 }
 
 // GrpcAuthzInterceptor is a gRPC interceptor that evaluates an embedded Rego policy for authorization. It reads the
@@ -60,11 +93,12 @@ type GrpcAuthzInterceptorBuilder struct {
 // evaluates the policy to determine if the request is allowed. On success it constructs a Subject containing the user
 // and tenants and stores it in the context.
 type GrpcAuthzInterceptor struct {
-	logger           *slog.Logger
-	anonymousMethods []*regexp.Regexp
-	inputCallback    func(ctx context.Context, input map[string]any) error
-	query            rego.PreparedEvalQuery
-	metadataFetcher  MetadataFetcher
+	logger                           *slog.Logger
+	anonymousMethods                 []*regexp.Regexp
+	inputCallback                    func(ctx context.Context, input map[string]any) error
+	query                            rego.PreparedEvalQuery
+	metadataFetcher                  MetadataFetcher
+	projectMembershipMetadataFetcher MetadataFetcher
 }
 
 // NewGrpcAuthzInterceptor creates a builder that can then be used to configure and create a new authorization
@@ -103,6 +137,14 @@ func (b *GrpcAuthzInterceptorBuilder) SetInputCallback(value func(ctx context.Co
 // This is optional - if not set, metadata will not be fetched for authorization.
 func (b *GrpcAuthzInterceptorBuilder) SetMetadataFetcher(value MetadataFetcher) *GrpcAuthzInterceptorBuilder {
 	b.metadataFetcher = value
+	return b
+}
+
+// SetProjectMembershipMetadataFetcher sets the function used to retrieve project membership metadata (tenant and
+// project name) for authorization of project membership operations.
+func (b *GrpcAuthzInterceptorBuilder) SetProjectMembershipMetadataFetcher(
+	value MetadataFetcher) *GrpcAuthzInterceptorBuilder {
+	b.projectMembershipMetadataFetcher = value
 	return b
 }
 
@@ -202,11 +244,12 @@ func (b *GrpcAuthzInterceptorBuilder) Build() (result *GrpcAuthzInterceptor, err
 
 	// Create the interceptor:
 	result = &GrpcAuthzInterceptor{
-		logger:           b.logger,
-		anonymousMethods: anonymousMethods,
-		metadataFetcher:  b.metadataFetcher,
-		inputCallback:    b.inputCallback,
-		query:            query,
+		logger:                           b.logger,
+		anonymousMethods:                 anonymousMethods,
+		metadataFetcher:                  b.metadataFetcher,
+		projectMembershipMetadataFetcher: b.projectMembershipMetadataFetcher,
+		inputCallback:                    b.inputCallback,
+		query:                            query,
 	}
 	return
 }
@@ -433,26 +476,33 @@ func (i *GrpcAuthzInterceptor) buildInput(ctx context.Context, method string, re
 	// Check if this the token corresponds to a Kubernetes service account:
 	_, kube := claims["kubernetes.io"]
 
-	// Try to extract the object identifier from the request so that the external authorization service can use
-	// it to make fine grained authorization decisions. The identifier is sent in the context extensions of the
-	// check request, available to OPA policies as `input.context.context_extensions.id`.
-	extensions := map[string]any{}
+	// Build the context extensions that the OPA policy reads from input.context.context_extensions.
+	var ext ContextExtensions
 	if request != nil {
-		id := i.extractId(request)
-		if id != "" {
-			extensions["id"] = id
-		}
+		ext.ID = i.extractId(request)
 
 		// For project Get/Delete/Update operations, fetch the authoritative tenant and name from the database
 		// to prevent clients from spoofing these values for authorization bypass.
-		if i.shouldFetchProjectMetadata(method, id) && i.metadataFetcher != nil {
-			tenant, name := i.metadataFetcher(ctx, id)
-			if tenant != "" {
-				extensions["tenant"] = tenant
+		if i.shouldFetchProjectMetadata(method, ext.ID) && i.metadataFetcher != nil {
+			if meta := i.metadataFetcher(ctx, ext.ID); meta != nil {
+				ext.Tenant = meta.Tenant
+				ext.Name = meta.Name
 			}
-			if name != "" {
-				extensions["name"] = name
+		}
+
+		// For project membership Get/Delete/Update, fetch the membership's tenant and project name
+		// from the database for authorization.
+		if i.shouldFetchProjectMembershipMetadata(method, ext.ID) && i.projectMembershipMetadataFetcher != nil {
+			if meta := i.projectMembershipMetadataFetcher(ctx, ext.ID); meta != nil {
+				ext.Tenant = meta.Tenant
+				ext.Project = meta.Project
 			}
+		}
+
+		// For project membership Create, extract the project name from the request body.
+		// The OPA policy iterates over the user's tenants to check manager group membership.
+		if method == "/osac.public.v1.ProjectMemberships/Create" {
+			ext.Project = i.extractProjectFromRequest(request)
 		}
 	}
 
@@ -501,7 +551,7 @@ func (i *GrpcAuthzInterceptor) buildInput(ctx context.Context, method string, re
 					"path": method,
 				},
 			},
-			"context_extensions": extensions,
+			"context_extensions": ext.ToMap(),
 		},
 		"auth": map[string]any{
 			"identity": identity,
@@ -521,6 +571,50 @@ func (i *GrpcAuthzInterceptor) shouldFetchProjectMetadata(method string, id stri
 	return method == "/osac.public.v1.Projects/Get" ||
 		method == "/osac.public.v1.Projects/Delete" ||
 		method == "/osac.public.v1.Projects/Update"
+}
+
+// shouldFetchProjectMembershipMetadata determines if we should fetch project membership metadata for authorization.
+func (i *GrpcAuthzInterceptor) shouldFetchProjectMembershipMetadata(method string, id string) bool {
+	if id == "" {
+		return false
+	}
+	return method == "/osac.public.v1.ProjectMemberships/Get" ||
+		method == "/osac.public.v1.ProjectMemberships/Delete" ||
+		method == "/osac.public.v1.ProjectMemberships/Update"
+}
+
+// extractProjectFromRequest extracts the project name from the request's embedded object metadata using proto
+// reflection. This navigates object -> metadata -> project.
+func (i *GrpcAuthzInterceptor) extractProjectFromRequest(request any) string {
+	message, ok := request.(proto.Message)
+	if !ok {
+		return ""
+	}
+	reflect := message.ProtoReflect()
+
+	objectField := reflect.Descriptor().Fields().ByName("object")
+	if objectField == nil {
+		return ""
+	}
+	if !reflect.Has(objectField) {
+		return ""
+	}
+	objectMsg := reflect.Get(objectField).Message()
+
+	metadataField := objectMsg.Descriptor().Fields().ByName("metadata")
+	if metadataField == nil {
+		return ""
+	}
+	if !objectMsg.Has(metadataField) {
+		return ""
+	}
+	metadataMsg := objectMsg.Get(metadataField).Message()
+
+	projectField := metadataMsg.Descriptor().Fields().ByName("project")
+	if projectField == nil {
+		return ""
+	}
+	return metadataMsg.Get(projectField).String()
 }
 
 // claimAsAnySlice extracts a claim value and returns it as []any, which is the type that JSON-decoded arrays produce

--- a/internal/auth/grpc_authz_interceptor_metadata_test.go
+++ b/internal/auth/grpc_authz_interceptor_metadata_test.go
@@ -30,8 +30,8 @@ var _ = Describe("GrpcExternalAuthInterceptor project metadata authorization", f
 		It("Should fetch metadata from database and include in context extensions", func(ctx context.Context) {
 			interceptor, err := NewGrpcAuthzInterceptor().
 				SetLogger(logger).
-				SetMetadataFetcher(func(ctx context.Context, id string) (string, string) {
-					return "authoritative-tenant", "authoritative-project"
+				SetMetadataFetcher(func(ctx context.Context, id string) *ObjectMetadata {
+					return &ObjectMetadata{Tenant: "authoritative-tenant", Name: "authoritative-project"}
 				}).
 				SetInputCallback(func(ctx context.Context, input map[string]any) error {
 					Expect(input).To(HaveKey("context"))
@@ -69,8 +69,8 @@ var _ = Describe("GrpcExternalAuthInterceptor project metadata authorization", f
 		It("Should fetch metadata from database and include in context extensions", func(ctx context.Context) {
 			interceptor, err := NewGrpcAuthzInterceptor().
 				SetLogger(logger).
-				SetMetadataFetcher(func(ctx context.Context, id string) (string, string) {
-					return "authoritative-tenant", "authoritative-project"
+				SetMetadataFetcher(func(ctx context.Context, id string) *ObjectMetadata {
+					return &ObjectMetadata{Tenant: "authoritative-tenant", Name: "authoritative-project"}
 				}).
 				SetInputCallback(func(ctx context.Context, input map[string]any) error {
 					Expect(input).To(HaveKey("context"))
@@ -108,8 +108,8 @@ var _ = Describe("GrpcExternalAuthInterceptor project metadata authorization", f
 		It("Should fetch metadata from database and include in context extensions", func(ctx context.Context) {
 			interceptor, err := NewGrpcAuthzInterceptor().
 				SetLogger(logger).
-				SetMetadataFetcher(func(ctx context.Context, id string) (string, string) {
-					return "authoritative-tenant", "authoritative-project"
+				SetMetadataFetcher(func(ctx context.Context, id string) *ObjectMetadata {
+					return &ObjectMetadata{Tenant: "authoritative-tenant", Name: "authoritative-project"}
 				}).
 				SetInputCallback(func(ctx context.Context, input map[string]any) error {
 					Expect(input).To(HaveKey("context"))
@@ -152,8 +152,8 @@ var _ = Describe("GrpcExternalAuthInterceptor project metadata authorization", f
 		It("Should ignore client-provided metadata values and use authoritative database values", func(ctx context.Context) {
 			interceptor, err := NewGrpcAuthzInterceptor().
 				SetLogger(logger).
-				SetMetadataFetcher(func(ctx context.Context, id string) (string, string) {
-					return "authoritative-tenant", "authoritative-project"
+				SetMetadataFetcher(func(ctx context.Context, id string) *ObjectMetadata {
+					return &ObjectMetadata{Tenant: "authoritative-tenant", Name: "authoritative-project"}
 				}).
 				SetInputCallback(func(ctx context.Context, input map[string]any) error {
 					Expect(input).To(HaveKey("context"))
@@ -199,9 +199,9 @@ var _ = Describe("GrpcExternalAuthInterceptor project metadata authorization", f
 		It("Should not fetch metadata for list operations", func(ctx context.Context) {
 			interceptor, err := NewGrpcAuthzInterceptor().
 				SetLogger(logger).
-				SetMetadataFetcher(func(ctx context.Context, id string) (string, string) {
+				SetMetadataFetcher(func(ctx context.Context, id string) *ObjectMetadata {
 					Fail("metadata fetcher should not be called for list operations")
-					return "", ""
+					return nil
 				}).
 				SetInputCallback(func(ctx context.Context, input map[string]any) error {
 					Expect(input).To(HaveKey("context"))
@@ -232,13 +232,173 @@ var _ = Describe("GrpcExternalAuthInterceptor project metadata authorization", f
 		})
 	})
 
+	Describe("ProjectMemberships Get operation", func() {
+		It("Should fetch project membership metadata and include in context extensions", func(ctx context.Context) {
+			interceptor, err := NewGrpcAuthzInterceptor().
+				SetLogger(logger).
+				SetProjectMembershipMetadataFetcher(func(ctx context.Context, id string) *ObjectMetadata {
+					Expect(id).To(Equal("pm-123"))
+					return &ObjectMetadata{Tenant: "authoritative-tenant", Project: "authoritative-project"}
+				}).
+				SetInputCallback(func(ctx context.Context, input map[string]any) error {
+					Expect(input).To(HaveKey("context"))
+					context, ok := input["context"].(map[string]any)
+					Expect(ok).To(BeTrue())
+					Expect(context).To(HaveKey("context_extensions"))
+					extensions, ok := context["context_extensions"].(map[string]any)
+					Expect(ok).To(BeTrue())
+					Expect(extensions).To(HaveKeyWithValue("id", "pm-123"))
+					Expect(extensions).To(HaveKeyWithValue("tenant", "authoritative-tenant"))
+					Expect(extensions).To(HaveKeyWithValue("project", "authoritative-project"))
+					return nil
+				}).
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+
+			token := MakeTokenObject(nil, nil)
+			ctx = ContextWithToken(ctx, token)
+			_, _ = interceptor.UnaryServer(
+				ctx,
+				publicv1.ProjectMembershipsGetRequest_builder{
+					Id: "pm-123",
+				}.Build(),
+				&grpc.UnaryServerInfo{
+					FullMethod: "/osac.public.v1.ProjectMemberships/Get",
+				},
+				func(ctx context.Context, req any) (any, error) {
+					return nil, nil
+				},
+			)
+		})
+	})
+
+	Describe("ProjectMemberships Delete operation", func() {
+		It("Should fetch project membership metadata and include in context extensions", func(ctx context.Context) {
+			interceptor, err := NewGrpcAuthzInterceptor().
+				SetLogger(logger).
+				SetProjectMembershipMetadataFetcher(func(ctx context.Context, id string) *ObjectMetadata {
+					return &ObjectMetadata{Tenant: "authoritative-tenant", Project: "authoritative-project"}
+				}).
+				SetInputCallback(func(ctx context.Context, input map[string]any) error {
+					Expect(input).To(HaveKey("context"))
+					context, ok := input["context"].(map[string]any)
+					Expect(ok).To(BeTrue())
+					Expect(context).To(HaveKey("context_extensions"))
+					extensions, ok := context["context_extensions"].(map[string]any)
+					Expect(ok).To(BeTrue())
+					Expect(extensions).To(HaveKeyWithValue("id", "pm-456"))
+					Expect(extensions).To(HaveKeyWithValue("tenant", "authoritative-tenant"))
+					Expect(extensions).To(HaveKeyWithValue("project", "authoritative-project"))
+					return nil
+				}).
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+
+			token := MakeTokenObject(nil, nil)
+			ctx = ContextWithToken(ctx, token)
+			_, _ = interceptor.UnaryServer(
+				ctx,
+				publicv1.ProjectMembershipsDeleteRequest_builder{
+					Id: "pm-456",
+				}.Build(),
+				&grpc.UnaryServerInfo{
+					FullMethod: "/osac.public.v1.ProjectMemberships/Delete",
+				},
+				func(ctx context.Context, req any) (any, error) {
+					return nil, nil
+				},
+			)
+		})
+	})
+
+	Describe("ProjectMemberships Create operation", func() {
+		It("Should extract project name from request body and include in context extensions", func(ctx context.Context) {
+			interceptor, err := NewGrpcAuthzInterceptor().
+				SetLogger(logger).
+				SetProjectMembershipMetadataFetcher(func(ctx context.Context, id string) *ObjectMetadata {
+					Fail("project membership metadata fetcher should not be called for Create")
+					return nil
+				}).
+				SetInputCallback(func(ctx context.Context, input map[string]any) error {
+					Expect(input).To(HaveKey("context"))
+					context, ok := input["context"].(map[string]any)
+					Expect(ok).To(BeTrue())
+					Expect(context).To(HaveKey("context_extensions"))
+					extensions, ok := context["context_extensions"].(map[string]any)
+					Expect(ok).To(BeTrue())
+					Expect(extensions).To(HaveKeyWithValue("project", "my-project"))
+					Expect(extensions).ToNot(HaveKey("tenant"))
+					return nil
+				}).
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+
+			token := MakeTokenObject(nil, nil)
+			ctx = ContextWithToken(ctx, token)
+			_, _ = interceptor.UnaryServer(
+				ctx,
+				publicv1.ProjectMembershipsCreateRequest_builder{
+					Object: publicv1.ProjectMembership_builder{
+						Metadata: publicv1.Metadata_builder{
+							Name:    "test-membership",
+							Project: "my-project",
+						}.Build(),
+					}.Build(),
+				}.Build(),
+				&grpc.UnaryServerInfo{
+					FullMethod: "/osac.public.v1.ProjectMemberships/Create",
+				},
+				func(ctx context.Context, req any) (any, error) {
+					return nil, nil
+				},
+			)
+		})
+	})
+
+	Describe("ProjectMemberships List operation", func() {
+		It("Should not fetch metadata for list operations", func(ctx context.Context) {
+			interceptor, err := NewGrpcAuthzInterceptor().
+				SetLogger(logger).
+				SetProjectMembershipMetadataFetcher(func(ctx context.Context, id string) *ObjectMetadata {
+					Fail("project membership metadata fetcher should not be called for List")
+					return nil
+				}).
+				SetInputCallback(func(ctx context.Context, input map[string]any) error {
+					Expect(input).To(HaveKey("context"))
+					context, ok := input["context"].(map[string]any)
+					Expect(ok).To(BeTrue())
+					Expect(context).To(HaveKey("context_extensions"))
+					extensions, ok := context["context_extensions"].(map[string]any)
+					Expect(ok).To(BeTrue())
+					Expect(extensions).ToNot(HaveKey("tenant"))
+					Expect(extensions).ToNot(HaveKey("project"))
+					return nil
+				}).
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+
+			token := MakeTokenObject(nil, nil)
+			ctx = ContextWithToken(ctx, token)
+			_, _ = interceptor.UnaryServer(
+				ctx,
+				publicv1.ProjectMembershipsListRequest_builder{}.Build(),
+				&grpc.UnaryServerInfo{
+					FullMethod: "/osac.public.v1.ProjectMemberships/List",
+				},
+				func(ctx context.Context, req any) (any, error) {
+					return nil, nil
+				},
+			)
+		})
+	})
+
 	Describe("Other resource operations", func() {
 		It("Should not fetch project metadata for Clusters operations", func(ctx context.Context) {
 			interceptor, err := NewGrpcAuthzInterceptor().
 				SetLogger(logger).
-				SetMetadataFetcher(func(ctx context.Context, id string) (string, string) {
+				SetMetadataFetcher(func(ctx context.Context, id string) *ObjectMetadata {
 					Fail("metadata fetcher should not be called for non-Projects resources")
-					return "", ""
+					return nil
 				}).
 				SetInputCallback(func(ctx context.Context, input map[string]any) error {
 					Expect(input).To(HaveKey("context"))

--- a/internal/auth/grpc_authz_interceptor_test.go
+++ b/internal/auth/grpc_authz_interceptor_test.go
@@ -26,7 +26,9 @@ import (
 	"google.golang.org/grpc"
 	grpccodes "google.golang.org/grpc/codes"
 	grpcstatus "google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/fieldmaskpb"
 
+	publicv1 "github.com/osac-project/fulfillment-service/internal/api/osac/public/v1"
 	"github.com/osac-project/fulfillment-service/internal/testing"
 	"github.com/osac-project/fulfillment-service/internal/uuid"
 )
@@ -677,6 +679,230 @@ var _ = Describe("Rego authorization interceptor", func() {
 					subject := SubjectFromContext(ctx)
 					Expect(subject.User).To(Equal("my-user"))
 					Expect(subject.Tenants.Universal()).To(BeTrue())
+					handled = true
+					return nil, nil
+				},
+			)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(handled).To(BeTrue())
+		})
+
+		It("Allows tenant admin to manage project memberships", func(ctx context.Context) {
+			token := createKeycloakUserToken("my-tenant", "my-user", jwt.MapClaims{
+				"realm_access": map[string]any{
+					"roles": []any{
+						"tenant-admin",
+					},
+				},
+			})
+			ctx = ContextWithToken(ctx, token)
+			handled := false
+			_, err := interceptor.UnaryServer(
+				ctx,
+				nil,
+				&grpc.UnaryServerInfo{
+					FullMethod: "/osac.public.v1.ProjectMemberships/Create",
+				},
+				func(ctx context.Context, req any) (any, error) {
+					subject := SubjectFromContext(ctx)
+					Expect(subject.User).To(Equal("my-user"))
+					Expect(subject.Tenants.Finite()).To(BeTrue())
+					Expect(subject.Tenants.Inclusions()).To(ConsistOf("my-tenant"))
+					handled = true
+					return nil, nil
+				},
+			)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(handled).To(BeTrue())
+		})
+
+		It("Denies regular user from creating project memberships", func(ctx context.Context) {
+			token := createKeycloakUserToken("my-tenant", "my-user", jwt.MapClaims{
+				"realm_access": map[string]any{
+					"roles": []any{},
+				},
+			})
+			ctx = ContextWithToken(ctx, token)
+			handled := false
+			_, err := interceptor.UnaryServer(
+				ctx,
+				nil,
+				&grpc.UnaryServerInfo{
+					FullMethod: "/osac.public.v1.ProjectMemberships/Create",
+				},
+				func(ctx context.Context, req any) (any, error) {
+					handled = true
+					return nil, nil
+				},
+			)
+			Expect(err).To(HaveOccurred())
+			status, ok := grpcstatus.FromError(err)
+			Expect(ok).To(BeTrue())
+			Expect(status.Code()).To(Equal(grpccodes.PermissionDenied))
+			Expect(handled).To(BeFalse())
+		})
+
+		It("Allows regular user to list project memberships", func(ctx context.Context) {
+			token := createKeycloakUserToken("my-tenant", "my-user", jwt.MapClaims{})
+			ctx = ContextWithToken(ctx, token)
+			handled := false
+			_, err := interceptor.UnaryServer(
+				ctx,
+				nil,
+				&grpc.UnaryServerInfo{
+					FullMethod: "/osac.public.v1.ProjectMemberships/List",
+				},
+				func(ctx context.Context, req any) (any, error) {
+					handled = true
+					return nil, nil
+				},
+			)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(handled).To(BeTrue())
+		})
+
+		It("Allows project manager to create project memberships", func(ctx context.Context) {
+			token := createKeycloakUserToken("", "my-user", jwt.MapClaims{
+				"organization": map[string]any{
+					"my-tenant": map[string]any{
+						"groups": []any{
+							"/my-project/system:managers",
+						},
+					},
+				},
+			})
+			ctx = ContextWithToken(ctx, token)
+			handled := false
+			_, err := interceptor.UnaryServer(
+				ctx,
+				publicv1.ProjectMembershipsCreateRequest_builder{
+					Object: publicv1.ProjectMembership_builder{
+						Metadata: publicv1.Metadata_builder{
+							Project: "my-project",
+						}.Build(),
+					}.Build(),
+				}.Build(),
+				&grpc.UnaryServerInfo{
+					FullMethod: "/osac.public.v1.ProjectMemberships/Create",
+				},
+				func(ctx context.Context, req any) (any, error) {
+					handled = true
+					return nil, nil
+				},
+			)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(handled).To(BeTrue())
+		})
+
+		It("Allows project manager to get project memberships", func(ctx context.Context) {
+			pmInterceptor, err := NewGrpcAuthzInterceptor().
+				SetLogger(logger).
+				SetProjectMembershipMetadataFetcher(func(ctx context.Context, id string) *ObjectMetadata {
+					Expect(id).To(Equal("pm-100"))
+					return &ObjectMetadata{Tenant: "my-tenant", Project: "my-project"}
+				}).
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+
+			token := createKeycloakUserToken("", "my-user", jwt.MapClaims{
+				"organization": map[string]any{
+					"my-tenant": map[string]any{
+						"groups": []any{
+							"/my-project/system:managers",
+						},
+					},
+				},
+			})
+			ctx = ContextWithToken(ctx, token)
+			handled := false
+			_, err = pmInterceptor.UnaryServer(
+				ctx,
+				publicv1.ProjectMembershipsGetRequest_builder{
+					Id: "pm-100",
+				}.Build(),
+				&grpc.UnaryServerInfo{
+					FullMethod: "/osac.public.v1.ProjectMemberships/Get",
+				},
+				func(ctx context.Context, req any) (any, error) {
+					handled = true
+					return nil, nil
+				},
+			)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(handled).To(BeTrue())
+		})
+
+		It("Allows project manager to update project memberships", func(ctx context.Context) {
+			pmInterceptor, err := NewGrpcAuthzInterceptor().
+				SetLogger(logger).
+				SetProjectMembershipMetadataFetcher(func(ctx context.Context, id string) *ObjectMetadata {
+					Expect(id).To(Equal("pm-200"))
+					return &ObjectMetadata{Tenant: "my-tenant", Project: "my-project"}
+				}).
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+
+			token := createKeycloakUserToken("", "my-user", jwt.MapClaims{
+				"organization": map[string]any{
+					"my-tenant": map[string]any{
+						"groups": []any{
+							"/my-project/system:managers",
+						},
+					},
+				},
+			})
+			ctx = ContextWithToken(ctx, token)
+			handled := false
+			_, err = pmInterceptor.UnaryServer(
+				ctx,
+				publicv1.ProjectMembershipsUpdateRequest_builder{
+					Object: publicv1.ProjectMembership_builder{
+						Id: "pm-200",
+					}.Build(),
+					UpdateMask: &fieldmaskpb.FieldMask{},
+				}.Build(),
+				&grpc.UnaryServerInfo{
+					FullMethod: "/osac.public.v1.ProjectMemberships/Update",
+				},
+				func(ctx context.Context, req any) (any, error) {
+					handled = true
+					return nil, nil
+				},
+			)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(handled).To(BeTrue())
+		})
+
+		It("Allows project manager to delete project memberships", func(ctx context.Context) {
+			pmInterceptor, err := NewGrpcAuthzInterceptor().
+				SetLogger(logger).
+				SetProjectMembershipMetadataFetcher(func(ctx context.Context, id string) *ObjectMetadata {
+					Expect(id).To(Equal("pm-300"))
+					return &ObjectMetadata{Tenant: "my-tenant", Project: "my-project"}
+				}).
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+
+			token := createKeycloakUserToken("", "my-user", jwt.MapClaims{
+				"organization": map[string]any{
+					"my-tenant": map[string]any{
+						"groups": []any{
+							"/my-project/system:managers",
+						},
+					},
+				},
+			})
+			ctx = ContextWithToken(ctx, token)
+			handled := false
+			_, err = pmInterceptor.UnaryServer(
+				ctx,
+				publicv1.ProjectMembershipsDeleteRequest_builder{
+					Id: "pm-300",
+				}.Build(),
+				&grpc.UnaryServerInfo{
+					FullMethod: "/osac.public.v1.ProjectMemberships/Delete",
+				},
+				func(ctx context.Context, req any) (any, error) {
 					handled = true
 					return nil, nil
 				},

--- a/internal/auth/policies/authz.rego
+++ b/internal/auth/policies/authz.rego
@@ -270,46 +270,39 @@ allow if {
   }
 }
 
-# Tenant admins can create and manage tenant-scoped bare metal catalog items.
-# The application layer (generic server) enforces that the tenant field is set from caller identity.
+# Tenant admins can manage bare metal catalog items, users, identity providers,
+# projects, and project memberships within their tenant. The application layer
+# (generic server) enforces resource-level authorization via tenant field validation.
 allow if {
   is_tenant_admin
   grpc_method in {
     "/osac.public.v1.BareMetalInstanceCatalogItems/Create",
     "/osac.public.v1.BareMetalInstanceCatalogItems/Update",
     "/osac.public.v1.BareMetalInstanceCatalogItems/Delete",
-  }
-}
-
-# Tenant-scoped user management for tenant admins
-# Note: Tenant admins can manage users. IdP managers cannot (they only manage IdP config).
-# OPA performs method-level authorization (can this user call this method?).
-# The application layer enforces resource-level authorization via the generic server's
-# determineAssignedTenant validation, which ensures users can only assign a tenant they have visibility to.
-allow if {
-  is_tenant_admin
-  grpc_method in {
-    "/osac.public.v1.Users/Create",
-    "/osac.public.v1.Users/Get",
-    "/osac.public.v1.Users/List",
-    "/osac.public.v1.Users/Update",
-    "/osac.public.v1.Users/Delete",
-  }
-}
-
-# Tenant-scoped IdP management for both tenant admins and IdP managers
-# Both roles can perform CRUD operations on identity providers within their tenant.
-# The application layer (generic server) enforces that the tenant field is set from caller identity.
-allow if {
-  is_tenant_admin
-  grpc_method in {
     "/osac.public.v1.IdentityProviders/Create",
     "/osac.public.v1.IdentityProviders/Get",
     "/osac.public.v1.IdentityProviders/List",
     "/osac.public.v1.IdentityProviders/Update",
     "/osac.public.v1.IdentityProviders/Delete",
+    "/osac.public.v1.Users/Create",
+    "/osac.public.v1.Users/Get",
+    "/osac.public.v1.Users/List",
+    "/osac.public.v1.Users/Update",
+    "/osac.public.v1.Users/Delete",
+    "/osac.public.v1.Projects/Create",
+    "/osac.public.v1.Projects/Get",
+    "/osac.public.v1.Projects/List",
+    "/osac.public.v1.Projects/Update",
+    "/osac.public.v1.Projects/Delete",
+    "/osac.public.v1.ProjectMemberships/Create",
+    "/osac.public.v1.ProjectMemberships/Get",
+    "/osac.public.v1.ProjectMemberships/List",
+    "/osac.public.v1.ProjectMemberships/Update",
+    "/osac.public.v1.ProjectMemberships/Delete",
   }
 }
+
+# Tenant IdP managers can manage identity providers (but not users or project memberships).
 allow if {
   is_tenant_idp_manager
   grpc_method in {
@@ -327,12 +320,6 @@ allow if {
 }
 
 # Project authorization
-# Tenant admins can create projects
-allow if {
-  is_tenant_admin
-  grpc_method == "/osac.public.v1.Projects/Create"
-}
-
 # All authenticated users with client permissions can list projects
 # (application layer filters results based on actual project memberships)
 allow if {
@@ -364,6 +351,40 @@ allow if {
   input.auth.identity.authnMethod == "jwt"
   some group in subject_org_groups[tenant].groups
   group == sprintf("/%s/system:managers", [name])
+}
+
+# All authenticated users with client permissions can list project memberships
+# (application layer filters results based on actual project memberships)
+allow if {
+  has_client_permissions
+  grpc_method == "/osac.public.v1.ProjectMemberships/List"
+}
+
+# Project managers can create memberships for their project.
+# For Create, only the project name is available from the request body (no DB lookup),
+# so we iterate over the user's tenants to find a matching manager group.
+allow if {
+  grpc_method == "/osac.public.v1.ProjectMemberships/Create"
+  input.auth.identity.authnMethod == "jwt"
+  project := input.context.context_extensions.project
+  some tenant in subject_tenants
+  some group in subject_org_groups[tenant].groups
+  group == sprintf("/%s/system:managers", [project])
+}
+
+# Project managers can get, update, and delete memberships for their project.
+# Uses DB-authoritative tenant and project name from context extensions.
+allow if {
+  grpc_method in {
+    "/osac.public.v1.ProjectMemberships/Get",
+    "/osac.public.v1.ProjectMemberships/Update",
+    "/osac.public.v1.ProjectMemberships/Delete",
+  }
+  input.auth.identity.authnMethod == "jwt"
+  tenant := input.context.context_extensions.tenant
+  project := input.context.context_extensions.project
+  some group in subject_org_groups[tenant].groups
+  group == sprintf("/%s/system:managers", [project])
 }
 
 # Subject construction:

--- a/internal/cmd/service/start/grpcserver/start_grpc_server_cmd.go
+++ b/internal/cmd/service/start/grpcserver/start_grpc_server_cmd.go
@@ -301,13 +301,20 @@ func (c *runnerContext) run(cmd *cobra.Command, argv []string) error { //nolint:
 		return fmt.Errorf("failed to create validation interceptor: %w", err)
 	}
 
-	// Create metadata fetcher for project authorization
+	// Create metadata fetchers for project and project membership authorization.
 	metadataFetcher, err := dao.NewMetadataFetcher().
 		SetLogger(c.logger).
 		SetTable("projects").
 		Build()
 	if err != nil {
 		return fmt.Errorf("failed to create metadata fetcher: %w", err)
+	}
+	pmMetadataFetcher, err := dao.NewMetadataFetcher().
+		SetLogger(c.logger).
+		SetTable("project_memberships").
+		Build()
+	if err != nil {
+		return fmt.Errorf("failed to create project membership metadata fetcher: %w", err)
 	}
 
 	// Prepare the authentication interceptor:
@@ -360,6 +367,7 @@ func (c *runnerContext) run(cmd *cobra.Command, argv []string) error { //nolint:
 		SetLogger(c.logger).
 		AddAnonymousMethodRegex(anonymousMethodsRegex).
 		SetMetadataFetcher(metadataFetcher).
+		SetProjectMembershipMetadataFetcher(pmMetadataFetcher).
 		AddEmergencyServiceAccounts(c.args.emergencyServiceAccounts...).
 		Build()
 	if err != nil {

--- a/internal/database/dao/metadata_fetcher.go
+++ b/internal/database/dao/metadata_fetcher.go
@@ -49,7 +49,6 @@ func (b *MetadataFetcherBuilder) SetTable(value string) *MetadataFetcherBuilder 
 // Build creates the metadata fetcher function.
 // This bypasses authorization checks since it's used FOR authorization.
 func (b *MetadataFetcherBuilder) Build() (auth.MetadataFetcher, error) {
-	// Check required parameters:
 	if b.logger == nil {
 		return nil, errors.New("logger is mandatory")
 	}
@@ -57,33 +56,30 @@ func (b *MetadataFetcherBuilder) Build() (auth.MetadataFetcher, error) {
 		return nil, errors.New("table is mandatory")
 	}
 
-	// Capture builder values in closure:
 	logger := b.logger
-	query := fmt.Sprintf("select tenant, name from %s where id = $1", b.table)
+	query := fmt.Sprintf("select tenant, name::text, project::text from %s where id = $1", b.table)
 
-	return func(ctx context.Context, id string) (tenant, project string) {
-		var objectTenant, objectName string
-
-		// Get transaction from context
+	return func(ctx context.Context, id string) *auth.ObjectMetadata {
 		tx, err := database.TxFromContext(ctx)
 		if err != nil {
 			logger.WarnContext(ctx, "Failed to get transaction from context for metadata fetch",
 				slog.String("id", id),
 				slog.Any("error", err),
 			)
-			return "", ""
+			return nil
 		}
 
+		var meta auth.ObjectMetadata
 		row := tx.QueryRow(ctx, query, id)
-		err = row.Scan(&objectTenant, &objectName)
+		err = row.Scan(&meta.Tenant, &meta.Name, &meta.Project)
 		if err != nil {
 			logger.WarnContext(ctx, "Failed to fetch object metadata for authorization",
 				slog.String("id", id),
 				slog.Any("error", err),
 			)
-			return "", ""
+			return nil
 		}
 
-		return objectTenant, objectName
+		return &meta
 	}, nil
 }


### PR DESCRIPTION
# Description
Previously, only the cloud provider admin could CRUD ProjectMembership.

This adds authz rules so that the tenant-admin can CRUD ProjectMemberships for all projects in their tenant.
Any project manager can CRUD ProjectMemberships for the projects they're members of.

# Testing

1. Deployed integration test environment, created tenant and associated IdP
2. Assigned tenant-admin role to an IdP user
3. Logged in as IdP user and created project 
4. Created ProjectMembership with the remaining IdP user 
5. Verified no errors occurred when creating ProjectMembership and verified on Keycloak console that the additional IdP user was added to the project

Assisted-by: Claude Code <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Authorization**
  * Expanded authorization for Project Memberships and Projects, including tenant-admin, project-manager, and client permissions across Create/Get/Update/Delete and List.
  * Tightened project-scoped checks by enforcing manager-group membership derived from request context and project membership data.
* **Bug Fixes**
  * Improved request context accuracy by conditionally enriching authorization metadata (and omitting it when not needed), preventing incorrect tenant/project attribution.
* **Tests**
  * Updated and extended interceptor and policy test coverage for Project Memberships, including permission outcomes and `context_extensions` assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->