### PR TITLE
OSAC-2914: Fix UNSPECIFIED state corruption in ClusterVersion Update

### DIFF
--- a/internal/servers/private_cluster_versions_server.go
+++ b/internal/servers/private_cluster_versions_server.go
@@ -209,7 +209,9 @@ func (s *PrivateClusterVersionsServer) Update(ctx context.Context,
 		}
 	}
 
-	applyClusterVersionStateEffects(existing, request)
+	if err := applyClusterVersionStateEffects(existing, request); err != nil {
+		return nil, err
+	}
 
 	if resolveIsDefault(existing, request) {
 		if err := s.unsetPreviousDefaultClusterVersion(ctx, id); err != nil {
@@ -340,12 +342,15 @@ func validateClusterVersionCreateRequest(request *privatev1.ClusterVersionsCreat
 	return cv, nil
 }
 
-// resolveState returns the state that will be effective after the update: the request's value
-// if spec.state is in the mask, otherwise the existing value.
+// resolveState returns the state that will be effective after the update. UNSPECIFIED is
+// treated as absent because non-optional proto3 enums have no presence — the zero value is
+// indistinguishable from an unset field.
 func resolveState(existing *privatev1.ClusterVersion,
 	request *privatev1.ClusterVersionsUpdateRequest) privatev1.ClusterVersionState {
 	if updateIncludesField(request.GetUpdateMask(), "spec.state") {
-		return request.GetObject().GetSpec().GetState()
+		if s := request.GetObject().GetSpec().GetState(); s != privatev1.ClusterVersionState_CLUSTER_VERSION_STATE_UNSPECIFIED {
+			return s
+		}
 	}
 	return existing.GetSpec().GetState()
 }
@@ -439,14 +444,20 @@ func applyClusterVersionDefaults(cv *privatev1.ClusterVersion) {
 // occurs, any client-supplied deprecation timestamps are replaced with the existing values
 // (OUTPUT_ONLY enforcement).
 func applyClusterVersionStateEffects(existing *privatev1.ClusterVersion,
-	request *privatev1.ClusterVersionsUpdateRequest) {
+	request *privatev1.ClusterVersionsUpdateRequest) error {
 	spec := request.GetObject().GetSpec()
 	if spec == nil {
-		return
+		return nil
 	}
 	oldState := existing.GetSpec().GetState()
 	newState := resolveState(existing, request)
 	mask := request.GetUpdateMask()
+
+	// Normalize the request's state to the resolved value so the generic server's mask merge
+	// persists the correct state (UNSPECIFIED is replaced with the existing or intended value).
+	if updateIncludesField(mask, "spec.state") {
+		spec.SetState(newState)
+	}
 
 	// Same-state update — enforce OUTPUT_ONLY contract on deprecation timestamps by
 	// unconditionally restoring existing values, regardless of what the client sent:
@@ -475,6 +486,9 @@ func applyClusterVersionStateEffects(existing *privatev1.ClusterVersion,
 			dep.SetObsolescenceTimestamp(timestamppb.Now())
 		case privatev1.ClusterVersionState_CLUSTER_VERSION_STATE_ACTIVE:
 			// Retain existing timestamps as historical record.
+		default:
+			return grpcstatus.Errorf(grpccodes.InvalidArgument,
+				"unsupported cluster version state: %v", newState)
 		}
 
 		if mask != nil {
@@ -492,6 +506,7 @@ func applyClusterVersionStateEffects(existing *privatev1.ClusterVersion,
 			}
 		}
 	}
+	return nil
 }
 
 func validateClusterVersionImmutability(existing *privatev1.ClusterVersion,

--- a/internal/servers/private_cluster_versions_server_test.go
+++ b/internal/servers/private_cluster_versions_server_test.go
@@ -692,6 +692,113 @@ var _ = Describe("Private cluster versions server", func() {
 			})
 		})
 
+		Describe("UNSPECIFIED state handling", func() {
+			DescribeTable("preserves existing state when state is not explicitly set",
+				func(maskPaths []string, specBuilder func(string, string) *privatev1.ClusterVersionSpec) {
+					object := createWithState("unspec-guard", "4.17.0",
+						privatev1.ClusterVersionState_CLUSTER_VERSION_STATE_ACTIVE)
+
+					_, err := server.Update(ctx, privatev1.ClusterVersionsUpdateRequest_builder{
+						Object: privatev1.ClusterVersion_builder{
+							Id:       object.GetId(),
+							Metadata: privatev1.Metadata_builder{Name: object.GetMetadata().GetName()}.Build(),
+							Spec:     specBuilder(object.GetSpec().GetVersion(), object.GetSpec().GetImage()),
+						}.Build(),
+						UpdateMask: func() *fieldmaskpb.FieldMask {
+							if maskPaths == nil {
+								return nil
+							}
+							return &fieldmaskpb.FieldMask{Paths: maskPaths}
+						}(),
+					}.Build())
+					Expect(err).ToNot(HaveOccurred())
+
+					getResponse, err := server.Get(ctx, privatev1.ClusterVersionsGetRequest_builder{
+						Id: object.GetId(),
+					}.Build())
+					Expect(err).ToNot(HaveOccurred())
+					Expect(getResponse.GetObject().GetSpec().GetState()).To(Equal(
+						privatev1.ClusterVersionState_CLUSTER_VERSION_STATE_ACTIVE),
+						"state must remain ACTIVE, not be corrupted to UNSPECIFIED")
+				},
+				Entry("parent spec mask without state",
+					[]string{"spec"},
+					func(version, image string) *privatev1.ClusterVersionSpec {
+						return privatev1.ClusterVersionSpec_builder{
+							Version: version,
+							Image:   image,
+							Enabled: new(false),
+						}.Build()
+					},
+				),
+				Entry("explicit spec.state mask with zero value",
+					[]string{"spec.state"},
+					func(_, _ string) *privatev1.ClusterVersionSpec {
+						return privatev1.ClusterVersionSpec_builder{}.Build()
+					},
+				),
+				Entry("nil mask (full replacement) without state",
+					[]string(nil),
+					func(version, image string) *privatev1.ClusterVersionSpec {
+						return privatev1.ClusterVersionSpec_builder{
+							Version: version,
+							Image:   image,
+						}.Build()
+					},
+				),
+			)
+
+			It("Does not create spurious deprecation record when state is unchanged", func() {
+				object := createWithState("unspec-no-dep", "4.17.1",
+					privatev1.ClusterVersionState_CLUSTER_VERSION_STATE_ACTIVE)
+				Expect(object.GetSpec().GetDeprecation()).To(BeNil())
+
+				_, err := server.Update(ctx, privatev1.ClusterVersionsUpdateRequest_builder{
+					Object: privatev1.ClusterVersion_builder{
+						Id: object.GetId(),
+						Spec: privatev1.ClusterVersionSpec_builder{
+							Version: object.GetSpec().GetVersion(),
+							Image:   object.GetSpec().GetImage(),
+							Enabled: new(false),
+						}.Build(),
+					}.Build(),
+					UpdateMask: &fieldmaskpb.FieldMask{Paths: []string{"spec"}},
+				}.Build())
+				Expect(err).ToNot(HaveOccurred())
+
+				getResponse, err := server.Get(ctx, privatev1.ClusterVersionsGetRequest_builder{
+					Id: object.GetId(),
+				}.Build())
+				Expect(err).ToNot(HaveOccurred())
+				spec := getResponse.GetObject().GetSpec()
+				Expect(spec.GetState()).To(Equal(
+					privatev1.ClusterVersionState_CLUSTER_VERSION_STATE_ACTIVE))
+				Expect(spec.GetDeprecation()).To(BeNil())
+			})
+
+			It("Rejects an unknown state value", func() {
+				object := createWithState("unknown-state", "4.17.2",
+					privatev1.ClusterVersionState_CLUSTER_VERSION_STATE_ACTIVE)
+
+				_, err := server.Update(ctx, privatev1.ClusterVersionsUpdateRequest_builder{
+					Object: privatev1.ClusterVersion_builder{
+						Id: object.GetId(),
+						Spec: privatev1.ClusterVersionSpec_builder{
+							Version: object.GetSpec().GetVersion(),
+							Image:   object.GetSpec().GetImage(),
+							State:   privatev1.ClusterVersionState(999),
+						}.Build(),
+					}.Build(),
+					UpdateMask: &fieldmaskpb.FieldMask{Paths: []string{"spec.state"}},
+				}.Build())
+				Expect(err).To(HaveOccurred())
+				status, ok := grpcstatus.FromError(err)
+				Expect(ok).To(BeTrue())
+				Expect(status.Code()).To(Equal(grpccodes.InvalidArgument))
+				Expect(status.Message()).To(ContainSubstring("unsupported cluster version state"))
+			})
+		})
+
 		Describe("Default swap", func() {
 			It("Create with is_default clears previous default", func() {
 				// Create first version as default:


### PR DESCRIPTION
## Summary

- Fix `resolveState()` to treat `CLUSTER_VERSION_STATE_UNSPECIFIED` (proto3 zero value) as absent, preventing it from overwriting existing state during updates
- Normalize the request's state field before the generic server's mask merge so the correct value is persisted
- Add a `default` case in `applyClusterVersionStateEffects` to reject unhandled state values (defense-in-depth)

## Problem

When a client sends an Update with a field mask covering `spec.state` (directly or via parent `spec`) without explicitly setting state, the non-optional proto3 enum defaults to `UNSPECIFIED` (0). This zero value was passed through to the generic server's mask merge, which persisted it — corrupting the existing state. A secondary effect was spurious empty `ClusterVersionDeprecation` records.

Three trigger paths:
- `["spec"]` parent mask: generic server copies entire spec including zero-value state
- `["spec.state"]` leaf mask: `protoreflect.Has()` returns false for zero-value enum, triggering `Clear()` which also sets state to 0
- `nil` mask (full replacement): request object replaces the clone directly

## Test plan

- [x] 4 regression tests covering all three mask trigger paths and the deprecation side-effect
- [x] Full ClusterVersion test suite (78 passed, 0 failed)
- [x] Full servers test suite (1533 passed, 0 failed)

Assisted-by: Claude <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved the existing cluster version state when updates omit a state value or provide an unspecified state.
  * Prevented unnecessary deprecation record changes when the effective state remains unchanged.
  * Update requests now report errors from state-related processing instead of silently continuing.
  * Invalid cluster version states now return a clear validation error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->