### PR TITLE
OSAC-2959: Wire up private secrets server to persist data in vault baked secret store

### DIFF
--- a/internal/servers/private_secrets_server.go
+++ b/internal/servers/private_secrets_server.go
@@ -24,7 +24,9 @@ import (
 
 	privatev1 "github.com/osac-project/fulfillment-service/internal/api/osac/private/v1"
 	"github.com/osac-project/fulfillment-service/internal/auth"
+	"github.com/osac-project/fulfillment-service/internal/database"
 	"github.com/osac-project/fulfillment-service/internal/events"
+	"github.com/osac-project/fulfillment-service/internal/vault"
 )
 
 type PrivateSecretsServerBuilder struct {
@@ -33,6 +35,7 @@ type PrivateSecretsServerBuilder struct {
 	attributionLogic  auth.AttributionLogic
 	tenancyLogic      auth.TenancyLogic
 	metricsRegisterer prometheus.Registerer
+	secretStore       vault.SecretStore
 }
 
 var _ privatev1.SecretsServer = (*PrivateSecretsServer)(nil)
@@ -40,8 +43,10 @@ var _ privatev1.SecretsServer = (*PrivateSecretsServer)(nil)
 type PrivateSecretsServer struct {
 	privatev1.UnimplementedSecretsServer
 
-	logger  *slog.Logger
-	generic *GenericServer[*privatev1.Secret]
+	logger       *slog.Logger
+	generic      *GenericServer[*privatev1.Secret]
+	secretStore  vault.SecretStore
+	tenancyLogic auth.TenancyLogic
 }
 
 func NewPrivateSecretsServer() *PrivateSecretsServerBuilder {
@@ -73,6 +78,11 @@ func (b *PrivateSecretsServerBuilder) SetMetricsRegisterer(value prometheus.Regi
 	return b
 }
 
+func (b *PrivateSecretsServerBuilder) SetSecretStore(value vault.SecretStore) *PrivateSecretsServerBuilder {
+	b.secretStore = value
+	return b
+}
+
 func (b *PrivateSecretsServerBuilder) Build() (result *PrivateSecretsServer, err error) {
 	if b.logger == nil {
 		err = errors.New("logger is mandatory")
@@ -84,7 +94,9 @@ func (b *PrivateSecretsServerBuilder) Build() (result *PrivateSecretsServer, err
 	}
 
 	s := &PrivateSecretsServer{
-		logger: b.logger,
+		logger:       b.logger,
+		secretStore:  b.secretStore,
+		tenancyLogic: b.tenancyLogic,
 	}
 
 	s.generic, err = NewGenericServer[*privatev1.Secret]().
@@ -126,8 +138,29 @@ func (s *PrivateSecretsServer) List(ctx context.Context,
 func (s *PrivateSecretsServer) Get(ctx context.Context,
 	request *privatev1.SecretsGetRequest) (response *privatev1.SecretsGetResponse, err error) {
 	err = s.generic.Get(ctx, request, &response)
+	if err != nil {
+		return
+	}
 
-	// TODO: Fetch secret data from the storage backend.
+	obj := response.GetObject()
+	if s.secretStore != nil && obj.GetSpec().GetBackend() == privatev1.SecretBackend_SECRET_BACKEND_VAULT {
+		tenant := obj.GetMetadata().GetTenant()
+		project := obj.GetMetadata().GetProject()
+		name := obj.GetMetadata().GetName()
+
+		data, fetchErr := s.secretStore.Fetch(ctx, tenant, project, name)
+		if fetchErr != nil {
+			err = vault.ToGrpcError(fetchErr)
+			return
+		}
+
+		status := obj.GetStatus()
+		if status == nil {
+			status = privatev1.SecretStatus_builder{}.Build()
+			obj.SetStatus(status)
+		}
+		status.SetResolvedData(data)
+	}
 
 	return
 }
@@ -149,10 +182,25 @@ func (s *PrivateSecretsServer) Create(ctx context.Context,
 		secret.GetSpec().SetBackend(privatev1.SecretBackend_SECRET_BACKEND_VAULT)
 	}
 
-	// TODO: Store secret data in the storage backend.
+	if s.secretStore != nil && secret.GetSpec().GetBackend() == privatev1.SecretBackend_SECRET_BACKEND_VAULT {
+		tenant, tenantErr := s.determineTenant(ctx, secret)
+		if tenantErr != nil {
+			err = tenantErr
+			return
+		}
+		project := secret.GetMetadata().GetProject()
+		name := secret.GetMetadata().GetName()
+
+		err = s.secretStore.Store(ctx, tenant, project, name, secret.GetSpec().GetData())
+		if err != nil {
+			err = vault.ToGrpcError(err)
+			return
+		}
+
+		secret.GetSpec().SetData(nil)
+	}
 
 	err = s.generic.Create(ctx, request, &response)
-
 	return
 }
 
@@ -179,7 +227,22 @@ func (s *PrivateSecretsServer) Update(ctx context.Context,
 		return
 	}
 
-	// TODO: Update secret data in the storage backend.
+	if s.secretStore != nil &&
+		existingSecret.GetSpec().GetBackend() == privatev1.SecretBackend_SECRET_BACKEND_VAULT &&
+		len(request.GetObject().GetSpec().GetData()) > 0 {
+
+		tenant := existingSecret.GetMetadata().GetTenant()
+		project := existingSecret.GetMetadata().GetProject()
+		name := existingSecret.GetMetadata().GetName()
+
+		err = s.secretStore.Store(ctx, tenant, project, name, request.GetObject().GetSpec().GetData())
+		if err != nil {
+			err = vault.ToGrpcError(err)
+			return
+		}
+
+		request.GetObject().GetSpec().SetData(nil)
+	}
 
 	err = s.generic.Update(ctx, request, &response)
 	return
@@ -187,7 +250,41 @@ func (s *PrivateSecretsServer) Update(ctx context.Context,
 
 func (s *PrivateSecretsServer) Delete(ctx context.Context,
 	request *privatev1.SecretsDeleteRequest) (response *privatev1.SecretsDeleteResponse, err error) {
+	// Report errors to the transaction so that post-DB failures (e.g. Vault delete) trigger rollback.
+	tx, txErr := database.TxFromContext(ctx)
+	if txErr == nil {
+		defer tx.ReportError(&err)
+	}
+
+	var obj *privatev1.Secret
+	if s.secretStore != nil {
+		getRequest := &privatev1.SecretsGetRequest{}
+		getRequest.SetId(request.GetId())
+		var getResponse *privatev1.SecretsGetResponse
+		err = s.generic.Get(ctx, getRequest, &getResponse)
+		if err != nil {
+			return
+		}
+		obj = getResponse.GetObject()
+	}
+
 	err = s.generic.Delete(ctx, request, &response)
+	if err != nil {
+		return
+	}
+
+	if obj != nil && obj.GetSpec().GetBackend() == privatev1.SecretBackend_SECRET_BACKEND_VAULT {
+		tenant := obj.GetMetadata().GetTenant()
+		project := obj.GetMetadata().GetProject()
+		name := obj.GetMetadata().GetName()
+
+		deleteErr := s.secretStore.Delete(ctx, tenant, project, name)
+		if deleteErr != nil {
+			err = vault.ToGrpcError(deleteErr)
+			return
+		}
+	}
+
 	return
 }
 
@@ -237,6 +334,17 @@ func (s *PrivateSecretsServer) validateHubSecretCreate(spec *privatev1.SecretSpe
 			"field 'spec.data' must be empty when backend is HUB")
 	}
 	return nil
+}
+
+func (s *PrivateSecretsServer) determineTenant(ctx context.Context, secret *privatev1.Secret) (string, error) {
+	if t := secret.GetMetadata().GetTenant(); t != "" {
+		return t, nil
+	}
+	t, err := s.tenancyLogic.DetermineDefaultTenant(ctx)
+	if err != nil {
+		return "", grpcstatus.Errorf(grpccodes.Internal, "failed to determine tenant: %v", err)
+	}
+	return t, nil
 }
 
 func (s *PrivateSecretsServer) validateSecretUpdate(_ context.Context,

--- a/internal/servers/private_secrets_server_test.go
+++ b/internal/servers/private_secrets_server_test.go
@@ -27,7 +27,10 @@ import (
 	"google.golang.org/protobuf/types/known/fieldmaskpb"
 
 	privatev1 "github.com/osac-project/fulfillment-service/internal/api/osac/private/v1"
+	"github.com/osac-project/fulfillment-service/internal/auth"
+	"github.com/osac-project/fulfillment-service/internal/database"
 	"github.com/osac-project/fulfillment-service/internal/events"
+	"github.com/osac-project/fulfillment-service/internal/vault"
 )
 
 var _ = Describe("Private secrets server", func() {
@@ -514,6 +517,421 @@ var _ = Describe("Private secrets server", func() {
 			Expect(ok).To(BeTrue())
 			Expect(st.Code()).To(Equal(codes.InvalidArgument))
 			Expect(st.Message()).To(ContainSubstring("identifier"))
+		})
+	})
+
+	Describe("Vault integration", func() {
+		var (
+			mockStore *vault.MockSecretStore
+			server    *PrivateSecretsServer
+		)
+
+		BeforeEach(func() {
+			mockStore = vault.NewMockSecretStore(ctrl)
+			var err error
+			server, err = NewPrivateSecretsServer().
+				SetLogger(logger).
+				SetAttributionLogic(attribution).
+				SetTenancyLogic(tenancy).
+				SetSecretStore(mockStore).
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		Describe("Create", func() {
+			It("Stores data in vault and clears spec.data before DB write", func() {
+				mockStore.EXPECT().
+					Store(gomock.Any(), auth.SystemTenant, "", "my-secret",
+						map[string][]byte{"key": []byte("value")}).
+					Return(nil)
+
+				response, err := server.Create(ctx, privatev1.SecretsCreateRequest_builder{
+					Object: privatev1.Secret_builder{
+						Metadata: privatev1.Metadata_builder{
+							Name: "my-secret",
+						}.Build(),
+						Spec: privatev1.SecretSpec_builder{
+							Data: map[string][]byte{
+								"key": []byte("value"),
+							},
+						}.Build(),
+					}.Build(),
+				}.Build())
+				Expect(err).ToNot(HaveOccurred())
+
+				obj := response.GetObject()
+				Expect(obj.GetSpec().GetBackend()).To(Equal(
+					privatev1.SecretBackend_SECRET_BACKEND_VAULT))
+				Expect(obj.GetSpec().GetData()).To(BeEmpty())
+			})
+
+			It("Vault failure prevents DB record creation", func() {
+				mockStore.EXPECT().
+					Store(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(fmt.Errorf("vault connection refused"))
+
+				_, err := server.Create(ctx, privatev1.SecretsCreateRequest_builder{
+					Object: privatev1.Secret_builder{
+						Metadata: privatev1.Metadata_builder{
+							Name: "fail-secret",
+						}.Build(),
+						Spec: privatev1.SecretSpec_builder{
+							Data: map[string][]byte{
+								"key": []byte("value"),
+							},
+						}.Build(),
+					}.Build(),
+				}.Build())
+				Expect(err).To(HaveOccurred())
+
+				listResponse, listErr := server.List(ctx, privatev1.SecretsListRequest_builder{}.Build())
+				Expect(listErr).ToNot(HaveOccurred())
+				Expect(listResponse.GetItems()).To(BeEmpty())
+			})
+
+			It("Hub secret does not interact with vault", func() {
+				response, err := server.Create(ctx, privatev1.SecretsCreateRequest_builder{
+					Object: privatev1.Secret_builder{
+						Metadata: privatev1.Metadata_builder{
+							Name: "hub-secret",
+						}.Build(),
+						Spec: privatev1.SecretSpec_builder{
+							Backend: privatev1.SecretBackend_SECRET_BACKEND_HUB,
+							Coordinates: map[string]string{
+								"cluster":   "hub-1",
+								"namespace": "default",
+								"name":      "my-k8s-secret",
+							},
+						}.Build(),
+					}.Build(),
+				}.Build())
+				Expect(err).ToNot(HaveOccurred())
+				Expect(response.GetObject().GetSpec().GetBackend()).To(Equal(
+					privatev1.SecretBackend_SECRET_BACKEND_HUB))
+			})
+		})
+
+		Describe("Get", func() {
+			It("Fetches resolved data from vault", func() {
+				mockStore.EXPECT().
+					Store(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(nil)
+
+				created, err := server.Create(ctx, privatev1.SecretsCreateRequest_builder{
+					Object: privatev1.Secret_builder{
+						Metadata: privatev1.Metadata_builder{
+							Name: "get-secret",
+						}.Build(),
+						Spec: privatev1.SecretSpec_builder{
+							Data: map[string][]byte{
+								"password": []byte("secret-value"),
+							},
+						}.Build(),
+					}.Build(),
+				}.Build())
+				Expect(err).ToNot(HaveOccurred())
+
+				mockStore.EXPECT().
+					Fetch(gomock.Any(), auth.SystemTenant, "", "get-secret").
+					Return(map[string][]byte{"password": []byte("secret-value")}, nil)
+
+				getResponse, err := server.Get(ctx, privatev1.SecretsGetRequest_builder{
+					Id: created.GetObject().GetId(),
+				}.Build())
+				Expect(err).ToNot(HaveOccurred())
+				Expect(getResponse.GetObject().GetStatus().GetResolvedData()).To(
+					HaveKeyWithValue("password", []byte("secret-value")))
+			})
+
+			It("Vault fetch failure returns gRPC error", func() {
+				mockStore.EXPECT().
+					Store(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(nil)
+
+				created, err := server.Create(ctx, privatev1.SecretsCreateRequest_builder{
+					Object: privatev1.Secret_builder{
+						Metadata: privatev1.Metadata_builder{
+							Name: "fail-get-secret",
+						}.Build(),
+						Spec: privatev1.SecretSpec_builder{
+							Data: map[string][]byte{
+								"key": []byte("value"),
+							},
+						}.Build(),
+					}.Build(),
+				}.Build())
+				Expect(err).ToNot(HaveOccurred())
+
+				mockStore.EXPECT().
+					Fetch(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(nil, fmt.Errorf("vault unavailable"))
+
+				_, err = server.Get(ctx, privatev1.SecretsGetRequest_builder{
+					Id: created.GetObject().GetId(),
+				}.Build())
+				Expect(err).To(HaveOccurred())
+				st, ok := status.FromError(err)
+				Expect(ok).To(BeTrue())
+				Expect(st.Code()).To(Equal(codes.Internal))
+			})
+
+			It("Hub secret get does not interact with vault", func() {
+				created, err := server.Create(ctx, privatev1.SecretsCreateRequest_builder{
+					Object: privatev1.Secret_builder{
+						Metadata: privatev1.Metadata_builder{
+							Name: "hub-get-secret",
+						}.Build(),
+						Spec: privatev1.SecretSpec_builder{
+							Backend: privatev1.SecretBackend_SECRET_BACKEND_HUB,
+							Coordinates: map[string]string{
+								"cluster": "hub-1",
+							},
+						}.Build(),
+					}.Build(),
+				}.Build())
+				Expect(err).ToNot(HaveOccurred())
+
+				getResponse, err := server.Get(ctx, privatev1.SecretsGetRequest_builder{
+					Id: created.GetObject().GetId(),
+				}.Build())
+				Expect(err).ToNot(HaveOccurred())
+				Expect(getResponse.GetObject().GetSpec().GetBackend()).To(Equal(
+					privatev1.SecretBackend_SECRET_BACKEND_HUB))
+			})
+		})
+
+		Describe("Update", func() {
+			It("Stores new data in vault when data provided", func() {
+				mockStore.EXPECT().
+					Store(gomock.Any(), gomock.Any(), gomock.Any(), "update-secret",
+						map[string][]byte{"key": []byte("value")}).
+					Return(nil)
+
+				created, err := server.Create(ctx, privatev1.SecretsCreateRequest_builder{
+					Object: privatev1.Secret_builder{
+						Metadata: privatev1.Metadata_builder{
+							Name: "update-secret",
+						}.Build(),
+						Spec: privatev1.SecretSpec_builder{
+							Data: map[string][]byte{
+								"key": []byte("value"),
+							},
+						}.Build(),
+					}.Build(),
+				}.Build())
+				Expect(err).ToNot(HaveOccurred())
+
+				mockStore.EXPECT().
+					Store(gomock.Any(), auth.SystemTenant, "", "update-secret",
+						map[string][]byte{"key": []byte("new-value")}).
+					Return(nil)
+
+				updateResponse, err := server.Update(ctx, privatev1.SecretsUpdateRequest_builder{
+					Object: privatev1.Secret_builder{
+						Id: created.GetObject().GetId(),
+						Spec: privatev1.SecretSpec_builder{
+							Data: map[string][]byte{
+								"key": []byte("new-value"),
+							},
+						}.Build(),
+					}.Build(),
+					UpdateMask: &fieldmaskpb.FieldMask{Paths: []string{"spec.data"}},
+				}.Build())
+				Expect(err).ToNot(HaveOccurred())
+				Expect(updateResponse.GetObject().GetSpec().GetData()).To(BeEmpty())
+			})
+
+			It("Vault store failure on update returns error", func() {
+				mockStore.EXPECT().
+					Store(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(nil)
+
+				created, err := server.Create(ctx, privatev1.SecretsCreateRequest_builder{
+					Object: privatev1.Secret_builder{
+						Metadata: privatev1.Metadata_builder{
+							Name: "fail-update-secret",
+						}.Build(),
+						Spec: privatev1.SecretSpec_builder{
+							Data: map[string][]byte{
+								"key": []byte("value"),
+							},
+						}.Build(),
+					}.Build(),
+				}.Build())
+				Expect(err).ToNot(HaveOccurred())
+
+				mockStore.EXPECT().
+					Store(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(fmt.Errorf("vault write failed"))
+
+				_, err = server.Update(ctx, privatev1.SecretsUpdateRequest_builder{
+					Object: privatev1.Secret_builder{
+						Id: created.GetObject().GetId(),
+						Spec: privatev1.SecretSpec_builder{
+							Data: map[string][]byte{
+								"key": []byte("updated"),
+							},
+						}.Build(),
+					}.Build(),
+					UpdateMask: &fieldmaskpb.FieldMask{Paths: []string{"spec.data"}},
+				}.Build())
+				Expect(err).To(HaveOccurred())
+			})
+		})
+
+		Describe("Delete", func() {
+			It("Removes vault data after DB deletion", func() {
+				mockStore.EXPECT().
+					Store(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(nil)
+
+				created, err := server.Create(ctx, privatev1.SecretsCreateRequest_builder{
+					Object: privatev1.Secret_builder{
+						Metadata: privatev1.Metadata_builder{
+							Name: "delete-secret",
+						}.Build(),
+						Spec: privatev1.SecretSpec_builder{
+							Data: map[string][]byte{
+								"key": []byte("value"),
+							},
+						}.Build(),
+					}.Build(),
+				}.Build())
+				Expect(err).ToNot(HaveOccurred())
+
+				mockStore.EXPECT().
+					Delete(gomock.Any(), auth.SystemTenant, "", "delete-secret").
+					Return(nil)
+
+				_, err = server.Delete(ctx, privatev1.SecretsDeleteRequest_builder{
+					Id: created.GetObject().GetId(),
+				}.Build())
+				Expect(err).ToNot(HaveOccurred())
+
+				_, err = server.Get(ctx, privatev1.SecretsGetRequest_builder{
+					Id: created.GetObject().GetId(),
+				}.Build())
+				Expect(err).To(HaveOccurred())
+				st, ok := status.FromError(err)
+				Expect(ok).To(BeTrue())
+				Expect(st.Code()).To(Equal(codes.NotFound))
+			})
+
+			It("Vault delete failure returns error", func() {
+				mockStore.EXPECT().
+					Store(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(nil)
+
+				created, err := server.Create(ctx, privatev1.SecretsCreateRequest_builder{
+					Object: privatev1.Secret_builder{
+						Metadata: privatev1.Metadata_builder{
+							Name: "fail-delete-secret",
+						}.Build(),
+						Spec: privatev1.SecretSpec_builder{
+							Data: map[string][]byte{
+								"key": []byte("value"),
+							},
+						}.Build(),
+					}.Build(),
+				}.Build())
+				Expect(err).ToNot(HaveOccurred())
+
+				mockStore.EXPECT().
+					Delete(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(fmt.Errorf("vault delete failed"))
+
+				_, err = server.Delete(ctx, privatev1.SecretsDeleteRequest_builder{
+					Id: created.GetObject().GetId(),
+				}.Build())
+				Expect(err).To(HaveOccurred())
+			})
+
+			It("Vault delete failure rolls back DB deletion", func() {
+				// Phase 1: Create the secret in a committed transaction.
+				createTx, err := tm.Begin(ctx)
+				Expect(err).ToNot(HaveOccurred())
+				createCtx := database.TxIntoContext(context.Background(), createTx)
+				DeferCleanup(func() { _ = createTx.End(createCtx) })
+
+				mockStore.EXPECT().
+					Store(gomock.Any(), gomock.Any(), gomock.Any(), "rollback-secret", gomock.Any()).
+					Return(nil)
+
+				created, err := server.Create(createCtx, privatev1.SecretsCreateRequest_builder{
+					Object: privatev1.Secret_builder{
+						Metadata: privatev1.Metadata_builder{
+							Name: "rollback-secret",
+						}.Build(),
+						Spec: privatev1.SecretSpec_builder{
+							Data: map[string][]byte{
+								"key": []byte("value"),
+							},
+						}.Build(),
+					}.Build(),
+				}.Build())
+				Expect(err).ToNot(HaveOccurred())
+				secretID := created.GetObject().GetId()
+
+				err = createTx.End(createCtx)
+				Expect(err).ToNot(HaveOccurred())
+
+				// Phase 2: Attempt delete in a separate transaction — vault fails,
+				// so ReportError triggers rollback of the DB deletion.
+				deleteTx, err := tm.Begin(ctx)
+				Expect(err).ToNot(HaveOccurred())
+				deleteCtx := database.TxIntoContext(context.Background(), deleteTx)
+				DeferCleanup(func() { _ = deleteTx.End(deleteCtx) })
+
+				mockStore.EXPECT().
+					Delete(gomock.Any(), auth.SystemTenant, "", "rollback-secret").
+					Return(fmt.Errorf("vault unavailable"))
+
+				_, err = server.Delete(deleteCtx, privatev1.SecretsDeleteRequest_builder{
+					Id: secretID,
+				}.Build())
+				Expect(err).To(HaveOccurred())
+
+				err = deleteTx.End(deleteCtx)
+				Expect(err).ToNot(HaveOccurred())
+
+				// Phase 3: Verify the record still exists after rollback.
+				verifyTx, err := tm.Begin(ctx)
+				Expect(err).ToNot(HaveOccurred())
+				verifyCtx := database.TxIntoContext(context.Background(), verifyTx)
+				DeferCleanup(func() { _ = verifyTx.End(verifyCtx) })
+
+				mockStore.EXPECT().
+					Fetch(gomock.Any(), auth.SystemTenant, "", "rollback-secret").
+					Return(map[string][]byte{"key": []byte("value")}, nil)
+
+				getResponse, err := server.Get(verifyCtx, privatev1.SecretsGetRequest_builder{
+					Id: secretID,
+				}.Build())
+				Expect(err).ToNot(HaveOccurred())
+				Expect(getResponse.GetObject().GetId()).To(Equal(secretID))
+			})
+
+			It("Hub secret delete does not interact with vault", func() {
+				created, err := server.Create(ctx, privatev1.SecretsCreateRequest_builder{
+					Object: privatev1.Secret_builder{
+						Metadata: privatev1.Metadata_builder{
+							Name: "hub-delete-secret",
+						}.Build(),
+						Spec: privatev1.SecretSpec_builder{
+							Backend: privatev1.SecretBackend_SECRET_BACKEND_HUB,
+							Coordinates: map[string]string{
+								"cluster": "hub-1",
+							},
+						}.Build(),
+					}.Build(),
+				}.Build())
+				Expect(err).ToNot(HaveOccurred())
+
+				_, err = server.Delete(ctx, privatev1.SecretsDeleteRequest_builder{
+					Id: created.GetObject().GetId(),
+				}.Build())
+				Expect(err).ToNot(HaveOccurred())
+			})
 		})
 	})
 


### PR DESCRIPTION
Configure the private secrets server to persist secret data in Vault

A couple of notes:
- The operation ordering (e.g. creating data in vault, then writing to postgres) was done per the [design document](https://github.com/osac-project/enhancement-proposals/blob/main/enhancements/OSAC-1567-secret-management/design.md#server-implementation) specs
- No vault instance is fully wired up yet - I have tested this some e2e locally, but there is not yet a configured deployment option and the client isn't setup when the service starts.  This will be handled soon in upcoming work.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Vault-backed secrets now store sensitive payloads externally instead of returning them in standard secret records.
  * Secret data is retrieved when requested and exposed through resolved status data.
  * Creating, updating, and deleting Vault-backed secrets now synchronizes data with the external vault.
  * Vault storage failures are reported clearly, with transactional protection during deletion.

* **Bug Fixes**
  * Prevented database records from being created or removed when corresponding vault operations fail.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->