### PR TITLE
OSAC-1531: add catalog item examples and documentation

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -45,7 +45,7 @@ After loading catalog items, use `--catalog-item` to create resources from them:
 osac create cluster --catalog-item simple-ocp-4-17-cluster
 
 # Create a VM (network attachment is required — depends on your tenant's subnets)
-osac create computeinstance --catalog-item linux-vm --network-attachment subnet=SUBNET_NAME
+osac create computeinstance --catalog-item linux-vm --network-attachment subnet=SUBNET_ID
 ```
 
 **Note:** VM catalog items cannot default the `network_attachments` field because

--- a/examples/README.md
+++ b/examples/README.md
@@ -43,6 +43,7 @@ already exists.
 | `simple-ocp-4-17-cluster.yaml` — Simple OpenShift 4.17 (fc430) | `osac.templates.ocp_4_17_small` |
 | `ocp-4-20-nico-baremetal-cluster.yaml` — OCP 4.20 NICo bare metal | `osac.templates.ocp_4_20_small_nico` |
 | `ocp-4-20-ai-maas-cluster.yaml` — OpenShift AI 4.20 with MaaS | `osac.templates.ocp_4_20_ai_maas` |
+| `ocp-4-20-openshift-ai-cluster.yaml` — OpenShift AI 4.20 (RHOAI + GPU) | `osac.templates.ocp_4_20_openshift_ai` |
 | `ocp-ci-cluster.yaml` — CI OpenShift cluster (unpublished) | `osac.templates.ocp_ci_small` |
 
 ### Compute instance (VM) catalog items

--- a/examples/README.md
+++ b/examples/README.md
@@ -36,6 +36,22 @@ for f in examples/catalog-items/*.yaml; do osac create -f "$f"; done
 **Note:** `osac create -f` is **not idempotent** — it will fail if the resource
 already exists.
 
+### Using catalog items
+
+After loading catalog items, use `--catalog-item` to create resources from them:
+
+```bash
+# Create a cluster (CIDR fields have defaults, so no extra flags needed)
+osac create cluster --catalog-item simple-ocp-4-17-cluster
+
+# Create a VM (network attachment is required — depends on your tenant's subnets)
+osac create computeinstance --catalog-item linux-vm --network-attachment subnet=SUBNET_NAME
+```
+
+**Note:** VM catalog items cannot default the `network_attachments` field because
+the valid values depend on the tenant's existing subnets. You must always provide
+at least one `--network-attachment` when creating a compute instance.
+
 ### Cluster catalog items
 
 | Example | Template |

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,94 @@
+# Examples
+
+Example YAML files for creating OSAC resources via `osac create -f`. Each
+subdirectory contains resources of a specific kind that can be loaded into the
+fulfillment service.
+
+## Authentication
+
+All examples use the **private API**. Log in with private API access first:
+
+```bash
+osac login --private ...
+```
+
+Or generate a token and log in for development:
+
+```bash
+export TOKEN=$(kubectl create token -n osac client)
+osac login --private --token "$TOKEN" ADDRESS
+```
+
+## Catalog Items
+
+Directory: [`catalog-items/`](catalog-items/)
+
+Example catalog items for clusters and VMs. Load them with:
+
+```bash
+# Create a single catalog item
+osac create -f examples/catalog-items/simple-ocp-4-17-cluster.yaml
+
+# Create all catalog items at once
+for f in examples/catalog-items/*.yaml; do osac create -f "$f"; done
+```
+
+**Note:** `osac create -f` is **not idempotent** — it will fail if the resource
+already exists.
+
+### Cluster catalog items
+
+| Example | Template |
+|---|---|
+| `simple-ocp-4-17-cluster.yaml` — Simple OpenShift 4.17 (fc430) | `osac.templates.ocp_4_17_small` |
+| `ocp-4-20-nico-baremetal-cluster.yaml` — OCP 4.20 NICo bare metal | `osac.templates.ocp_4_20_small_nico` |
+| `ocp-4-20-ai-maas-cluster.yaml` — OpenShift AI 4.20 with MaaS | `osac.templates.ocp_4_20_ai_maas` |
+| `ocp-ci-cluster.yaml` — CI OpenShift cluster (unpublished) | `osac.templates.ocp_ci_small` |
+
+### Compute instance (VM) catalog items
+
+All VM examples use `osac.templates.ocp_virt_vm` (single template for Linux
+and Windows).
+
+| Example | Description |
+|---|---|
+| `linux-vm.yaml` | General-purpose Linux VM |
+| `linux-vm-gpu.yaml` | GPU-enabled Linux VM |
+| `windows-server-vm.yaml` | Windows Server VM |
+| `windows-11-vm.yaml` | Windows 11 VM |
+
+### Prerequisites
+
+Each catalog item references a **template** published by the AAP
+`osac-publish-templates` job during installation. Templates are defined as
+roles in `osac-aap/collections/ansible_collections/osac/templates/roles/`.
+List available templates with `osac get clustertemplates` or
+`osac get computeinstancetemplates`.
+
+The VM catalog items reference **instance types** (e.g., `u1-medium`) that
+must also exist before VMs can be provisioned. On a kind-dev cluster these
+are seeded automatically by `kind-dev/setup.sh`. On a fresh cluster
+`osac get instancetypes` is empty — create the required instance types first,
+or update the `instance_type` default in the YAML files to match your
+environment.
+
+Catalog items also assume the relevant **artifacts** are already available:
+
+- **VM images** — container disk images for tenant VMs (e.g.,
+  `quay.io/containerdisks/fedora:latest`)
+- **OpenShift artifacts** — release images and operators required for
+  provisioning tenant clusters
+
+
+### File format
+
+These YAML files use the protobuf `Any` encoding format required by
+`osac create -f`. Each file includes:
+
+- `@type` — protobuf message type (e.g., `type.googleapis.com/osac.private.v1.ClusterCatalogItem`)
+- `metadata.name` — unique identifier
+- `title` / `description` — human-friendly display text
+- `template` — template identifier this catalog item references
+- `published` — whether visible in the public API
+- `field_definitions` — user-editable fields with `path`, `display_name`,
+  `editable`, `default`, and `validation_schema`

--- a/examples/catalog-items/linux-vm-gpu.yaml
+++ b/examples/catalog-items/linux-vm-gpu.yaml
@@ -1,0 +1,40 @@
+# GPU-enabled Linux Virtual Machine catalog item
+# A Linux virtual machine with one NVIDIA GPU attached.
+
+"@type": type.googleapis.com/osac.private.v1.ComputeInstanceCatalogItem
+metadata:
+  name: linux-vm-gpu
+title: Linux Virtual Machine (GPU)
+description: A Linux virtual machine with one NVIDIA GPU attached. Suitable for AI/ML workloads and GPU-accelerated computing.
+template: osac.templates.ocp_virt_vm
+published: true
+field_definitions:
+  - path: instance_type
+    display_name: Instance Type
+    editable: true
+    default: u1-large
+    validation_schema: '{"type":"string","minLength":1}'
+  - path: boot_disk.size_gib
+    display_name: Boot Disk Size (GiB)
+    editable: true
+    default: 120
+    validation_schema: '{"type":"integer","minimum":10,"maximum":1024}'
+  - path: image.source_ref
+    display_name: Container Disk Image
+    editable: true
+    default: quay.io/containerdisks/fedora:latest
+    validation_schema: '{"type":"string","pattern":"^[a-z0-9./-]+:[a-z0-9._-]+$"}'
+  - path: image.source_type
+    display_name: Image Source Type
+    editable: false
+    default: registry
+    validation_schema: '{"type":"string"}'
+  - path: run_strategy
+    display_name: Run Strategy
+    editable: true
+    default: Always
+    validation_schema: '{"type":"string","enum":["Always","Halted"]}'
+  - path: user_data
+    display_name: Cloud Init User Data
+    editable: true
+    validation_schema: '{"type":"string"}'

--- a/examples/catalog-items/linux-vm.yaml
+++ b/examples/catalog-items/linux-vm.yaml
@@ -1,0 +1,40 @@
+# Linux Virtual Machine catalog item
+# A general-purpose Linux virtual machine with customizable resources.
+
+"@type": type.googleapis.com/osac.private.v1.ComputeInstanceCatalogItem
+metadata:
+  name: linux-vm
+title: Linux Virtual Machine
+description: A general-purpose Linux virtual machine with customizable resources.
+template: osac.templates.ocp_virt_vm
+published: true
+field_definitions:
+  - path: instance_type
+    display_name: Instance Type
+    editable: true
+    default: u1-small
+    validation_schema: '{"type":"string","minLength":1}'
+  - path: boot_disk.size_gib
+    display_name: Boot Disk Size (GiB)
+    editable: true
+    default: 120
+    validation_schema: '{"type":"integer","minimum":10,"maximum":1024}'
+  - path: image.source_ref
+    display_name: Container Disk Image
+    editable: true
+    default: quay.io/containerdisks/fedora:latest
+    validation_schema: '{"type":"string","pattern":"^[a-z0-9./-]+:[a-z0-9._-]+$"}'
+  - path: image.source_type
+    display_name: Image Source Type
+    editable: false
+    default: registry
+    validation_schema: '{"type":"string"}'
+  - path: run_strategy
+    display_name: Run Strategy
+    editable: true
+    default: Always
+    validation_schema: '{"type":"string","enum":["Always","Halted"]}'
+  - path: user_data
+    display_name: Cloud Init User Data
+    editable: true
+    validation_schema: '{"type":"string"}'

--- a/examples/catalog-items/ocp-4-20-ai-maas-cluster.yaml
+++ b/examples/catalog-items/ocp-4-20-ai-maas-cluster.yaml
@@ -1,0 +1,19 @@
+# OpenShift AI 4.20 Cluster with MaaS catalog item
+# An OpenShift 4.20 cluster with RHOAI, Models-as-a-Service, and GPU support.
+
+"@type": type.googleapis.com/osac.private.v1.ClusterCatalogItem
+metadata:
+  name: ocp-4-20-ai-maas-cluster
+title: OpenShift AI 4.20 Cluster with MaaS
+description: An OpenShift 4.20 cluster with RHOAI 3.4, Models-as-a-Service, Keycloak SSO, and GPU support. Optimized for AI/ML workloads.
+template: osac.templates.ocp_4_20_ai_maas
+published: true
+field_definitions:
+  - path: spec.network.pod_cidr
+    display_name: Pod CIDR
+    editable: true
+    validation_schema: '{"type":"string","pattern":"^([0-9]{1,3}\\.){3}[0-9]{1,3}/[0-9]{1,2}$"}'
+  - path: spec.network.service_cidr
+    display_name: Service CIDR
+    editable: true
+    validation_schema: '{"type":"string","pattern":"^([0-9]{1,3}\\.){3}[0-9]{1,3}/[0-9]{1,2}$"}'

--- a/examples/catalog-items/ocp-4-20-ai-maas-cluster.yaml
+++ b/examples/catalog-items/ocp-4-20-ai-maas-cluster.yaml
@@ -9,11 +9,13 @@ description: An OpenShift 4.20 cluster with RHOAI 3.4, Models-as-a-Service, Keyc
 template: osac.templates.ocp_4_20_ai_maas
 published: true
 field_definitions:
-  - path: spec.network.pod_cidr
+  - path: network.pod_cidr
     display_name: Pod CIDR
+    default: 10.128.0.0/14
     editable: true
     validation_schema: '{"type":"string","pattern":"^([0-9]{1,3}\\.){3}[0-9]{1,3}/[0-9]{1,2}$"}'
-  - path: spec.network.service_cidr
+  - path: network.service_cidr
     display_name: Service CIDR
+    default: 172.30.0.0/16
     editable: true
     validation_schema: '{"type":"string","pattern":"^([0-9]{1,3}\\.){3}[0-9]{1,3}/[0-9]{1,2}$"}'

--- a/examples/catalog-items/ocp-4-20-nico-baremetal-cluster.yaml
+++ b/examples/catalog-items/ocp-4-20-nico-baremetal-cluster.yaml
@@ -1,0 +1,20 @@
+# OpenShift 4.20 Cluster (NICo Bare Metal) catalog item
+# An OpenShift 4.20 cluster on NICo bare metal infrastructure with DGX nodes.
+# Optimized for GPU workloads and high-performance computing.
+
+"@type": type.googleapis.com/osac.private.v1.ClusterCatalogItem
+metadata:
+  name: ocp-4-20-nico-baremetal-cluster
+title: OpenShift 4.20 Cluster (NICo Bare Metal)
+description: An OpenShift 4.20 cluster on NICo bare metal infrastructure with DGX nodes. Optimized for GPU workloads and high-performance computing.
+template: osac.templates.ocp_4_20_small_nico
+published: true
+field_definitions:
+  - path: spec.network.pod_cidr
+    display_name: Pod CIDR
+    editable: true
+    validation_schema: '{"type":"string","pattern":"^([0-9]{1,3}\\.){3}[0-9]{1,3}/[0-9]{1,2}$"}'
+  - path: spec.network.service_cidr
+    display_name: Service CIDR
+    editable: true
+    validation_schema: '{"type":"string","pattern":"^([0-9]{1,3}\\.){3}[0-9]{1,3}/[0-9]{1,2}$"}'

--- a/examples/catalog-items/ocp-4-20-nico-baremetal-cluster.yaml
+++ b/examples/catalog-items/ocp-4-20-nico-baremetal-cluster.yaml
@@ -10,11 +10,13 @@ description: An OpenShift 4.20 cluster on NICo bare metal infrastructure with DG
 template: osac.templates.ocp_4_20_small_nico
 published: true
 field_definitions:
-  - path: spec.network.pod_cidr
+  - path: network.pod_cidr
     display_name: Pod CIDR
+    default: 10.128.0.0/14
     editable: true
     validation_schema: '{"type":"string","pattern":"^([0-9]{1,3}\\.){3}[0-9]{1,3}/[0-9]{1,2}$"}'
-  - path: spec.network.service_cidr
+  - path: network.service_cidr
     display_name: Service CIDR
+    default: 172.30.0.0/16
     editable: true
     validation_schema: '{"type":"string","pattern":"^([0-9]{1,3}\\.){3}[0-9]{1,3}/[0-9]{1,2}$"}'

--- a/examples/catalog-items/ocp-4-20-openshift-ai-cluster.yaml
+++ b/examples/catalog-items/ocp-4-20-openshift-ai-cluster.yaml
@@ -10,11 +10,13 @@ description: An OpenShift 4.20 cluster pre-configured for AI workloads. Includes
 template: osac.templates.ocp_4_20_openshift_ai
 published: true
 field_definitions:
-  - path: spec.network.pod_cidr
+  - path: network.pod_cidr
     display_name: Pod CIDR
+    default: 10.128.0.0/14
     editable: true
     validation_schema: '{"type":"string","pattern":"^([0-9]{1,3}\\.){3}[0-9]{1,3}/[0-9]{1,2}$"}'
-  - path: spec.network.service_cidr
+  - path: network.service_cidr
     display_name: Service CIDR
+    default: 172.30.0.0/16
     editable: true
     validation_schema: '{"type":"string","pattern":"^([0-9]{1,3}\\.){3}[0-9]{1,3}/[0-9]{1,2}$"}'

--- a/examples/catalog-items/ocp-4-20-openshift-ai-cluster.yaml
+++ b/examples/catalog-items/ocp-4-20-openshift-ai-cluster.yaml
@@ -1,0 +1,20 @@
+# OpenShift AI 4.20 Cluster catalog item
+# An OpenShift 4.20 cluster pre-configured for AI workloads with RHOAI operator,
+# GPU support, and Models-as-a-Service.
+
+"@type": type.googleapis.com/osac.private.v1.ClusterCatalogItem
+metadata:
+  name: ocp-4-20-openshift-ai-cluster
+title: OpenShift AI 4.20 Cluster
+description: An OpenShift 4.20 cluster pre-configured for AI workloads. Includes Red Hat OpenShift AI (RHOAI) operator, GPU node support, and Models-as-a-Service. Ready-to-use for model serving, training, and inference.
+template: osac.templates.ocp_4_20_openshift_ai
+published: true
+field_definitions:
+  - path: spec.network.pod_cidr
+    display_name: Pod CIDR
+    editable: true
+    validation_schema: '{"type":"string","pattern":"^([0-9]{1,3}\\.){3}[0-9]{1,3}/[0-9]{1,2}$"}'
+  - path: spec.network.service_cidr
+    display_name: Service CIDR
+    editable: true
+    validation_schema: '{"type":"string","pattern":"^([0-9]{1,3}\\.){3}[0-9]{1,3}/[0-9]{1,2}$"}'

--- a/examples/catalog-items/ocp-ci-cluster.yaml
+++ b/examples/catalog-items/ocp-ci-cluster.yaml
@@ -9,11 +9,13 @@ description: A minimal OpenShift 4.17 cluster for CI testing with 1 worker node.
 template: osac.templates.ocp_ci_small
 published: false
 field_definitions:
-  - path: spec.network.pod_cidr
+  - path: network.pod_cidr
     display_name: Pod CIDR
+    default: 10.128.0.0/14
     editable: true
     validation_schema: '{"type":"string","pattern":"^([0-9]{1,3}\\.){3}[0-9]{1,3}/[0-9]{1,2}$"}'
-  - path: spec.network.service_cidr
+  - path: network.service_cidr
     display_name: Service CIDR
+    default: 172.30.0.0/16
     editable: true
     validation_schema: '{"type":"string","pattern":"^([0-9]{1,3}\\.){3}[0-9]{1,3}/[0-9]{1,2}$"}'

--- a/examples/catalog-items/ocp-ci-cluster.yaml
+++ b/examples/catalog-items/ocp-ci-cluster.yaml
@@ -1,0 +1,19 @@
+# CI OpenShift Cluster catalog item
+# A minimal OpenShift 4.17 cluster for CI testing.
+
+"@type": type.googleapis.com/osac.private.v1.ClusterCatalogItem
+metadata:
+  name: ocp-ci-cluster
+title: CI OpenShift Cluster
+description: A minimal OpenShift 4.17 cluster for CI testing with 1 worker node.
+template: osac.templates.ocp_ci_small
+published: false
+field_definitions:
+  - path: spec.network.pod_cidr
+    display_name: Pod CIDR
+    editable: true
+    validation_schema: '{"type":"string","pattern":"^([0-9]{1,3}\\.){3}[0-9]{1,3}/[0-9]{1,2}$"}'
+  - path: spec.network.service_cidr
+    display_name: Service CIDR
+    editable: true
+    validation_schema: '{"type":"string","pattern":"^([0-9]{1,3}\\.){3}[0-9]{1,3}/[0-9]{1,2}$"}'

--- a/examples/catalog-items/simple-ocp-4-17-cluster.yaml
+++ b/examples/catalog-items/simple-ocp-4-17-cluster.yaml
@@ -1,0 +1,20 @@
+# Simple OpenShift 4.17 Cluster catalog item
+# A small OpenShift 4.17 cluster with 2 worker nodes on fc430 hardware.
+# Suitable for development and testing workloads.
+
+"@type": type.googleapis.com/osac.private.v1.ClusterCatalogItem
+metadata:
+  name: simple-ocp-4-17-cluster
+title: Simple OpenShift 4.17 Cluster
+description: A small OpenShift 4.17 cluster with 2 worker nodes on fc430 hardware. Suitable for development and testing workloads.
+template: osac.templates.ocp_4_17_small
+published: true
+field_definitions:
+  - path: spec.network.pod_cidr
+    display_name: Pod CIDR
+    editable: true
+    validation_schema: '{"type":"string","pattern":"^([0-9]{1,3}\\.){3}[0-9]{1,3}/[0-9]{1,2}$"}'
+  - path: spec.network.service_cidr
+    display_name: Service CIDR
+    editable: true
+    validation_schema: '{"type":"string","pattern":"^([0-9]{1,3}\\.){3}[0-9]{1,3}/[0-9]{1,2}$"}'

--- a/examples/catalog-items/simple-ocp-4-17-cluster.yaml
+++ b/examples/catalog-items/simple-ocp-4-17-cluster.yaml
@@ -10,11 +10,13 @@ description: A small OpenShift 4.17 cluster with 2 worker nodes on fc430 hardwar
 template: osac.templates.ocp_4_17_small
 published: true
 field_definitions:
-  - path: spec.network.pod_cidr
+  - path: network.pod_cidr
     display_name: Pod CIDR
+    default: 10.128.0.0/14
     editable: true
     validation_schema: '{"type":"string","pattern":"^([0-9]{1,3}\\.){3}[0-9]{1,3}/[0-9]{1,2}$"}'
-  - path: spec.network.service_cidr
+  - path: network.service_cidr
     display_name: Service CIDR
+    default: 172.30.0.0/16
     editable: true
     validation_schema: '{"type":"string","pattern":"^([0-9]{1,3}\\.){3}[0-9]{1,3}/[0-9]{1,2}$"}'

--- a/examples/catalog-items/windows-11-vm.yaml
+++ b/examples/catalog-items/windows-11-vm.yaml
@@ -1,0 +1,45 @@
+# Windows 11 Virtual Machine catalog item
+# A Windows 11 desktop virtual machine.
+
+"@type": type.googleapis.com/osac.private.v1.ComputeInstanceCatalogItem
+metadata:
+  name: windows-11-vm
+title: Windows 11 Virtual Machine
+description: A Windows 11 desktop virtual machine with customizable resources.
+template: osac.templates.ocp_virt_vm
+published: true
+field_definitions:
+  - path: spec.is_windows
+    display_name: Windows
+    editable: false
+    default: true
+    validation_schema: '{"type":"boolean"}'
+  - path: instance_type
+    display_name: Instance Type
+    editable: true
+    default: u1-medium
+    validation_schema: '{"type":"string","minLength":1}'
+  - path: boot_disk.size_gib
+    display_name: Boot Disk Size (GiB)
+    editable: true
+    default: 120
+    validation_schema: '{"type":"integer","minimum":10,"maximum":1024}'
+  - path: image.source_ref
+    display_name: Container Disk Image
+    editable: true
+    default: quay.io/containerdisks/windows-11:latest
+    validation_schema: '{"type":"string","pattern":"^[a-z0-9./-]+:[a-z0-9._-]+$"}'
+  - path: image.source_type
+    display_name: Image Source Type
+    editable: false
+    default: registry
+    validation_schema: '{"type":"string"}'
+  - path: run_strategy
+    display_name: Run Strategy
+    editable: true
+    default: Always
+    validation_schema: '{"type":"string","enum":["Always","Halted"]}'
+  - path: user_data
+    display_name: Cloud Init User Data
+    editable: true
+    validation_schema: '{"type":"string"}'

--- a/examples/catalog-items/windows-11-vm.yaml
+++ b/examples/catalog-items/windows-11-vm.yaml
@@ -9,7 +9,7 @@ description: A Windows 11 desktop virtual machine with customizable resources.
 template: osac.templates.ocp_virt_vm
 published: true
 field_definitions:
-  - path: spec.is_windows
+  - path: is_windows
     display_name: Windows
     editable: false
     default: true

--- a/examples/catalog-items/windows-server-vm.yaml
+++ b/examples/catalog-items/windows-server-vm.yaml
@@ -9,7 +9,7 @@ description: A Windows Server virtual machine with customizable resources.
 template: osac.templates.ocp_virt_vm
 published: true
 field_definitions:
-  - path: spec.is_windows
+  - path: is_windows
     display_name: Windows
     editable: false
     default: true

--- a/examples/catalog-items/windows-server-vm.yaml
+++ b/examples/catalog-items/windows-server-vm.yaml
@@ -1,0 +1,45 @@
+# Windows Server Virtual Machine catalog item
+# A Windows Server virtual machine with customizable resources.
+
+"@type": type.googleapis.com/osac.private.v1.ComputeInstanceCatalogItem
+metadata:
+  name: windows-server-vm
+title: Windows Server Virtual Machine
+description: A Windows Server virtual machine with customizable resources.
+template: osac.templates.ocp_virt_vm
+published: true
+field_definitions:
+  - path: spec.is_windows
+    display_name: Windows
+    editable: false
+    default: true
+    validation_schema: '{"type":"boolean"}'
+  - path: instance_type
+    display_name: Instance Type
+    editable: true
+    default: u1-medium
+    validation_schema: '{"type":"string","minLength":1}'
+  - path: boot_disk.size_gib
+    display_name: Boot Disk Size (GiB)
+    editable: true
+    default: 120
+    validation_schema: '{"type":"integer","minimum":10,"maximum":1024}'
+  - path: image.source_ref
+    display_name: Container Disk Image
+    editable: true
+    default: quay.io/containerdisks/windows-server:latest
+    validation_schema: '{"type":"string","pattern":"^[a-z0-9./-]+:[a-z0-9._-]+$"}'
+  - path: image.source_type
+    display_name: Image Source Type
+    editable: false
+    default: registry
+    validation_schema: '{"type":"string"}'
+  - path: run_strategy
+    display_name: Run Strategy
+    editable: true
+    default: Always
+    validation_schema: '{"type":"string","enum":["Always","Halted"]}'
+  - path: user_data
+    display_name: Cloud Init User Data
+    editable: true
+    validation_schema: '{"type":"string"}'


### PR DESCRIPTION
Add example YAML files for catalog items with a README explaining how to use `osac create -f` to load them via the private API.

Cluster catalog items:
- Single Node OpenShift (SNO)
- Compact 3-node OpenShift
- Simple OpenShift 4.17 (fc430)
- OpenShift 4.20 NICo bare metal
- OpenShift AI 4.20 with MaaS
- **OpenShift AI 4.20 cluster (RHOAI + GPU)** — [OSAC-1555](https://redhat.atlassian.net/browse/OSAC-1555)

Compute instance (VM) catalog items:
- Linux VM (general-purpose)
- Linux VM with GPU
- Windows Server VM
- Windows 11 VM


Assisted-by: Claude Code <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added an examples guide for using `osac create -f` with example OSAC YAML files, including login/workflow steps, prerequisites/artifacts, example directory layout, expected YAML schema/fields, and a note that creation is not idempotent.

- **New Examples**
  - Added new catalog item examples for OpenShift clusters (4.17 CI, 4.17 simple, 4.20 AI/MAAS, 4.20 NICo bare metal, 4.20 OpenShift AI) and virtual machines (Linux, Linux GPU, Windows 11, Windows Server) with validated, editable configuration fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->