### PR TITLE
OSAC-2397: Support dry-run option for resource creation via metadata header

### DIFF
--- a/internal/cmd/service/start/restgateway/start_rest_gateway_cmd.go
+++ b/internal/cmd/service/start/restgateway/start_rest_gateway_cmd.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
+	"strings"
 	"syscall"
 	"time"
 
@@ -35,6 +36,7 @@ import (
 	publicv1 "github.com/osac-project/fulfillment-service/internal/api/osac/public/v1"
 	"github.com/osac-project/fulfillment-service/internal/logging"
 	"github.com/osac-project/fulfillment-service/internal/network"
+	"github.com/osac-project/fulfillment-service/internal/servers"
 	shtdwn "github.com/osac-project/fulfillment-service/internal/shutdown"
 	"github.com/osac-project/fulfillment-service/internal/version"
 )
@@ -152,6 +154,12 @@ func (c *runnerContext) run(cmd *cobra.Command, argv []string) error {
 	gatewayMux := runtime.NewServeMux(
 		runtime.WithMarshalerOption(runtime.MIMEWildcard, &runtime.HTTPBodyMarshaler{
 			Marshaler: gatewayMarshaller,
+		}),
+		runtime.WithIncomingHeaderMatcher(func(key string) (string, bool) {
+			if strings.EqualFold(key, servers.DryRunHTTPHeader) {
+				return servers.DryRunMetadataKey, true
+			}
+			return runtime.DefaultHeaderMatcher(key)
 		}),
 	)
 

--- a/internal/servers/clusters_server_test.go
+++ b/internal/servers/clusters_server_test.go
@@ -14,11 +14,13 @@ language governing permissions and limitations under the License.
 package servers
 
 import (
+	"context"
 	"fmt"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	grpccodes "google.golang.org/grpc/codes"
+	grpcmetadata "google.golang.org/grpc/metadata"
 	grpcstatus "google.golang.org/grpc/status"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/anypb"
@@ -1801,6 +1803,52 @@ var _ = Describe("Clusters server", func() {
 			Expect(ok).To(BeTrue())
 			Expect(status.Code()).To(Equal(grpccodes.InvalidArgument))
 			Expect(status.Message()).To(ContainSubstring("service_cidr"))
+		})
+
+		Describe("Dry run", func() {
+			dryRunCtx := func() context.Context {
+				md := grpcmetadata.Pairs("x-dry-run", "true")
+				return grpcmetadata.NewIncomingContext(ctx, md)
+			}
+
+			It("Returns resolved cluster without persisting", func() {
+				response, err := server.Create(dryRunCtx(), publicv1.ClustersCreateRequest_builder{
+					Object: publicv1.Cluster_builder{
+						Spec: publicv1.ClusterSpec_builder{
+							Template: "my_template",
+						}.Build(),
+					}.Build(),
+				}.Build())
+				Expect(err).ToNot(HaveOccurred())
+				Expect(response).ToNot(BeNil())
+				Expect(response.GetObject()).ToNot(BeNil())
+
+				listResponse, err := server.List(ctx, publicv1.ClustersListRequest_builder{}.Build())
+				Expect(err).ToNot(HaveOccurred())
+				Expect(listResponse.GetTotal()).To(Equal(int32(0)))
+			})
+
+			It("Returns same error as real creation for invalid template", func() {
+				_, realErr := server.Create(ctx, publicv1.ClustersCreateRequest_builder{
+					Object: publicv1.Cluster_builder{
+						Spec: publicv1.ClusterSpec_builder{
+							Template: "non-existent",
+						}.Build(),
+					}.Build(),
+				}.Build())
+				Expect(realErr).To(HaveOccurred())
+
+				_, dryRunErr := server.Create(dryRunCtx(), publicv1.ClustersCreateRequest_builder{
+					Object: publicv1.Cluster_builder{
+						Spec: publicv1.ClusterSpec_builder{
+							Template: "non-existent",
+						}.Build(),
+					}.Build(),
+				}.Build())
+				Expect(dryRunErr).To(HaveOccurred())
+				Expect(grpcstatus.Code(dryRunErr)).To(Equal(grpcstatus.Code(realErr)))
+				Expect(grpcstatus.Convert(dryRunErr).Message()).To(Equal(grpcstatus.Convert(realErr).Message()))
+			})
 		})
 	})
 })

--- a/internal/servers/clusters_server_test.go
+++ b/internal/servers/clusters_server_test.go
@@ -14,13 +14,11 @@ language governing permissions and limitations under the License.
 package servers
 
 import (
-	"context"
 	"fmt"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	grpccodes "google.golang.org/grpc/codes"
-	grpcmetadata "google.golang.org/grpc/metadata"
 	grpcstatus "google.golang.org/grpc/status"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/anypb"
@@ -1806,11 +1804,6 @@ var _ = Describe("Clusters server", func() {
 		})
 
 		Describe("Dry run", func() {
-			dryRunCtx := func() context.Context {
-				md := grpcmetadata.Pairs("x-dry-run", "true")
-				return grpcmetadata.NewIncomingContext(ctx, md)
-			}
-
 			It("Returns resolved cluster without persisting", func() {
 				response, err := server.Create(dryRunCtx(), publicv1.ClustersCreateRequest_builder{
 					Object: publicv1.Cluster_builder{

--- a/internal/servers/generic_server.go
+++ b/internal/servers/generic_server.go
@@ -25,6 +25,7 @@ import (
 	"buf.build/go/protovalidate"
 	"github.com/prometheus/client_golang/prometheus"
 	grpccodes "google.golang.org/grpc/codes"
+	grpcmetadata "google.golang.org/grpc/metadata"
 	grpcstatus "google.golang.org/grpc/status"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/reflect/protoreflect"
@@ -462,40 +463,16 @@ func (s *GenericServer[O]) Get(ctx context.Context, request any, response any) e
 }
 
 func (s *GenericServer[O]) Create(ctx context.Context, request any, response any) error {
-	// Extract the object from the request message:
-	type requestIface interface {
-		GetObject() O
-	}
-	requestMsg := request.(requestIface)
-	requestObject := requestMsg.GetObject()
-	if s.isNil(requestObject) {
-		requestObject = proto.Clone(s.template).(O)
-	} else {
-		requestMetadata := s.getMetadata(requestObject)
-		if requestMetadata != nil {
-			err := s.validateMetadata(ctx, requestMetadata)
-			if err != nil {
-				return err
-			}
-		}
+	// Route dry-run requests to skip persistence and event emission. Resource-specific
+	// validation (template resolution, catalog item field definitions, spec defaults)
+	// runs in the calling server before reaching GenericServer. The dry-run flag is
+	// carried as gRPC metadata (HTTP header X-Dry-Run: true) rather than a proto field
+	// to keep request messages purely declarative.
+	if isDryRun(ctx) {
+		return s.createDryRun(ctx, request, response)
 	}
 
-	// Calculate the assigned creator:
-	assignedCreator, err := s.determineAssignedCreator(ctx)
-	if err != nil {
-		return err
-	}
-	err = s.setCreator(ctx, requestObject, assignedCreator)
-	if err != nil {
-		return err
-	}
-
-	// Calculate the assigned tenant:
-	assignedTenant, err := s.determineAssignedTenant(ctx, requestObject, requestObject)
-	if err != nil {
-		return err
-	}
-	err = s.setTenant(ctx, requestObject, assignedTenant)
+	requestObject, err := s.prepareForCreate(ctx, request)
 	if err != nil {
 		return err
 	}
@@ -539,6 +516,76 @@ func (s *GenericServer[O]) Create(ctx context.Context, request any, response any
 	s.setPointer(response, responseMsg)
 
 	return nil
+}
+
+func (s *GenericServer[O]) prepareForCreate(ctx context.Context, request any) (O, error) {
+	var nilObject O
+
+	type requestIface interface {
+		GetObject() O
+	}
+	requestMsg := request.(requestIface)
+	requestObject := requestMsg.GetObject()
+	if s.isNil(requestObject) {
+		requestObject = proto.Clone(s.template).(O)
+	} else {
+		requestMetadata := s.getMetadata(requestObject)
+		if requestMetadata != nil {
+			if err := s.validateMetadata(ctx, requestMetadata); err != nil {
+				return nilObject, err
+			}
+		}
+	}
+
+	assignedCreator, err := s.determineAssignedCreator(ctx)
+	if err != nil {
+		return nilObject, err
+	}
+	if err = s.setCreator(ctx, requestObject, assignedCreator); err != nil {
+		return nilObject, err
+	}
+
+	assignedTenant, err := s.determineAssignedTenant(ctx, requestObject, requestObject)
+	if err != nil {
+		return nilObject, err
+	}
+	if err = s.setTenant(ctx, requestObject, assignedTenant); err != nil {
+		return nilObject, err
+	}
+
+	return requestObject, nil
+}
+
+func (s *GenericServer[O]) createDryRun(ctx context.Context, request any, response any) error {
+	requestObject, err := s.prepareForCreate(ctx, request)
+	if err != nil {
+		return err
+	}
+
+	type responseIface interface {
+		SetObject(O)
+	}
+	responseMsg := proto.Clone(s.createResponse).(responseIface)
+	responseMsg.SetObject(requestObject)
+	s.setPointer(response, responseMsg)
+
+	return nil
+}
+
+const dryRunMetadataKey = "x-dry-run"
+
+func isDryRun(ctx context.Context) bool {
+	md, ok := grpcmetadata.FromIncomingContext(ctx)
+	if !ok {
+		return false
+	}
+	values := md.Get(dryRunMetadataKey)
+	for _, v := range values {
+		if strings.EqualFold(v, "true") {
+			return true
+		}
+	}
+	return false
 }
 
 func (s *GenericServer[O]) Update(ctx context.Context, request any, response any) error {

--- a/internal/servers/generic_server.go
+++ b/internal/servers/generic_server.go
@@ -572,14 +572,18 @@ func (s *GenericServer[O]) createDryRun(ctx context.Context, request any, respon
 	return nil
 }
 
-const dryRunMetadataKey = "x-dry-run"
+// DryRunHTTPHeader is the HTTP header name REST clients use to request dry-run mode.
+// The REST gateway forwards it as gRPC metadata with key DryRunMetadataKey.
+const DryRunHTTPHeader = "X-Dry-Run"
+
+const DryRunMetadataKey = "x-dry-run"
 
 func isDryRun(ctx context.Context) bool {
 	md, ok := grpcmetadata.FromIncomingContext(ctx)
 	if !ok {
 		return false
 	}
-	values := md.Get(dryRunMetadataKey)
+	values := md.Get(DryRunMetadataKey)
 	for _, v := range values {
 		if strings.EqualFold(v, "true") {
 			return true

--- a/internal/servers/generic_server_test.go
+++ b/internal/servers/generic_server_test.go
@@ -19,9 +19,13 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"go.uber.org/mock/gomock"
+	"google.golang.org/grpc/codes"
+	grpcmetadata "google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/proto"
 
 	privatev1 "github.com/osac-project/fulfillment-service/internal/api/osac/private/v1"
+	"github.com/osac-project/fulfillment-service/internal/auth"
 	"github.com/osac-project/fulfillment-service/internal/events"
 )
 
@@ -132,5 +136,105 @@ var _ = Describe("Generic server", func() {
 
 		// Verify that the original object has not been modified:
 		Expect(object.GetDescription()).To(Equal("My description."))
+	})
+})
+
+var _ = Describe("Generic server dry run", func() {
+	var server *GenericServer[*privatev1.HostType]
+
+	dryRunCtx := func() context.Context {
+		md := grpcmetadata.Pairs("x-dry-run", "true")
+		return grpcmetadata.NewIncomingContext(ctx, md)
+	}
+
+	BeforeEach(func() {
+		var err error
+		notifier := events.NewMockNotifier(gomock.NewController(GinkgoT()))
+		server, err = NewGenericServer[*privatev1.HostType]().
+			SetLogger(logger).
+			SetService(privatev1.HostTypes_ServiceDesc.ServiceName).
+			SetAttributionLogic(attribution).
+			SetTenancyLogic(tenancy).
+			SetNotifier(notifier).
+			Build()
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	It("Assigns creator and tenant to the object", func() {
+		response := &privatev1.HostTypesCreateResponse{}
+		err := server.Create(
+			dryRunCtx(),
+			privatev1.HostTypesCreateRequest_builder{
+				Object: privatev1.HostType_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name: "my-dry-run-object",
+					}.Build(),
+				}.Build(),
+			}.Build(),
+			&response,
+		)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(response.GetObject()).ToNot(BeNil())
+		Expect(response.GetObject().GetMetadata().GetName()).To(Equal("my-dry-run-object"))
+		Expect(response.GetObject().GetMetadata().GetCreator()).To(Equal("system"))
+		Expect(response.GetObject().GetMetadata().GetTenant()).To(Equal(auth.SystemTenant))
+	})
+
+	It("Validates metadata and rejects invalid labels", func() {
+		response := &privatev1.HostTypesCreateResponse{}
+		err := server.Create(
+			dryRunCtx(),
+			privatev1.HostTypesCreateRequest_builder{
+				Object: privatev1.HostType_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name:   "valid-name",
+						Labels: map[string]string{"!!!invalid": "value"},
+					}.Build(),
+				}.Build(),
+			}.Build(),
+			&response,
+		)
+		Expect(err).To(HaveOccurred())
+		Expect(status.Code(err)).To(Equal(codes.InvalidArgument))
+	})
+
+	It("Does not persist the object", func() {
+		response := &privatev1.HostTypesCreateResponse{}
+		err := server.Create(
+			dryRunCtx(),
+			privatev1.HostTypesCreateRequest_builder{
+				Object: privatev1.HostType_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name: "dry-run-no-persist",
+					}.Build(),
+				}.Build(),
+			}.Build(),
+			&response,
+		)
+		Expect(err).ToNot(HaveOccurred())
+
+		listResponse := &privatev1.HostTypesListResponse{}
+		err = server.List(ctx,
+			privatev1.HostTypesListRequest_builder{}.Build(),
+			&listResponse,
+		)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(listResponse.GetTotal()).To(Equal(int32(0)))
+	})
+
+	It("Does not emit events", func() {
+		response := &privatev1.HostTypesCreateResponse{}
+		err := server.Create(
+			dryRunCtx(),
+			privatev1.HostTypesCreateRequest_builder{
+				Object: privatev1.HostType_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name: "dry-run-no-events",
+					}.Build(),
+				}.Build(),
+			}.Build(),
+			&response,
+		)
+		Expect(err).ToNot(HaveOccurred())
 	})
 })

--- a/internal/servers/generic_server_test.go
+++ b/internal/servers/generic_server_test.go
@@ -142,11 +142,6 @@ var _ = Describe("Generic server", func() {
 var _ = Describe("Generic server dry run", func() {
 	var server *GenericServer[*privatev1.HostType]
 
-	dryRunCtx := func() context.Context {
-		md := grpcmetadata.Pairs("x-dry-run", "true")
-		return grpcmetadata.NewIncomingContext(ctx, md)
-	}
-
 	BeforeEach(func() {
 		var err error
 		notifier := events.NewMockNotifier(gomock.NewController(GinkgoT()))
@@ -236,5 +231,44 @@ var _ = Describe("Generic server dry run", func() {
 			&response,
 		)
 		Expect(err).ToNot(HaveOccurred())
+	})
+
+	It("Persists normally when header value is false", func() {
+		ctrl := gomock.NewController(GinkgoT())
+		notifier := events.NewMockNotifier(ctrl)
+		notifier.EXPECT().Notify(gomock.Any(), gomock.Any()).Return(nil)
+		srv, err := NewGenericServer[*privatev1.HostType]().
+			SetLogger(logger).
+			SetService(privatev1.HostTypes_ServiceDesc.ServiceName).
+			SetAttributionLogic(attribution).
+			SetTenancyLogic(tenancy).
+			SetNotifier(notifier).
+			Build()
+		Expect(err).ToNot(HaveOccurred())
+
+		falseCtx := grpcmetadata.NewIncomingContext(ctx,
+			grpcmetadata.Pairs(DryRunMetadataKey, "false"))
+
+		response := &privatev1.HostTypesCreateResponse{}
+		err = srv.Create(
+			falseCtx,
+			privatev1.HostTypesCreateRequest_builder{
+				Object: privatev1.HostType_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name: "not-a-dry-run",
+					}.Build(),
+				}.Build(),
+			}.Build(),
+			&response,
+		)
+		Expect(err).ToNot(HaveOccurred())
+
+		listResponse := &privatev1.HostTypesListResponse{}
+		err = srv.List(ctx,
+			privatev1.HostTypesListRequest_builder{}.Build(),
+			&listResponse,
+		)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(listResponse.GetTotal()).To(Equal(int32(1)))
 	})
 })

--- a/internal/servers/private_clusters_server_test.go
+++ b/internal/servers/private_clusters_server_test.go
@@ -14,12 +14,14 @@ language governing permissions and limitations under the License.
 package servers
 
 import (
+	"context"
 	"fmt"
 	"math"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	grpccodes "google.golang.org/grpc/codes"
+	grpcmetadata "google.golang.org/grpc/metadata"
 	grpcstatus "google.golang.org/grpc/status"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/anypb"
@@ -1707,6 +1709,122 @@ var _ = Describe("Private clusters server", func() {
 				object = getResponse.GetObject()
 				Expect(object.GetStatus().GetHub()).To(Equal("your-hub-id"))
 
+			})
+		})
+
+		Describe("Dry run", func() {
+			dryRunCtx := func() context.Context {
+				md := grpcmetadata.Pairs("x-dry-run", "true")
+				return grpcmetadata.NewIncomingContext(ctx, md)
+			}
+
+			It("Returns resolved cluster with template path", func() {
+				response, err := server.Create(dryRunCtx(), privatev1.ClustersCreateRequest_builder{
+					Object: privatev1.Cluster_builder{
+						Spec: privatev1.ClusterSpec_builder{
+							Template: "my-template-name",
+							NodeSets: map[string]*privatev1.ClusterNodeSet{
+								"compute": privatev1.ClusterNodeSet_builder{
+									HostType: "acme-1ti-name",
+									Size:     7,
+								}.Build(),
+							},
+						}.Build(),
+						Status: privatev1.ClusterStatus_builder{
+							Hub: "my-hub-id",
+						}.Build(),
+					}.Build(),
+				}.Build())
+				Expect(err).ToNot(HaveOccurred())
+				object := response.GetObject()
+				Expect(object).ToNot(BeNil())
+				Expect(object.GetSpec().GetTemplate()).To(Equal("my-template-id"))
+				nodeSets := object.GetSpec().GetNodeSets()
+				Expect(nodeSets).To(HaveKey("compute"))
+				Expect(nodeSets["compute"].GetHostType()).To(Equal("acme-1ti-id"))
+			})
+
+			It("Returns resolved cluster with catalog item path", func() {
+				catalogItemsDao, err := dao.NewGenericDAO[*privatev1.ClusterCatalogItem]().
+					SetLogger(logger).
+					SetTenancyLogic(tenancy).
+					Build()
+				Expect(err).ToNot(HaveOccurred())
+				_, err = catalogItemsDao.Create().SetObject(
+					privatev1.ClusterCatalogItem_builder{
+						Id: "cat-dry-run",
+						Metadata: privatev1.Metadata_builder{
+							Name:   "cat-dry-run-name",
+							Tenant: "shared",
+						}.Build(),
+						Title:     "Dry Run Catalog Item",
+						Published: true,
+						Template:  "my-template-id",
+					}.Build(),
+				).Do(ctx)
+				Expect(err).ToNot(HaveOccurred())
+
+				response, err := server.Create(dryRunCtx(), privatev1.ClustersCreateRequest_builder{
+					Object: privatev1.Cluster_builder{
+						Spec: privatev1.ClusterSpec_builder{
+							CatalogItem: "cat-dry-run",
+						}.Build(),
+						Status: privatev1.ClusterStatus_builder{
+							Hub: "my-hub-id",
+						}.Build(),
+					}.Build(),
+				}.Build())
+				Expect(err).ToNot(HaveOccurred())
+				object := response.GetObject()
+				Expect(object).ToNot(BeNil())
+				Expect(object.GetSpec().GetTemplate()).To(Equal("my-template-id"))
+				Expect(object.GetSpec().GetCatalogItem()).To(Equal("cat-dry-run"))
+			})
+
+			It("Does not persist the object", func() {
+				_, err := server.Create(dryRunCtx(), privatev1.ClustersCreateRequest_builder{
+					Object: privatev1.Cluster_builder{
+						Spec: privatev1.ClusterSpec_builder{
+							Template: "my-template-name",
+						}.Build(),
+						Status: privatev1.ClusterStatus_builder{
+							Hub: "my-hub-id",
+						}.Build(),
+					}.Build(),
+				}.Build())
+				Expect(err).ToNot(HaveOccurred())
+
+				listResponse, err := server.List(ctx, privatev1.ClustersListRequest_builder{}.Build())
+				Expect(err).ToNot(HaveOccurred())
+				Expect(listResponse.GetTotal()).To(Equal(int32(0)))
+			})
+
+			It("Returns same error as real creation for invalid template", func() {
+				_, realErr := server.Create(ctx, privatev1.ClustersCreateRequest_builder{
+					Object: privatev1.Cluster_builder{
+						Spec: privatev1.ClusterSpec_builder{
+							Template: "non-existent-template",
+						}.Build(),
+						Status: privatev1.ClusterStatus_builder{
+							Hub: "my-hub-id",
+						}.Build(),
+					}.Build(),
+				}.Build())
+				Expect(realErr).To(HaveOccurred())
+
+				_, dryRunErr := server.Create(dryRunCtx(), privatev1.ClustersCreateRequest_builder{
+					Object: privatev1.Cluster_builder{
+						Spec: privatev1.ClusterSpec_builder{
+							Template: "non-existent-template",
+						}.Build(),
+						Status: privatev1.ClusterStatus_builder{
+							Hub: "my-hub-id",
+						}.Build(),
+					}.Build(),
+				}.Build())
+				Expect(dryRunErr).To(HaveOccurred())
+				Expect(grpcstatus.Code(dryRunErr)).To(Equal(grpcstatus.Code(realErr)))
+				Expect(grpcstatus.Convert(dryRunErr).Message()).To(Equal(grpcstatus.Convert(realErr).Message()))
 			})
 		})
 	})

--- a/internal/servers/private_clusters_server_test.go
+++ b/internal/servers/private_clusters_server_test.go
@@ -14,14 +14,12 @@ language governing permissions and limitations under the License.
 package servers
 
 import (
-	"context"
 	"fmt"
 	"math"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	grpccodes "google.golang.org/grpc/codes"
-	grpcmetadata "google.golang.org/grpc/metadata"
 	grpcstatus "google.golang.org/grpc/status"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/anypb"
@@ -1713,11 +1711,6 @@ var _ = Describe("Private clusters server", func() {
 		})
 
 		Describe("Dry run", func() {
-			dryRunCtx := func() context.Context {
-				md := grpcmetadata.Pairs("x-dry-run", "true")
-				return grpcmetadata.NewIncomingContext(ctx, md)
-			}
-
 			It("Returns resolved cluster with template path", func() {
 				response, err := server.Create(dryRunCtx(), privatev1.ClustersCreateRequest_builder{
 					Object: privatev1.Cluster_builder{

--- a/internal/servers/servers_suite_test.go
+++ b/internal/servers/servers_suite_test.go
@@ -22,6 +22,7 @@ import (
 	. "github.com/onsi/ginkgo/v2/dsl/core"
 	. "github.com/onsi/gomega"
 	"go.uber.org/mock/gomock"
+	grpcmetadata "google.golang.org/grpc/metadata"
 
 	"github.com/osac-project/fulfillment-service/internal/auth"
 	"github.com/osac-project/fulfillment-service/internal/database"
@@ -122,3 +123,8 @@ var _ = BeforeEach(func() {
 	})
 	ctx = database.TxIntoContext(ctx, tx)
 })
+
+func dryRunCtx() context.Context {
+	md := grpcmetadata.Pairs(DryRunMetadataKey, "true")
+	return grpcmetadata.NewIncomingContext(ctx, md)
+}


### PR DESCRIPTION
## [OSAC-2397](https://redhat.atlassian.net/browse/OSAC-2397): Support dry-run option for cluster creation API

**Jira:** https://redhat.atlassian.net/browse/OSAC-2397

### Summary

Add dry-run support for resource creation using gRPC metadata (`X-Dry-Run: true` HTTP header) instead of a proto field. When set, the request goes through the full validation pipeline (auth, tenant isolation, template resolution, catalog item field definitions, spec defaults) but does not persist the resource or trigger provisioning. The response contains the fully resolved object.

The dry-run flag is carried as gRPC metadata rather than a proto field to keep request messages purely declarative - the flag is an operational modifier, not a property of the resource being created.

Supersedes #906.

### Changes

**GenericServer (`internal/servers/generic_server.go`):**
- `isDryRun(ctx)` reads `x-dry-run` metadata key from the gRPC context (auto-mapped from `X-Dry-Run` HTTP header by grpc-gateway)
- `Create` routes to `createDryRun` when the metadata flag is set
- `prepareForCreate` extracts shared validation (metadata, creator/tenant assignment) used by both `Create` and `createDryRun`
- Works for all resource types automatically - no per-server wiring needed

### How to use

**REST (via grpc-gateway):**
```
POST /api/fulfillment/v1/clusters
X-Dry-Run: true

{"spec": {"template": "my-template"}}
```

**gRPC:**
```go
md := metadata.Pairs("x-dry-run", "true")
ctx := metadata.NewOutgoingContext(ctx, md)
client.Create(ctx, request)
```

### Testing
- **Unit tests:** 10 new tests across 3 files (GenericServer, PrivateClustersServer, public ClustersServer)
- **Coverage:** All behavioral paths covered (creator/tenant assignment, metadata validation, no persistence, no events, template resolution, catalog item resolution, error parity with message matching)

### Acceptance Criteria

- [x] AC-1: REST endpoint accepts dry-run via `X-Dry-Run: true` header
- [x] AC-2: Full validation pipeline executes during dry-run
- [x] AC-3: Response returns the fully resolved cluster object
- [x] AC-4: No database write occurs and no provisioning is triggered
- [x] AC-5: Error responses match what a real creation would return
- [x] AC-6: Unit tests covering dry-run path for both success and validation failure cases


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added dry-run support for create requests using the `X-Dry-Run` header.
  * Dry-run requests validate and resolve resources without saving changes or emitting events.
  * Dry-run responses include the prepared resource details, including resolved templates and catalog items.

* **Bug Fixes**
  * Dry-run operations now return the same validation errors as regular creation requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->