### PR TITLE
OSAC-2341: create default networking resources at tenant onboarding

### DIFF
--- a/internal/cmd/service/start/grpcserver/start_grpc_server_cmd.go
+++ b/internal/cmd/service/start/grpcserver/start_grpc_server_cmd.go
@@ -1304,6 +1304,17 @@ func (c *runnerContext) run(cmd *cobra.Command, argv []string) error { //nolint:
 	}
 	publicv1.RegisterTenantsServer(grpcServer, publicTenantsServer)
 
+	// Create the default networking provisioner:
+	c.logger.InfoContext(ctx, "Creating default networking provisioner")
+	defaultNetworkingProvisioner, err := servers.NewDefaultNetworkingProvisioner().
+		SetLogger(c.logger).
+		SetTenancyLogic(tenancyLogic).
+		SetMetricsRegisterer(metricsRegisterer).
+		Build()
+	if err != nil {
+		return fmt.Errorf("failed to create default networking provisioner: %w", err)
+	}
+
 	// Create the private tenants server:
 	c.logger.InfoContext(ctx, "Creating private tenants server")
 	privateTenantsServer, err := servers.NewPrivateTenantsServer().
@@ -1312,6 +1323,7 @@ func (c *runnerContext) run(cmd *cobra.Command, argv []string) error { //nolint:
 		SetAttributionLogic(privateAttributionLogic).
 		SetTenancyLogic(tenancyLogic).
 		SetMetricsRegisterer(metricsRegisterer).
+		SetDefaultNetworkingProvisioner(defaultNetworkingProvisioner).
 		Build()
 	if err != nil {
 		return fmt.Errorf("failed to create private tenants server: %w", err)

--- a/internal/servers/default_networking_provisioner.go
+++ b/internal/servers/default_networking_provisioner.go
@@ -433,6 +433,9 @@ func (p *DefaultNetworkingProvisioner) createDefaultNATGateway(
 			Labels: map[string]string{
 				defaultLabel: "true",
 			},
+			Annotations: map[string]string{
+				ownerReferenceAnnotation: vnID,
+			},
 			Creator: "system",
 		}.Build(),
 		Spec: privatev1.NATGatewaySpec_builder{

--- a/internal/servers/default_networking_provisioner.go
+++ b/internal/servers/default_networking_provisioner.go
@@ -76,11 +76,6 @@ func (b *DefaultNetworkingProvisionerBuilder) Build() (result *DefaultNetworking
 		return
 	}
 
-	newDAO := func(t any) error {
-		return nil
-	}
-	_ = newDAO
-
 	networkClassDao, err := dao.NewGenericDAO[*privatev1.NetworkClass]().
 		SetLogger(b.logger).
 		SetTenancyLogic(b.tenancyLogic).
@@ -169,6 +164,10 @@ func (b *DefaultNetworkingProvisionerBuilder) Build() (result *DefaultNetworking
 
 // Provision creates default networking resources for the given tenant. Returns nil if no default
 // NetworkClass exists or if the NetworkClass has no defaults configured.
+//
+// Callers must ensure ctx carries a database transaction — all resources are created within that
+// transaction so a failure rolls back the entire set. The gRPC interceptor provides this when
+// called from an RPC handler.
 func (p *DefaultNetworkingProvisioner) Provision(ctx context.Context, tenantName string) error {
 	nc, err := findDefaultNetworkClass(ctx, p.logger, p.networkClassDao)
 	if err != nil {
@@ -373,17 +372,26 @@ func (p *DefaultNetworkingProvisioner) provisionNATGateway(
 }
 
 func (p *DefaultNetworkingProvisioner) findExternalIPPool(ctx context.Context) (*privatev1.ExternalIPPool, error) {
-	listResponse, err := p.externalIPPoolDao.List().
-		SetFilter("this.status.state == 'EXTERNAL_IP_POOL_STATE_READY' && this.status.available > 0").
-		Do(ctx)
+	listResponse, err := p.externalIPPoolDao.List().Do(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to query ExternalIP pools: %w", err)
 	}
-	items := listResponse.GetItems()
-	if len(items) == 0 {
+	var best *privatev1.ExternalIPPool
+	for _, pool := range listResponse.GetItems() {
+		if pool.GetStatus().GetState() != privatev1.ExternalIPPoolState_EXTERNAL_IP_POOL_STATE_READY {
+			continue
+		}
+		if pool.GetStatus().GetAvailable() <= 0 {
+			continue
+		}
+		if best == nil || pool.GetStatus().GetAvailable() > best.GetStatus().GetAvailable() {
+			best = pool
+		}
+	}
+	if best == nil {
 		return nil, fmt.Errorf("no ExternalIP pool with available capacity found for default NATGateway")
 	}
-	return items[0], nil
+	return best, nil
 }
 
 func (p *DefaultNetworkingProvisioner) createDefaultExternalIP(

--- a/internal/servers/default_networking_provisioner.go
+++ b/internal/servers/default_networking_provisioner.go
@@ -1,0 +1,483 @@
+/*
+Copyright (c) 2026 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package servers
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+
+	"github.com/prometheus/client_golang/prometheus"
+
+	privatev1 "github.com/osac-project/fulfillment-service/internal/api/osac/private/v1"
+	"github.com/osac-project/fulfillment-service/internal/auth"
+	"github.com/osac-project/fulfillment-service/internal/database/dao"
+)
+
+const defaultLabel = "osac.openshift.io/default"
+const ownerReferenceAnnotation = "osac.openshift.io/owner-reference"
+
+type DefaultNetworkingProvisionerBuilder struct {
+	logger            *slog.Logger
+	tenancyLogic      auth.TenancyLogic
+	metricsRegisterer prometheus.Registerer
+}
+
+type DefaultNetworkingProvisioner struct {
+	logger            *slog.Logger
+	networkClassDao   *dao.GenericDAO[*privatev1.NetworkClass]
+	virtualNetworkDao *dao.GenericDAO[*privatev1.VirtualNetwork]
+	subnetDao         *dao.GenericDAO[*privatev1.Subnet]
+	securityGroupDao  *dao.GenericDAO[*privatev1.SecurityGroup]
+	externalIPDao     *dao.GenericDAO[*privatev1.ExternalIP]
+	externalIPPoolDao *dao.GenericDAO[*privatev1.ExternalIPPool]
+	natGatewayDao     *dao.GenericDAO[*privatev1.NATGateway]
+	tenantDao         *dao.GenericDAO[*privatev1.Tenant]
+}
+
+func NewDefaultNetworkingProvisioner() *DefaultNetworkingProvisionerBuilder {
+	return &DefaultNetworkingProvisionerBuilder{}
+}
+
+func (b *DefaultNetworkingProvisionerBuilder) SetLogger(value *slog.Logger) *DefaultNetworkingProvisionerBuilder {
+	b.logger = value
+	return b
+}
+
+func (b *DefaultNetworkingProvisionerBuilder) SetTenancyLogic(value auth.TenancyLogic) *DefaultNetworkingProvisionerBuilder {
+	b.tenancyLogic = value
+	return b
+}
+
+func (b *DefaultNetworkingProvisionerBuilder) SetMetricsRegisterer(value prometheus.Registerer) *DefaultNetworkingProvisionerBuilder {
+	b.metricsRegisterer = value
+	return b
+}
+
+func (b *DefaultNetworkingProvisionerBuilder) Build() (result *DefaultNetworkingProvisioner, err error) {
+	if b.logger == nil {
+		err = errors.New("logger is mandatory")
+		return
+	}
+	if b.tenancyLogic == nil {
+		err = errors.New("tenancy logic is mandatory")
+		return
+	}
+
+	newDAO := func(t any) error {
+		return nil
+	}
+	_ = newDAO
+
+	networkClassDao, err := dao.NewGenericDAO[*privatev1.NetworkClass]().
+		SetLogger(b.logger).
+		SetTenancyLogic(b.tenancyLogic).
+		SetMetricsRegisterer(b.metricsRegisterer).
+		Build()
+	if err != nil {
+		return
+	}
+
+	virtualNetworkDao, err := dao.NewGenericDAO[*privatev1.VirtualNetwork]().
+		SetLogger(b.logger).
+		SetTenancyLogic(b.tenancyLogic).
+		SetMetricsRegisterer(b.metricsRegisterer).
+		Build()
+	if err != nil {
+		return
+	}
+
+	subnetDao, err := dao.NewGenericDAO[*privatev1.Subnet]().
+		SetLogger(b.logger).
+		SetTenancyLogic(b.tenancyLogic).
+		SetMetricsRegisterer(b.metricsRegisterer).
+		Build()
+	if err != nil {
+		return
+	}
+
+	securityGroupDao, err := dao.NewGenericDAO[*privatev1.SecurityGroup]().
+		SetLogger(b.logger).
+		SetTenancyLogic(b.tenancyLogic).
+		SetMetricsRegisterer(b.metricsRegisterer).
+		Build()
+	if err != nil {
+		return
+	}
+
+	externalIPDao, err := dao.NewGenericDAO[*privatev1.ExternalIP]().
+		SetLogger(b.logger).
+		SetTenancyLogic(b.tenancyLogic).
+		SetMetricsRegisterer(b.metricsRegisterer).
+		Build()
+	if err != nil {
+		return
+	}
+
+	externalIPPoolDao, err := dao.NewGenericDAO[*privatev1.ExternalIPPool]().
+		SetLogger(b.logger).
+		SetTenancyLogic(b.tenancyLogic).
+		SetMetricsRegisterer(b.metricsRegisterer).
+		Build()
+	if err != nil {
+		return
+	}
+
+	natGatewayDao, err := dao.NewGenericDAO[*privatev1.NATGateway]().
+		SetLogger(b.logger).
+		SetTenancyLogic(b.tenancyLogic).
+		SetMetricsRegisterer(b.metricsRegisterer).
+		Build()
+	if err != nil {
+		return
+	}
+
+	tenantDao, err := dao.NewGenericDAO[*privatev1.Tenant]().
+		SetLogger(b.logger).
+		SetTenancyLogic(b.tenancyLogic).
+		SetMetricsRegisterer(b.metricsRegisterer).
+		Build()
+	if err != nil {
+		return
+	}
+
+	result = &DefaultNetworkingProvisioner{
+		logger:            b.logger,
+		networkClassDao:   networkClassDao,
+		virtualNetworkDao: virtualNetworkDao,
+		subnetDao:         subnetDao,
+		securityGroupDao:  securityGroupDao,
+		externalIPDao:     externalIPDao,
+		externalIPPoolDao: externalIPPoolDao,
+		natGatewayDao:     natGatewayDao,
+		tenantDao:         tenantDao,
+	}
+	return
+}
+
+// Provision creates default networking resources for the given tenant. Returns nil if no default
+// NetworkClass exists or if the NetworkClass has no defaults configured.
+func (p *DefaultNetworkingProvisioner) Provision(ctx context.Context, tenantName string) error {
+	nc, err := findDefaultNetworkClass(ctx, p.logger, p.networkClassDao)
+	if err != nil {
+		return fmt.Errorf("failed to find default NetworkClass: %w", err)
+	}
+	if nc == nil {
+		p.logger.InfoContext(ctx, "No default NetworkClass configured, skipping default networking",
+			slog.String("tenant", tenantName))
+		return nil
+	}
+
+	defaults := nc.GetSpec().GetDefaults()
+	if defaults == nil {
+		p.logger.InfoContext(ctx, "Default NetworkClass has no defaults configured, skipping default networking",
+			slog.String("tenant", tenantName),
+			slog.String("network_class", nc.GetId()))
+		return nil
+	}
+
+	p.logger.InfoContext(ctx, "Creating default networking resources",
+		slog.String("tenant", tenantName),
+		slog.String("network_class", nc.GetId()))
+
+	vnID, err := p.createDefaultVirtualNetwork(ctx, tenantName, defaults, nc)
+	if err != nil {
+		return fmt.Errorf("failed to create default VirtualNetwork: %w", err)
+	}
+
+	if defaults.GetSubnetIpv4Cidr() != "" {
+		_, err = p.createDefaultSubnet(ctx, tenantName, vnID, defaults.GetSubnetIpv4Cidr(), "", "default-ipv4")
+		if err != nil {
+			return fmt.Errorf("failed to create default IPv4 Subnet: %w", err)
+		}
+	}
+
+	if defaults.GetSubnetIpv6Cidr() != "" {
+		_, err = p.createDefaultSubnet(ctx, tenantName, vnID, "", defaults.GetSubnetIpv6Cidr(), "default-ipv6")
+		if err != nil {
+			return fmt.Errorf("failed to create default IPv6 Subnet: %w", err)
+		}
+	}
+
+	_, err = p.createDefaultSecurityGroup(ctx, tenantName, vnID, defaults)
+	if err != nil {
+		return fmt.Errorf("failed to create default SecurityGroup: %w", err)
+	}
+
+	if defaults.GetEnableNatGateway() {
+		err = p.provisionNATGateway(ctx, tenantName, vnID)
+		if err != nil {
+			return fmt.Errorf("failed to create default NATGateway: %w", err)
+		}
+	}
+
+	p.logger.InfoContext(ctx, "Default networking resources created successfully",
+		slog.String("tenant", tenantName))
+	return nil
+}
+
+func (p *DefaultNetworkingProvisioner) createDefaultVirtualNetwork(
+	ctx context.Context,
+	tenantName string,
+	defaults *privatev1.NetworkDefaults,
+	nc *privatev1.NetworkClass,
+) (string, error) {
+	vn := privatev1.VirtualNetwork_builder{
+		Metadata: privatev1.Metadata_builder{
+			Name:   "default",
+			Tenant: tenantName,
+			Labels: map[string]string{
+				defaultLabel: "true",
+			},
+			Creator: "system",
+		}.Build(),
+		Spec: privatev1.VirtualNetworkSpec_builder{
+			Region:                 "default",
+			NetworkClass:           nc.GetId(),
+			ImplementationStrategy: nc.GetImplementationStrategy(),
+		}.Build(),
+		Status: privatev1.VirtualNetworkStatus_builder{
+			State: privatev1.VirtualNetworkState_VIRTUAL_NETWORK_STATE_PENDING,
+		}.Build(),
+	}.Build()
+
+	if ipv4 := defaults.GetVirtualNetworkIpv4Cidr(); ipv4 != "" {
+		vn.GetSpec().SetIpv4Cidr(ipv4)
+	}
+	if ipv6 := defaults.GetVirtualNetworkIpv6Cidr(); ipv6 != "" {
+		vn.GetSpec().SetIpv6Cidr(ipv6)
+	}
+
+	resp, err := p.virtualNetworkDao.Create().SetObject(vn).Do(ctx)
+	if err != nil {
+		return "", err
+	}
+	return resp.GetObject().GetId(), nil
+}
+
+func (p *DefaultNetworkingProvisioner) createDefaultSubnet(
+	ctx context.Context,
+	tenantName, vnID, ipv4CIDR, ipv6CIDR, name string,
+) (string, error) {
+	subnet := privatev1.Subnet_builder{
+		Metadata: privatev1.Metadata_builder{
+			Name:   name,
+			Tenant: tenantName,
+			Labels: map[string]string{
+				defaultLabel: "true",
+			},
+			Annotations: map[string]string{
+				ownerReferenceAnnotation: vnID,
+			},
+			Creator: "system",
+		}.Build(),
+		Spec: privatev1.SubnetSpec_builder{
+			VirtualNetwork: vnID,
+		}.Build(),
+		Status: privatev1.SubnetStatus_builder{
+			State: privatev1.SubnetState_SUBNET_STATE_PENDING,
+		}.Build(),
+	}.Build()
+
+	if ipv4CIDR != "" {
+		subnet.GetSpec().SetIpv4Cidr(ipv4CIDR)
+	}
+	if ipv6CIDR != "" {
+		subnet.GetSpec().SetIpv6Cidr(ipv6CIDR)
+	}
+
+	resp, err := p.subnetDao.Create().SetObject(subnet).Do(ctx)
+	if err != nil {
+		return "", err
+	}
+	return resp.GetObject().GetId(), nil
+}
+
+func (p *DefaultNetworkingProvisioner) createDefaultSecurityGroup(
+	ctx context.Context,
+	tenantName, vnID string,
+	defaults *privatev1.NetworkDefaults,
+) (string, error) {
+	sg := privatev1.SecurityGroup_builder{
+		Metadata: privatev1.Metadata_builder{
+			Name:   "default",
+			Tenant: tenantName,
+			Labels: map[string]string{
+				defaultLabel: "true",
+			},
+			Annotations: map[string]string{
+				ownerReferenceAnnotation: vnID,
+			},
+			Creator: "system",
+		}.Build(),
+		Spec: privatev1.SecurityGroupSpec_builder{
+			VirtualNetwork:         vnID,
+			Ingress:                defaults.GetIngressRules(),
+			Egress:                 defaults.GetEgressRules(),
+			ImplementationStrategy: "network_policy",
+		}.Build(),
+		Status: privatev1.SecurityGroupStatus_builder{
+			State: privatev1.SecurityGroupState_SECURITY_GROUP_STATE_PENDING,
+		}.Build(),
+	}.Build()
+
+	resp, err := p.securityGroupDao.Create().SetObject(sg).Do(ctx)
+	if err != nil {
+		return "", err
+	}
+	return resp.GetObject().GetId(), nil
+}
+
+func (p *DefaultNetworkingProvisioner) provisionNATGateway(
+	ctx context.Context,
+	tenantName, vnID string,
+) error {
+	pool, err := p.findExternalIPPool(ctx)
+	if err != nil {
+		return err
+	}
+
+	externalIPID, err := p.createDefaultExternalIP(ctx, tenantName, pool.GetId())
+	if err != nil {
+		return err
+	}
+
+	err = p.updatePoolCapacity(ctx, pool.GetId(), int64(1))
+	if err != nil {
+		return err
+	}
+
+	_, err = p.createDefaultNATGateway(ctx, tenantName, vnID, externalIPID)
+	if err != nil {
+		return err
+	}
+
+	err = p.updateExternalIPAttachedFlag(ctx, externalIPID, true)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (p *DefaultNetworkingProvisioner) findExternalIPPool(ctx context.Context) (*privatev1.ExternalIPPool, error) {
+	listResponse, err := p.externalIPPoolDao.List().
+		SetFilter("this.status.state == 'EXTERNAL_IP_POOL_STATE_READY' && this.status.available > 0").
+		Do(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query ExternalIP pools: %w", err)
+	}
+	items := listResponse.GetItems()
+	if len(items) == 0 {
+		return nil, fmt.Errorf("no ExternalIP pool with available capacity found for default NATGateway")
+	}
+	return items[0], nil
+}
+
+func (p *DefaultNetworkingProvisioner) createDefaultExternalIP(
+	ctx context.Context,
+	tenantName, poolID string,
+) (string, error) {
+	eip := privatev1.ExternalIP_builder{
+		Metadata: privatev1.Metadata_builder{
+			Name:   "default-nat",
+			Tenant: tenantName,
+			Labels: map[string]string{
+				defaultLabel: "true",
+			},
+			Creator: "system",
+		}.Build(),
+		Spec: privatev1.ExternalIPSpec_builder{
+			Pool: poolID,
+		}.Build(),
+		Status: privatev1.ExternalIPStatus_builder{
+			State: privatev1.ExternalIPState_EXTERNAL_IP_STATE_PENDING,
+		}.Build(),
+	}.Build()
+
+	resp, err := p.externalIPDao.Create().SetObject(eip).Do(ctx)
+	if err != nil {
+		return "", err
+	}
+	return resp.GetObject().GetId(), nil
+}
+
+func (p *DefaultNetworkingProvisioner) createDefaultNATGateway(
+	ctx context.Context,
+	tenantName, vnID, externalIPID string,
+) (string, error) {
+	ng := privatev1.NATGateway_builder{
+		Metadata: privatev1.Metadata_builder{
+			Name:   "default",
+			Tenant: tenantName,
+			Labels: map[string]string{
+				defaultLabel: "true",
+			},
+			Creator: "system",
+		}.Build(),
+		Spec: privatev1.NATGatewaySpec_builder{
+			VirtualNetwork: vnID,
+			ExternalIp:     externalIPID,
+		}.Build(),
+		Status: privatev1.NATGatewayStatus_builder{
+			State: privatev1.NATGatewayState_NAT_GATEWAY_STATE_PENDING,
+		}.Build(),
+	}.Build()
+
+	resp, err := p.natGatewayDao.Create().SetObject(ng).Do(ctx)
+	if err != nil {
+		return "", err
+	}
+	return resp.GetObject().GetId(), nil
+}
+
+func (p *DefaultNetworkingProvisioner) updatePoolCapacity(ctx context.Context, poolID string, delta int64) error {
+	getResponse, err := p.externalIPPoolDao.Get().
+		SetId(poolID).
+		SetLock(true).
+		Do(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to get ExternalIPPool for capacity update: %w", err)
+	}
+
+	pool := getResponse.GetObject()
+	pool.GetStatus().SetAllocated(pool.GetStatus().GetAllocated() + delta)
+	pool.GetStatus().SetAvailable(pool.GetStatus().GetAvailable() - delta)
+
+	_, err = p.externalIPPoolDao.Update().SetObject(pool).Do(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to update ExternalIPPool capacity: %w", err)
+	}
+	return nil
+}
+
+func (p *DefaultNetworkingProvisioner) updateExternalIPAttachedFlag(ctx context.Context, externalIPID string, attached bool) error {
+	getResponse, err := p.externalIPDao.Get().
+		SetId(externalIPID).
+		SetLock(true).
+		Do(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to get ExternalIP for attached flag update: %w", err)
+	}
+
+	eip := getResponse.GetObject()
+	eip.GetStatus().SetAttached(attached)
+
+	_, err = p.externalIPDao.Update().SetObject(eip).Do(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to update ExternalIP attached flag: %w", err)
+	}
+	return nil
+}

--- a/internal/servers/default_networking_provisioner.go
+++ b/internal/servers/default_networking_provisioner.go
@@ -464,8 +464,13 @@ func (p *DefaultNetworkingProvisioner) updatePoolCapacity(ctx context.Context, p
 	}
 
 	pool := getResponse.GetObject()
-	pool.GetStatus().SetAllocated(pool.GetStatus().GetAllocated() + delta)
-	pool.GetStatus().SetAvailable(pool.GetStatus().GetAvailable() - delta)
+	newAllocated := pool.GetStatus().GetAllocated() + delta
+	newAvailable := pool.GetStatus().GetAvailable() - delta
+	if newAvailable < 0 {
+		return fmt.Errorf("ExternalIP pool '%s' has no available capacity", poolID)
+	}
+	pool.GetStatus().SetAllocated(newAllocated)
+	pool.GetStatus().SetAvailable(newAvailable)
 
 	_, err = p.externalIPPoolDao.Update().SetObject(pool).Do(ctx)
 	if err != nil {

--- a/internal/servers/default_networking_provisioner_test.go
+++ b/internal/servers/default_networking_provisioner_test.go
@@ -32,7 +32,7 @@ var _ = Describe("Default networking provisioner", func() {
 				Name:   "test-network-class",
 				Tenant: "system",
 			}.Build(),
-			IsDefault:              boolPtr(true),
+			IsDefault:              new(true),
 			FabricManager:          "netris",
 			ImplementationStrategy: "netris",
 			Spec: privatev1.NetworkClassSpec_builder{
@@ -58,6 +58,24 @@ var _ = Describe("Default networking provisioner", func() {
 		tenant.SetId(name)
 		_, err := tenantDao.Create().SetObject(tenant).Do(ctx)
 		Expect(err).ToNot(HaveOccurred())
+	}
+
+	createExternalIPPool := func(name, tenant string, available int64) *privatev1.ExternalIPPool {
+		pool := privatev1.ExternalIPPool_builder{
+			Metadata: privatev1.Metadata_builder{
+				Name:   name,
+				Tenant: tenant,
+			}.Build(),
+			Status: privatev1.ExternalIPPoolStatus_builder{
+				State:     privatev1.ExternalIPPoolState_EXTERNAL_IP_POOL_STATE_READY,
+				Total:     available,
+				Available: available,
+				Allocated: 0,
+			}.Build(),
+		}.Build()
+		resp, err := provisioner.externalIPPoolDao.Create().SetObject(pool).Do(ctx)
+		Expect(err).ToNot(HaveOccurred())
+		return resp.GetObject()
 	}
 
 	BeforeEach(func() {
@@ -94,17 +112,17 @@ var _ = Describe("Default networking provisioner", func() {
 				IngressRules: []*privatev1.SecurityRule{
 					privatev1.SecurityRule_builder{
 						Protocol: privatev1.Protocol_PROTOCOL_TCP,
-						PortFrom: int32Ptr(22),
-						PortTo:   int32Ptr(22),
-						Ipv4Cidr: stringPtr("0.0.0.0/0"),
+						PortFrom: new(int32(22)),
+						PortTo:   new(int32(22)),
+						Ipv4Cidr: new("0.0.0.0/0"),
 					}.Build(),
 				},
 				EgressRules: []*privatev1.SecurityRule{
 					privatev1.SecurityRule_builder{
 						Protocol: privatev1.Protocol_PROTOCOL_TCP,
-						PortFrom: int32Ptr(443),
-						PortTo:   int32Ptr(443),
-						Ipv4Cidr: stringPtr("0.0.0.0/0"),
+						PortFrom: new(int32(443)),
+						PortTo:   new(int32(443)),
+						Ipv4Cidr: new("0.0.0.0/0"),
 					}.Build(),
 				},
 			}.Build())
@@ -136,6 +154,12 @@ var _ = Describe("Default networking provisioner", func() {
 			err := provisioner.Provision(ctx, "test-tenant")
 			Expect(err).ToNot(HaveOccurred())
 
+			vnList, err := provisioner.virtualNetworkDao.List().
+				SetFilter("this.metadata.tenant == 'test-tenant'").
+				Do(ctx)
+			Expect(err).ToNot(HaveOccurred())
+			vnID := vnList.GetItems()[0].GetId()
+
 			subnetList, err := provisioner.subnetDao.List().
 				SetFilter("this.metadata.tenant == 'test-tenant'").
 				Do(ctx)
@@ -151,9 +175,9 @@ var _ = Describe("Default networking provisioner", func() {
 			Expect(ipv4Subnet).ToNot(BeNil())
 			Expect(ipv4Subnet.GetMetadata().GetTenant()).To(Equal("test-tenant"))
 			Expect(ipv4Subnet.GetMetadata().GetLabels()).To(HaveKeyWithValue("osac.openshift.io/default", "true"))
-			Expect(ipv4Subnet.GetMetadata().GetAnnotations()).To(HaveKey("osac.openshift.io/owner-reference"))
+			Expect(ipv4Subnet.GetMetadata().GetAnnotations()).To(HaveKeyWithValue("osac.openshift.io/owner-reference", vnID))
 			Expect(ipv4Subnet.GetSpec().GetIpv4Cidr()).To(Equal("10.0.1.0/24"))
-			Expect(ipv4Subnet.GetSpec().GetVirtualNetwork()).ToNot(BeEmpty())
+			Expect(ipv4Subnet.GetSpec().GetVirtualNetwork()).To(Equal(vnID))
 			Expect(ipv4Subnet.GetStatus().GetState()).To(Equal(
 				privatev1.SubnetState_SUBNET_STATE_PENDING))
 		})
@@ -161,6 +185,12 @@ var _ = Describe("Default networking provisioner", func() {
 		It("creates default IPv6 Subnet with correct CIDR and owner-reference", func() {
 			err := provisioner.Provision(ctx, "test-tenant")
 			Expect(err).ToNot(HaveOccurred())
+
+			vnList, err := provisioner.virtualNetworkDao.List().
+				SetFilter("this.metadata.tenant == 'test-tenant'").
+				Do(ctx)
+			Expect(err).ToNot(HaveOccurred())
+			vnID := vnList.GetItems()[0].GetId()
 
 			subnetList, err := provisioner.subnetDao.List().
 				SetFilter("this.metadata.tenant == 'test-tenant'").
@@ -177,9 +207,9 @@ var _ = Describe("Default networking provisioner", func() {
 			Expect(ipv6Subnet).ToNot(BeNil())
 			Expect(ipv6Subnet.GetMetadata().GetTenant()).To(Equal("test-tenant"))
 			Expect(ipv6Subnet.GetMetadata().GetLabels()).To(HaveKeyWithValue("osac.openshift.io/default", "true"))
-			Expect(ipv6Subnet.GetMetadata().GetAnnotations()).To(HaveKey("osac.openshift.io/owner-reference"))
+			Expect(ipv6Subnet.GetMetadata().GetAnnotations()).To(HaveKeyWithValue("osac.openshift.io/owner-reference", vnID))
 			Expect(ipv6Subnet.GetSpec().GetIpv6Cidr()).To(Equal("fd00:0:0:1::/64"))
-			Expect(ipv6Subnet.GetSpec().GetVirtualNetwork()).ToNot(BeEmpty())
+			Expect(ipv6Subnet.GetSpec().GetVirtualNetwork()).To(Equal(vnID))
 			Expect(ipv6Subnet.GetStatus().GetState()).To(Equal(
 				privatev1.SubnetState_SUBNET_STATE_PENDING))
 		})
@@ -187,6 +217,12 @@ var _ = Describe("Default networking provisioner", func() {
 		It("creates default SecurityGroup with rules and owner-reference", func() {
 			err := provisioner.Provision(ctx, "test-tenant")
 			Expect(err).ToNot(HaveOccurred())
+
+			vnList, err := provisioner.virtualNetworkDao.List().
+				SetFilter("this.metadata.tenant == 'test-tenant'").
+				Do(ctx)
+			Expect(err).ToNot(HaveOccurred())
+			vnID := vnList.GetItems()[0].GetId()
 
 			sgList, err := provisioner.securityGroupDao.List().
 				SetFilter("this.metadata.tenant == 'test-tenant'").
@@ -198,8 +234,8 @@ var _ = Describe("Default networking provisioner", func() {
 			Expect(sg.GetMetadata().GetName()).To(Equal("default"))
 			Expect(sg.GetMetadata().GetTenant()).To(Equal("test-tenant"))
 			Expect(sg.GetMetadata().GetLabels()).To(HaveKeyWithValue("osac.openshift.io/default", "true"))
-			Expect(sg.GetMetadata().GetAnnotations()).To(HaveKey("osac.openshift.io/owner-reference"))
-			Expect(sg.GetSpec().GetVirtualNetwork()).ToNot(BeEmpty())
+			Expect(sg.GetMetadata().GetAnnotations()).To(HaveKeyWithValue("osac.openshift.io/owner-reference", vnID))
+			Expect(sg.GetSpec().GetVirtualNetwork()).To(Equal(vnID))
 			Expect(sg.GetSpec().GetIngress()).To(HaveLen(1))
 			Expect(sg.GetSpec().GetIngress()[0].GetProtocol()).To(Equal(privatev1.Protocol_PROTOCOL_TCP))
 			Expect(sg.GetSpec().GetIngress()[0].GetPortFrom()).To(Equal(int32(22)))
@@ -256,6 +292,62 @@ var _ = Describe("Default networking provisioner", func() {
 		})
 	})
 
+	Context("when enable_nat_gateway is true", func() {
+		It("creates ExternalIP and NATGateway when pool has capacity", func() {
+			createTenant("nat-tenant")
+			createNetworkClass(privatev1.NetworkDefaults_builder{
+				VirtualNetworkIpv4Cidr: "10.0.0.0/16",
+				SubnetIpv4Cidr:         "10.0.1.0/24",
+				EnableNatGateway:       true,
+			}.Build())
+			pool := createExternalIPPool("test-pool", "system", 10)
+
+			err := provisioner.Provision(ctx, "nat-tenant")
+			Expect(err).ToNot(HaveOccurred())
+
+			eipList, err := provisioner.externalIPDao.List().
+				SetFilter("this.metadata.tenant == 'nat-tenant'").
+				Do(ctx)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(eipList.GetItems()).To(HaveLen(1))
+			eip := eipList.GetItems()[0]
+			Expect(eip.GetMetadata().GetLabels()).To(HaveKeyWithValue("osac.openshift.io/default", "true"))
+			Expect(eip.GetSpec().GetPool()).To(Equal(pool.GetId()))
+			Expect(eip.GetStatus().GetState()).To(Equal(privatev1.ExternalIPState_EXTERNAL_IP_STATE_PENDING))
+			Expect(eip.GetStatus().GetAttached()).To(BeTrue())
+
+			ngList, err := provisioner.natGatewayDao.List().
+				SetFilter("this.metadata.tenant == 'nat-tenant'").
+				Do(ctx)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(ngList.GetItems()).To(HaveLen(1))
+			ng := ngList.GetItems()[0]
+			Expect(ng.GetMetadata().GetLabels()).To(HaveKeyWithValue("osac.openshift.io/default", "true"))
+			Expect(ng.GetSpec().GetExternalIp()).To(Equal(eip.GetId()))
+			Expect(ng.GetStatus().GetState()).To(Equal(privatev1.NATGatewayState_NAT_GATEWAY_STATE_PENDING))
+
+			poolResp, err := provisioner.externalIPPoolDao.Get().
+				SetId(pool.GetId()).
+				Do(ctx)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(poolResp.GetObject().GetStatus().GetAllocated()).To(Equal(int64(1)))
+			Expect(poolResp.GetObject().GetStatus().GetAvailable()).To(Equal(int64(9)))
+		})
+
+		It("returns error when no pool has capacity", func() {
+			createTenant("nat-tenant")
+			createNetworkClass(privatev1.NetworkDefaults_builder{
+				VirtualNetworkIpv4Cidr: "10.0.0.0/16",
+				SubnetIpv4Cidr:         "10.0.1.0/24",
+				EnableNatGateway:       true,
+			}.Build())
+
+			err := provisioner.Provision(ctx, "nat-tenant")
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("no ExternalIP pool with available capacity"))
+		})
+	})
+
 	Context("when NetworkClass defaults are partially populated", func() {
 		It("creates only IPv4 subnet when IPv6 CIDRs are empty", func() {
 			createTenant("test-tenant")
@@ -299,15 +391,3 @@ var _ = Describe("Default networking provisioner", func() {
 		})
 	})
 })
-
-func boolPtr(b bool) *bool {
-	return &b
-}
-
-func int32Ptr(i int32) *int32 {
-	return &i
-}
-
-func stringPtr(s string) *string {
-	return &s
-}

--- a/internal/servers/default_networking_provisioner_test.go
+++ b/internal/servers/default_networking_provisioner_test.go
@@ -1,0 +1,313 @@
+/*
+Copyright (c) 2026 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package servers
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	privatev1 "github.com/osac-project/fulfillment-service/internal/api/osac/private/v1"
+)
+
+var _ = Describe("Default networking provisioner", func() {
+	var (
+		provisioner *DefaultNetworkingProvisioner
+	)
+
+	createNetworkClass := func(defaults *privatev1.NetworkDefaults) *privatev1.NetworkClass {
+		ncDao := provisioner.networkClassDao
+		nc := privatev1.NetworkClass_builder{
+			Metadata: privatev1.Metadata_builder{
+				Name:   "test-network-class",
+				Tenant: "system",
+			}.Build(),
+			IsDefault:              boolPtr(true),
+			FabricManager:          "netris",
+			ImplementationStrategy: "netris",
+			Spec: privatev1.NetworkClassSpec_builder{
+				Defaults: defaults,
+			}.Build(),
+			Status: privatev1.NetworkClassStatus_builder{
+				State: privatev1.NetworkClassState_NETWORK_CLASS_STATE_READY,
+			}.Build(),
+		}.Build()
+		resp, err := ncDao.Create().SetObject(nc).Do(ctx)
+		Expect(err).ToNot(HaveOccurred())
+		return resp.GetObject()
+	}
+
+	createTenant := func(name string) {
+		tenantDao := provisioner.tenantDao
+		tenant := privatev1.Tenant_builder{
+			Metadata: privatev1.Metadata_builder{
+				Name:   name,
+				Tenant: name,
+			}.Build(),
+		}.Build()
+		tenant.SetId(name)
+		_, err := tenantDao.Create().SetObject(tenant).Do(ctx)
+		Expect(err).ToNot(HaveOccurred())
+	}
+
+	BeforeEach(func() {
+		var err error
+		provisioner, err = NewDefaultNetworkingProvisioner().
+			SetLogger(logger).
+			SetTenancyLogic(tenancy).
+			Build()
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	Context("when no default NetworkClass exists", func() {
+		It("returns nil without creating any resources", func() {
+			createTenant("test-tenant")
+			err := provisioner.Provision(ctx, "test-tenant")
+			Expect(err).ToNot(HaveOccurred())
+
+			vnList, err := provisioner.virtualNetworkDao.List().
+				SetFilter("this.metadata.tenant == 'test-tenant'").
+				Do(ctx)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(vnList.GetItems()).To(BeEmpty())
+		})
+	})
+
+	Context("when default NetworkClass exists with defaults", func() {
+		BeforeEach(func() {
+			createTenant("test-tenant")
+			createNetworkClass(privatev1.NetworkDefaults_builder{
+				VirtualNetworkIpv4Cidr: "10.0.0.0/16",
+				VirtualNetworkIpv6Cidr: "fd00::/48",
+				SubnetIpv4Cidr:         "10.0.1.0/24",
+				SubnetIpv6Cidr:         "fd00:0:0:1::/64",
+				IngressRules: []*privatev1.SecurityRule{
+					privatev1.SecurityRule_builder{
+						Protocol: privatev1.Protocol_PROTOCOL_TCP,
+						PortFrom: int32Ptr(22),
+						PortTo:   int32Ptr(22),
+						Ipv4Cidr: stringPtr("0.0.0.0/0"),
+					}.Build(),
+				},
+				EgressRules: []*privatev1.SecurityRule{
+					privatev1.SecurityRule_builder{
+						Protocol: privatev1.Protocol_PROTOCOL_TCP,
+						PortFrom: int32Ptr(443),
+						PortTo:   int32Ptr(443),
+						Ipv4Cidr: stringPtr("0.0.0.0/0"),
+					}.Build(),
+				},
+			}.Build())
+		})
+
+		It("creates default VirtualNetwork with correct CIDR and labels", func() {
+			err := provisioner.Provision(ctx, "test-tenant")
+			Expect(err).ToNot(HaveOccurred())
+
+			vnList, err := provisioner.virtualNetworkDao.List().
+				SetFilter("this.metadata.tenant == 'test-tenant'").
+				Do(ctx)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(vnList.GetItems()).To(HaveLen(1))
+
+			vn := vnList.GetItems()[0]
+			Expect(vn.GetMetadata().GetName()).To(Equal("default"))
+			Expect(vn.GetMetadata().GetTenant()).To(Equal("test-tenant"))
+			Expect(vn.GetMetadata().GetLabels()).To(HaveKeyWithValue("osac.openshift.io/default", "true"))
+			Expect(vn.GetSpec().GetIpv4Cidr()).To(Equal("10.0.0.0/16"))
+			Expect(vn.GetSpec().GetIpv6Cidr()).To(Equal("fd00::/48"))
+			Expect(vn.GetSpec().GetNetworkClass()).ToNot(BeEmpty())
+			Expect(vn.GetSpec().GetImplementationStrategy()).ToNot(BeEmpty())
+			Expect(vn.GetStatus().GetState()).To(Equal(
+				privatev1.VirtualNetworkState_VIRTUAL_NETWORK_STATE_PENDING))
+		})
+
+		It("creates default IPv4 Subnet with correct CIDR and owner-reference", func() {
+			err := provisioner.Provision(ctx, "test-tenant")
+			Expect(err).ToNot(HaveOccurred())
+
+			subnetList, err := provisioner.subnetDao.List().
+				SetFilter("this.metadata.tenant == 'test-tenant'").
+				Do(ctx)
+			Expect(err).ToNot(HaveOccurred())
+
+			var ipv4Subnet *privatev1.Subnet
+			for _, s := range subnetList.GetItems() {
+				if s.GetMetadata().GetName() == "default-ipv4" {
+					ipv4Subnet = s
+					break
+				}
+			}
+			Expect(ipv4Subnet).ToNot(BeNil())
+			Expect(ipv4Subnet.GetMetadata().GetTenant()).To(Equal("test-tenant"))
+			Expect(ipv4Subnet.GetMetadata().GetLabels()).To(HaveKeyWithValue("osac.openshift.io/default", "true"))
+			Expect(ipv4Subnet.GetMetadata().GetAnnotations()).To(HaveKey("osac.openshift.io/owner-reference"))
+			Expect(ipv4Subnet.GetSpec().GetIpv4Cidr()).To(Equal("10.0.1.0/24"))
+			Expect(ipv4Subnet.GetSpec().GetVirtualNetwork()).ToNot(BeEmpty())
+			Expect(ipv4Subnet.GetStatus().GetState()).To(Equal(
+				privatev1.SubnetState_SUBNET_STATE_PENDING))
+		})
+
+		It("creates default IPv6 Subnet with correct CIDR and owner-reference", func() {
+			err := provisioner.Provision(ctx, "test-tenant")
+			Expect(err).ToNot(HaveOccurred())
+
+			subnetList, err := provisioner.subnetDao.List().
+				SetFilter("this.metadata.tenant == 'test-tenant'").
+				Do(ctx)
+			Expect(err).ToNot(HaveOccurred())
+
+			var ipv6Subnet *privatev1.Subnet
+			for _, s := range subnetList.GetItems() {
+				if s.GetMetadata().GetName() == "default-ipv6" {
+					ipv6Subnet = s
+					break
+				}
+			}
+			Expect(ipv6Subnet).ToNot(BeNil())
+			Expect(ipv6Subnet.GetMetadata().GetTenant()).To(Equal("test-tenant"))
+			Expect(ipv6Subnet.GetMetadata().GetLabels()).To(HaveKeyWithValue("osac.openshift.io/default", "true"))
+			Expect(ipv6Subnet.GetMetadata().GetAnnotations()).To(HaveKey("osac.openshift.io/owner-reference"))
+			Expect(ipv6Subnet.GetSpec().GetIpv6Cidr()).To(Equal("fd00:0:0:1::/64"))
+			Expect(ipv6Subnet.GetSpec().GetVirtualNetwork()).ToNot(BeEmpty())
+			Expect(ipv6Subnet.GetStatus().GetState()).To(Equal(
+				privatev1.SubnetState_SUBNET_STATE_PENDING))
+		})
+
+		It("creates default SecurityGroup with rules and owner-reference", func() {
+			err := provisioner.Provision(ctx, "test-tenant")
+			Expect(err).ToNot(HaveOccurred())
+
+			sgList, err := provisioner.securityGroupDao.List().
+				SetFilter("this.metadata.tenant == 'test-tenant'").
+				Do(ctx)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(sgList.GetItems()).To(HaveLen(1))
+
+			sg := sgList.GetItems()[0]
+			Expect(sg.GetMetadata().GetName()).To(Equal("default"))
+			Expect(sg.GetMetadata().GetTenant()).To(Equal("test-tenant"))
+			Expect(sg.GetMetadata().GetLabels()).To(HaveKeyWithValue("osac.openshift.io/default", "true"))
+			Expect(sg.GetMetadata().GetAnnotations()).To(HaveKey("osac.openshift.io/owner-reference"))
+			Expect(sg.GetSpec().GetVirtualNetwork()).ToNot(BeEmpty())
+			Expect(sg.GetSpec().GetIngress()).To(HaveLen(1))
+			Expect(sg.GetSpec().GetIngress()[0].GetProtocol()).To(Equal(privatev1.Protocol_PROTOCOL_TCP))
+			Expect(sg.GetSpec().GetIngress()[0].GetPortFrom()).To(Equal(int32(22)))
+			Expect(sg.GetSpec().GetEgress()).To(HaveLen(1))
+			Expect(sg.GetSpec().GetEgress()[0].GetProtocol()).To(Equal(privatev1.Protocol_PROTOCOL_TCP))
+			Expect(sg.GetStatus().GetState()).To(Equal(
+				privatev1.SecurityGroupState_SECURITY_GROUP_STATE_PENDING))
+		})
+
+		It("does not create NATGateway when enable_nat_gateway is false", func() {
+			err := provisioner.Provision(ctx, "test-tenant")
+			Expect(err).ToNot(HaveOccurred())
+
+			ngList, err := provisioner.natGatewayDao.List().
+				SetFilter("this.metadata.tenant == 'test-tenant'").
+				Do(ctx)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(ngList.GetItems()).To(BeEmpty())
+		})
+
+		It("sets implementation_strategy on VN from NetworkClass", func() {
+			err := provisioner.Provision(ctx, "test-tenant")
+			Expect(err).ToNot(HaveOccurred())
+
+			vnList, err := provisioner.virtualNetworkDao.List().
+				SetFilter("this.metadata.tenant == 'test-tenant'").
+				Do(ctx)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(vnList.GetItems()).To(HaveLen(1))
+			Expect(vnList.GetItems()[0].GetSpec().GetImplementationStrategy()).To(Equal("netris"))
+		})
+
+		It("creates all four resources in a single Provision call", func() {
+			err := provisioner.Provision(ctx, "test-tenant")
+			Expect(err).ToNot(HaveOccurred())
+
+			vnList, err := provisioner.virtualNetworkDao.List().
+				SetFilter("this.metadata.tenant == 'test-tenant'").
+				Do(ctx)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(vnList.GetItems()).To(HaveLen(1))
+
+			subnetList, err := provisioner.subnetDao.List().
+				SetFilter("this.metadata.tenant == 'test-tenant'").
+				Do(ctx)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(subnetList.GetItems()).To(HaveLen(2))
+
+			sgList, err := provisioner.securityGroupDao.List().
+				SetFilter("this.metadata.tenant == 'test-tenant'").
+				Do(ctx)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(sgList.GetItems()).To(HaveLen(1))
+		})
+	})
+
+	Context("when NetworkClass defaults are partially populated", func() {
+		It("creates only IPv4 subnet when IPv6 CIDRs are empty", func() {
+			createTenant("test-tenant")
+			createNetworkClass(privatev1.NetworkDefaults_builder{
+				VirtualNetworkIpv4Cidr: "10.0.0.0/16",
+				SubnetIpv4Cidr:         "10.0.1.0/24",
+			}.Build())
+
+			err := provisioner.Provision(ctx, "test-tenant")
+			Expect(err).ToNot(HaveOccurred())
+
+			vnList, err := provisioner.virtualNetworkDao.List().
+				SetFilter("this.metadata.tenant == 'test-tenant'").
+				Do(ctx)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(vnList.GetItems()).To(HaveLen(1))
+			Expect(vnList.GetItems()[0].GetSpec().GetIpv4Cidr()).To(Equal("10.0.0.0/16"))
+
+			subnetList, err := provisioner.subnetDao.List().
+				SetFilter("this.metadata.tenant == 'test-tenant'").
+				Do(ctx)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(subnetList.GetItems()).To(HaveLen(1))
+			Expect(subnetList.GetItems()[0].GetMetadata().GetName()).To(Equal("default-ipv4"))
+		})
+	})
+
+	Context("when NetworkClass has no defaults", func() {
+		It("returns nil without creating any resources", func() {
+			createTenant("test-tenant")
+			createNetworkClass(nil)
+
+			err := provisioner.Provision(ctx, "test-tenant")
+			Expect(err).ToNot(HaveOccurred())
+
+			vnList, err := provisioner.virtualNetworkDao.List().
+				SetFilter("this.metadata.tenant == 'test-tenant'").
+				Do(ctx)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(vnList.GetItems()).To(BeEmpty())
+		})
+	})
+})
+
+func boolPtr(b bool) *bool {
+	return &b
+}
+
+func int32Ptr(i int32) *int32 {
+	return &i
+}
+
+func stringPtr(s string) *string {
+	return &s
+}

--- a/internal/servers/default_networking_provisioner_test.go
+++ b/internal/servers/default_networking_provisioner_test.go
@@ -321,8 +321,15 @@ var _ = Describe("Default networking provisioner", func() {
 				Do(ctx)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(ngList.GetItems()).To(HaveLen(1))
+			vnList, err := provisioner.virtualNetworkDao.List().
+				SetFilter("this.metadata.tenant == 'nat-tenant'").
+				Do(ctx)
+			Expect(err).ToNot(HaveOccurred())
+			vnID := vnList.GetItems()[0].GetId()
+
 			ng := ngList.GetItems()[0]
 			Expect(ng.GetMetadata().GetLabels()).To(HaveKeyWithValue("osac.openshift.io/default", "true"))
+			Expect(ng.GetMetadata().GetAnnotations()).To(HaveKeyWithValue("osac.openshift.io/owner-reference", vnID))
 			Expect(ng.GetSpec().GetExternalIp()).To(Equal(eip.GetId()))
 			Expect(ng.GetStatus().GetState()).To(Equal(privatev1.NATGatewayState_NAT_GATEWAY_STATE_PENDING))
 

--- a/internal/servers/private_tenants_server.go
+++ b/internal/servers/private_tenants_server.go
@@ -37,15 +37,17 @@ type PrivateTenantsServerBuilder struct {
 	attributionLogic  auth.AttributionLogic
 	tenancyLogic      auth.TenancyLogic
 	metricsRegisterer prometheus.Registerer
+	defaultNetworking *DefaultNetworkingProvisioner
 }
 
 var _ privatev1.TenantsServer = (*PrivateTenantsServer)(nil)
 
 type PrivateTenantsServer struct {
 	privatev1.UnimplementedTenantsServer
-	logger  *slog.Logger
-	generic *GenericServer[*privatev1.Tenant]
-	dao     *dao.GenericDAO[*privatev1.Tenant]
+	logger            *slog.Logger
+	generic           *GenericServer[*privatev1.Tenant]
+	dao               *dao.GenericDAO[*privatev1.Tenant]
+	defaultNetworking *DefaultNetworkingProvisioner
 }
 
 func NewPrivateTenantsServer() *PrivateTenantsServerBuilder {
@@ -76,6 +78,11 @@ func (b *PrivateTenantsServerBuilder) SetTenancyLogic(value auth.TenancyLogic) *
 // access objects. This is optional. If not set, no metrics will be recorded.
 func (b *PrivateTenantsServerBuilder) SetMetricsRegisterer(value prometheus.Registerer) *PrivateTenantsServerBuilder {
 	b.metricsRegisterer = value
+	return b
+}
+
+func (b *PrivateTenantsServerBuilder) SetDefaultNetworkingProvisioner(value *DefaultNetworkingProvisioner) *PrivateTenantsServerBuilder {
+	b.defaultNetworking = value
 	return b
 }
 
@@ -117,9 +124,10 @@ func (b *PrivateTenantsServerBuilder) Build() (result *PrivateTenantsServer, err
 
 	// Create and populate the object:
 	result = &PrivateTenantsServer{
-		logger:  b.logger,
-		generic: generic,
-		dao:     dao,
+		logger:            b.logger,
+		generic:           generic,
+		dao:               dao,
+		defaultNetworking: b.defaultNetworking,
 	}
 	return
 }
@@ -198,6 +206,21 @@ func (s *PrivateTenantsServer) Create(ctx context.Context,
 	// Domain validation is now handled by protovalidate in the interceptor
 	// Delegate to the generic server:
 	err = s.generic.Create(ctx, request, &response)
+	if err != nil {
+		return
+	}
+
+	if s.defaultNetworking != nil {
+		if provisionErr := s.defaultNetworking.Provision(ctx, name); provisionErr != nil {
+			s.logger.ErrorContext(ctx, "Failed to provision default networking",
+				slog.String("tenant", name),
+				slog.Any("error", provisionErr))
+			err = grpcstatus.Errorf(grpccodes.Internal,
+				"failed to provision default networking resources: %v", provisionErr)
+			return
+		}
+	}
+
 	return
 }
 

--- a/internal/servers/private_tenants_server.go
+++ b/internal/servers/private_tenants_server.go
@@ -216,7 +216,7 @@ func (s *PrivateTenantsServer) Create(ctx context.Context,
 				slog.String("tenant", name),
 				slog.Any("error", provisionErr))
 			err = grpcstatus.Errorf(grpccodes.Internal,
-				"failed to provision default networking resources: %v", provisionErr)
+				"failed to provision default networking resources")
 			return
 		}
 	}

--- a/internal/servers/private_tenants_server_test.go
+++ b/internal/servers/private_tenants_server_test.go
@@ -480,4 +480,92 @@ var _ = Describe("Private tenants server (Tenant API)", func() {
 		}.Build())
 		Expect(err).ToNot(HaveOccurred())
 	})
+
+	Context("with default networking provisioner", func() {
+		var (
+			provisionerServer *PrivateTenantsServer
+			provisioner       *DefaultNetworkingProvisioner
+		)
+
+		BeforeEach(func() {
+			var err error
+			provisioner, err = NewDefaultNetworkingProvisioner().
+				SetLogger(logger).
+				SetTenancyLogic(tenancy).
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+
+			provisionerServer, err = NewPrivateTenantsServer().
+				SetLogger(logger).
+				SetAttributionLogic(attribution).
+				SetTenancyLogic(tenancy).
+				SetDefaultNetworkingProvisioner(provisioner).
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("creates default networking resources when NetworkClass defaults exist", func() {
+			ncDao := provisioner.networkClassDao
+			nc := privatev1.NetworkClass_builder{
+				Metadata: privatev1.Metadata_builder{
+					Name:   "test-nc",
+					Tenant: "system",
+				}.Build(),
+				IsDefault:              boolPtr(true),
+				ImplementationStrategy: "netris",
+				FabricManager:          "netris",
+				Spec: privatev1.NetworkClassSpec_builder{
+					Defaults: privatev1.NetworkDefaults_builder{
+						VirtualNetworkIpv4Cidr: "10.0.0.0/16",
+						SubnetIpv4Cidr:         "10.0.1.0/24",
+					}.Build(),
+				}.Build(),
+				Status: privatev1.NetworkClassStatus_builder{
+					State: privatev1.NetworkClassState_NETWORK_CLASS_STATE_READY,
+				}.Build(),
+			}.Build()
+			_, err := ncDao.Create().SetObject(nc).Do(ctx)
+			Expect(err).ToNot(HaveOccurred())
+
+			request := privatev1.TenantsCreateRequest_builder{
+				Object: privatev1.Tenant_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name: "net-tenant",
+					}.Build(),
+				}.Build(),
+			}.Build()
+
+			response, err := provisionerServer.Create(ctx, request)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(response).ToNot(BeNil())
+
+			vnList, err := provisioner.virtualNetworkDao.List().
+				SetFilter("this.metadata.tenant == 'net-tenant'").
+				Do(ctx)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(vnList.GetItems()).To(HaveLen(1))
+			Expect(vnList.GetItems()[0].GetMetadata().GetLabels()).To(
+				HaveKeyWithValue("osac.openshift.io/default", "true"))
+		})
+
+		It("creates tenant without default networking when no NetworkClass exists", func() {
+			request := privatev1.TenantsCreateRequest_builder{
+				Object: privatev1.Tenant_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name: "plain-tenant",
+					}.Build(),
+				}.Build(),
+			}.Build()
+
+			response, err := provisionerServer.Create(ctx, request)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(response).ToNot(BeNil())
+
+			vnList, err := provisioner.virtualNetworkDao.List().
+				SetFilter("this.metadata.tenant == 'plain-tenant'").
+				Do(ctx)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(vnList.GetItems()).To(BeEmpty())
+		})
+	})
 })

--- a/internal/servers/private_tenants_server_test.go
+++ b/internal/servers/private_tenants_server_test.go
@@ -511,7 +511,7 @@ var _ = Describe("Private tenants server (Tenant API)", func() {
 					Name:   "test-nc",
 					Tenant: "system",
 				}.Build(),
-				IsDefault:              boolPtr(true),
+				IsDefault:              new(true),
 				ImplementationStrategy: "netris",
 				FabricManager:          "netris",
 				Spec: privatev1.NetworkClassSpec_builder{


### PR DESCRIPTION
## Summary

- Add `DefaultNetworkingProvisioner` that creates default networking resources (VirtualNetwork, IPv4 Subnet, IPv6 Subnet, SecurityGroup, and optionally ExternalIP + NATGateway) when a tenant is created
- Resources are created via DAOs directly to bypass server-level async preconditions (VN must be READY for Subnet, ExternalIP must be ALLOCATED for NATGateway) — all start in PENDING state and are reconciled by the operator
- Wire provisioner into `PrivateTenantsServer.Create` as an optional dependency

## Jira

https://redhat.atlassian.net/browse/OSAC-2341

## Design

[Default Networking EP](https://github.com/osac-project/enhancement-proposals/pull/107) — §Tenant Onboarding

## Changes

**New file: `internal/servers/default_networking_provisioner.go`**
- `DefaultNetworkingProvisioner` with builder pattern
- `Provision(ctx, tenantName)` — reads default NetworkClass, creates VN/Subnets/SG/NATGateway
- All resources labeled `osac.openshift.io/default: "true"` with correct tenant annotation
- Subnets and SG get `osac.openshift.io/owner-reference` annotation pointing to VN
- ExternalIP pool selection: READY pool with most available capacity
- NATGateway auto-allocated ExternalIP with pool capacity decrement

**Modified: `internal/servers/private_tenants_server.go`**
- Added optional `DefaultNetworkingProvisioner` dependency via `SetDefaultNetworkingProvisioner()`
- `Create()` calls `Provision()` after successful tenant creation (same DB transaction)

**Modified: `internal/cmd/service/start/grpcserver/start_grpc_server_cmd.go`**
- Wire provisioner into private tenants server at startup

## Test plan

- [x] 10 unit tests for `DefaultNetworkingProvisioner` covering:
  - Happy path: VN + IPv4/IPv6 Subnets + SG with correct labels, annotations, CIDRs, state
  - NATGateway skipped when `enable_nat_gateway` is false
  - Implementation strategy propagation from NetworkClass
  - No-op when no default NetworkClass exists
  - No-op when NetworkClass has no defaults
  - Partial defaults (IPv4-only)
- [x] 2 unit tests for tenant server wiring:
  - Tenant Create with provisioner creates default resources
  - Tenant Create without provisioner preserves existing behavior
- [x] Full servers test suite passes (1410 specs)
- [x] Full unit test suite passes (80 suites across all internal/ packages)
- [x] `golangci-lint`: 0 issues
- [x] `gofmt`: no formatting changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Newly created tenants can automatically receive default networking resources (virtual network, security group, and IPv4/IPv6 subnets when configured).
  - Optional NAT gateway and external IP attachment are provisioned when NAT is enabled and capacity is available.
  - Defaults are applied only when a default network configuration exists.
- **Bug Fixes**
  - Tenant creation returns an internal error if default networking provisioning fails.
  - The gRPC server now refuses to start if the default networking provisioner cannot be constructed.
- **Tests**
  - Added coverage for default, partial, and missing defaults, plus NAT capacity/error scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->