### PR TITLE
OSAC-3247: grant tenant admins Create/Update/Delete on cluster and compute instance catalog items

### DIFF
--- a/internal/auth/grpc_authz_interceptor_test.go
+++ b/internal/auth/grpc_authz_interceptor_test.go
@@ -660,6 +660,80 @@ var _ = Describe("Rego authorization interceptor", func() {
 			Expect(handled).To(BeFalse())
 		})
 
+		DescribeTable(
+			"Allows tenant admin to manage catalog items",
+			func(ctx context.Context, grpcMethod string) {
+				token := createKeycloakUserToken("my-tenant", "my-user", jwt.MapClaims{
+					"realm_access": map[string]any{
+						"roles": []any{
+							"tenant-admin",
+						},
+					},
+				})
+				ctx = ContextWithToken(ctx, token)
+				handled := false
+				_, err := interceptor.UnaryServer(
+					ctx,
+					nil,
+					&grpc.UnaryServerInfo{
+						FullMethod: grpcMethod,
+					},
+					func(ctx context.Context, req any) (any, error) {
+						subject := SubjectFromContext(ctx)
+						Expect(subject.User).To(Equal("my-user"))
+						Expect(subject.Tenants.Finite()).To(BeTrue())
+						Expect(subject.Tenants.Inclusions()).To(ConsistOf("my-tenant"))
+						handled = true
+						return nil, nil
+					},
+				)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(handled).To(BeTrue())
+			},
+			Entry("Cluster catalog items create", "/osac.public.v1.ClusterCatalogItems/Create"),
+			Entry("Cluster catalog items update", "/osac.public.v1.ClusterCatalogItems/Update"),
+			Entry("Cluster catalog items delete", "/osac.public.v1.ClusterCatalogItems/Delete"),
+			Entry("Compute instance catalog items create", "/osac.public.v1.ComputeInstanceCatalogItems/Create"),
+			Entry("Compute instance catalog items update", "/osac.public.v1.ComputeInstanceCatalogItems/Update"),
+			Entry("Compute instance catalog items delete", "/osac.public.v1.ComputeInstanceCatalogItems/Delete"),
+			Entry("Bare metal instance catalog items create", "/osac.public.v1.BareMetalInstanceCatalogItems/Create"),
+			Entry("Bare metal instance catalog items update", "/osac.public.v1.BareMetalInstanceCatalogItems/Update"),
+			Entry("Bare metal instance catalog items delete", "/osac.public.v1.BareMetalInstanceCatalogItems/Delete"),
+		)
+
+		DescribeTable(
+			"Denies regular user from managing catalog items",
+			func(ctx context.Context, grpcMethod string) {
+				token := createKeycloakUserToken("my-tenant", "my-user", jwt.MapClaims{
+					"realm_access": map[string]any{
+						"roles": []any{},
+					},
+				})
+				ctx = ContextWithToken(ctx, token)
+				handled := false
+				_, err := interceptor.UnaryServer(
+					ctx,
+					nil,
+					&grpc.UnaryServerInfo{
+						FullMethod: grpcMethod,
+					},
+					func(ctx context.Context, req any) (any, error) {
+						handled = true
+						return nil, nil
+					},
+				)
+				Expect(err).To(HaveOccurred())
+				status, ok := grpcstatus.FromError(err)
+				Expect(ok).To(BeTrue())
+				Expect(status.Code()).To(Equal(grpccodes.PermissionDenied))
+				Expect(status.Message()).To(Equal("permission denied"))
+				Expect(handled).To(BeFalse())
+			},
+			Entry("Cluster catalog items create", "/osac.public.v1.ClusterCatalogItems/Create"),
+			Entry("Compute instance catalog items create", "/osac.public.v1.ComputeInstanceCatalogItems/Create"),
+			Entry("Bare metal instance catalog items create", "/osac.public.v1.BareMetalInstanceCatalogItems/Create"),
+		)
+
 		It("Grants admin privileges when groups include the admins group", func(ctx context.Context) {
 			token := createKeycloakUserToken("", "my-user", jwt.MapClaims{
 				"organization": nil,

--- a/internal/auth/policies/authz.rego
+++ b/internal/auth/policies/authz.rego
@@ -258,12 +258,19 @@ allow if {
   }
 }
 
-# Tenant admins can manage bare metal catalog items, users, identity providers,
-# projects, and project memberships within their tenant. The application layer
-# (generic server) enforces resource-level authorization via tenant field validation.
+# Tenant admins can manage cluster, compute instance, and bare metal catalog items,
+# users, identity providers, projects, and project memberships within their tenant.
+# The application layer (generic server) enforces resource-level authorization via
+# tenant field validation.
 allow if {
   is_tenant_admin
   grpc_method in {
+    "/osac.public.v1.ClusterCatalogItems/Create",
+    "/osac.public.v1.ClusterCatalogItems/Update",
+    "/osac.public.v1.ClusterCatalogItems/Delete",
+    "/osac.public.v1.ComputeInstanceCatalogItems/Create",
+    "/osac.public.v1.ComputeInstanceCatalogItems/Update",
+    "/osac.public.v1.ComputeInstanceCatalogItems/Delete",
     "/osac.public.v1.BareMetalInstanceCatalogItems/Create",
     "/osac.public.v1.BareMetalInstanceCatalogItems/Update",
     "/osac.public.v1.BareMetalInstanceCatalogItems/Delete",


### PR DESCRIPTION
## Summary
- The OPA policy (`authz.rego`) allowed tenant admins to Create/Update/Delete `BareMetalInstanceCatalogItems` but not `ClusterCatalogItems`/`ComputeInstanceCatalogItems`, which fell through to admin-only despite `Get`/`List` already being open to tenant admins.
- This contradicts the Tenant Admin persona (`docs/personas.md`: "manages organization-specific catalogs of templates") and the `catalog-items` enhancement proposal, which already documents tenant-scoped CRUD for all three catalog item types.
- No application-layer changes needed: `ClusterCatalogItemsServer`/`ComputeInstanceCatalogItemsServer` are structurally identical to `BareMetalInstanceCatalogItemsServer` and already delegate to the same tenancy-aware generic DAO, so tenant-scoped enforcement (auto-set tenant on create, restrict update/delete to the caller's own tenant) already works for all three — this PR only opens the OPA gate.
- Added authz-interceptor unit tests covering tenant-admin allow / regular-user deny for all three catalog item types (none had coverage at this layer before, including the already-working `BareMetalInstanceCatalogItems` case).

## Jira
[OSAC-3247](https://redhat.atlassian.net/browse/OSAC-3247)

## Test plan
- [x] `go build ./...`
- [x] `go test ./internal/auth/...` (240/240 specs passing, including the 12 new entries)
- [x] `go vet ./internal/auth/...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)