### PR TITLE
OSAC-3060: use kind-dev GH Action for CI integration tests

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -40,6 +40,13 @@ jobs:
       with:
         persist-credentials: false
     - uses: ./.github/actions/setup-go
+
+    - name: Create Kind cluster with OSAC infrastructure
+      uses: osac-project/osac-test-infra/.github/actions/kind-dev@main
+      with:
+        cluster-name: fulfillment-service-it
+        mode: skip-osac
+
     - run: |
         echo '127.0.0.1 fulfillment-api.osac.svc.cluster.local' | sudo tee -a /etc/hosts
         echo '127.0.0.1 fulfillment-internal-api.osac.svc.cluster.local' | sudo tee -a /etc/hosts


### PR DESCRIPTION
## Summary

- Add kind-dev reusable GitHub Action to CI integration test workflow
- Uses `osac-workspace/kind-dev/setup.sh --skip-osac` as single source of truth for Kind environment
- Go test code detects existing cluster and reuses it (faster CI, no duplicate infra install)

### Motivation

Converge on kind-dev as the single deployment path for Kind-based environments across all OSAC repos. Infrastructure versions (cert-manager, trust-manager, etc.) are managed in one place.

### How it works

The kind-dev GH Action creates a cluster named `fulfillment-service-it` with all infrastructure installed. When `ginkgo run it` starts, `it/it_tool.go` calls `Start()` which detects the existing cluster (`existed=true`) and skips infrastructure installation. The tests then build/deploy fulfillment-service on top and run.

### Companion PRs

- osac-test-infra#273 — kind-dev GH Action + itenv removal
- osac-operator#389 — kustomize removal + kind-dev migration
- bare-metal-fulfillment-operator#77 — kustomize removal + kind-dev migration

## Test plan

- [ ] CI integration tests pass with kind-dev providing the cluster
- [ ] Local `IT_KEEP_KIND=true ginkgo run it` still works (Go code creates its own cluster when none exists)