### PR TITLE
OSAC-2398: VMaaS: ComputeInstance stuck in STARTING forever when Kubernetes CRD validation fails

### DIFF
--- a/internal/controllers/baremetalinstance/baremetalinstance_reconciler_function.go
+++ b/internal/controllers/baremetalinstance/baremetalinstance_reconciler_function.go
@@ -189,6 +189,10 @@ func (t *task) update(ctx context.Context) error {
 		return t.mutateBMI(ctx, object)
 	})
 	if err != nil {
+		if apierrors.IsInvalid(err) {
+			t.setFailed(err)
+			return nil
+		}
 		return err
 	}
 	t.r.logger.DebugContext(
@@ -387,6 +391,19 @@ func (t *task) removeFinalizer() {
 		})
 		t.bareMetalInstance.GetMetadata().SetFinalizers(list)
 	}
+}
+
+func (t *task) setFailed(err error) {
+	if !t.bareMetalInstance.HasStatus() {
+		t.bareMetalInstance.SetStatus(&privatev1.BareMetalInstanceStatus{})
+	}
+	t.bareMetalInstance.GetStatus().SetState(privatev1.BareMetalInstanceState_BARE_METAL_INSTANCE_STATE_FAILED)
+	t.updateCondition(
+		privatev1.BareMetalInstanceConditionType_BARE_METAL_INSTANCE_CONDITION_TYPE_CONFIGURATION_APPLIED,
+		privatev1.ConditionStatus_CONDITION_STATUS_FALSE,
+		"ValidationFailed",
+		err.Error(),
+	)
 }
 
 func (t *task) updateCondition(conditionType privatev1.BareMetalInstanceConditionType, status privatev1.ConditionStatus,

--- a/internal/controllers/cluster/cluster_reconciler_function.go
+++ b/internal/controllers/cluster/cluster_reconciler_function.go
@@ -24,6 +24,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/protobuf/proto"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clnt "sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -222,6 +223,10 @@ func (t *task) update(ctx context.Context) error {
 		}
 		err = t.hubClient.Create(ctx, object)
 		if err != nil {
+			if apierrors.IsInvalid(err) {
+				t.setFailed(err)
+				return nil
+			}
 			return err
 		}
 		t.r.logger.DebugContext(
@@ -235,6 +240,10 @@ func (t *task) update(ctx context.Context) error {
 		update.Spec = spec
 		err = t.hubClient.Patch(ctx, update, clnt.MergeFrom(object))
 		if err != nil {
+			if apierrors.IsInvalid(err) {
+				t.setFailed(err)
+				return nil
+			}
 			return err
 		}
 		t.r.logger.DebugContext(
@@ -464,6 +473,22 @@ func (t *task) getKubeObject(ctx context.Context) (result *osacv1alpha1.ClusterO
 		result = &items[0]
 	}
 	return
+}
+
+// setFailed transitions the cluster to FAILED state with the given error message.
+// Used when a permanent error (e.g., Kubernetes CRD validation failure) means the resource
+// cannot be provisioned.
+func (t *task) setFailed(err error) {
+	if !t.cluster.HasStatus() {
+		t.cluster.SetStatus(&privatev1.ClusterStatus{})
+	}
+	t.cluster.GetStatus().SetState(privatev1.ClusterState_CLUSTER_STATE_FAILED)
+	t.updateCondition(
+		privatev1.ClusterConditionType_CLUSTER_CONDITION_TYPE_PROGRESSING,
+		privatev1.ConditionStatus_CONDITION_STATUS_FALSE,
+		"ValidationFailed",
+		err.Error(),
+	)
 }
 
 // updateCondition updates or creates a condition with the specified type, status, reason, and message.

--- a/internal/controllers/computeinstance/computeinstance_reconciler_function.go
+++ b/internal/controllers/computeinstance/computeinstance_reconciler_function.go
@@ -52,6 +52,12 @@ const userDataSecretSuffix = "-user-data"
 // userDataSecretKey is the key used in the Secret's stringData to store the cloud-init user data.
 const userDataSecretKey = "userdata"
 
+// errTransientK8sError marks errors from Kubernetes Create/Patch calls that are not permanent
+// validation failures. Reconciliation errors are normally recorded as a FAILED state via
+// setReconciliationFailed, but transient errors should just be retried, leaving the compute
+// instance's state untouched so it doesn't look like a permanent failure while it is retried.
+var errTransientK8sError = errors.New("transient kubernetes error")
+
 // FunctionBuilder contains the data and logic needed to build a function that reconciles compute instances.
 type FunctionBuilder struct {
 	logger     *slog.Logger
@@ -141,7 +147,7 @@ func (r *function) run(ctx context.Context, computeInstance *privatev1.ComputeIn
 	} else {
 		reconcileErr = t.update(ctx)
 	}
-	if reconcileErr != nil {
+	if reconcileErr != nil && !errors.Is(reconcileErr, errTransientK8sError) {
 		t.setReconciliationFailed(reconcileErr)
 	}
 	// Calculate which fields the reconciler actually modified and use a field mask
@@ -224,7 +230,11 @@ func (t *task) update(ctx context.Context) error {
 		}
 		err = t.hubClient.Create(ctx, object)
 		if err != nil {
-			return err
+			if apierrors.IsInvalid(err) {
+				t.setFailed(err)
+				return nil
+			}
+			return fmt.Errorf("%w: %w", errTransientK8sError, err)
 		}
 		t.r.logger.DebugContext(
 			ctx,
@@ -237,7 +247,11 @@ func (t *task) update(ctx context.Context) error {
 		update.Spec = spec
 		err = t.hubClient.Patch(ctx, update, clnt.MergeFrom(object))
 		if err != nil {
-			return err
+			if apierrors.IsInvalid(err) {
+				t.setFailed(err)
+				return nil
+			}
+			return fmt.Errorf("%w: %w", errTransientK8sError, err)
 		}
 		t.r.logger.DebugContext(
 			ctx,
@@ -497,6 +511,22 @@ func (t *task) removeFinalizer() {
 		})
 		t.computeInstance.GetMetadata().SetFinalizers(list)
 	}
+}
+
+// setFailed transitions the compute instance to FAILED state with the given error message.
+// Used when a permanent error (e.g., Kubernetes CRD validation failure) means the resource
+// cannot be provisioned.
+func (t *task) setFailed(err error) {
+	if !t.computeInstance.HasStatus() {
+		t.computeInstance.SetStatus(&privatev1.ComputeInstanceStatus{})
+	}
+	t.computeInstance.GetStatus().SetState(privatev1.ComputeInstanceState_COMPUTE_INSTANCE_STATE_FAILED)
+	t.updateCondition(
+		privatev1.ComputeInstanceConditionType_COMPUTE_INSTANCE_CONDITION_TYPE_CONFIGURATION_APPLIED,
+		privatev1.ConditionStatus_CONDITION_STATUS_FALSE,
+		"ValidationFailed",
+		err.Error(),
+	)
 }
 
 // updateCondition updates or creates a condition with the specified type, status, reason, and message.

--- a/internal/controllers/computeinstance/computeinstance_reconciler_function_test.go
+++ b/internal/controllers/computeinstance/computeinstance_reconciler_function_test.go
@@ -29,9 +29,12 @@ import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 	"google.golang.org/protobuf/types/known/wrapperspb"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/validation/field"
 	clnt "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
@@ -1988,4 +1991,346 @@ var _ = Describe("instance_type resolution in reconciler", func() {
 		Expect(err.Error()).To(ContainSubstring("connection refused"))
 	})
 
+})
+
+var _ = Describe("Kubernetes validation error handling", func() {
+	const (
+		computeInstanceID = "test-ci-validation"
+		tenantName        = "test-tenant"
+		hubID             = "test-hub"
+		hubNamespace      = "test-ns"
+		subnetID          = "test-subnet"
+	)
+
+	var (
+		ctx  context.Context
+		ctrl *gomock.Controller
+	)
+
+	BeforeEach(func() {
+		ctx = context.Background()
+		ctrl = gomock.NewController(GinkgoT())
+		DeferCleanup(ctrl.Finish)
+	})
+
+	It("should set state to FAILED when K8s Create returns Invalid error", func() {
+		subnetCR := &osacv1alpha1.Subnet{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: hubNamespace,
+				Name:      "test-sn",
+				Labels:    map[string]string{labels.SubnetUuid: subnetID},
+			},
+		}
+
+		scheme := runtime.NewScheme()
+		Expect(osacv1alpha1.AddToScheme(scheme)).To(Succeed())
+		Expect(corev1.AddToScheme(scheme)).To(Succeed())
+
+		fakeClient := fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithObjects(subnetCR).
+			WithInterceptorFuncs(interceptor.Funcs{
+				Create: func(ctx context.Context, client clnt.WithWatch, obj clnt.Object, opts ...clnt.CreateOption) error {
+					if _, ok := obj.(*osacv1alpha1.ComputeInstance); ok {
+						return apierrors.NewInvalid(
+							schema.GroupKind{Group: "osac.openshift.io", Kind: "ComputeInstance"},
+							"vm-test",
+							field.ErrorList{
+								field.Invalid(
+									field.NewPath("spec", "cores"),
+									150,
+									"spec.cores in body should be less than or equal to 128",
+								),
+							},
+						)
+					}
+					return client.Create(ctx, obj, opts...)
+				},
+			}).
+			Build()
+
+		hubCache := controllers.NewMockHubCache(ctrl)
+		hubCache.EXPECT().
+			Get(gomock.Any(), hubID).
+			Return(&controllers.HubEntry{
+				Namespace: hubNamespace,
+				Client:    fakeClient,
+			}, nil).
+			AnyTimes()
+
+		hubsClient := controllers.NewMockHubsClient(ctrl)
+
+		mockInstanceTypesClient := NewMockInstanceTypesClient(ctrl)
+		mockInstanceTypesClient.EXPECT().
+			Get(gomock.Any(), gomock.Any()).
+			Return(privatev1.InstanceTypesGetResponse_builder{
+				Object: privatev1.InstanceType_builder{
+					Spec: privatev1.InstanceTypeSpec_builder{
+						Cores:     150,
+						MemoryGib: 2,
+					}.Build(),
+				}.Build(),
+			}.Build(), nil)
+
+		computeInstancesClient := NewMockComputeInstancesClient(ctrl)
+		computeInstancesClient.EXPECT().
+			Update(gomock.Any(), gomock.Any(), gomock.Any()).
+			DoAndReturn(func(ctx context.Context, req *privatev1.ComputeInstancesUpdateRequest, opts ...grpc.CallOption) (*privatev1.ComputeInstancesUpdateResponse, error) {
+				return &privatev1.ComputeInstancesUpdateResponse{Object: req.GetObject()}, nil
+			}).
+			AnyTimes()
+
+		computeInstance := privatev1.ComputeInstance_builder{
+			Id: computeInstanceID,
+			Metadata: privatev1.Metadata_builder{
+				Finalizers: []string{finalizers.Controller},
+				Tenant:     tenantName,
+			}.Build(),
+			Spec: privatev1.ComputeInstanceSpec_builder{
+				Template:     "osac.templates.ocp_virt_vm",
+				InstanceType: new("test-type"),
+				NetworkAttachments: []*privatev1.NetworkAttachment{
+					privatev1.NetworkAttachment_builder{Subnet: subnetID}.Build(),
+				},
+			}.Build(),
+			Status: privatev1.ComputeInstanceStatus_builder{
+				State: privatev1.ComputeInstanceState_COMPUTE_INSTANCE_STATE_STARTING,
+				Hub:   hubID,
+			}.Build(),
+		}.Build()
+
+		f := &function{
+			logger:                 logger,
+			hubCache:               hubCache,
+			computeInstancesClient: computeInstancesClient,
+			hubsClient:             hubsClient,
+			instanceTypesClient:    mockInstanceTypesClient,
+			maskCalculator:         nil,
+		}
+
+		err := f.run(ctx, computeInstance)
+		Expect(err).ToNot(HaveOccurred())
+
+		Expect(computeInstance.GetStatus().GetState()).To(
+			Equal(privatev1.ComputeInstanceState_COMPUTE_INSTANCE_STATE_FAILED),
+		)
+
+		conditions := computeInstance.GetStatus().GetConditions()
+		var configCondition *privatev1.ComputeInstanceCondition
+		for _, c := range conditions {
+			if c.GetType() == privatev1.ComputeInstanceConditionType_COMPUTE_INSTANCE_CONDITION_TYPE_CONFIGURATION_APPLIED {
+				configCondition = c
+				break
+			}
+		}
+		Expect(configCondition).ToNot(BeNil())
+		Expect(configCondition.GetStatus()).To(Equal(privatev1.ConditionStatus_CONDITION_STATUS_FALSE))
+		Expect(configCondition.GetReason()).To(Equal("ValidationFailed"))
+		Expect(configCondition.GetMessage()).To(ContainSubstring("spec.cores"))
+		Expect(configCondition.GetMessage()).To(ContainSubstring("128"))
+	})
+
+	It("should set state to FAILED when K8s Patch returns Invalid error", func() {
+		existingCR := &osacv1alpha1.ComputeInstance{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: hubNamespace,
+				Name:      "vm-existing",
+				Labels: map[string]string{
+					labels.ComputeInstanceUuid: computeInstanceID,
+				},
+			},
+		}
+
+		subnetCR := &osacv1alpha1.Subnet{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: hubNamespace,
+				Name:      "test-sn",
+				Labels:    map[string]string{labels.SubnetUuid: subnetID},
+			},
+		}
+
+		scheme := runtime.NewScheme()
+		Expect(osacv1alpha1.AddToScheme(scheme)).To(Succeed())
+		Expect(corev1.AddToScheme(scheme)).To(Succeed())
+
+		fakeClient := fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithObjects(existingCR, subnetCR).
+			WithInterceptorFuncs(interceptor.Funcs{
+				Patch: func(ctx context.Context, client clnt.WithWatch, obj clnt.Object, patch clnt.Patch, opts ...clnt.PatchOption) error {
+					if _, ok := obj.(*osacv1alpha1.ComputeInstance); ok {
+						return apierrors.NewInvalid(
+							schema.GroupKind{Group: "osac.openshift.io", Kind: "ComputeInstance"},
+							"vm-existing",
+							field.ErrorList{
+								field.Invalid(
+									field.NewPath("spec", "cores"),
+									200,
+									"spec.cores in body should be less than or equal to 128",
+								),
+							},
+						)
+					}
+					return client.Patch(ctx, obj, patch, opts...)
+				},
+			}).
+			Build()
+
+		hubCache := controllers.NewMockHubCache(ctrl)
+		hubCache.EXPECT().
+			Get(gomock.Any(), hubID).
+			Return(&controllers.HubEntry{
+				Namespace: hubNamespace,
+				Client:    fakeClient,
+			}, nil).
+			AnyTimes()
+
+		hubsClient := controllers.NewMockHubsClient(ctrl)
+
+		mockInstanceTypesClient := NewMockInstanceTypesClient(ctrl)
+		mockInstanceTypesClient.EXPECT().
+			Get(gomock.Any(), gomock.Any()).
+			Return(privatev1.InstanceTypesGetResponse_builder{
+				Object: privatev1.InstanceType_builder{
+					Spec: privatev1.InstanceTypeSpec_builder{
+						Cores:     200,
+						MemoryGib: 2,
+					}.Build(),
+				}.Build(),
+			}.Build(), nil)
+
+		computeInstancesClient := NewMockComputeInstancesClient(ctrl)
+		computeInstancesClient.EXPECT().
+			Update(gomock.Any(), gomock.Any(), gomock.Any()).
+			DoAndReturn(func(ctx context.Context, req *privatev1.ComputeInstancesUpdateRequest, opts ...grpc.CallOption) (*privatev1.ComputeInstancesUpdateResponse, error) {
+				return &privatev1.ComputeInstancesUpdateResponse{Object: req.GetObject()}, nil
+			}).
+			AnyTimes()
+
+		computeInstance := privatev1.ComputeInstance_builder{
+			Id: computeInstanceID,
+			Metadata: privatev1.Metadata_builder{
+				Finalizers: []string{finalizers.Controller},
+				Tenant:     tenantName,
+			}.Build(),
+			Spec: privatev1.ComputeInstanceSpec_builder{
+				Template:     "osac.templates.ocp_virt_vm",
+				InstanceType: new("test-type"),
+				NetworkAttachments: []*privatev1.NetworkAttachment{
+					privatev1.NetworkAttachment_builder{Subnet: subnetID}.Build(),
+				},
+			}.Build(),
+			Status: privatev1.ComputeInstanceStatus_builder{
+				State: privatev1.ComputeInstanceState_COMPUTE_INSTANCE_STATE_STARTING,
+				Hub:   hubID,
+			}.Build(),
+		}.Build()
+
+		f := &function{
+			logger:                 logger,
+			hubCache:               hubCache,
+			computeInstancesClient: computeInstancesClient,
+			hubsClient:             hubsClient,
+			instanceTypesClient:    mockInstanceTypesClient,
+			maskCalculator:         nil,
+		}
+
+		err := f.run(ctx, computeInstance)
+		Expect(err).ToNot(HaveOccurred())
+
+		Expect(computeInstance.GetStatus().GetState()).To(
+			Equal(privatev1.ComputeInstanceState_COMPUTE_INSTANCE_STATE_FAILED),
+		)
+	})
+
+	It("should still return transient errors from K8s Create", func() {
+		subnetCR := &osacv1alpha1.Subnet{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: hubNamespace,
+				Name:      "test-sn",
+				Labels:    map[string]string{labels.SubnetUuid: subnetID},
+			},
+		}
+
+		scheme := runtime.NewScheme()
+		Expect(osacv1alpha1.AddToScheme(scheme)).To(Succeed())
+		Expect(corev1.AddToScheme(scheme)).To(Succeed())
+
+		fakeClient := fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithObjects(subnetCR).
+			WithInterceptorFuncs(interceptor.Funcs{
+				Create: func(ctx context.Context, client clnt.WithWatch, obj clnt.Object, opts ...clnt.CreateOption) error {
+					if _, ok := obj.(*osacv1alpha1.ComputeInstance); ok {
+						return errors.New("connection refused")
+					}
+					return client.Create(ctx, obj, opts...)
+				},
+			}).
+			Build()
+
+		hubCache := controllers.NewMockHubCache(ctrl)
+		hubCache.EXPECT().
+			Get(gomock.Any(), hubID).
+			Return(&controllers.HubEntry{
+				Namespace: hubNamespace,
+				Client:    fakeClient,
+			}, nil).
+			AnyTimes()
+
+		hubsClient := controllers.NewMockHubsClient(ctrl)
+
+		mockInstanceTypesClient := NewMockInstanceTypesClient(ctrl)
+		mockInstanceTypesClient.EXPECT().
+			Get(gomock.Any(), gomock.Any()).
+			Return(privatev1.InstanceTypesGetResponse_builder{
+				Object: privatev1.InstanceType_builder{
+					Spec: privatev1.InstanceTypeSpec_builder{}.Build(),
+				}.Build(),
+			}.Build(), nil)
+
+		computeInstancesClient := NewMockComputeInstancesClient(ctrl)
+		computeInstancesClient.EXPECT().
+			Update(gomock.Any(), gomock.Any(), gomock.Any()).
+			DoAndReturn(func(ctx context.Context, req *privatev1.ComputeInstancesUpdateRequest, opts ...grpc.CallOption) (*privatev1.ComputeInstancesUpdateResponse, error) {
+				return &privatev1.ComputeInstancesUpdateResponse{Object: req.GetObject()}, nil
+			}).
+			AnyTimes()
+
+		computeInstance := privatev1.ComputeInstance_builder{
+			Id: computeInstanceID,
+			Metadata: privatev1.Metadata_builder{
+				Finalizers: []string{finalizers.Controller},
+				Tenant:     tenantName,
+			}.Build(),
+			Spec: privatev1.ComputeInstanceSpec_builder{
+				Template:     "osac.templates.ocp_virt_vm",
+				InstanceType: new("test-type"),
+				NetworkAttachments: []*privatev1.NetworkAttachment{
+					privatev1.NetworkAttachment_builder{Subnet: subnetID}.Build(),
+				},
+			}.Build(),
+			Status: privatev1.ComputeInstanceStatus_builder{
+				State: privatev1.ComputeInstanceState_COMPUTE_INSTANCE_STATE_STARTING,
+				Hub:   hubID,
+			}.Build(),
+		}.Build()
+
+		f := &function{
+			logger:                 logger,
+			hubCache:               hubCache,
+			computeInstancesClient: computeInstancesClient,
+			hubsClient:             hubsClient,
+			instanceTypesClient:    mockInstanceTypesClient,
+			maskCalculator:         nil,
+		}
+
+		err := f.run(ctx, computeInstance)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("connection refused"))
+
+		Expect(computeInstance.GetStatus().GetState()).To(
+			Equal(privatev1.ComputeInstanceState_COMPUTE_INSTANCE_STATE_STARTING),
+		)
+	})
 })

--- a/internal/controllers/externalip/external_ip_reconciler_function.go
+++ b/internal/controllers/externalip/external_ip_reconciler_function.go
@@ -24,6 +24,7 @@ import (
 
 	"google.golang.org/grpc"
 	"google.golang.org/protobuf/proto"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clnt "sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -194,6 +195,10 @@ func (t *task) update(ctx context.Context) error {
 		}
 		err = t.hubClient.Create(ctx, newObject)
 		if err != nil {
+			if apierrors.IsInvalid(err) {
+				t.setFailed(err)
+				return nil
+			}
 			return err
 		}
 		t.r.logger.DebugContext(
@@ -207,6 +212,10 @@ func (t *task) update(ctx context.Context) error {
 		update.Spec = spec
 		err = t.hubClient.Patch(ctx, update, clnt.MergeFrom(object))
 		if err != nil {
+			if apierrors.IsInvalid(err) {
+				t.setFailed(err)
+				return nil
+			}
 			return err
 		}
 		t.r.logger.DebugContext(
@@ -397,6 +406,17 @@ func (t *task) removeFinalizer() {
 		})
 		t.externalIP.GetMetadata().SetFinalizers(list)
 	}
+}
+
+// setFailed transitions the external IP to FAILED state with the given error message.
+// Used when a permanent error (e.g., Kubernetes CRD validation failure) means the resource
+// cannot be provisioned.
+func (t *task) setFailed(err error) {
+	if !t.externalIP.HasStatus() {
+		t.externalIP.SetStatus(&privatev1.ExternalIPStatus{})
+	}
+	t.externalIP.GetStatus().SetState(privatev1.ExternalIPState_EXTERNAL_IP_STATE_FAILED)
+	t.externalIP.GetStatus().SetMessage(err.Error())
 }
 
 // buildSpec constructs the spec map for the Kubernetes ExternalIP object based on the

--- a/internal/controllers/externalipattachment/external_ip_attachment_reconciler_function.go
+++ b/internal/controllers/externalipattachment/external_ip_attachment_reconciler_function.go
@@ -22,6 +22,7 @@ import (
 
 	"google.golang.org/grpc"
 	"google.golang.org/protobuf/proto"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clnt "sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -177,6 +178,10 @@ func (t *task) update(ctx context.Context) error {
 		}
 		err = t.hubClient.Create(ctx, newObject)
 		if err != nil {
+			if apierrors.IsInvalid(err) {
+				t.setFailed(err)
+				return nil
+			}
 			return err
 		}
 		t.r.logger.DebugContext(
@@ -190,6 +195,10 @@ func (t *task) update(ctx context.Context) error {
 		update.Spec = spec
 		err = t.hubClient.Patch(ctx, update, clnt.MergeFrom(object))
 		if err != nil {
+			if apierrors.IsInvalid(err) {
+				t.setFailed(err)
+				return nil
+			}
 			return err
 		}
 		t.r.logger.DebugContext(
@@ -365,6 +374,17 @@ func (t *task) removeFinalizer() {
 		})
 		t.externalIPAttachment.GetMetadata().SetFinalizers(list)
 	}
+}
+
+// setFailed transitions the external IP attachment to FAILED state with the given error message.
+// Used when a permanent error (e.g., Kubernetes CRD validation failure) means the resource
+// cannot be provisioned.
+func (t *task) setFailed(err error) {
+	if !t.externalIPAttachment.HasStatus() {
+		t.externalIPAttachment.SetStatus(&privatev1.ExternalIPAttachmentStatus{})
+	}
+	t.externalIPAttachment.GetStatus().SetState(privatev1.ExternalIPAttachmentState_EXTERNAL_IP_ATTACHMENT_STATE_FAILED)
+	t.externalIPAttachment.GetStatus().SetMessage(err.Error())
 }
 
 func (t *task) buildSpec() osacv1alpha1.ExternalIPAttachmentSpec {

--- a/internal/controllers/externalippool/external_ip_pool_reconciler_function.go
+++ b/internal/controllers/externalippool/external_ip_pool_reconciler_function.go
@@ -25,6 +25,7 @@ import (
 
 	"google.golang.org/grpc"
 	"google.golang.org/protobuf/proto"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clnt "sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -197,6 +198,10 @@ func (t *task) update(ctx context.Context) error {
 		}
 		err = t.hubClient.Create(ctx, object)
 		if err != nil {
+			if apierrors.IsInvalid(err) {
+				t.setFailed(err)
+				return nil
+			}
 			return err
 		}
 		t.r.logger.DebugContext(
@@ -210,6 +215,10 @@ func (t *task) update(ctx context.Context) error {
 		update.Spec = spec
 		err = t.hubClient.Patch(ctx, update, clnt.MergeFrom(existingObject))
 		if err != nil {
+			if apierrors.IsInvalid(err) {
+				t.setFailed(err)
+				return nil
+			}
 			return err
 		}
 		t.r.logger.DebugContext(
@@ -388,6 +397,17 @@ func (t *task) removeFinalizer() {
 		})
 		t.externalIPPool.GetMetadata().SetFinalizers(list)
 	}
+}
+
+// setFailed transitions the external IP pool to FAILED state with the given error message.
+// Used when a permanent error (e.g., Kubernetes CRD validation failure) means the resource
+// cannot be provisioned.
+func (t *task) setFailed(err error) {
+	if !t.externalIPPool.HasStatus() {
+		t.externalIPPool.SetStatus(&privatev1.ExternalIPPoolStatus{})
+	}
+	t.externalIPPool.GetStatus().SetState(privatev1.ExternalIPPoolState_EXTERNAL_IP_POOL_STATE_FAILED)
+	t.externalIPPool.GetStatus().SetMessage(err.Error())
 }
 
 func (t *task) buildSpec() osacv1alpha1.ExternalIPPoolSpec {

--- a/internal/controllers/natgateway/nat_gateway_reconciler_function.go
+++ b/internal/controllers/natgateway/nat_gateway_reconciler_function.go
@@ -22,6 +22,7 @@ import (
 
 	"google.golang.org/grpc"
 	"google.golang.org/protobuf/proto"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clnt "sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -177,6 +178,10 @@ func (t *task) update(ctx context.Context) error {
 		}
 		err = t.hubClient.Create(ctx, newObject)
 		if err != nil {
+			if apierrors.IsInvalid(err) {
+				t.setFailed(err)
+				return nil
+			}
 			return err
 		}
 		t.r.logger.DebugContext(
@@ -190,6 +195,10 @@ func (t *task) update(ctx context.Context) error {
 		update.Spec = spec
 		err = t.hubClient.Patch(ctx, update, clnt.MergeFrom(object))
 		if err != nil {
+			if apierrors.IsInvalid(err) {
+				t.setFailed(err)
+				return nil
+			}
 			return err
 		}
 		t.r.logger.DebugContext(
@@ -365,6 +374,14 @@ func (t *task) removeFinalizer() {
 		})
 		t.natGateway.GetMetadata().SetFinalizers(list)
 	}
+}
+
+func (t *task) setFailed(err error) {
+	if !t.natGateway.HasStatus() {
+		t.natGateway.SetStatus(&privatev1.NATGatewayStatus{})
+	}
+	t.natGateway.GetStatus().SetState(privatev1.NATGatewayState_NAT_GATEWAY_STATE_FAILED)
+	t.natGateway.GetStatus().SetMessage(err.Error())
 }
 
 func (t *task) buildSpec() osacv1alpha1.NATGatewaySpec {

--- a/internal/controllers/publicip/public_ip_reconciler_function.go
+++ b/internal/controllers/publicip/public_ip_reconciler_function.go
@@ -24,6 +24,7 @@ import (
 
 	"google.golang.org/grpc"
 	"google.golang.org/protobuf/proto"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clnt "sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -194,6 +195,10 @@ func (t *task) update(ctx context.Context) error {
 		}
 		err = t.hubClient.Create(ctx, newObject)
 		if err != nil {
+			if apierrors.IsInvalid(err) {
+				t.setFailed(err)
+				return nil
+			}
 			return err
 		}
 		t.r.logger.DebugContext(
@@ -207,6 +212,10 @@ func (t *task) update(ctx context.Context) error {
 		update.Spec = spec
 		err = t.hubClient.Patch(ctx, update, clnt.MergeFrom(object))
 		if err != nil {
+			if apierrors.IsInvalid(err) {
+				t.setFailed(err)
+				return nil
+			}
 			return err
 		}
 		t.r.logger.DebugContext(
@@ -397,6 +406,17 @@ func (t *task) removeFinalizer() {
 		})
 		t.publicIP.GetMetadata().SetFinalizers(list)
 	}
+}
+
+// setFailed transitions the public IP to FAILED state with the given error message.
+// Used when a permanent error (e.g., Kubernetes CRD validation failure) means the resource
+// cannot be provisioned.
+func (t *task) setFailed(err error) {
+	if !t.publicIP.HasStatus() {
+		t.publicIP.SetStatus(&privatev1.PublicIPStatus{})
+	}
+	t.publicIP.GetStatus().SetState(privatev1.PublicIPState_PUBLIC_IP_STATE_FAILED)
+	t.publicIP.GetStatus().SetMessage(err.Error())
 }
 
 // buildSpec constructs the spec map for the Kubernetes PublicIP object based on the

--- a/internal/controllers/publicipattachment/public_ip_attachment_reconciler_function.go
+++ b/internal/controllers/publicipattachment/public_ip_attachment_reconciler_function.go
@@ -22,6 +22,7 @@ import (
 
 	"google.golang.org/grpc"
 	"google.golang.org/protobuf/proto"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clnt "sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -177,6 +178,10 @@ func (t *task) update(ctx context.Context) error {
 		}
 		err = t.hubClient.Create(ctx, newObject)
 		if err != nil {
+			if apierrors.IsInvalid(err) {
+				t.setFailed(err)
+				return nil
+			}
 			return err
 		}
 		t.r.logger.DebugContext(
@@ -190,6 +195,10 @@ func (t *task) update(ctx context.Context) error {
 		update.Spec = spec
 		err = t.hubClient.Patch(ctx, update, clnt.MergeFrom(object))
 		if err != nil {
+			if apierrors.IsInvalid(err) {
+				t.setFailed(err)
+				return nil
+			}
 			return err
 		}
 		t.r.logger.DebugContext(
@@ -365,6 +374,17 @@ func (t *task) removeFinalizer() {
 		})
 		t.publicIPAttachment.GetMetadata().SetFinalizers(list)
 	}
+}
+
+// setFailed transitions the public IP attachment to FAILED state with the given error message.
+// Used when a permanent error (e.g., Kubernetes CRD validation failure) means the resource
+// cannot be provisioned.
+func (t *task) setFailed(err error) {
+	if !t.publicIPAttachment.HasStatus() {
+		t.publicIPAttachment.SetStatus(&privatev1.PublicIPAttachmentStatus{})
+	}
+	t.publicIPAttachment.GetStatus().SetState(privatev1.PublicIPAttachmentState_PUBLIC_IP_ATTACHMENT_STATE_FAILED)
+	t.publicIPAttachment.GetStatus().SetMessage(err.Error())
 }
 
 func (t *task) buildSpec() osacv1alpha1.PublicIPAttachmentSpec {

--- a/internal/controllers/publicippool/public_ip_pool_reconciler_function.go
+++ b/internal/controllers/publicippool/public_ip_pool_reconciler_function.go
@@ -25,6 +25,7 @@ import (
 
 	"google.golang.org/grpc"
 	"google.golang.org/protobuf/proto"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clnt "sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -197,6 +198,10 @@ func (t *task) update(ctx context.Context) error {
 		}
 		err = t.hubClient.Create(ctx, object)
 		if err != nil {
+			if apierrors.IsInvalid(err) {
+				t.setFailed(err)
+				return nil
+			}
 			return err
 		}
 		t.r.logger.DebugContext(
@@ -210,6 +215,10 @@ func (t *task) update(ctx context.Context) error {
 		update.Spec = spec
 		err = t.hubClient.Patch(ctx, update, clnt.MergeFrom(existingObject))
 		if err != nil {
+			if apierrors.IsInvalid(err) {
+				t.setFailed(err)
+				return nil
+			}
 			return err
 		}
 		t.r.logger.DebugContext(
@@ -388,6 +397,17 @@ func (t *task) removeFinalizer() {
 		})
 		t.publicIPPool.GetMetadata().SetFinalizers(list)
 	}
+}
+
+// setFailed transitions the public IP pool to FAILED state with the given error message.
+// Used when a permanent error (e.g., Kubernetes CRD validation failure) means the resource
+// cannot be provisioned.
+func (t *task) setFailed(err error) {
+	if !t.publicIPPool.HasStatus() {
+		t.publicIPPool.SetStatus(&privatev1.PublicIPPoolStatus{})
+	}
+	t.publicIPPool.GetStatus().SetState(privatev1.PublicIPPoolState_PUBLIC_IP_POOL_STATE_FAILED)
+	t.publicIPPool.GetStatus().SetMessage(err.Error())
 }
 
 func (t *task) buildSpec() osacv1alpha1.PublicIPPoolSpec {

--- a/internal/controllers/securitygroup/securitygroup_reconciler_function.go
+++ b/internal/controllers/securitygroup/securitygroup_reconciler_function.go
@@ -23,6 +23,7 @@ import (
 
 	"google.golang.org/grpc"
 	"google.golang.org/protobuf/proto"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clnt "sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -204,6 +205,10 @@ func (t *task) update(ctx context.Context) error {
 		}
 		err = t.hubClient.Create(ctx, object)
 		if err != nil {
+			if apierrors.IsInvalid(err) {
+				t.setFailed(err)
+				return nil
+			}
 			return err
 		}
 		t.r.logger.DebugContext(
@@ -217,6 +222,10 @@ func (t *task) update(ctx context.Context) error {
 		update.Spec = spec
 		err = t.hubClient.Patch(ctx, update, clnt.MergeFrom(object))
 		if err != nil {
+			if apierrors.IsInvalid(err) {
+				t.setFailed(err)
+				return nil
+			}
 			return err
 		}
 		t.r.logger.DebugContext(
@@ -390,6 +399,17 @@ func (t *task) removeFinalizer() {
 		})
 		t.securityGroup.GetMetadata().SetFinalizers(list)
 	}
+}
+
+// setFailed transitions the security group to FAILED state with the given error message.
+// Used when a permanent error (e.g., Kubernetes CRD validation failure) means the resource
+// cannot be provisioned.
+func (t *task) setFailed(err error) {
+	if !t.securityGroup.HasStatus() {
+		t.securityGroup.SetStatus(&privatev1.SecurityGroupStatus{})
+	}
+	t.securityGroup.GetStatus().SetState(privatev1.SecurityGroupState_SECURITY_GROUP_STATE_FAILED)
+	t.securityGroup.GetStatus().SetMessage(err.Error())
 }
 
 // buildSpec constructs the spec for the Kubernetes SecurityGroup object based on the

--- a/internal/controllers/subnet/subnet_reconciler_function.go
+++ b/internal/controllers/subnet/subnet_reconciler_function.go
@@ -25,6 +25,7 @@ import (
 
 	"google.golang.org/grpc"
 	"google.golang.org/protobuf/proto"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clnt "sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -195,6 +196,10 @@ func (t *task) update(ctx context.Context) error {
 		}
 		err = t.hubClient.Create(ctx, object)
 		if err != nil {
+			if apierrors.IsInvalid(err) {
+				t.setFailed(err)
+				return nil
+			}
 			return err
 		}
 		t.r.logger.DebugContext(
@@ -208,6 +213,10 @@ func (t *task) update(ctx context.Context) error {
 		update.Spec = spec
 		err = t.hubClient.Patch(ctx, update, clnt.MergeFrom(object))
 		if err != nil {
+			if apierrors.IsInvalid(err) {
+				t.setFailed(err)
+				return nil
+			}
 			return err
 		}
 		t.r.logger.DebugContext(
@@ -388,6 +397,17 @@ func (t *task) removeFinalizer() {
 		})
 		t.subnet.GetMetadata().SetFinalizers(list)
 	}
+}
+
+// setFailed transitions the subnet to FAILED state with the given error message.
+// Used when a permanent error (e.g., Kubernetes CRD validation failure) means the resource
+// cannot be provisioned.
+func (t *task) setFailed(err error) {
+	if !t.subnet.HasStatus() {
+		t.subnet.SetStatus(&privatev1.SubnetStatus{})
+	}
+	t.subnet.GetStatus().SetState(privatev1.SubnetState_SUBNET_STATE_FAILED)
+	t.subnet.GetStatus().SetMessage(err.Error())
 }
 
 // buildSpec constructs the spec for the Kubernetes Subnet object based on the

--- a/internal/controllers/virtualnetwork/virtual_network_reconciler_function.go
+++ b/internal/controllers/virtualnetwork/virtual_network_reconciler_function.go
@@ -25,6 +25,7 @@ import (
 
 	"google.golang.org/grpc"
 	"google.golang.org/protobuf/proto"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clnt "sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -195,6 +196,10 @@ func (t *task) update(ctx context.Context) error {
 		}
 		err = t.hubClient.Create(ctx, object)
 		if err != nil {
+			if apierrors.IsInvalid(err) {
+				t.setFailed(err)
+				return nil
+			}
 			return err
 		}
 		t.r.logger.DebugContext(
@@ -208,6 +213,10 @@ func (t *task) update(ctx context.Context) error {
 		update.Spec = spec
 		err = t.hubClient.Patch(ctx, update, clnt.MergeFrom(object))
 		if err != nil {
+			if apierrors.IsInvalid(err) {
+				t.setFailed(err)
+				return nil
+			}
 			return err
 		}
 		t.r.logger.DebugContext(
@@ -388,6 +397,17 @@ func (t *task) removeFinalizer() {
 		})
 		t.virtualNetwork.GetMetadata().SetFinalizers(list)
 	}
+}
+
+// setFailed transitions the virtual network to FAILED state with the given error message.
+// Used when a permanent error (e.g., Kubernetes CRD validation failure) means the resource
+// cannot be provisioned.
+func (t *task) setFailed(err error) {
+	if !t.virtualNetwork.HasStatus() {
+		t.virtualNetwork.SetStatus(&privatev1.VirtualNetworkStatus{})
+	}
+	t.virtualNetwork.GetStatus().SetState(privatev1.VirtualNetworkState_VIRTUAL_NETWORK_STATE_FAILED)
+	t.virtualNetwork.GetStatus().SetMessage(err.Error())
 }
 
 // buildSpec constructs the spec for the Kubernetes VirtualNetwork object based on the


### PR DESCRIPTION
## What
Reconcilers now transition a resource to FAILED, with a clear condition message, when the Kubernetes API rejects a Create/Patch as invalid, instead of retrying forever.

## Why
When the generated Kubernetes CRD spec fails admission validation (e.g. an out-of-range field), the error is permanent — retrying the reconcile will never succeed. Resources were left stuck in STARTING/PROGRESSING indefinitely with no useful signal to the user about what went wrong.

## Changes
- Detect Kubernetes "Invalid" API errors on Create/Patch across all hub-backed reconcilers (compute instances, clusters, bare metal instances, networking resources) and mark the resource FAILED with a ValidationFailed condition carrying the API error message
- For compute instances specifically, distinguish permanent validation errors from transient Kubernetes API errors (e.g. connection issues) so transient failures keep retrying without prematurely marking the resource as failed

## Testing
Added unit tests covering: CRD validation failures on Create and on Patch resulting in a FAILED state with the expected condition, and transient (non-validation) Kubernetes errors continuing to be retried without changing state.

Assisted-by: Claude Code <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of invalid resource configurations across infrastructure provisioning workflows.
  - Resources now transition to **FAILED** with a clear validation error message instead of repeatedly retrying an unrecoverable request.
  - Configuration and progress conditions provide more specific failure details.
  - Temporary infrastructure or connection errors continue to be retried appropriately without prematurely marking resources as failed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->