### PR TITLE
OSAC-1684: Add scan-e2e-logs listener

### DIFF
--- a/.github/workflows/scan-e2e-logs.yml
+++ b/.github/workflows/scan-e2e-logs.yml
@@ -1,0 +1,221 @@
+---
+name: Scan E2E logs
+
+# Mirrors osac-test-infra's own scan-e2e-logs.yml so this repo's own e2e
+# runs also get immediate post-run credential scanning: workflow_run can't
+# cross repos, so each repo that calls the reusable e2e workflows needs its
+# own listener. The actual scanning logic is NOT duplicated -- this just
+# invokes osac-test-infra's shared composite actions cross-repo. Keep the
+# `workflows:` list in sync with whatever this repo's own e2e-calling
+# workflow(s) are named (see osac-test-infra's
+# audit-workflow-logs.yml / discover-e2e-runs.sh for how to check for drift).
+#
+# This -- and the equivalent copy in every other repo that calls the
+# reusable e2e workflows -- becomes unnecessary once the planned monorepo
+# migration lands and everything is one repo.
+#
+# Fires for any conclusion including cancelled -- earlier jobs may already
+# have printed secrets before cancel.
+on:
+  workflow_run:
+    workflows:
+      - E2E VMaaS Full Install
+      - E2E BMaaS Full Install
+    types: [completed]
+
+concurrency:
+  group: scan-e2e-logs-${{ github.event.workflow_run.id }}
+  cancel-in-progress: false
+
+# Deny-by-default at the workflow level, so a future job added to this file
+# without its own explicit `permissions:` block gets nothing rather than a
+# broad implicit GITHUB_TOKEN scope -- the job below already sets its own
+# least-privilege block regardless, this is just the safety net for later.
+permissions: {}
+
+jobs:
+  scan-logs:
+    name: Scan and purge run logs
+    runs-on: osac-ci
+    permissions:
+      contents: read  # not used for checkout here; reserved for future local steps
+      # Fetching and deleting the completed run's logs needs actions:write.
+      actions: write  # fetch/delete completed run's logs
+      pull-requests: write  # comment leak findings on the triggering PR
+    steps:
+      - name: Scan and purge run logs
+        id: scan
+        uses: osac-project/osac-test-infra/.github/actions/scan-and-purge-logs@main
+        with:
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      # Comment on an associated open PR when leaks were found. Schedule /
+      # dispatch / no-PR runs skip quietly. Body uses sanitized findings
+      # only (Rule / File / Line) -- never secret values.
+      # md_cell is inlined (mirrors have no checkout / no md-cell.jq); keep
+      # transforms in sync with osac-test-infra .github/scripts/md-cell.jq.
+      - name: Comment on PR if leaks found
+        if: always() && steps.scan.outputs.leaks-found == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          E2E_RUN_ID: ${{ github.event.workflow_run.id }}
+          E2E_RUN_URL: ${{ github.event.workflow_run.html_url }}
+          E2E_NAME: ${{ github.event.workflow_run.name }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
+          # Often empty on workflow_run (esp. fork PRs) -- fallback below.
+          PR_FROM_EVENT: ${{ github.event.workflow_run.pull_requests[0].number }}
+          FINDINGS_COUNT: ${{ steps.scan.outputs.findings-count }}
+          PURGE_OK: ${{ steps.scan.outputs.purge-ok }}
+          OUTPUT_DIR: ${{ steps.scan.outputs.output-dir }}
+          SCAN_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+
+          # Resolve exactly one open PR for this e2e head SHA. Paginate the
+          # commit→PRs API so a truncated first page cannot hide siblings.
+          # Event PR number alone is not enough (stale/closed/ambiguous).
+          PR_NUMBER=""
+          # Do not `|| echo '[]'` after jq: with pipefail, gh failure can make
+          # jq already emit [] and then echo append a second [], breaking jq.
+          if ! OPEN_PRS_JSON=$(gh api --paginate "repos/${REPO}/commits/${HEAD_SHA}/pulls" \
+            --jq '.[] | select(.state == "open") | .number' 2>/dev/null \
+            | jq -s 'unique'); then
+            echo "::warning::Unable to resolve an open PR for ${HEAD_SHA} (${HEAD_BRANCH}); skipping PR comment."
+            exit 0
+          fi
+          OPEN_PR_COUNT=$(jq 'length' <<<"${OPEN_PRS_JSON}")
+          if [[ "${OPEN_PR_COUNT}" -eq 1 ]]; then
+            PR_NUMBER=$(jq -r '.[0]' <<<"${OPEN_PRS_JSON}")
+          elif [[ "${OPEN_PR_COUNT}" -gt 1 ]]; then
+            echo "Ambiguous: ${OPEN_PR_COUNT} open PRs for ${HEAD_SHA} (${HEAD_BRANCH}) -- skipping PR comment."
+            exit 0
+          else
+            echo "No open PR associated with ${HEAD_SHA} (${HEAD_BRANCH}) -- skipping PR comment."
+            exit 0
+          fi
+          if [[ -n "${PR_FROM_EVENT}" && "${PR_FROM_EVENT}" != "null" \
+            && "${PR_FROM_EVENT}" != "${PR_NUMBER}" ]]; then
+            echo "Note: workflow_run event PR #${PR_FROM_EVENT} differs from unique open PR #${PR_NUMBER} for ${HEAD_SHA}; commenting on #${PR_NUMBER}."
+          fi
+
+          # Same transforms as osac-test-infra .github/scripts/md-cell.jq
+          md_cell() {
+            printf '%s' "${1}" | jq -Rrs '
+              gsub("[\r\n]"; " ")
+              | gsub("&"; "&amp;")
+              | gsub("<"; "&lt;")
+              | gsub(">"; "&gt;")
+              | gsub("\\|"; "\\|")
+            '
+          }
+
+          E2E_NAME_SAFE=$(md_cell "${E2E_NAME}")
+
+          BODY_FILE="${RUNNER_TEMP}/pr-leak-comment.md"
+          {
+            echo "### :rotating_light: Credential leak scan found secrets in e2e run logs/artifacts"
+            echo ""
+            echo "**Workflow:** ${E2E_NAME_SAFE}"
+            echo "**E2E run:** [${E2E_RUN_ID}](${E2E_RUN_URL})"
+            echo "**Scan run:** [Scan E2E logs](${SCAN_RUN_URL})"
+            echo "**Findings:** ${FINDINGS_COUNT}"
+            echo ""
+            if [[ "${PURGE_OK}" == "true" ]]; then
+              echo "Tainted raw logs and/or artifacts for that e2e run were deleted to close the exposure window."
+            else
+              echo ":warning: **Purge incomplete** -- raw logs and/or artifacts may still be on GitHub. Check the scan run and delete manually if needed."
+            fi
+            echo ""
+            echo "Rotate any credential(s) below that are real (not test/dev-only values)."
+            echo ""
+            echo "| Rule | File | Line |"
+            echo "|---|---|---|"
+            if [[ -f "${OUTPUT_DIR}/findings.json" ]]; then
+              jq -r '
+                def cell:
+                  tostring
+                  | gsub("[\r\n]"; " ")
+                  | gsub("&"; "&amp;")
+                  | gsub("<"; "&lt;")
+                  | gsub(">"; "&gt;")
+                  | gsub("\\|"; "\\|");
+                .[] | "| \(.RuleID | cell) | \(.File | cell) | \(.StartLine) |"
+              ' "${OUTPUT_DIR}/findings.json"
+            else
+              echo "| _(findings.json missing)_ | | |"
+            fi
+          } > "${BODY_FILE}"
+
+          # Comment is best-effort -- scan/purge already succeeded; a
+          # transient API error or closed-PR race must not fail the job.
+          if gh pr comment "${PR_NUMBER}" -R "${REPO}" --body-file "${BODY_FILE}"; then
+            echo "Commented on PR #${PR_NUMBER}."
+          else
+            echo "::warning::Failed to comment on PR #${PR_NUMBER} -- leak was still detected; see scan job summary/Slack for purge status."
+          fi
+
+      # --- Secret bootstrap (inline — must not run PR-controlled code) ---
+      # Fetched only if actually needed for the Slack notification below, so
+      # a Vault/AppRole outage can never block the scan/purge above -- that's
+      # the security-critical part and must run regardless. `outcome ==
+      # 'failure'` (not just the leaks-found/scan-ok outputs) covers the case
+      # where the composite action fails so hard it never sets either output.
+      - name: Read AppRole credentials
+        if: >
+          always() &&
+          (steps.scan.outcome == 'failure' || steps.scan.outputs.leaks-found == 'true' || steps.scan.outputs.scan-ok == 'false')
+        id: approle
+        run: |
+          APPROLE_DIR="${HOME}/.vault-server/.approle"
+          echo "role-id=$(cat "${APPROLE_DIR}/role-id")" >> "$GITHUB_OUTPUT"
+          echo "::add-mask::$(cat "${APPROLE_DIR}/secret-id")"
+          echo "secret-id=$(cat "${APPROLE_DIR}/secret-id")" >> "$GITHUB_OUTPUT"
+
+      - name: Retrieve Slack webhook from Vault
+        if: >
+          always() &&
+          (steps.scan.outcome == 'failure' || steps.scan.outputs.leaks-found == 'true' || steps.scan.outputs.scan-ok == 'false')
+        id: vault
+        uses: hashicorp/vault-action@892a26828f195e65540a40b4768ae4571f51ebfc # v4
+        with:
+          url: http://127.0.0.1:8200
+          method: approle
+          roleId: ${{ steps.approle.outputs.role-id }}
+          secretId: ${{ steps.approle.outputs.secret-id }}
+          exportEnv: false
+          secrets: |
+            secret/data/osac/e2e/slack-webhook-url url | SLACK_WEBHOOK_URL
+
+      # always(): a bare boolean condition implicitly ANDs with success(), so
+      # without this, a hard failure in the scan/purge step above -- exactly
+      # the failure most worth alerting on -- would skip this notification.
+      # steps.scan.outputs.purge-ok isn't listed in the condition itself --
+      # it can only be 'false' when leaks-found is already 'true' (purge
+      # only ever runs after a leak is found), so that's already covered;
+      # it's surfaced in the message below instead, prioritized ahead of
+      # the plain "detected" message since it needs more urgent action.
+      #
+      # Credential-only findings (leaks found, scan completed, raw logs
+      # purged) use status=warning, not failure: today's e2e logs still
+      # commonly contain secrets we have not finished scrubbing, and
+      # treating those as FAILED blocks blessing otherwise-green PRs.
+      # Real problems -- purge failed, scan failed, or the scan action
+      # itself hard-failed -- stay failure.
+      - name: Notify Slack on leak or scan failure
+        if: >
+          always() &&
+          (steps.scan.outcome == 'failure' || steps.scan.outputs.leaks-found == 'true' || steps.scan.outputs.scan-ok == 'false')
+        uses: osac-project/osac-test-infra/.github/actions/notify-slack@main
+        with:
+          status: ${{ steps.scan.outputs.leaks-found == 'true' && steps.scan.outcome == 'success' && steps.scan.outputs.scan-ok == 'true' && steps.scan.outputs.purge-ok == 'true' && 'warning' || 'failure' }}
+          workflow-name: ${{ github.event.workflow_run.name }}
+          # Order matters: purge-ok=false covers both "leak found but
+          # delete failed" and "scan failed after fetch" (raw content remains).
+          failed-step: "${{ steps.scan.outputs.leaks-found == 'true' && steps.scan.outputs.scan-ok == 'true' && steps.scan.outputs.purge-ok == 'false' && 'Credential(s) detected, but raw logs/artifacts could not be fully deleted -- exposure window is still open, immediate remediation required' || steps.scan.outputs.scan-ok == 'false' && steps.scan.outputs.purge-ok == 'false' && 'Scan failed after content was fetched -- raw logs/artifacts may still be on GitHub, check run logs' || steps.scan.outputs.leaks-found == 'true' && steps.scan.outcome != 'success' && format('Credential(s) detected in run logs/artifacts ({0} finding(s)); scan action did not complete -- see run logs', steps.scan.outputs.findings-count) || steps.scan.outcome != 'success' && 'Scan/purge action did not complete -- see run logs' || steps.scan.outputs.leaks-found == 'true' && format('Credential(s) detected in run logs/artifacts ({0} finding(s))', steps.scan.outputs.findings-count) || 'Could not fully scan run logs/artifacts for leaked credentials' }}"
+          slack-webhook-url: ${{ steps.vault.outputs.SLACK_WEBHOOK_URL }}
+          workflow-url: ${{ github.event.workflow_run.html_url }}
+          branch-name: ${{ github.event.workflow_run.head_branch }}
+          commit-sha: ${{ github.event.workflow_run.head_sha }}


### PR DESCRIPTION
## Summary
- Mirrors the `osac-test-infra` `scan-e2e-logs` listener via the cross-repo composite action.
- Listens for **E2E VMaaS Full Install** and **E2E BMaaS Full Install**.
- Comments sanitized findings on the triggering PR; Slack warns when credential-only findings were purged from artifacts.
- Depends on [osac-test-infra#262](https://github.com/osac-project/osac-test-infra/pull/262) for artifact purge inside the composite action `@main`.

## Test plan
- [ ] Confirm workflow triggers on completed VMaaS/BMaaS Full Install runs (including cancelled).
- [ ] Verify PR comment appears with sanitized findings when leaks are detected.
- [ ] Confirm Slack notification wording matches osac-test-infra artifact scan/purge behavior.
- [ ] After osac-test-infra#262 merges, pin/use composite `@main` and spot-check purged credential-only path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated scanning and cleanup of end-to-end workflow logs and artifacts.
  * Added pull request comments summarizing detected sensitive-data leaks.
  * Added Slack notifications for scan failures, detected leaks, and cleanup status.
* **Security**
  * Restricted workflow permissions and protected sensitive credentials during notifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->