### PR TITLE
OSAC-2959: Private Secrets server

### DIFF
--- a/internal/cmd/service/start/grpcserver/start_grpc_server_cmd.go
+++ b/internal/cmd/service/start/grpcserver/start_grpc_server_cmd.go
@@ -1043,6 +1043,20 @@ func (c *runnerContext) run(cmd *cobra.Command, argv []string) error { //nolint:
 	}
 	privatev1.RegisterStorageBackendsServer(grpcServer, privateStorageBackendsServer)
 
+	// Create the private secrets server:
+	c.logger.InfoContext(ctx, "Creating private secrets server")
+	privateSecretsServer, err := servers.NewPrivateSecretsServer().
+		SetLogger(c.logger).
+		SetNotifier(notifier).
+		SetAttributionLogic(privateAttributionLogic).
+		SetTenancyLogic(tenancyLogic).
+		SetMetricsRegisterer(metricsRegisterer).
+		Build()
+	if err != nil {
+		return fmt.Errorf("failed to create private secrets server: %w", err)
+	}
+	privatev1.RegisterSecretsServer(grpcServer, privateSecretsServer)
+
 	// Create the storage backends DAO for cross-resource validation in the storage tiers server:
 	storageBackendsDAO, err := dao.NewGenericDAO[*privatev1.StorageBackend]().
 		SetLogger(c.logger).

--- a/internal/cmd/service/start/restgateway/start_rest_gateway_cmd.go
+++ b/internal/cmd/service/start/restgateway/start_rest_gateway_cmd.go
@@ -332,6 +332,7 @@ func (c *runnerContext) registerHandlers(ctx context.Context, mux *runtime.Serve
 		privatev1.RegisterBareMetalInstanceCatalogItemsHandler,
 		privatev1.RegisterBareMetalInstancesHandler,
 		privatev1.RegisterNetworkClassesHandler,
+		privatev1.RegisterSecretsHandler,
 		privatev1.RegisterStorageBackendsHandler,
 		privatev1.RegisterStorageTiersHandler,
 		privatev1.RegisterVirtualNetworksHandler,

--- a/internal/servers/private_secrets_server.go
+++ b/internal/servers/private_secrets_server.go
@@ -1,0 +1,256 @@
+/*
+Copyright (c) 2026 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package servers
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+
+	"github.com/prometheus/client_golang/prometheus"
+	grpccodes "google.golang.org/grpc/codes"
+	grpcstatus "google.golang.org/grpc/status"
+
+	privatev1 "github.com/osac-project/fulfillment-service/internal/api/osac/private/v1"
+	"github.com/osac-project/fulfillment-service/internal/auth"
+	"github.com/osac-project/fulfillment-service/internal/events"
+)
+
+type PrivateSecretsServerBuilder struct {
+	logger            *slog.Logger
+	notifier          events.Notifier
+	attributionLogic  auth.AttributionLogic
+	tenancyLogic      auth.TenancyLogic
+	metricsRegisterer prometheus.Registerer
+}
+
+var _ privatev1.SecretsServer = (*PrivateSecretsServer)(nil)
+
+type PrivateSecretsServer struct {
+	privatev1.UnimplementedSecretsServer
+
+	logger  *slog.Logger
+	generic *GenericServer[*privatev1.Secret]
+}
+
+func NewPrivateSecretsServer() *PrivateSecretsServerBuilder {
+	return &PrivateSecretsServerBuilder{}
+}
+
+func (b *PrivateSecretsServerBuilder) SetLogger(value *slog.Logger) *PrivateSecretsServerBuilder {
+	b.logger = value
+	return b
+}
+
+func (b *PrivateSecretsServerBuilder) SetNotifier(value events.Notifier) *PrivateSecretsServerBuilder {
+	b.notifier = value
+	return b
+}
+
+func (b *PrivateSecretsServerBuilder) SetAttributionLogic(value auth.AttributionLogic) *PrivateSecretsServerBuilder {
+	b.attributionLogic = value
+	return b
+}
+
+func (b *PrivateSecretsServerBuilder) SetTenancyLogic(value auth.TenancyLogic) *PrivateSecretsServerBuilder {
+	b.tenancyLogic = value
+	return b
+}
+
+func (b *PrivateSecretsServerBuilder) SetMetricsRegisterer(value prometheus.Registerer) *PrivateSecretsServerBuilder {
+	b.metricsRegisterer = value
+	return b
+}
+
+func (b *PrivateSecretsServerBuilder) Build() (result *PrivateSecretsServer, err error) {
+	if b.logger == nil {
+		err = errors.New("logger is mandatory")
+		return
+	}
+	if b.tenancyLogic == nil {
+		err = errors.New("tenancy logic is mandatory")
+		return
+	}
+
+	s := &PrivateSecretsServer{
+		logger: b.logger,
+	}
+
+	s.generic, err = NewGenericServer[*privatev1.Secret]().
+		SetLogger(b.logger).
+		SetService(privatev1.Secrets_ServiceDesc.ServiceName).
+		SetNotifier(b.notifier).
+		SetRedactFunc(s.redact).
+		SetAttributionLogic(b.attributionLogic).
+		SetTenancyLogic(b.tenancyLogic).
+		SetMetricsRegisterer(b.metricsRegisterer).
+		Build()
+	if err != nil {
+		return
+	}
+
+	result = s
+	return
+}
+
+func (s *PrivateSecretsServer) redact(object *privatev1.Secret) *privatev1.Secret {
+	if spec := object.GetSpec(); spec != nil {
+		spec.SetData(nil)
+	}
+	if status := object.GetStatus(); status != nil {
+		status.SetResolvedData(nil)
+	}
+	return object
+}
+
+// List fetches a list of secret objects from postgres.
+// Secret data itself should never be included in the response, and users should use Get
+// to fetch individual secrets with populated status.resolved_data.
+func (s *PrivateSecretsServer) List(ctx context.Context,
+	request *privatev1.SecretsListRequest) (response *privatev1.SecretsListResponse, err error) {
+	err = s.generic.List(ctx, request, &response)
+	return
+}
+
+func (s *PrivateSecretsServer) Get(ctx context.Context,
+	request *privatev1.SecretsGetRequest) (response *privatev1.SecretsGetResponse, err error) {
+	err = s.generic.Get(ctx, request, &response)
+
+	// TODO: Fetch secret data from the storage backend.
+
+	return
+}
+
+func (s *PrivateSecretsServer) Create(ctx context.Context,
+	request *privatev1.SecretsCreateRequest) (response *privatev1.SecretsCreateResponse, err error) {
+
+	secret := request.GetObject()
+
+	err = s.validateSecretCreate(secret)
+	if err != nil {
+		return
+	}
+
+	secret.SetId("")
+
+	// Default unspecified backend to Vault.
+	if secret.GetSpec().GetBackend() == privatev1.SecretBackend_SECRET_BACKEND_UNSPECIFIED {
+		secret.GetSpec().SetBackend(privatev1.SecretBackend_SECRET_BACKEND_VAULT)
+	}
+
+	// TODO: Store secret data in the storage backend.
+
+	err = s.generic.Create(ctx, request, &response)
+
+	return
+}
+
+func (s *PrivateSecretsServer) Update(ctx context.Context,
+	request *privatev1.SecretsUpdateRequest) (response *privatev1.SecretsUpdateResponse, err error) {
+	id := request.GetObject().GetId()
+	if id == "" {
+		err = grpcstatus.Errorf(grpccodes.InvalidArgument, "object identifier is mandatory")
+		return
+	}
+
+	getRequest := &privatev1.SecretsGetRequest{}
+	getRequest.SetId(id)
+	var getResponse *privatev1.SecretsGetResponse
+	err = s.generic.Get(ctx, getRequest, &getResponse)
+	if err != nil {
+		return
+	}
+
+	existingSecret := getResponse.GetObject()
+
+	err = s.validateSecretUpdate(ctx, request.GetObject(), existingSecret)
+	if err != nil {
+		return
+	}
+
+	// TODO: Update secret data in the storage backend.
+
+	err = s.generic.Update(ctx, request, &response)
+	return
+}
+
+func (s *PrivateSecretsServer) Delete(ctx context.Context,
+	request *privatev1.SecretsDeleteRequest) (response *privatev1.SecretsDeleteResponse, err error) {
+	err = s.generic.Delete(ctx, request, &response)
+	return
+}
+
+func (s *PrivateSecretsServer) Signal(ctx context.Context,
+	request *privatev1.SecretsSignalRequest) (response *privatev1.SecretsSignalResponse, err error) {
+	err = s.generic.Signal(ctx, request, &response)
+	return
+}
+
+func (s *PrivateSecretsServer) validateSecretCreate(secret *privatev1.Secret) error {
+	if secret == nil {
+		return grpcstatus.Errorf(grpccodes.InvalidArgument, "secret is mandatory")
+	}
+	if secret.GetMetadata() == nil || secret.GetMetadata().GetName() == "" {
+		return grpcstatus.Errorf(grpccodes.InvalidArgument, "field 'metadata.name' is required")
+	}
+	spec := secret.GetSpec()
+	if spec == nil {
+		return grpcstatus.Errorf(grpccodes.InvalidArgument, "field 'spec' is required")
+	}
+
+	switch spec.GetBackend() {
+	case privatev1.SecretBackend_SECRET_BACKEND_HUB:
+		if err := s.validateHubSecretCreate(spec); err != nil {
+			return err
+		}
+	default:
+		if len(spec.GetData()) == 0 {
+			return grpcstatus.Errorf(grpccodes.InvalidArgument,
+				"field 'spec.data' is required")
+		}
+	}
+
+	return nil
+}
+
+// Hub secret data is created by external sources and fully managed elsewhere - the Secret type
+// only manages the metadata and provides utility for fetching the secret data and
+// is not the source of truth for the data itself - hence why we reject spec.data
+func (s *PrivateSecretsServer) validateHubSecretCreate(spec *privatev1.SecretSpec) error {
+	if len(spec.GetCoordinates()) == 0 {
+		return grpcstatus.Errorf(grpccodes.InvalidArgument,
+			"field 'spec.coordinates' is required when backend is HUB")
+	}
+	if len(spec.GetData()) > 0 {
+		return grpcstatus.Errorf(grpccodes.InvalidArgument,
+			"field 'spec.data' must be empty when backend is HUB")
+	}
+	return nil
+}
+
+func (s *PrivateSecretsServer) validateSecretUpdate(_ context.Context,
+	newSecret *privatev1.Secret, existingSecret *privatev1.Secret) error {
+	if newSecret.GetSpec().GetBackend() != privatev1.SecretBackend_SECRET_BACKEND_UNSPECIFIED &&
+		newSecret.GetSpec().GetBackend() != existingSecret.GetSpec().GetBackend() {
+		return grpcstatus.Errorf(grpccodes.InvalidArgument,
+			"field 'spec.backend' is immutable and cannot be changed from '%s' to '%s'",
+			existingSecret.GetSpec().GetBackend(), newSecret.GetSpec().GetBackend())
+	}
+	if existingSecret.GetSpec().GetBackend() == privatev1.SecretBackend_SECRET_BACKEND_HUB &&
+		len(newSecret.GetSpec().GetData()) > 0 {
+		return grpcstatus.Errorf(grpccodes.InvalidArgument,
+			"field 'spec.data' must be empty when backend is HUB")
+	}
+	return nil
+}

--- a/internal/servers/private_secrets_server_test.go
+++ b/internal/servers/private_secrets_server_test.go
@@ -1,0 +1,563 @@
+/*
+Copyright (c) 2026 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package servers
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/google/uuid"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"go.uber.org/mock/gomock"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/fieldmaskpb"
+
+	privatev1 "github.com/osac-project/fulfillment-service/internal/api/osac/private/v1"
+	"github.com/osac-project/fulfillment-service/internal/events"
+)
+
+var _ = Describe("Private secrets server", func() {
+	Describe("Creation", func() {
+		It("Can be built if all the required parameters are set", func() {
+			server, err := NewPrivateSecretsServer().
+				SetLogger(logger).
+				SetAttributionLogic(attribution).
+				SetTenancyLogic(tenancy).
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(server).ToNot(BeNil())
+		})
+
+		It("Fails if logger is not set", func() {
+			server, err := NewPrivateSecretsServer().
+				SetAttributionLogic(attribution).
+				SetTenancyLogic(tenancy).
+				Build()
+			Expect(err).To(MatchError("logger is mandatory"))
+			Expect(server).To(BeNil())
+		})
+
+		It("Fails if tenancy logic is not set", func() {
+			server, err := NewPrivateSecretsServer().
+				SetLogger(logger).
+				SetAttributionLogic(attribution).
+				Build()
+			Expect(err).To(MatchError("tenancy logic is mandatory"))
+			Expect(server).To(BeNil())
+		})
+	})
+
+	Describe("Behaviour", func() {
+		var server *PrivateSecretsServer
+
+		BeforeEach(func() {
+			var err error
+			server, err = NewPrivateSecretsServer().
+				SetLogger(logger).
+				SetAttributionLogic(attribution).
+				SetTenancyLogic(tenancy).
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		createVaultSecret := func() *privatev1.Secret {
+			response, err := server.Create(ctx, privatev1.SecretsCreateRequest_builder{
+				Object: privatev1.Secret_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name: "my-secret",
+					}.Build(),
+					Spec: privatev1.SecretSpec_builder{
+						Data: map[string][]byte{
+							"key": []byte("value"),
+						},
+					}.Build(),
+				}.Build(),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+			return response.GetObject()
+		}
+
+		createVaultSecretWithName := func(name string) *privatev1.Secret {
+			response, err := server.Create(ctx, privatev1.SecretsCreateRequest_builder{
+				Object: privatev1.Secret_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name: name,
+					}.Build(),
+					Spec: privatev1.SecretSpec_builder{
+						Data: map[string][]byte{
+							"key": []byte("value"),
+						},
+					}.Build(),
+				}.Build(),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+			return response.GetObject()
+		}
+
+		createHubSecret := func() *privatev1.Secret {
+			response, err := server.Create(ctx, privatev1.SecretsCreateRequest_builder{
+				Object: privatev1.Secret_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name: "hub-secret",
+					}.Build(),
+					Spec: privatev1.SecretSpec_builder{
+						Backend: privatev1.SecretBackend_SECRET_BACKEND_HUB,
+						Coordinates: map[string]string{
+							"cluster":   "hub-1",
+							"namespace": "default",
+							"name":      "my-k8s-secret",
+						},
+					}.Build(),
+				}.Build(),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+			return response.GetObject()
+		}
+
+		It("Creates and gets a Vault secret", func() {
+			created := createVaultSecret()
+
+			Expect(created.GetId()).ToNot(BeEmpty())
+			Expect(created.GetSpec().GetBackend()).To(Equal(
+				privatev1.SecretBackend_SECRET_BACKEND_VAULT))
+			Expect(created.GetSpec().GetData()).To(HaveKeyWithValue("key", []byte("value")))
+
+			getResponse, err := server.Get(ctx, privatev1.SecretsGetRequest_builder{
+				Id: created.GetId(),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+			obj := getResponse.GetObject()
+			Expect(obj.GetId()).To(Equal(created.GetId()))
+			Expect(obj.GetSpec().GetBackend()).To(Equal(
+				privatev1.SecretBackend_SECRET_BACKEND_VAULT))
+		})
+
+		It("Defaults unspecified backend to Vault", func() {
+			created := createVaultSecret()
+			Expect(created.GetSpec().GetBackend()).To(Equal(
+				privatev1.SecretBackend_SECRET_BACKEND_VAULT))
+		})
+
+		It("Creates a Hub secret with coordinates", func() {
+			created := createHubSecret()
+
+			Expect(created.GetId()).ToNot(BeEmpty())
+			Expect(created.GetSpec().GetBackend()).To(Equal(
+				privatev1.SecretBackend_SECRET_BACKEND_HUB))
+			Expect(created.GetSpec().GetCoordinates()).To(HaveKeyWithValue("cluster", "hub-1"))
+			Expect(created.GetSpec().GetData()).To(BeEmpty())
+		})
+
+		It("List secrets", func() {
+			const count = 5
+			for i := range count {
+				createVaultSecretWithName(fmt.Sprintf("secret-%d", i))
+			}
+
+			response, err := server.List(ctx, privatev1.SecretsListRequest_builder{}.Build())
+			Expect(err).ToNot(HaveOccurred())
+			Expect(response.GetItems()).To(HaveLen(count))
+		})
+
+		It("List secrets with limit", func() {
+			const count = 5
+			for i := range count {
+				createVaultSecretWithName(fmt.Sprintf("secret-%d", i))
+			}
+
+			response, err := server.List(ctx, privatev1.SecretsListRequest_builder{
+				Limit: new(int32(2)),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+			Expect(response.GetSize()).To(BeNumerically("==", 2))
+		})
+
+		It("List secrets with offset", func() {
+			const count = 5
+			for i := range count {
+				createVaultSecretWithName(fmt.Sprintf("secret-%d", i))
+			}
+
+			response, err := server.List(ctx, privatev1.SecretsListRequest_builder{
+				Offset: new(int32(2)),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+			Expect(response.GetSize()).To(BeNumerically("==", count-2))
+		})
+
+		It("List secrets with filter", func() {
+			const count = 3
+			var ids []string
+			for i := range count {
+				obj := createVaultSecretWithName(fmt.Sprintf("secret-%d", i))
+				ids = append(ids, obj.GetId())
+			}
+
+			for _, id := range ids {
+				response, err := server.List(ctx, privatev1.SecretsListRequest_builder{
+					Filter: new(fmt.Sprintf("this.id == '%s'", id)),
+				}.Build())
+				Expect(err).ToNot(HaveOccurred())
+				Expect(response.GetSize()).To(BeNumerically("==", 1))
+				Expect(response.GetItems()[0].GetId()).To(Equal(id))
+			}
+		})
+
+		It("List secrets with order", func() {
+			createVaultSecretWithName("aaa-secret")
+			createVaultSecretWithName("zzz-secret")
+
+			response, err := server.List(ctx, privatev1.SecretsListRequest_builder{
+				Order: new("metadata.name asc"),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+			Expect(response.GetSize()).To(BeNumerically("==", 2))
+			Expect(response.GetItems()[0].GetMetadata().GetName()).To(Equal("aaa-secret"))
+			Expect(response.GetItems()[1].GetMetadata().GetName()).To(Equal("zzz-secret"))
+		})
+
+		It("Update applies partial changes via field mask", func() {
+			created := createVaultSecret()
+
+			updateResponse, err := server.Update(ctx, privatev1.SecretsUpdateRequest_builder{
+				Object: privatev1.Secret_builder{
+					Id: created.GetId(),
+					Spec: privatev1.SecretSpec_builder{
+						Data: map[string][]byte{
+							"new-key": []byte("new-value"),
+						},
+					}.Build(),
+				}.Build(),
+				UpdateMask: &fieldmaskpb.FieldMask{Paths: []string{"spec.data"}},
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+			Expect(updateResponse.GetObject().GetSpec().GetData()).To(
+				HaveKeyWithValue("new-key", []byte("new-value")))
+		})
+
+		It("Delete removes the object", func() {
+			created := createVaultSecret()
+
+			_, err := server.Delete(ctx, privatev1.SecretsDeleteRequest_builder{
+				Id: created.GetId(),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+
+			_, err = server.Get(ctx, privatev1.SecretsGetRequest_builder{
+				Id: created.GetId(),
+			}.Build())
+			Expect(err).To(HaveOccurred())
+			st, ok := status.FromError(err)
+			Expect(ok).To(BeTrue())
+			Expect(st.Code()).To(Equal(codes.NotFound))
+		})
+
+		It("Generates UUID for id ignoring caller-provided value", func() {
+			callerProvidedId := "my-custom-id"
+			response, err := server.Create(ctx, privatev1.SecretsCreateRequest_builder{
+				Object: privatev1.Secret_builder{
+					Id: callerProvidedId,
+					Metadata: privatev1.Metadata_builder{
+						Name: "my-secret",
+					}.Build(),
+					Spec: privatev1.SecretSpec_builder{
+						Data: map[string][]byte{
+							"key": []byte("value"),
+						},
+					}.Build(),
+				}.Build(),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+			Expect(response.GetObject().GetId()).ToNot(Equal(callerProvidedId))
+			_, err = uuid.Parse(response.GetObject().GetId())
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		Describe("Validation", func() {
+			It("Create without name fails", func() {
+				_, err := server.Create(ctx, privatev1.SecretsCreateRequest_builder{
+					Object: privatev1.Secret_builder{
+						Spec: privatev1.SecretSpec_builder{
+							Data: map[string][]byte{
+								"key": []byte("value"),
+							},
+						}.Build(),
+					}.Build(),
+				}.Build())
+				Expect(err).To(HaveOccurred())
+				st, ok := status.FromError(err)
+				Expect(ok).To(BeTrue())
+				Expect(st.Code()).To(Equal(codes.InvalidArgument))
+				Expect(st.Message()).To(ContainSubstring("metadata.name"))
+			})
+
+			It("Create without spec fails", func() {
+				_, err := server.Create(ctx, privatev1.SecretsCreateRequest_builder{
+					Object: privatev1.Secret_builder{
+						Metadata: privatev1.Metadata_builder{
+							Name: "my-secret",
+						}.Build(),
+					}.Build(),
+				}.Build())
+				Expect(err).To(HaveOccurred())
+				st, ok := status.FromError(err)
+				Expect(ok).To(BeTrue())
+				Expect(st.Code()).To(Equal(codes.InvalidArgument))
+				Expect(st.Message()).To(ContainSubstring("spec"))
+			})
+
+			It("Create Vault secret without data fails", func() {
+				_, err := server.Create(ctx, privatev1.SecretsCreateRequest_builder{
+					Object: privatev1.Secret_builder{
+						Metadata: privatev1.Metadata_builder{
+							Name: "my-secret",
+						}.Build(),
+						Spec: privatev1.SecretSpec_builder{
+							Backend: privatev1.SecretBackend_SECRET_BACKEND_VAULT,
+						}.Build(),
+					}.Build(),
+				}.Build())
+				Expect(err).To(HaveOccurred())
+				st, ok := status.FromError(err)
+				Expect(ok).To(BeTrue())
+				Expect(st.Code()).To(Equal(codes.InvalidArgument))
+				Expect(st.Message()).To(ContainSubstring("spec.data"))
+			})
+
+			It("Create unspecified backend without data fails", func() {
+				_, err := server.Create(ctx, privatev1.SecretsCreateRequest_builder{
+					Object: privatev1.Secret_builder{
+						Metadata: privatev1.Metadata_builder{
+							Name: "my-secret",
+						}.Build(),
+						Spec: privatev1.SecretSpec_builder{}.Build(),
+					}.Build(),
+				}.Build())
+				Expect(err).To(HaveOccurred())
+				st, ok := status.FromError(err)
+				Expect(ok).To(BeTrue())
+				Expect(st.Code()).To(Equal(codes.InvalidArgument))
+				Expect(st.Message()).To(ContainSubstring("spec.data"))
+			})
+
+			It("Create Hub secret without coordinates fails", func() {
+				_, err := server.Create(ctx, privatev1.SecretsCreateRequest_builder{
+					Object: privatev1.Secret_builder{
+						Metadata: privatev1.Metadata_builder{
+							Name: "my-secret",
+						}.Build(),
+						Spec: privatev1.SecretSpec_builder{
+							Backend: privatev1.SecretBackend_SECRET_BACKEND_HUB,
+						}.Build(),
+					}.Build(),
+				}.Build())
+				Expect(err).To(HaveOccurred())
+				st, ok := status.FromError(err)
+				Expect(ok).To(BeTrue())
+				Expect(st.Code()).To(Equal(codes.InvalidArgument))
+				Expect(st.Message()).To(ContainSubstring("spec.coordinates"))
+			})
+
+			It("Create Hub secret with data fails", func() {
+				_, err := server.Create(ctx, privatev1.SecretsCreateRequest_builder{
+					Object: privatev1.Secret_builder{
+						Metadata: privatev1.Metadata_builder{
+							Name: "my-secret",
+						}.Build(),
+						Spec: privatev1.SecretSpec_builder{
+							Backend: privatev1.SecretBackend_SECRET_BACKEND_HUB,
+							Coordinates: map[string]string{
+								"cluster": "hub-1",
+							},
+							Data: map[string][]byte{
+								"key": []byte("value"),
+							},
+						}.Build(),
+					}.Build(),
+				}.Build())
+				Expect(err).To(HaveOccurred())
+				st, ok := status.FromError(err)
+				Expect(ok).To(BeTrue())
+				Expect(st.Code()).To(Equal(codes.InvalidArgument))
+				Expect(st.Message()).To(ContainSubstring("spec.data"))
+			})
+		})
+
+		Describe("Immutability", func() {
+			It("Update changing backend fails", func() {
+				created := createVaultSecret()
+
+				_, err := server.Update(ctx, privatev1.SecretsUpdateRequest_builder{
+					Object: privatev1.Secret_builder{
+						Id: created.GetId(),
+						Spec: privatev1.SecretSpec_builder{
+							Backend: privatev1.SecretBackend_SECRET_BACKEND_HUB,
+						}.Build(),
+					}.Build(),
+					UpdateMask: &fieldmaskpb.FieldMask{Paths: []string{"spec.backend"}},
+				}.Build())
+				Expect(err).To(HaveOccurred())
+				st, ok := status.FromError(err)
+				Expect(ok).To(BeTrue())
+				Expect(st.Code()).To(Equal(codes.InvalidArgument))
+				Expect(st.Message()).To(ContainSubstring("backend"))
+				Expect(st.Message()).To(ContainSubstring("immutable"))
+			})
+
+			It("Update Hub secret with data fails", func() {
+				created := createHubSecret()
+
+				_, err := server.Update(ctx, privatev1.SecretsUpdateRequest_builder{
+					Object: privatev1.Secret_builder{
+						Id: created.GetId(),
+						Spec: privatev1.SecretSpec_builder{
+							Data: map[string][]byte{
+								"key": []byte("should-not-be-allowed"),
+							},
+						}.Build(),
+					}.Build(),
+					UpdateMask: &fieldmaskpb.FieldMask{Paths: []string{"spec.data"}},
+				}.Build())
+				Expect(err).To(HaveOccurred())
+				st, ok := status.FromError(err)
+				Expect(ok).To(BeTrue())
+				Expect(st.Code()).To(Equal(codes.InvalidArgument))
+				Expect(st.Message()).To(ContainSubstring("spec.data"))
+			})
+
+			It("Update with metadata.tenant in update_mask fails", func() {
+				created := createVaultSecret()
+
+				_, err := server.Update(ctx, privatev1.SecretsUpdateRequest_builder{
+					Object: privatev1.Secret_builder{
+						Id: created.GetId(),
+						Metadata: privatev1.Metadata_builder{
+							Tenant: "other-tenant",
+						}.Build(),
+					}.Build(),
+					UpdateMask: &fieldmaskpb.FieldMask{Paths: []string{"metadata.tenant"}},
+				}.Build())
+				Expect(err).To(HaveOccurred())
+			})
+		})
+
+		Describe("Name scoping", func() {
+			It("Allows multiple secrets with same name in same tenant", func() {
+				createVaultSecretWithName("shared-name")
+				second := createVaultSecretWithName("shared-name")
+				Expect(second.GetId()).ToNot(BeEmpty())
+			})
+		})
+
+		Describe("Optimistic locking", func() {
+			It("Update with stale version and lock=true fails", func() {
+				created := createVaultSecret()
+
+				_, err := server.Update(ctx, privatev1.SecretsUpdateRequest_builder{
+					Object: privatev1.Secret_builder{
+						Id: created.GetId(),
+						Spec: privatev1.SecretSpec_builder{
+							Data: map[string][]byte{
+								"key": []byte("first-update"),
+							},
+						}.Build(),
+					}.Build(),
+					UpdateMask: &fieldmaskpb.FieldMask{Paths: []string{"spec.data"}},
+					Lock:       true,
+				}.Build())
+				Expect(err).ToNot(HaveOccurred())
+
+				_, err = server.Update(ctx, privatev1.SecretsUpdateRequest_builder{
+					Object: privatev1.Secret_builder{
+						Id: created.GetId(),
+						Spec: privatev1.SecretSpec_builder{
+							Data: map[string][]byte{
+								"key": []byte("second-update"),
+							},
+						}.Build(),
+						Metadata: privatev1.Metadata_builder{
+							Version: created.GetMetadata().GetVersion(),
+						}.Build(),
+					}.Build(),
+					Lock: true,
+				}.Build())
+				Expect(err).To(HaveOccurred())
+			})
+		})
+
+		It("Update without id fails", func() {
+			_, err := server.Update(ctx, privatev1.SecretsUpdateRequest_builder{
+				Object: privatev1.Secret_builder{
+					Spec: privatev1.SecretSpec_builder{
+						Data: map[string][]byte{
+							"key": []byte("updated"),
+						},
+					}.Build(),
+				}.Build(),
+			}.Build())
+			Expect(err).To(HaveOccurred())
+			st, ok := status.FromError(err)
+			Expect(ok).To(BeTrue())
+			Expect(st.Code()).To(Equal(codes.InvalidArgument))
+			Expect(st.Message()).To(ContainSubstring("identifier"))
+		})
+	})
+
+	It("Redacts event payload", func() {
+		var event *privatev1.Event
+		notifier := events.NewMockNotifier(ctrl)
+		notifier.EXPECT().
+			Notify(gomock.Any(), gomock.Any()).
+			DoAndReturn(
+				func(ctx context.Context, payload proto.Message) error {
+					event = payload.(*privatev1.Event)
+					return nil
+				},
+			)
+
+		server, err := NewPrivateSecretsServer().
+			SetLogger(logger).
+			SetAttributionLogic(attribution).
+			SetTenancyLogic(tenancy).
+			SetNotifier(notifier).
+			Build()
+		Expect(err).ToNot(HaveOccurred())
+
+		_, err = server.Create(
+			ctx,
+			privatev1.SecretsCreateRequest_builder{
+				Object: privatev1.Secret_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name: "redact-test",
+					}.Build(),
+					Spec: privatev1.SecretSpec_builder{
+						Data: map[string][]byte{
+							"password": []byte("super-secret"),
+						},
+					}.Build(),
+				}.Build(),
+			}.Build(),
+		)
+		Expect(err).ToNot(HaveOccurred())
+
+		Expect(event).ToNot(BeNil())
+		Expect(event.GetType()).To(Equal(privatev1.EventType_EVENT_TYPE_OBJECT_CREATED))
+		object := event.GetSecret()
+		Expect(object).ToNot(BeNil())
+		Expect(object.GetSpec().GetData()).To(BeEmpty())
+	})
+})


### PR DESCRIPTION
Adds a private Secrets server over the postgres db.  Dispatch to secrets backends is not yet implemented, and those methods are stubbed out.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added private secrets API support through gRPC and REST.
  * Added create, retrieve, list, update, delete, and signal operations for secrets.
  * Added Vault and HUB backend validation, tenant-aware access, filtering, ordering, and pagination.
  * Secret data is automatically redacted from responses and emitted events.
  * Added validation, optimistic locking, update restrictions, and automatic ID generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->