### PR TITLE
OSAC-2159: Add ClusterVersion CLI commands and table rendering

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,6 +24,11 @@ This file contains only frequently-needed commands and non-obvious rules. For de
   - Python: `pyproject.toml`
   - YAML: `.yamllint.yaml`
 
+**Before planning or implementing any change, read every document listed above that is
+relevant to the area you are working in.** Do not rely solely on existing source code as a
+reference -- the documents above describe design intent and conventions that are not always
+obvious from the code alone. Skipping them leads to subtle bugs and convention violations.
+
 ## Overview
 
 The fulfillment-service is a gRPC server with REST gateway for managing infrastructure resources

--- a/internal/cmd/cli/create/cluster/create_cluster_cmd.go
+++ b/internal/cmd/cli/create/cluster/create_cluster_cmd.go
@@ -345,8 +345,8 @@ func (c *runnerContext) findTemplate(ctx context.Context) (result *publicv1.Clus
 		c.args.template,
 	)
 	response, err := c.templatesClient.List(ctx, publicv1.ClusterTemplatesListRequest_builder{
-		Filter: new(filter),
-		Limit:  new(int32(10)),
+		Filter: proto.String(filter),
+		Limit:  proto.Int32(10),
 	}.Build())
 	if err != nil {
 		return nil, fmt.Errorf("failed to list templates: %w", err)
@@ -373,7 +373,7 @@ func (c *runnerContext) findTemplate(ctx context.Context) (result *publicv1.Clus
 
 	// If we are here then no matches were found, we will show to the user some of the available templates:
 	response, err = c.templatesClient.List(ctx, publicv1.ClusterTemplatesListRequest_builder{
-		Limit: new(int32(10)),
+		Limit: proto.Int32(10),
 	}.Build())
 	if err != nil {
 		return nil, fmt.Errorf("failed to list templates: %w", err)

--- a/internal/cmd/cli/create/clusterversion/create_clusterversion_cmd.go
+++ b/internal/cmd/cli/create/clusterversion/create_clusterversion_cmd.go
@@ -1,0 +1,235 @@
+/*
+Copyright (c) 2026 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package clusterversion
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"google.golang.org/protobuf/proto"
+
+	privatev1 "github.com/osac-project/fulfillment-service/internal/api/osac/private/v1"
+	"github.com/osac-project/fulfillment-service/internal/config"
+	"github.com/osac-project/fulfillment-service/internal/terminal"
+)
+
+// Cmd creates the command to create a cluster version.
+func Cmd() *cobra.Command {
+	runner := &runnerContext{}
+	result := &cobra.Command{
+		Use:                   "clusterversion",
+		Aliases:               []string{string(proto.MessageName((*privatev1.ClusterVersion)(nil)))},
+		Short:                 shortHelp,
+		Long:                  longHelp,
+		DisableFlagsInUseLine: true,
+		Args:                  cobra.NoArgs,
+		RunE:                  runner.run,
+	}
+	flags := result.Flags()
+	flags.StringVar(
+		&runner.name,
+		"name",
+		"",
+		nameFlagHelp,
+	)
+	flags.StringVar(
+		&runner.version,
+		"version",
+		"",
+		versionFlagHelp,
+	)
+	flags.StringVar(
+		&runner.image,
+		"image",
+		"",
+		imageFlagHelp,
+	)
+	flags.BoolVar(
+		&runner.enabled,
+		"enabled",
+		true,
+		enabledFlagHelp,
+	)
+	flags.BoolVar(
+		&runner.isDefault,
+		"default",
+		false,
+		defaultFlagHelp,
+	)
+	flags.StringVar(
+		&runner.state,
+		"state",
+		"",
+		stateFlagHelp,
+	)
+	flags.StringSliceVar(
+		&runner.allowedUpgrades,
+		"allowed-upgrade",
+		nil,
+		allowedUpgradeFlagHelp,
+	)
+	result.MarkFlagRequired("version") //nolint:errcheck
+	result.MarkFlagRequired("image")   //nolint:errcheck
+	return result
+}
+
+type runnerContext struct {
+	console         *terminal.Console
+	name            string
+	version         string
+	image           string
+	enabled         bool
+	isDefault       bool
+	state           string
+	allowedUpgrades []string
+}
+
+func (c *runnerContext) run(cmd *cobra.Command, args []string) error {
+	ctx := cmd.Context()
+	c.console = terminal.ConsoleFromContext(ctx)
+
+	cfg := config.SettingsFromContext(ctx)
+	if !cfg.Armed() {
+		return fmt.Errorf("there is no configuration, run the 'login' command")
+	}
+
+	parsedState, err := parseState(c.state)
+	if err != nil {
+		return err
+	}
+
+	conn, err := cfg.Connect(ctx, cmd.Flags())
+	if err != nil {
+		return fmt.Errorf("failed to create gRPC connection: %w", err)
+	}
+	defer conn.Close()
+
+	client := privatev1.NewClusterVersionsClient(conn)
+
+	spec := privatev1.ClusterVersionSpec_builder{
+		Version: c.version,
+		Image:   c.image,
+		State:   parsedState,
+	}
+	if cmd.Flags().Changed("enabled") {
+		spec.Enabled = proto.Bool(c.enabled)
+	}
+	if cmd.Flags().Changed("default") {
+		spec.IsDefault = proto.Bool(c.isDefault)
+	}
+	if len(c.allowedUpgrades) > 0 {
+		spec.AllowedUpgrades = privatev1.ClusterVersionAllowedUpgrades_builder{
+			VersionNames: c.allowedUpgrades,
+		}.Build()
+	}
+
+	cv := privatev1.ClusterVersion_builder{
+		Spec: spec.Build(),
+	}
+	if c.name != "" {
+		cv.Metadata = privatev1.Metadata_builder{
+			Name: c.name,
+		}.Build()
+	}
+
+	response, err := client.Create(ctx, privatev1.ClusterVersionsCreateRequest_builder{
+		Object: cv.Build(),
+	}.Build())
+	if err != nil {
+		return fmt.Errorf("failed to create cluster version: %w", err)
+	}
+
+	c.console.Infof(ctx, "Created cluster version '%s'.\n", response.GetObject().GetId())
+
+	return nil
+}
+
+func parseState(value string) (privatev1.ClusterVersionState, error) {
+	switch strings.ToUpper(value) {
+	case "ACTIVE":
+		return privatev1.ClusterVersionState_CLUSTER_VERSION_STATE_ACTIVE, nil
+	case "DEPRECATED":
+		return privatev1.ClusterVersionState_CLUSTER_VERSION_STATE_DEPRECATED, nil
+	case "OBSOLETE":
+		return privatev1.ClusterVersionState_CLUSTER_VERSION_STATE_OBSOLETE, nil
+	case "":
+		return privatev1.ClusterVersionState_CLUSTER_VERSION_STATE_UNSPECIFIED, nil
+	default:
+		return 0, fmt.Errorf("invalid state '%s', must be ACTIVE, DEPRECATED, or OBSOLETE", value)
+	}
+}
+
+const shortHelp = `Create a cluster version.`
+
+const longHelp = `
+Create a cluster version.
+
+A cluster version defines an available OpenShift version that can be selected when creating
+clusters. Cluster versions are managed by Cloud Provider Admins and control which release images
+are available for provisioning.
+
+If {{ bt }}--name{{ bt }} is omitted, the server auto-generates it from the version string by
+lowercasing and replacing non-alphanumeric characters with dashes (e.g., {{ bt }}4.17.0{{ bt }}
+becomes {{ bt }}4-17-0{{ bt }}).
+
+To create a cluster version:
+
+{{ bt 3 }}shell
+{{ binary }} create clusterversion --version 4.17.0 \
+  --image quay.io/openshift-release-dev/ocp-release:4.17.0-multi \
+  --enabled --default
+{{ bt 3 }}
+
+To create a cluster version with allowed upgrade targets:
+
+{{ bt 3 }}shell
+{{ binary }} create clusterversion --version 4.16.0 \
+  --image quay.io/openshift-release-dev/ocp-release:4.16.0-multi \
+  --allowed-upgrade 4-17-0,4-17-1
+{{ bt 3 }}
+`
+
+const nameFlagHelp = `
+_NAME_ - Name of the cluster version. If omitted, auto-generated from the version string.
+`
+
+const versionFlagHelp = `
+_VERSION_ - SemVer 2.0.0 version string (e.g., {{ bt }}4.17.0{{ bt }}, {{ bt }}4.17.0-rc.1{{ bt }}).
+Must be unique among active cluster versions.
+`
+
+const imageFlagHelp = `
+_IMAGE_ - OCI release image pullspec
+(e.g., {{ bt }}quay.io/openshift-release-dev/ocp-release:4.17.0-multi{{ bt }}).
+`
+
+const enabledFlagHelp = `
+_[BOOLEAN]_ - Whether new clusters may select this version. Defaults to true if not specified.
+`
+
+const defaultFlagHelp = `
+_[BOOLEAN]_ - Whether this is the default version for new clusters. At most one active cluster
+version may be the default.
+`
+
+const stateFlagHelp = `
+_STATE_ - Lifecycle state: {{ bt }}ACTIVE{{ bt }}, {{ bt }}DEPRECATED{{ bt }}, or
+{{ bt }}OBSOLETE{{ bt }}. Defaults to ACTIVE if not specified.
+`
+
+const allowedUpgradeFlagHelp = `
+_NAME_ - Cluster version names ({{ bt }}metadata.name{{ bt }}) that clusters on this version may
+upgrade to. Repeatable or comma-separated.
+`

--- a/internal/cmd/cli/create/clusterversion/create_clusterversion_cmd_test.go
+++ b/internal/cmd/cli/create/clusterversion/create_clusterversion_cmd_test.go
@@ -1,0 +1,106 @@
+/*
+Copyright (c) 2026 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package clusterversion
+
+import (
+	. "github.com/onsi/ginkgo/v2/dsl/core"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Create clusterversion flag registration", func() {
+	It("should create command without error", func() {
+		cmd := Cmd()
+		Expect(cmd).NotTo(BeNil())
+		Expect(cmd.Use).To(Equal("clusterversion"))
+	})
+
+	It("should register --name flag", func() {
+		cmd := Cmd()
+		flag := cmd.Flags().Lookup("name")
+		Expect(flag).NotTo(BeNil())
+		Expect(flag.Usage).To(ContainSubstring("Name"))
+	})
+
+	It("should register --version flag", func() {
+		cmd := Cmd()
+		flag := cmd.Flags().Lookup("version")
+		Expect(flag).NotTo(BeNil())
+		Expect(flag.Usage).To(ContainSubstring("SemVer"))
+	})
+
+	It("should register --image flag", func() {
+		cmd := Cmd()
+		flag := cmd.Flags().Lookup("image")
+		Expect(flag).NotTo(BeNil())
+		Expect(flag.Usage).To(ContainSubstring("OCI"))
+	})
+
+	It("should register --enabled flag", func() {
+		cmd := Cmd()
+		flag := cmd.Flags().Lookup("enabled")
+		Expect(flag).NotTo(BeNil())
+	})
+
+	It("should register --default flag", func() {
+		cmd := Cmd()
+		flag := cmd.Flags().Lookup("default")
+		Expect(flag).NotTo(BeNil())
+	})
+
+	It("should register --state flag", func() {
+		cmd := Cmd()
+		flag := cmd.Flags().Lookup("state")
+		Expect(flag).NotTo(BeNil())
+		Expect(flag.Usage).To(ContainSubstring("ACTIVE"))
+	})
+
+	It("should register --allowed-upgrade flag", func() {
+		cmd := Cmd()
+		flag := cmd.Flags().Lookup("allowed-upgrade")
+		Expect(flag).NotTo(BeNil())
+		Expect(flag.Usage).To(ContainSubstring("upgrade"))
+	})
+})
+
+var _ = Describe("State parsing", func() {
+	It("should parse ACTIVE", func() {
+		state, err := parseState("ACTIVE")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(state.String()).To(ContainSubstring("ACTIVE"))
+	})
+
+	It("should parse case-insensitive input", func() {
+		state, err := parseState("deprecated")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(state.String()).To(ContainSubstring("DEPRECATED"))
+	})
+
+	It("should parse OBSOLETE", func() {
+		state, err := parseState("Obsolete")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(state.String()).To(ContainSubstring("OBSOLETE"))
+	})
+
+	It("should return UNSPECIFIED for empty string", func() {
+		state, err := parseState("")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(state.String()).To(ContainSubstring("UNSPECIFIED"))
+	})
+
+	It("should reject invalid state", func() {
+		_, err := parseState("INVALID")
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("invalid state"))
+	})
+})

--- a/internal/cmd/cli/create/clusterversion/create_clusterversion_suite_test.go
+++ b/internal/cmd/cli/create/clusterversion/create_clusterversion_suite_test.go
@@ -1,0 +1,26 @@
+/*
+Copyright (c) 2026 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package clusterversion
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestCreateClusterversion(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Create clusterversion command")
+}

--- a/internal/cmd/cli/create/computeinstance/create_compute_instance_cmd.go
+++ b/internal/cmd/cli/create/computeinstance/create_compute_instance_cmd.go
@@ -338,8 +338,8 @@ func (c *runnerContext) findTemplate(ctx context.Context) (result *publicv1.Comp
 		c.args.template,
 	)
 	response, err := c.templatesClient.List(ctx, publicv1.ComputeInstanceTemplatesListRequest_builder{
-		Filter: new(filter),
-		Limit:  new(int32(10)),
+		Filter: proto.String(filter),
+		Limit:  proto.Int32(10),
 	}.Build())
 	if err != nil {
 		return nil, fmt.Errorf("failed to list templates: %w", err)
@@ -366,7 +366,7 @@ func (c *runnerContext) findTemplate(ctx context.Context) (result *publicv1.Comp
 
 	// If we are here then no matches were found, we will show to the user some of the available templates:
 	response, err = c.templatesClient.List(ctx, publicv1.ComputeInstanceTemplatesListRequest_builder{
-		Limit: new(int32(10)),
+		Limit: proto.Int32(10),
 	}.Build())
 	if err != nil {
 		return nil, fmt.Errorf("failed to list templates: %w", err)
@@ -709,10 +709,10 @@ func (c *runnerContext) buildSpec(templateID string,
 		}.Build()
 	}
 	if c.args.instanceType != "" {
-		spec.InstanceType = new(c.args.instanceType)
+		spec.InstanceType = proto.String(c.args.instanceType)
 	}
 	if c.args.sshPublicKey != "" {
-		spec.SshPublicKey = new(c.args.sshPublicKey)
+		spec.SshPublicKey = proto.String(c.args.sshPublicKey)
 	}
 	if c.args.bootDiskSizeGiB > 0 {
 		spec.BootDisk = publicv1.ComputeInstanceDisk_builder{
@@ -727,13 +727,13 @@ func (c *runnerContext) buildSpec(templateID string,
 		spec.AdditionalDisks = disks
 	}
 	if c.args.runStrategy != "" {
-		spec.RunStrategy = new(c.args.runStrategy)
+		spec.RunStrategy = proto.String(c.args.runStrategy)
 	}
 	if c.args.userData != "" {
-		spec.UserData = new(c.args.userData)
+		spec.UserData = proto.String(c.args.userData)
 	}
 	if c.args.windows {
-		spec.IsWindows = new(true)
+		spec.IsWindows = proto.Bool(true)
 	}
 	if err := c.applyNetworkingFlags(&spec); err != nil {
 		return nil, err
@@ -855,10 +855,10 @@ func (c *runnerContext) buildSpecFromCatalogItem(catalogItemID string) (*publicv
 		}.Build()
 	}
 	if c.args.instanceType != "" {
-		spec.InstanceType = new(c.args.instanceType)
+		spec.InstanceType = proto.String(c.args.instanceType)
 	}
 	if c.args.sshPublicKey != "" {
-		spec.SshPublicKey = new(c.args.sshPublicKey)
+		spec.SshPublicKey = proto.String(c.args.sshPublicKey)
 	}
 	if c.args.bootDiskSizeGiB > 0 {
 		spec.BootDisk = publicv1.ComputeInstanceDisk_builder{
@@ -873,13 +873,13 @@ func (c *runnerContext) buildSpecFromCatalogItem(catalogItemID string) (*publicv
 		spec.AdditionalDisks = disks
 	}
 	if c.args.runStrategy != "" {
-		spec.RunStrategy = new(c.args.runStrategy)
+		spec.RunStrategy = proto.String(c.args.runStrategy)
 	}
 	if c.args.userData != "" {
-		spec.UserData = new(c.args.userData)
+		spec.UserData = proto.String(c.args.userData)
 	}
 	if c.args.windows {
-		spec.IsWindows = new(true)
+		spec.IsWindows = proto.Bool(true)
 	}
 	if err := c.applyNetworkingFlags(&spec); err != nil {
 		return nil, err

--- a/internal/cmd/cli/create/create_cmd.go
+++ b/internal/cmd/cli/create/create_cmd.go
@@ -33,6 +33,7 @@ import (
 	"github.com/osac-project/fulfillment-service/internal/cmd/cli/create/baremetalinstancecatalogitem"
 	"github.com/osac-project/fulfillment-service/internal/cmd/cli/create/cluster"
 	"github.com/osac-project/fulfillment-service/internal/cmd/cli/create/clustercatalogitem"
+	"github.com/osac-project/fulfillment-service/internal/cmd/cli/create/clusterversion"
 	"github.com/osac-project/fulfillment-service/internal/cmd/cli/create/computeinstance"
 	"github.com/osac-project/fulfillment-service/internal/cmd/cli/create/computeinstancecatalogitem"
 	"github.com/osac-project/fulfillment-service/internal/cmd/cli/create/externalip"
@@ -66,6 +67,7 @@ func Cmd() *cobra.Command {
 	result.AddCommand(baremetalinstancecatalogitem.Cmd())
 	result.AddCommand(cluster.Cmd())
 	result.AddCommand(clustercatalogitem.Cmd())
+	result.AddCommand(clusterversion.Cmd())
 	result.AddCommand(computeinstance.Cmd())
 	result.AddCommand(computeinstancecatalogitem.Cmd())
 	result.AddCommand(externalip.Cmd())

--- a/internal/cmd/cli/create/create_cmd_test.go
+++ b/internal/cmd/cli/create/create_cmd_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/osac-project/fulfillment-service/internal/cmd/cli/create/baremetalinstancecatalogitem"
 	"github.com/osac-project/fulfillment-service/internal/cmd/cli/create/cluster"
 	"github.com/osac-project/fulfillment-service/internal/cmd/cli/create/clustercatalogitem"
+	"github.com/osac-project/fulfillment-service/internal/cmd/cli/create/clusterversion"
 	"github.com/osac-project/fulfillment-service/internal/cmd/cli/create/computeinstance"
 	"github.com/osac-project/fulfillment-service/internal/cmd/cli/create/computeinstancecatalogitem"
 	"github.com/osac-project/fulfillment-service/internal/cmd/cli/create/hub"
@@ -44,6 +45,7 @@ var _ = Describe("Create command", func() {
 		Entry("baremetalinstancecatalogitem", baremetalinstancecatalogitem.Cmd, (*publicv1.BareMetalInstanceCatalogItem)(nil)),
 		Entry("cluster", cluster.Cmd, (*publicv1.Cluster)(nil)),
 		Entry("clustercatalogitem", clustercatalogitem.Cmd, (*publicv1.ClusterCatalogItem)(nil)),
+		Entry("clusterversion", clusterversion.Cmd, (*privatev1.ClusterVersion)(nil)),
 		Entry("computeinstance", computeinstance.Cmd, (*publicv1.ComputeInstance)(nil)),
 		Entry("computeinstancecatalogitem", computeinstancecatalogitem.Cmd, (*publicv1.ComputeInstanceCatalogItem)(nil)),
 		Entry("hub", hub.Cmd, (*privatev1.Hub)(nil)),
@@ -63,7 +65,7 @@ var _ = Describe("Create command", func() {
 				subcommandNames = append(subcommandNames, subcmd.Name())
 			}
 
-			Expect(subcommandNames).To(ContainElements("baremetalinstancecatalogitem", "cluster", "clustercatalogitem", "computeinstance", "computeinstancecatalogitem", "hub", "publicip", "publicipattachment", "virtualnetwork", "subnet", "securitygroup"))
+			Expect(subcommandNames).To(ContainElements("baremetalinstancecatalogitem", "cluster", "clustercatalogitem", "clusterversion", "computeinstance", "computeinstancecatalogitem", "hub", "publicip", "publicipattachment", "virtualnetwork", "subnet", "securitygroup"))
 		})
 	})
 })

--- a/internal/cmd/cli/describe/clusterversion/describe_clusterversion_cmd.go
+++ b/internal/cmd/cli/describe/clusterversion/describe_clusterversion_cmd.go
@@ -1,0 +1,157 @@
+/*
+Copyright (c) 2026 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package clusterversion
+
+import (
+	"fmt"
+	"io"
+	"log/slog"
+	"strings"
+	"text/tabwriter"
+	"time"
+
+	"github.com/spf13/cobra"
+	"google.golang.org/protobuf/proto"
+
+	publicv1 "github.com/osac-project/fulfillment-service/internal/api/osac/public/v1"
+	"github.com/osac-project/fulfillment-service/internal/cmd/cli/lookup"
+	"github.com/osac-project/fulfillment-service/internal/config"
+	"github.com/osac-project/fulfillment-service/internal/logging"
+	"github.com/osac-project/fulfillment-service/internal/terminal"
+)
+
+// Cmd creates the command to describe a cluster version.
+func Cmd() *cobra.Command {
+	runner := &runnerContext{}
+	result := &cobra.Command{
+		Use:                   "clusterversion [FLAG...] ID|NAME",
+		Aliases:               []string{"clusterversions"},
+		Short:                 shortHelp,
+		Long:                  longHelp,
+		DisableFlagsInUseLine: true,
+		Args:                  cobra.ExactArgs(1),
+		RunE:                  runner.run,
+	}
+	return result
+}
+
+type runnerContext struct {
+	logger  *slog.Logger
+	console *terminal.Console
+}
+
+func (c *runnerContext) run(cmd *cobra.Command, args []string) error {
+	ref := args[0]
+
+	ctx := cmd.Context()
+
+	c.logger = logging.LoggerFromContext(ctx)
+	c.console = terminal.ConsoleFromContext(ctx)
+
+	cfg := config.SettingsFromContext(ctx)
+	if !cfg.Armed() {
+		return fmt.Errorf("there is no configuration, run the 'login' command")
+	}
+
+	conn, err := cfg.Connect(ctx, cmd.Flags())
+	if err != nil {
+		return fmt.Errorf("failed to create gRPC connection: %w", err)
+	}
+	defer conn.Close()
+
+	client := publicv1.NewClusterVersionsClient(conn)
+
+	matched, err := lookup.Find(ref, "cluster version", func(filter string, limit int32) ([]*publicv1.ClusterVersion, error) {
+		resp, err := client.List(ctx, publicv1.ClusterVersionsListRequest_builder{
+			Filter: proto.String(filter),
+			Limit:  proto.Int32(limit),
+		}.Build())
+		if err != nil {
+			return nil, fmt.Errorf("failed to describe cluster version: %w", err)
+		}
+		return resp.GetItems(), nil
+	})
+	if err != nil {
+		return err
+	}
+
+	renderClusterVersion(c.console, matched)
+
+	return nil
+}
+
+func renderClusterVersion(w io.Writer, cv *publicv1.ClusterVersion) {
+	writer := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
+
+	name := "-"
+	if v := cv.GetMetadata().GetName(); v != "" {
+		name = v
+	}
+	fmt.Fprintf(writer, "Name:\t%s\n", name)
+
+	spec := cv.GetSpec()
+	if spec != nil {
+		fmt.Fprintf(writer, "Version:\t%s\n", spec.GetVersion())
+
+		state := strings.TrimPrefix(spec.GetState().String(), "CLUSTER_VERSION_STATE_")
+		fmt.Fprintf(writer, "State:\t%s\n", state)
+
+		enabled := "-"
+		if spec.HasEnabled() {
+			enabled = fmt.Sprintf("%t", spec.GetEnabled())
+		}
+		fmt.Fprintf(writer, "Enabled:\t%s\n", enabled)
+
+		isDefault := "-"
+		if spec.HasIsDefault() {
+			isDefault = fmt.Sprintf("%t", spec.GetIsDefault())
+		}
+		fmt.Fprintf(writer, "Default:\t%s\n", isDefault)
+
+		if dep := spec.GetDeprecation(); dep != nil {
+			if ts := dep.GetDeprecationTimestamp(); ts != nil {
+				fmt.Fprintf(writer, "Deprecated At:\t%s\n", ts.AsTime().Format(time.RFC3339))
+			}
+			if ts := dep.GetObsolescenceTimestamp(); ts != nil {
+				fmt.Fprintf(writer, "Obsolete At:\t%s\n", ts.AsTime().Format(time.RFC3339))
+			}
+		}
+
+		allowedUpgrades := "(unrestricted)"
+		if spec.HasAllowedUpgrades() {
+			allowedUpgrades = "(none)"
+		}
+		if names := spec.GetAllowedUpgrades().GetVersionNames(); len(names) > 0 {
+			allowedUpgrades = strings.Join(names, ", ")
+		}
+		fmt.Fprintf(writer, "Allowed Upgrades:\t%s\n", allowedUpgrades)
+	}
+
+	writer.Flush()
+}
+
+const shortHelp = `Describe a cluster version.`
+
+const longHelp = `
+Describe a cluster version.
+
+Displays detailed information about a cluster version, including its version string, lifecycle
+state, availability, deprecation details, and allowed upgrade targets.
+
+To describe a cluster version by name:
+
+{{ bt 3 }}shell
+{{ binary }} describe clusterversion 4-17-0
+{{ bt 3 }}
+`

--- a/internal/cmd/cli/describe/clusterversion/describe_clusterversion_cmd_test.go
+++ b/internal/cmd/cli/describe/clusterversion/describe_clusterversion_cmd_test.go
@@ -1,0 +1,184 @@
+/*
+Copyright (c) 2026 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package clusterversion
+
+import (
+	"bytes"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2/dsl/core"
+	. "github.com/onsi/gomega"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	publicv1 "github.com/osac-project/fulfillment-service/internal/api/osac/public/v1"
+)
+
+func formatClusterVersion(cv *publicv1.ClusterVersion) string {
+	var buf bytes.Buffer
+	renderClusterVersion(&buf, cv)
+	return buf.String()
+}
+
+var _ = Describe("Rendering tests", func() {
+	It("should display all base fields for ACTIVE version", func() {
+		cv := publicv1.ClusterVersion_builder{
+			Id: "cv-001",
+			Metadata: publicv1.Metadata_builder{
+				Name: "4-17-0",
+			}.Build(),
+			Spec: publicv1.ClusterVersionSpec_builder{
+				Version:   "4.17.0",
+				State:     publicv1.ClusterVersionState_CLUSTER_VERSION_STATE_ACTIVE,
+				Enabled:   proto.Bool(true),
+				IsDefault: proto.Bool(false),
+			}.Build(),
+		}.Build()
+		output := formatClusterVersion(cv)
+		Expect(output).To(MatchRegexp(`Name:\s+4-17-0`))
+		Expect(output).To(MatchRegexp(`Version:\s+4\.17\.0`))
+		Expect(output).To(ContainSubstring("ACTIVE"))
+		Expect(output).NotTo(ContainSubstring("CLUSTER_VERSION_STATE_"))
+		Expect(output).To(MatchRegexp(`Enabled:\s+true`))
+		Expect(output).To(MatchRegexp(`Default:\s+false`))
+	})
+
+	It("should strip CLUSTER_VERSION_STATE_ prefix from DEPRECATED state", func() {
+		cv := publicv1.ClusterVersion_builder{
+			Id: "cv-002",
+			Metadata: publicv1.Metadata_builder{
+				Name: "4-16-0",
+			}.Build(),
+			Spec: publicv1.ClusterVersionSpec_builder{
+				Version: "4.16.0",
+				State:   publicv1.ClusterVersionState_CLUSTER_VERSION_STATE_DEPRECATED,
+			}.Build(),
+		}.Build()
+		output := formatClusterVersion(cv)
+		Expect(output).To(ContainSubstring("DEPRECATED"))
+		Expect(output).NotTo(ContainSubstring("CLUSTER_VERSION_STATE_"))
+	})
+
+	It("should show deprecation timestamps when present", func() {
+		depTime := time.Date(2026, 7, 15, 10, 30, 0, 0, time.UTC)
+		obsTime := time.Date(2026, 10, 15, 10, 30, 0, 0, time.UTC)
+		cv := publicv1.ClusterVersion_builder{
+			Id: "cv-003",
+			Metadata: publicv1.Metadata_builder{
+				Name: "4-16-0",
+			}.Build(),
+			Spec: publicv1.ClusterVersionSpec_builder{
+				Version: "4.16.0",
+				State:   publicv1.ClusterVersionState_CLUSTER_VERSION_STATE_DEPRECATED,
+				Deprecation: publicv1.ClusterVersionDeprecation_builder{
+					DeprecationTimestamp:  timestamppb.New(depTime),
+					ObsolescenceTimestamp: timestamppb.New(obsTime),
+				}.Build(),
+			}.Build(),
+		}.Build()
+		output := formatClusterVersion(cv)
+		Expect(output).To(MatchRegexp(`Deprecated At:\s+2026-07-15T10:30:00Z`))
+		Expect(output).To(MatchRegexp(`Obsolete At:\s+2026-10-15T10:30:00Z`))
+	})
+
+	It("should omit deprecation section when absent", func() {
+		cv := publicv1.ClusterVersion_builder{
+			Id: "cv-004",
+			Metadata: publicv1.Metadata_builder{
+				Name: "4-17-0",
+			}.Build(),
+			Spec: publicv1.ClusterVersionSpec_builder{
+				Version: "4.17.0",
+				State:   publicv1.ClusterVersionState_CLUSTER_VERSION_STATE_ACTIVE,
+			}.Build(),
+		}.Build()
+		output := formatClusterVersion(cv)
+		Expect(output).NotTo(ContainSubstring("Deprecated At:"))
+		Expect(output).NotTo(ContainSubstring("Obsolete At:"))
+	})
+
+	It("should show '-' for enabled when not set", func() {
+		cv := publicv1.ClusterVersion_builder{
+			Id: "cv-005",
+			Metadata: publicv1.Metadata_builder{
+				Name: "4-17-0",
+			}.Build(),
+			Spec: publicv1.ClusterVersionSpec_builder{
+				Version: "4.17.0",
+			}.Build(),
+		}.Build()
+		output := formatClusterVersion(cv)
+		Expect(output).To(MatchRegexp(`Enabled:\s+-`))
+		Expect(output).To(MatchRegexp(`Default:\s+-`))
+	})
+
+	It("should show allowed upgrades when present", func() {
+		cv := publicv1.ClusterVersion_builder{
+			Id: "cv-006",
+			Metadata: publicv1.Metadata_builder{
+				Name: "4-16-0",
+			}.Build(),
+			Spec: publicv1.ClusterVersionSpec_builder{
+				Version: "4.16.0",
+				AllowedUpgrades: publicv1.ClusterVersionAllowedUpgrades_builder{
+					VersionNames: []string{"4-17-0", "4-17-1"},
+				}.Build(),
+			}.Build(),
+		}.Build()
+		output := formatClusterVersion(cv)
+		Expect(output).To(MatchRegexp(`Allowed Upgrades:\s+4-17-0, 4-17-1`))
+	})
+
+	It("should show (none) for empty allowed upgrades", func() {
+		cv := publicv1.ClusterVersion_builder{
+			Id: "cv-007",
+			Metadata: publicv1.Metadata_builder{
+				Name: "4-17-0",
+			}.Build(),
+			Spec: publicv1.ClusterVersionSpec_builder{
+				Version: "4.17.0",
+				AllowedUpgrades: publicv1.ClusterVersionAllowedUpgrades_builder{
+					VersionNames: []string{},
+				}.Build(),
+			}.Build(),
+		}.Build()
+		output := formatClusterVersion(cv)
+		Expect(output).To(MatchRegexp(`Allowed Upgrades:\s+\(none\)`))
+	})
+
+	It("should show (unrestricted) when allowed upgrades absent", func() {
+		cv := publicv1.ClusterVersion_builder{
+			Id: "cv-008",
+			Metadata: publicv1.Metadata_builder{
+				Name: "4-17-0",
+			}.Build(),
+			Spec: publicv1.ClusterVersionSpec_builder{
+				Version: "4.17.0",
+			}.Build(),
+		}.Build()
+		output := formatClusterVersion(cv)
+		Expect(output).To(MatchRegexp(`Allowed Upgrades:\s+\(unrestricted\)`))
+	})
+
+	It("should show '-' for name when metadata is nil", func() {
+		cv := publicv1.ClusterVersion_builder{
+			Id: "cv-009",
+			Spec: publicv1.ClusterVersionSpec_builder{
+				Version: "4.17.0",
+			}.Build(),
+		}.Build()
+		output := formatClusterVersion(cv)
+		Expect(output).To(MatchRegexp(`Name:\s+-`))
+	})
+})

--- a/internal/cmd/cli/describe/clusterversion/describe_clusterversion_suite_test.go
+++ b/internal/cmd/cli/describe/clusterversion/describe_clusterversion_suite_test.go
@@ -1,0 +1,26 @@
+/*
+Copyright (c) 2026 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package clusterversion
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestDescribeClusterversion(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Describe clusterversion command")
+}

--- a/internal/cmd/cli/describe/describe_cmd.go
+++ b/internal/cmd/cli/describe/describe_cmd.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/osac-project/fulfillment-service/internal/cmd/cli/describe/baremetalinstance"
 	"github.com/osac-project/fulfillment-service/internal/cmd/cli/describe/cluster"
+	"github.com/osac-project/fulfillment-service/internal/cmd/cli/describe/clusterversion"
 	"github.com/osac-project/fulfillment-service/internal/cmd/cli/describe/computeinstance"
 	"github.com/osac-project/fulfillment-service/internal/cmd/cli/describe/externalip"
 	"github.com/osac-project/fulfillment-service/internal/cmd/cli/describe/externalipattachment"
@@ -41,6 +42,7 @@ func Cmd() *cobra.Command {
 	}
 	result.AddCommand(baremetalinstance.Cmd())
 	result.AddCommand(cluster.Cmd())
+	result.AddCommand(clusterversion.Cmd())
 	result.AddCommand(computeinstance.Cmd())
 	result.AddCommand(externalip.Cmd())
 	result.AddCommand(externalipattachment.Cmd())

--- a/internal/cmd/cli/describe/describe_cmd_test.go
+++ b/internal/cmd/cli/describe/describe_cmd_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/osac-project/fulfillment-service/internal/cmd/cli/describe/cluster"
+	"github.com/osac-project/fulfillment-service/internal/cmd/cli/describe/clusterversion"
 	"github.com/osac-project/fulfillment-service/internal/cmd/cli/describe/computeinstance"
 	"github.com/osac-project/fulfillment-service/internal/cmd/cli/describe/networkclass"
 	"github.com/osac-project/fulfillment-service/internal/cmd/cli/describe/publicip"
@@ -38,6 +39,7 @@ var _ = Describe("Describe command", func() {
 			Expect(cmd.Aliases).To(ContainElement(expectedAlias))
 		},
 		Entry("cluster", cluster.Cmd, "clusters"),
+		Entry("clusterversion", clusterversion.Cmd, "clusterversions"),
 		Entry("computeinstance", computeinstance.Cmd, "computeinstances"),
 		Entry("networkclass", networkclass.Cmd, "networkclasses"),
 		Entry("publicip", publicip.Cmd, "publicips"),
@@ -57,7 +59,7 @@ var _ = Describe("Describe command", func() {
 				subcommandNames = append(subcommandNames, subcmd.Name())
 			}
 
-			Expect(subcommandNames).To(ContainElements("cluster", "computeinstance", "networkclass", "publicip", "publicipattachment", "virtualnetwork", "subnet", "securitygroup"))
+			Expect(subcommandNames).To(ContainElements("cluster", "clusterversion", "computeinstance", "networkclass", "publicip", "publicipattachment", "virtualnetwork", "subnet", "securitygroup"))
 		})
 	})
 

--- a/internal/cmd/cli/get/kubeconfig/get_kubeconfig_cmd.go
+++ b/internal/cmd/cli/get/kubeconfig/get_kubeconfig_cmd.go
@@ -23,6 +23,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"google.golang.org/grpc"
+	"google.golang.org/protobuf/proto"
 	"gopkg.in/yaml.v3"
 
 	publicv1 "github.com/osac-project/fulfillment-service/internal/api/osac/public/v1"
@@ -116,8 +117,8 @@ func (c *runnerContext) run(cmd *cobra.Command, args []string) error {
 		key,
 	)
 	listResponse, err := client.List(ctx, publicv1.ClustersListRequest_builder{
-		Filter: new(listFilter),
-		Limit:  new(int32(10)),
+		Filter: proto.String(listFilter),
+		Limit:  proto.Int32(10),
 	}.Build())
 	if err != nil {
 		return fmt.Errorf("failed to list clusters: %w", err)

--- a/internal/cmd/cli/get/password/get_password_cmd.go
+++ b/internal/cmd/cli/get/password/get_password_cmd.go
@@ -23,6 +23,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"google.golang.org/grpc"
+	"google.golang.org/protobuf/proto"
 
 	publicv1 "github.com/osac-project/fulfillment-service/internal/api/osac/public/v1"
 	"github.com/osac-project/fulfillment-service/internal/config"
@@ -116,8 +117,8 @@ func (c *runnerContext) run(cmd *cobra.Command, args []string) error {
 		key,
 	)
 	listResponse, err := client.List(ctx, publicv1.ClustersListRequest_builder{
-		Filter: new(listFilter),
-		Limit:  new(int32(10)),
+		Filter: proto.String(listFilter),
+		Limit:  proto.Int32(10),
 	}.Build())
 	if err != nil {
 		return fmt.Errorf("failed to list clusters: %w", err)

--- a/internal/rendering/tables/osac.private.v1.ClusterVersion.yaml
+++ b/internal/rendering/tables/osac.private.v1.ClusterVersion.yaml
@@ -1,0 +1,33 @@
+#
+# Copyright (c) 2026 Red Hat Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+# the License. You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+columns:
+
+- header: NAME
+  value: "has(this.metadata.name)? this.metadata.name: '-'"
+
+- header: VERSION
+  value: this.spec.version
+
+- header: STATE
+  value: this.spec.state
+  type: osac.private.v1.ClusterVersionState
+
+- header: ENABLED
+  value: "has(this.spec.enabled) ? (this.spec.enabled ? 'true' : 'false') : '-'"
+
+- header: DEFAULT
+  value: "has(this.spec.is_default) ? (this.spec.is_default ? 'true' : 'false') : '-'"
+
+- header: IMAGE
+  value: this.spec.image

--- a/internal/rendering/tables/osac.public.v1.ClusterVersion.yaml
+++ b/internal/rendering/tables/osac.public.v1.ClusterVersion.yaml
@@ -1,0 +1,30 @@
+#
+# Copyright (c) 2026 Red Hat Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+# the License. You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+columns:
+
+- header: NAME
+  value: "has(this.metadata.name)? this.metadata.name: '-'"
+
+- header: VERSION
+  value: this.spec.version
+
+- header: STATE
+  value: this.spec.state
+  type: osac.public.v1.ClusterVersionState
+
+- header: ENABLED
+  value: "has(this.spec.enabled) ? (this.spec.enabled ? 'true' : 'false') : '-'"
+
+- header: DEFAULT
+  value: "has(this.spec.is_default) ? (this.spec.is_default ? 'true' : 'false') : '-'"


### PR DESCRIPTION
A few examples: 

**Private api:** 
```bash
 
❯ osac create clusterversion --version "4.20.33" --image "quay.io/openshift-release-dev/ocp-release:4.20.2-mult" --allowed-upgrade "4-20-2-b3c1" --allowed-upgrade "4-20-3-b22e"
Created cluster version '019f7f2c-3db2-7bdc-be30-02d6eac13c92'.
❯ osac get clusterversion
NAME          DELETING  VERSION  STATE     ENABLED  DEFAULT  IMAGE
4-20-0-b09b   -         4.20.0   OBSOLETE  true     false    quay.io/openshift-release-dev/ocp-release:4.20.0-mult
4-20-1-af08   -         4.20.1   ACTIVE    true     false    quay.io/openshift-release-dev/ocp-release:4.20.1-mult
4-20-2-b3c1   -         4.20.2   ACTIVE    true     false    quay.io/openshift-release-dev/ocp-release:4.20.2-mult
4-20-3-b22e   -         4.20.3   ACTIVE    true     false    quay.io/openshift-release-dev/ocp-release:4.20.2-mult
4-20-33-63a7  -         4.20.33  ACTIVE    true     false    quay.io/openshift-release-dev/ocp-release:4.20.2-mult
❯ osac describe clusterversion 4-20-33-63a7
Name:              4-20-33-63a7
Version:           4.20.33
State:             ACTIVE
Enabled:           true
Default:           false
Allowed Upgrades:  4-20-2-b3c1, 4-20-3-b22e
```
**Public API:**
```bash
❯ osac get clusterversion # no image 
NAME          DELETING  VERSION  STATE   ENABLED  DEFAULT
4-20-1-af08   -         4.20.1   ACTIVE  true     false
4-20-2-b3c1   -         4.20.2   ACTIVE  true     false
4-20-3-b22e   -         4.20.3   ACTIVE  true     false
4-20-33-63a7  -         4.20.33  ACTIVE  true     false
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added CLI support to create cluster versions (name, version, image, state, enabled/default, and allowed upgrade targets).
  * Added CLI support to describe a cluster version by ID or name (including plural alias).
  * Added rendered cluster version tables for key fields (name, version, state, enabled/default, image), including allowed-upgrades formatting.
* **Documentation**
  * Updated agent guidance to require reviewing relevant reference documents before planning or implementing changes.
* **Tests**
  * Added Ginkgo/Gomega coverage for cluster version create/describe command registration, state handling, and output formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->