### PR TITLE
OSAC-2960: Public Secrets Server

### DIFF
--- a/internal/auth/grpc_authz_interceptor_test.go
+++ b/internal/auth/grpc_authz_interceptor_test.go
@@ -604,6 +604,69 @@ var _ = Describe("Rego authorization interceptor", func() {
 			),
 		)
 
+		DescribeTable(
+			"Allows Keycloak users on the public Secrets API",
+			func(ctx context.Context, method string) {
+				token := createKeycloakUserToken("my-tenant", "my-user", nil)
+				ctx = ContextWithToken(ctx, token)
+				handled := false
+				_, err := interceptor.UnaryServer(
+					ctx,
+					nil,
+					&grpc.UnaryServerInfo{
+						FullMethod: method,
+					},
+					func(ctx context.Context, req any) (any, error) {
+						subject := SubjectFromContext(ctx)
+						Expect(subject.User).To(Equal("my-user"))
+						Expect(subject.Tenants.Finite()).To(BeTrue())
+						Expect(subject.Tenants.Inclusions()).To(ConsistOf("my-tenant"))
+						handled = true
+						return nil, nil
+					},
+				)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(handled).To(BeTrue())
+			},
+			Entry("List", "/osac.public.v1.Secrets/List"),
+			Entry("Get", "/osac.public.v1.Secrets/Get"),
+			Entry("Create", "/osac.public.v1.Secrets/Create"),
+			Entry("Update", "/osac.public.v1.Secrets/Update"),
+			Entry("Delete", "/osac.public.v1.Secrets/Delete"),
+		)
+
+		DescribeTable(
+			"Denies Keycloak users on the private Secrets API",
+			func(ctx context.Context, method string) {
+				token := createKeycloakUserToken("my-tenant", "my-user", nil)
+				ctx = ContextWithToken(ctx, token)
+				handled := false
+				_, err := interceptor.UnaryServer(
+					ctx,
+					nil,
+					&grpc.UnaryServerInfo{
+						FullMethod: method,
+					},
+					func(ctx context.Context, req any) (any, error) {
+						handled = true
+						return nil, nil
+					},
+				)
+				Expect(err).To(HaveOccurred())
+				status, ok := grpcstatus.FromError(err)
+				Expect(ok).To(BeTrue())
+				Expect(status.Code()).To(Equal(grpccodes.PermissionDenied))
+				Expect(status.Message()).To(Equal("permission denied"))
+				Expect(handled).To(BeFalse())
+			},
+			Entry("List", "/osac.private.v1.Secrets/List"),
+			Entry("Get", "/osac.private.v1.Secrets/Get"),
+			Entry("Create", "/osac.private.v1.Secrets/Create"),
+			Entry("Update", "/osac.private.v1.Secrets/Update"),
+			Entry("Delete", "/osac.private.v1.Secrets/Delete"),
+			Entry("Signal", "/osac.private.v1.Secrets/Signal"),
+		)
+
 		It("Allows tenant admin to manage users", func(ctx context.Context) {
 			token := createKeycloakUserToken("my-tenant", "my-user", jwt.MapClaims{
 				"realm_access": map[string]any{

--- a/internal/auth/policies/authz.rego
+++ b/internal/auth/policies/authz.rego
@@ -255,6 +255,11 @@ allow if {
     "/osac.public.v1.Roles/List",
     "/osac.public.v1.RoleBindings/Get",
     "/osac.public.v1.RoleBindings/List",
+    "/osac.public.v1.Secrets/Create",
+    "/osac.public.v1.Secrets/Delete",
+    "/osac.public.v1.Secrets/Get",
+    "/osac.public.v1.Secrets/List",
+    "/osac.public.v1.Secrets/Update",
   }
 }
 

--- a/internal/cmd/service/start/grpcserver/start_grpc_server_cmd.go
+++ b/internal/cmd/service/start/grpcserver/start_grpc_server_cmd.go
@@ -1070,6 +1070,20 @@ func (c *runnerContext) run(cmd *cobra.Command, argv []string) error { //nolint:
 	}
 	privatev1.RegisterSecretsServer(grpcServer, privateSecretsServer)
 
+	// Create the public secrets server:
+	c.logger.InfoContext(ctx, "Creating public secrets server")
+	publicSecretsServer, err := servers.NewSecretsServer().
+		SetLogger(c.logger).
+		SetNotifier(notifier).
+		SetAttributionLogic(publicAttributionLogic).
+		SetTenancyLogic(tenancyLogic).
+		SetMetricsRegisterer(metricsRegisterer).
+		Build()
+	if err != nil {
+		return fmt.Errorf("failed to create public secrets server: %w", err)
+	}
+	publicv1.RegisterSecretsServer(grpcServer, publicSecretsServer)
+
 	// Create the storage backends DAO for cross-resource validation in the storage tiers server:
 	storageBackendsDAO, err := dao.NewGenericDAO[*privatev1.StorageBackend]().
 		SetLogger(c.logger).

--- a/internal/rendering/tables/osac.private.v1.Secret.yaml
+++ b/internal/rendering/tables/osac.private.v1.Secret.yaml
@@ -1,0 +1,33 @@
+#
+# Copyright (c) 2026 Red Hat Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+# the License. You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+columns:
+
+- header: PROJECT
+  value: "has(this.metadata.project)? this.metadata.project: '-'"
+
+- header: ID
+  value: this.id
+
+- header: NAME
+  value: "has(this.metadata.name)? this.metadata.name: '-'"
+
+- header: BACKEND
+  value: this.spec.backend
+  type: osac.private.v1.SecretBackend
+
+- header: CREATED
+  value: "has(this.metadata.creation_timestamp)? string(this.metadata.creation_timestamp): '-'"
+
+- header: LABELS
+  value: "this.metadata.labels.size() > 0? string(this.metadata.labels.size()): '-'"

--- a/internal/rendering/tables/osac.public.v1.Secret.yaml
+++ b/internal/rendering/tables/osac.public.v1.Secret.yaml
@@ -1,0 +1,29 @@
+#
+# Copyright (c) 2026 Red Hat Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+# the License. You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+columns:
+
+- header: PROJECT
+  value: "has(this.metadata.project)? this.metadata.project: '-'"
+
+- header: ID
+  value: this.id
+
+- header: NAME
+  value: "has(this.metadata.name)? this.metadata.name: '-'"
+
+- header: CREATED
+  value: "has(this.metadata.creation_timestamp)? string(this.metadata.creation_timestamp): '-'"
+
+- header: LABELS
+  value: "this.metadata.labels.size() > 0? string(this.metadata.labels.size()): '-'"

--- a/internal/servers/secrets_server.go
+++ b/internal/servers/secrets_server.go
@@ -1,0 +1,298 @@
+/*
+Copyright (c) 2026 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package servers
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+
+	"github.com/prometheus/client_golang/prometheus"
+	grpccodes "google.golang.org/grpc/codes"
+	grpcstatus "google.golang.org/grpc/status"
+
+	privatev1 "github.com/osac-project/fulfillment-service/internal/api/osac/private/v1"
+	publicv1 "github.com/osac-project/fulfillment-service/internal/api/osac/public/v1"
+	"github.com/osac-project/fulfillment-service/internal/auth"
+	"github.com/osac-project/fulfillment-service/internal/events"
+	"github.com/osac-project/fulfillment-service/internal/vault"
+)
+
+type SecretsServerBuilder struct {
+	logger            *slog.Logger
+	notifier          events.Notifier
+	attributionLogic  auth.AttributionLogic
+	tenancyLogic      auth.TenancyLogic
+	metricsRegisterer prometheus.Registerer
+	secretStore       vault.SecretStore
+}
+
+var _ publicv1.SecretsServer = (*SecretsServer)(nil)
+
+type SecretsServer struct {
+	publicv1.UnimplementedSecretsServer
+
+	logger    *slog.Logger
+	private   privatev1.SecretsServer
+	inMapper  *GenericMapper[*publicv1.Secret, *privatev1.Secret]
+	outMapper *GenericMapper[*privatev1.Secret, *publicv1.Secret]
+}
+
+func NewSecretsServer() *SecretsServerBuilder {
+	return &SecretsServerBuilder{}
+}
+
+func (b *SecretsServerBuilder) SetLogger(value *slog.Logger) *SecretsServerBuilder {
+	b.logger = value
+	return b
+}
+
+func (b *SecretsServerBuilder) SetNotifier(value events.Notifier) *SecretsServerBuilder {
+	b.notifier = value
+	return b
+}
+
+func (b *SecretsServerBuilder) SetAttributionLogic(value auth.AttributionLogic) *SecretsServerBuilder {
+	b.attributionLogic = value
+	return b
+}
+
+func (b *SecretsServerBuilder) SetTenancyLogic(value auth.TenancyLogic) *SecretsServerBuilder {
+	b.tenancyLogic = value
+	return b
+}
+
+func (b *SecretsServerBuilder) SetMetricsRegisterer(value prometheus.Registerer) *SecretsServerBuilder {
+	b.metricsRegisterer = value
+	return b
+}
+
+func (b *SecretsServerBuilder) SetSecretStore(value vault.SecretStore) *SecretsServerBuilder {
+	b.secretStore = value
+	return b
+}
+
+func (b *SecretsServerBuilder) Build() (result *SecretsServer, err error) {
+	if b.logger == nil {
+		err = errors.New("logger is mandatory")
+		return
+	}
+	if b.tenancyLogic == nil {
+		err = errors.New("tenancy logic is mandatory")
+		return
+	}
+
+	inMapper, err := NewGenericMapper[*publicv1.Secret, *privatev1.Secret]().
+		SetLogger(b.logger).
+		SetStrict(true).
+		Build()
+	if err != nil {
+		return
+	}
+	outMapper, err := NewGenericMapper[*privatev1.Secret, *publicv1.Secret]().
+		SetLogger(b.logger).
+		SetStrict(false).
+		Build()
+	if err != nil {
+		return
+	}
+
+	delegate, err := NewPrivateSecretsServer().
+		SetLogger(b.logger).
+		SetNotifier(b.notifier).
+		SetAttributionLogic(b.attributionLogic).
+		SetTenancyLogic(b.tenancyLogic).
+		SetMetricsRegisterer(b.metricsRegisterer).
+		SetSecretStore(b.secretStore).
+		Build()
+	if err != nil {
+		return
+	}
+
+	result = &SecretsServer{
+		logger:    b.logger,
+		private:   delegate,
+		inMapper:  inMapper,
+		outMapper: outMapper,
+	}
+	return
+}
+
+func (s *SecretsServer) Create(ctx context.Context,
+	request *publicv1.SecretsCreateRequest) (response *publicv1.SecretsCreateResponse, err error) {
+	privateObject := &privatev1.Secret{}
+	err = s.inMapper.Copy(ctx, request.GetObject(), privateObject)
+	if err != nil {
+		s.logger.ErrorContext(ctx, "Failed to map public secret to private", slog.Any("error", err))
+		return nil, err
+	}
+
+	// Public API always uses the Vault backend.
+	if spec := privateObject.GetSpec(); spec != nil {
+		spec.SetBackend(privatev1.SecretBackend_SECRET_BACKEND_VAULT)
+	}
+
+	privateRequest := &privatev1.SecretsCreateRequest{}
+	privateRequest.SetObject(privateObject)
+
+	privateResponse, err := s.private.Create(ctx, privateRequest)
+	if err != nil {
+		return nil, err
+	}
+
+	publicObject := &publicv1.Secret{}
+	err = s.outMapper.Copy(ctx, privateResponse.GetObject(), publicObject)
+	if err != nil {
+		s.logger.ErrorContext(ctx, "Failed to map private secret to public", slog.Any("error", err))
+		return nil, err
+	}
+
+	response = &publicv1.SecretsCreateResponse{}
+	response.SetObject(publicObject)
+	return
+}
+
+func (s *SecretsServer) List(ctx context.Context,
+	request *publicv1.SecretsListRequest) (response *publicv1.SecretsListResponse, err error) {
+	privateRequest := &privatev1.SecretsListRequest{}
+	privateRequest.SetOffset(request.GetOffset())
+	privateRequest.SetLimit(request.GetLimit())
+	privateRequest.SetFilter(request.GetFilter())
+	privateRequest.SetOrder(request.GetOrder())
+
+	privateResponse, err := s.private.List(ctx, privateRequest)
+	if err != nil {
+		return nil, err
+	}
+
+	privateItems := privateResponse.GetItems()
+	publicItems := make([]*publicv1.Secret, len(privateItems))
+	for i, privateItem := range privateItems {
+		publicItem := &publicv1.Secret{}
+		err = s.outMapper.Copy(ctx, privateItem, publicItem)
+		if err != nil {
+			s.logger.ErrorContext(ctx, "Failed to map private secret to public", slog.Any("error", err))
+			return nil, err
+		}
+		if spec := publicItem.GetSpec(); spec != nil {
+			spec.SetData(nil)
+		}
+		if status := publicItem.GetStatus(); status != nil {
+			status.SetResolvedData(nil)
+		}
+		publicItems[i] = publicItem
+	}
+
+	response = &publicv1.SecretsListResponse{}
+	response.SetSize(privateResponse.GetSize())
+	response.SetTotal(privateResponse.GetTotal())
+	response.SetItems(publicItems)
+	return
+}
+
+func (s *SecretsServer) Get(ctx context.Context,
+	request *publicv1.SecretsGetRequest) (response *publicv1.SecretsGetResponse, err error) {
+	privateRequest := &privatev1.SecretsGetRequest{}
+	privateRequest.SetId(request.GetId())
+
+	privateResponse, err := s.private.Get(ctx, privateRequest)
+	if err != nil {
+		return nil, err
+	}
+
+	publicObject := &publicv1.Secret{}
+	err = s.outMapper.Copy(ctx, privateResponse.GetObject(), publicObject)
+	if err != nil {
+		s.logger.ErrorContext(ctx, "Failed to map private secret to public", slog.Any("error", err))
+		return nil, err
+	}
+
+	response = &publicv1.SecretsGetResponse{}
+	response.SetObject(publicObject)
+	return
+}
+
+func (s *SecretsServer) Update(ctx context.Context,
+	request *publicv1.SecretsUpdateRequest) (response *publicv1.SecretsUpdateResponse, err error) {
+	id := request.GetObject().GetId()
+
+	getRequest := &privatev1.SecretsGetRequest{}
+	getRequest.SetId(id)
+	getResponse, err := s.private.Get(ctx, getRequest)
+	if err != nil {
+		return nil, err
+	}
+
+	existing := getResponse.GetObject()
+	if existing.GetSpec().GetBackend() == privatev1.SecretBackend_SECRET_BACKEND_HUB &&
+		len(request.GetObject().GetSpec().GetData()) > 0 {
+		return nil, grpcstatus.Errorf(grpccodes.FailedPrecondition,
+			"cannot update data for hub-backed secrets via public API")
+	}
+
+	privateObject := &privatev1.Secret{}
+	err = s.inMapper.Copy(ctx, request.GetObject(), privateObject)
+	if err != nil {
+		s.logger.ErrorContext(ctx, "Failed to map public secret to private", slog.Any("error", err))
+		return nil, err
+	}
+
+	privateRequest := &privatev1.SecretsUpdateRequest{}
+	privateRequest.SetObject(privateObject)
+	privateRequest.SetUpdateMask(request.GetUpdateMask())
+	privateRequest.SetLock(request.GetLock())
+
+	privateResponse, err := s.private.Update(ctx, privateRequest)
+	if err != nil {
+		return nil, err
+	}
+
+	publicObject := &publicv1.Secret{}
+	err = s.outMapper.Copy(ctx, privateResponse.GetObject(), publicObject)
+	if err != nil {
+		s.logger.ErrorContext(ctx, "Failed to map private secret to public", slog.Any("error", err))
+		return nil, err
+	}
+
+	response = &publicv1.SecretsUpdateResponse{}
+	response.SetObject(publicObject)
+	return
+}
+
+func (s *SecretsServer) Delete(ctx context.Context,
+	request *publicv1.SecretsDeleteRequest) (response *publicv1.SecretsDeleteResponse, err error) {
+	getRequest := &privatev1.SecretsGetRequest{}
+	getRequest.SetId(request.GetId())
+	getResponse, err := s.private.Get(ctx, getRequest)
+	if err != nil {
+		return nil, err
+	}
+
+	existing := getResponse.GetObject()
+	if existing.GetSpec().GetBackend() == privatev1.SecretBackend_SECRET_BACKEND_HUB {
+		return nil, grpcstatus.Errorf(grpccodes.FailedPrecondition,
+			"cannot delete hub-backed secrets via public API")
+	}
+
+	privateRequest := &privatev1.SecretsDeleteRequest{}
+	privateRequest.SetId(request.GetId())
+
+	_, err = s.private.Delete(ctx, privateRequest)
+	if err != nil {
+		return nil, err
+	}
+
+	response = &publicv1.SecretsDeleteResponse{}
+	return
+}

--- a/internal/servers/secrets_server.go
+++ b/internal/servers/secrets_server.go
@@ -129,6 +129,15 @@ func (b *SecretsServerBuilder) Build() (result *SecretsServer, err error) {
 	return
 }
 
+func (s *SecretsServer) redactPublicSecret(secret *publicv1.Secret) {
+	if spec := secret.GetSpec(); spec != nil {
+		spec.SetData(nil)
+	}
+	if status := secret.GetStatus(); status != nil {
+		status.SetResolvedData(nil)
+	}
+}
+
 func (s *SecretsServer) Create(ctx context.Context,
 	request *publicv1.SecretsCreateRequest) (response *publicv1.SecretsCreateResponse, err error) {
 	privateObject := &privatev1.Secret{}
@@ -157,6 +166,7 @@ func (s *SecretsServer) Create(ctx context.Context,
 		s.logger.ErrorContext(ctx, "Failed to map private secret to public", slog.Any("error", err))
 		return nil, err
 	}
+	s.redactPublicSecret(publicObject)
 
 	response = &publicv1.SecretsCreateResponse{}
 	response.SetObject(publicObject)
@@ -185,12 +195,7 @@ func (s *SecretsServer) List(ctx context.Context,
 			s.logger.ErrorContext(ctx, "Failed to map private secret to public", slog.Any("error", err))
 			return nil, err
 		}
-		if spec := publicItem.GetSpec(); spec != nil {
-			spec.SetData(nil)
-		}
-		if status := publicItem.GetStatus(); status != nil {
-			status.SetResolvedData(nil)
-		}
+		s.redactPublicSecret(publicItem)
 		publicItems[i] = publicItem
 	}
 
@@ -248,6 +253,14 @@ func (s *SecretsServer) Update(ctx context.Context,
 		return nil, err
 	}
 
+	// Preserve the existing backend (public API has no backend field).
+	spec := privateObject.GetSpec()
+	if spec == nil {
+		privateObject.SetSpec(privatev1.SecretSpec_builder{}.Build())
+		spec = privateObject.GetSpec()
+	}
+	spec.SetBackend(existing.GetSpec().GetBackend())
+
 	privateRequest := &privatev1.SecretsUpdateRequest{}
 	privateRequest.SetObject(privateObject)
 	privateRequest.SetUpdateMask(request.GetUpdateMask())
@@ -264,6 +277,7 @@ func (s *SecretsServer) Update(ctx context.Context,
 		s.logger.ErrorContext(ctx, "Failed to map private secret to public", slog.Any("error", err))
 		return nil, err
 	}
+	s.redactPublicSecret(publicObject)
 
 	response = &publicv1.SecretsUpdateResponse{}
 	response.SetObject(publicObject)

--- a/internal/servers/secrets_server_test.go
+++ b/internal/servers/secrets_server_test.go
@@ -189,7 +189,7 @@ var _ = Describe("Secrets Server", func() {
 				To(Equal(privatev1.SecretBackend_SECRET_BACKEND_VAULT))
 		})
 
-		It("strips backend and coordinates from response", func() {
+		It("redacts data from response", func() {
 			mock := &mockPrivateSecretsServer{
 				createFunc: func(_ context.Context,
 					_ *privatev1.SecretsCreateRequest) (*privatev1.SecretsCreateResponse, error) {
@@ -200,8 +200,12 @@ var _ = Describe("Secrets Server", func() {
 							Name: "my-secret",
 						}.Build(),
 						Spec: privatev1.SecretSpec_builder{
+							Data:        map[string][]byte{"key": []byte("value")},
 							Backend:     privatev1.SecretBackend_SECRET_BACKEND_VAULT,
 							Coordinates: map[string]string{"path": "/secret/data/test"},
+						}.Build(),
+						Status: privatev1.SecretStatus_builder{
+							ResolvedData: map[string][]byte{"key": []byte("resolved")},
 						}.Build(),
 					}.Build())
 					return resp, nil
@@ -223,6 +227,7 @@ var _ = Describe("Secrets Server", func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(resp.GetObject().GetId()).To(Equal("secret-1"))
 			Expect(resp.GetObject().GetSpec().GetData()).To(BeEmpty())
+			Expect(resp.GetObject().GetStatus().GetResolvedData()).To(BeEmpty())
 		})
 	})
 
@@ -301,7 +306,7 @@ var _ = Describe("Secrets Server", func() {
 	})
 
 	Describe("Get", func() {
-		It("returns status.resolved_data in response", func() {
+		It("returns data and resolved_data in response", func() {
 			mock := &mockPrivateSecretsServer{
 				getFunc: func(_ context.Context,
 					_ *privatev1.SecretsGetRequest) (*privatev1.SecretsGetResponse, error) {
@@ -312,6 +317,7 @@ var _ = Describe("Secrets Server", func() {
 							Name: "my-secret",
 						}.Build(),
 						Spec: privatev1.SecretSpec_builder{
+							Data:    map[string][]byte{"key": []byte("value")},
 							Backend: privatev1.SecretBackend_SECRET_BACKEND_VAULT,
 						}.Build(),
 						Status: privatev1.SecretStatus_builder{
@@ -331,6 +337,7 @@ var _ = Describe("Secrets Server", func() {
 			}.Build())
 
 			Expect(err).ToNot(HaveOccurred())
+			Expect(resp.GetObject().GetSpec().GetData()).To(HaveKeyWithValue("key", []byte("value")))
 			Expect(resp.GetObject().GetStatus().GetResolvedData()).To(HaveLen(2))
 			Expect(resp.GetObject().GetStatus().GetResolvedData()).To(HaveKeyWithValue("tls.crt", []byte("cert-data")))
 			Expect(resp.GetObject().GetStatus().GetResolvedData()).To(HaveKeyWithValue("tls.key", []byte("key-data")))
@@ -370,7 +377,9 @@ var _ = Describe("Secrets Server", func() {
 			Expect(st.Message()).To(ContainSubstring("hub-backed"))
 		})
 
-		It("allows update of hub-backed secret with empty data", func() {
+		It("preserves backend for hub-backed secret with empty data", func() {
+			var capturedRequest *privatev1.SecretsUpdateRequest
+
 			mock := &mockPrivateSecretsServer{
 				getFunc: func(_ context.Context,
 					_ *privatev1.SecretsGetRequest) (*privatev1.SecretsGetResponse, error) {
@@ -387,7 +396,8 @@ var _ = Describe("Secrets Server", func() {
 					return resp, nil
 				},
 				updateFunc: func(_ context.Context,
-					_ *privatev1.SecretsUpdateRequest) (*privatev1.SecretsUpdateResponse, error) {
+					req *privatev1.SecretsUpdateRequest) (*privatev1.SecretsUpdateResponse, error) {
+					capturedRequest = req
 					resp := &privatev1.SecretsUpdateResponse{}
 					resp.SetObject(privatev1.Secret_builder{
 						Id: "hub-secret",
@@ -414,9 +424,14 @@ var _ = Describe("Secrets Server", func() {
 
 			Expect(err).ToNot(HaveOccurred())
 			Expect(resp.GetObject().GetMetadata().GetName()).To(Equal("hub-secret-updated"))
+			Expect(capturedRequest).ToNot(BeNil())
+			Expect(capturedRequest.GetObject().GetSpec().GetBackend()).
+				To(Equal(privatev1.SecretBackend_SECRET_BACKEND_HUB))
 		})
 
-		It("delegates to private server for vault-backed secret", func() {
+		It("preserves backend and redacts response for vault-backed secret", func() {
+			var capturedRequest *privatev1.SecretsUpdateRequest
+
 			mock := &mockPrivateSecretsServer{
 				getFunc: func(_ context.Context,
 					_ *privatev1.SecretsGetRequest) (*privatev1.SecretsGetResponse, error) {
@@ -430,12 +445,17 @@ var _ = Describe("Secrets Server", func() {
 					return resp, nil
 				},
 				updateFunc: func(_ context.Context,
-					_ *privatev1.SecretsUpdateRequest) (*privatev1.SecretsUpdateResponse, error) {
+					req *privatev1.SecretsUpdateRequest) (*privatev1.SecretsUpdateResponse, error) {
+					capturedRequest = req
 					resp := &privatev1.SecretsUpdateResponse{}
 					resp.SetObject(privatev1.Secret_builder{
 						Id: "vault-secret",
 						Spec: privatev1.SecretSpec_builder{
+							Data:    map[string][]byte{"key": []byte("new-value")},
 							Backend: privatev1.SecretBackend_SECRET_BACKEND_VAULT,
+						}.Build(),
+						Status: privatev1.SecretStatus_builder{
+							ResolvedData: map[string][]byte{"key": []byte("resolved")},
 						}.Build(),
 					}.Build())
 					return resp, nil
@@ -454,6 +474,11 @@ var _ = Describe("Secrets Server", func() {
 
 			Expect(err).ToNot(HaveOccurred())
 			Expect(resp.GetObject().GetId()).To(Equal("vault-secret"))
+			Expect(capturedRequest).ToNot(BeNil())
+			Expect(capturedRequest.GetObject().GetSpec().GetBackend()).
+				To(Equal(privatev1.SecretBackend_SECRET_BACKEND_VAULT))
+			Expect(resp.GetObject().GetSpec().GetData()).To(BeEmpty())
+			Expect(resp.GetObject().GetStatus().GetResolvedData()).To(BeEmpty())
 		})
 	})
 

--- a/internal/servers/secrets_server_test.go
+++ b/internal/servers/secrets_server_test.go
@@ -1,0 +1,519 @@
+/*
+Copyright (c) 2026 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package servers
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"go.uber.org/mock/gomock"
+	grpccodes "google.golang.org/grpc/codes"
+	grpcstatus "google.golang.org/grpc/status"
+
+	privatev1 "github.com/osac-project/fulfillment-service/internal/api/osac/private/v1"
+	publicv1 "github.com/osac-project/fulfillment-service/internal/api/osac/public/v1"
+	"github.com/osac-project/fulfillment-service/internal/auth"
+)
+
+type mockPrivateSecretsServer struct {
+	privatev1.UnimplementedSecretsServer
+
+	createFunc func(context.Context, *privatev1.SecretsCreateRequest) (*privatev1.SecretsCreateResponse, error)
+	listFunc   func(context.Context, *privatev1.SecretsListRequest) (*privatev1.SecretsListResponse, error)
+	getFunc    func(context.Context, *privatev1.SecretsGetRequest) (*privatev1.SecretsGetResponse, error)
+	updateFunc func(context.Context, *privatev1.SecretsUpdateRequest) (*privatev1.SecretsUpdateResponse, error)
+	deleteFunc func(context.Context, *privatev1.SecretsDeleteRequest) (*privatev1.SecretsDeleteResponse, error)
+}
+
+func (m *mockPrivateSecretsServer) Create(ctx context.Context,
+	req *privatev1.SecretsCreateRequest) (*privatev1.SecretsCreateResponse, error) {
+	if m.createFunc != nil {
+		return m.createFunc(ctx, req)
+	}
+	return m.UnimplementedSecretsServer.Create(ctx, req)
+}
+
+func (m *mockPrivateSecretsServer) List(ctx context.Context,
+	req *privatev1.SecretsListRequest) (*privatev1.SecretsListResponse, error) {
+	if m.listFunc != nil {
+		return m.listFunc(ctx, req)
+	}
+	return m.UnimplementedSecretsServer.List(ctx, req)
+}
+
+func (m *mockPrivateSecretsServer) Get(ctx context.Context,
+	req *privatev1.SecretsGetRequest) (*privatev1.SecretsGetResponse, error) {
+	if m.getFunc != nil {
+		return m.getFunc(ctx, req)
+	}
+	return m.UnimplementedSecretsServer.Get(ctx, req)
+}
+
+func (m *mockPrivateSecretsServer) Update(ctx context.Context,
+	req *privatev1.SecretsUpdateRequest) (*privatev1.SecretsUpdateResponse, error) {
+	if m.updateFunc != nil {
+		return m.updateFunc(ctx, req)
+	}
+	return m.UnimplementedSecretsServer.Update(ctx, req)
+}
+
+func (m *mockPrivateSecretsServer) Delete(ctx context.Context,
+	req *privatev1.SecretsDeleteRequest) (*privatev1.SecretsDeleteResponse, error) {
+	if m.deleteFunc != nil {
+		return m.deleteFunc(ctx, req)
+	}
+	return m.UnimplementedSecretsServer.Delete(ctx, req)
+}
+
+func newTestSecretsServer(mock privatev1.SecretsServer) *SecretsServer {
+	inMapper, err := NewGenericMapper[*publicv1.Secret, *privatev1.Secret]().
+		SetLogger(logger).
+		SetStrict(true).
+		Build()
+	Expect(err).ToNot(HaveOccurred())
+
+	outMapper, err := NewGenericMapper[*privatev1.Secret, *publicv1.Secret]().
+		SetLogger(logger).
+		SetStrict(false).
+		Build()
+	Expect(err).ToNot(HaveOccurred())
+
+	return &SecretsServer{
+		logger:    logger,
+		private:   mock,
+		inMapper:  inMapper,
+		outMapper: outMapper,
+	}
+}
+
+var _ = Describe("Secrets Server", func() {
+	Describe("Builder", func() {
+		var (
+			ctrl         *gomock.Controller
+			tenancyLogic *auth.MockTenancyLogic
+		)
+
+		BeforeEach(func() {
+			ctrl = gomock.NewController(GinkgoT())
+			tenancyLogic = auth.NewMockTenancyLogic(ctrl)
+		})
+
+		AfterEach(func() {
+			ctrl.Finish()
+		})
+		It("builds successfully with all required parameters", func() {
+			attributionLogic := auth.NewMockAttributionLogic(ctrl)
+			server, err := NewSecretsServer().
+				SetLogger(logger).
+				SetTenancyLogic(tenancyLogic).
+				SetAttributionLogic(attributionLogic).
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(server).ToNot(BeNil())
+		})
+
+		It("fails if logger is not set", func() {
+			server, err := NewSecretsServer().
+				SetTenancyLogic(tenancyLogic).
+				Build()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("logger is mandatory"))
+			Expect(server).To(BeNil())
+		})
+
+		It("fails if tenancy logic is not set", func() {
+			server, err := NewSecretsServer().
+				SetLogger(logger).
+				Build()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("tenancy logic is mandatory"))
+			Expect(server).To(BeNil())
+		})
+	})
+
+	Describe("Interface compliance", func() {
+		It("implements SecretsServer interface", func() {
+			var _ publicv1.SecretsServer = (*SecretsServer)(nil)
+		})
+	})
+
+	Describe("Create", func() {
+		It("sets backend to VAULT on the private request", func() {
+			var capturedRequest *privatev1.SecretsCreateRequest
+
+			mock := &mockPrivateSecretsServer{
+				createFunc: func(_ context.Context,
+					req *privatev1.SecretsCreateRequest) (*privatev1.SecretsCreateResponse, error) {
+					capturedRequest = req
+					resp := &privatev1.SecretsCreateResponse{}
+					resp.SetObject(privatev1.Secret_builder{
+						Id: "secret-1",
+						Metadata: privatev1.Metadata_builder{
+							Name: "my-secret",
+						}.Build(),
+						Spec: privatev1.SecretSpec_builder{
+							Backend: privatev1.SecretBackend_SECRET_BACKEND_VAULT,
+						}.Build(),
+					}.Build())
+					return resp, nil
+				},
+			}
+
+			server := newTestSecretsServer(mock)
+			_, err := server.Create(ctx, publicv1.SecretsCreateRequest_builder{
+				Object: publicv1.Secret_builder{
+					Metadata: publicv1.Metadata_builder{
+						Name: "my-secret",
+					}.Build(),
+					Spec: publicv1.SecretSpec_builder{
+						Data: map[string][]byte{"key": []byte("value")},
+					}.Build(),
+				}.Build(),
+			}.Build())
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(capturedRequest).ToNot(BeNil())
+			Expect(capturedRequest.GetObject().GetSpec().GetBackend()).
+				To(Equal(privatev1.SecretBackend_SECRET_BACKEND_VAULT))
+		})
+
+		It("strips backend and coordinates from response", func() {
+			mock := &mockPrivateSecretsServer{
+				createFunc: func(_ context.Context,
+					_ *privatev1.SecretsCreateRequest) (*privatev1.SecretsCreateResponse, error) {
+					resp := &privatev1.SecretsCreateResponse{}
+					resp.SetObject(privatev1.Secret_builder{
+						Id: "secret-1",
+						Metadata: privatev1.Metadata_builder{
+							Name: "my-secret",
+						}.Build(),
+						Spec: privatev1.SecretSpec_builder{
+							Backend:     privatev1.SecretBackend_SECRET_BACKEND_VAULT,
+							Coordinates: map[string]string{"path": "/secret/data/test"},
+						}.Build(),
+					}.Build())
+					return resp, nil
+				},
+			}
+
+			server := newTestSecretsServer(mock)
+			resp, err := server.Create(ctx, publicv1.SecretsCreateRequest_builder{
+				Object: publicv1.Secret_builder{
+					Metadata: publicv1.Metadata_builder{
+						Name: "my-secret",
+					}.Build(),
+					Spec: publicv1.SecretSpec_builder{
+						Data: map[string][]byte{"key": []byte("value")},
+					}.Build(),
+				}.Build(),
+			}.Build())
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(resp.GetObject().GetId()).To(Equal("secret-1"))
+			Expect(resp.GetObject().GetSpec().GetData()).To(BeEmpty())
+		})
+	})
+
+	Describe("List", func() {
+		It("strips spec.data and status.resolved_data from all items", func() {
+			mock := &mockPrivateSecretsServer{
+				listFunc: func(_ context.Context,
+					_ *privatev1.SecretsListRequest) (*privatev1.SecretsListResponse, error) {
+					resp := &privatev1.SecretsListResponse{}
+					resp.SetSize(2)
+					resp.SetTotal(2)
+					resp.SetItems([]*privatev1.Secret{
+						privatev1.Secret_builder{
+							Id: "secret-1",
+							Spec: privatev1.SecretSpec_builder{
+								Data:    map[string][]byte{"key1": []byte("val1")},
+								Backend: privatev1.SecretBackend_SECRET_BACKEND_VAULT,
+							}.Build(),
+							Status: privatev1.SecretStatus_builder{
+								ResolvedData: map[string][]byte{"key1": []byte("resolved1")},
+							}.Build(),
+						}.Build(),
+						privatev1.Secret_builder{
+							Id: "secret-2",
+							Spec: privatev1.SecretSpec_builder{
+								Data:    map[string][]byte{"key2": []byte("val2")},
+								Backend: privatev1.SecretBackend_SECRET_BACKEND_VAULT,
+							}.Build(),
+							Status: privatev1.SecretStatus_builder{
+								ResolvedData: map[string][]byte{"key2": []byte("resolved2")},
+							}.Build(),
+						}.Build(),
+					})
+					return resp, nil
+				},
+			}
+
+			server := newTestSecretsServer(mock)
+			resp, err := server.List(ctx, publicv1.SecretsListRequest_builder{}.Build())
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(resp.GetItems()).To(HaveLen(2))
+			for _, item := range resp.GetItems() {
+				Expect(item.GetSpec().GetData()).To(BeEmpty())
+				Expect(item.GetStatus().GetResolvedData()).To(BeEmpty())
+			}
+		})
+
+		It("forwards offset, limit, filter, and order to private request", func() {
+			var capturedRequest *privatev1.SecretsListRequest
+
+			mock := &mockPrivateSecretsServer{
+				listFunc: func(_ context.Context,
+					req *privatev1.SecretsListRequest) (*privatev1.SecretsListResponse, error) {
+					capturedRequest = req
+					resp := &privatev1.SecretsListResponse{}
+					return resp, nil
+				},
+			}
+
+			server := newTestSecretsServer(mock)
+			_, err := server.List(ctx, publicv1.SecretsListRequest_builder{
+				Offset: new(int32(10)),
+				Limit:  new(int32(25)),
+				Filter: new("this.metadata.name == 'test'"),
+				Order:  new("metadata.name desc"),
+			}.Build())
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(capturedRequest).ToNot(BeNil())
+			Expect(capturedRequest.GetOffset()).To(Equal(int32(10)))
+			Expect(capturedRequest.GetLimit()).To(Equal(int32(25)))
+			Expect(capturedRequest.GetFilter()).To(Equal("this.metadata.name == 'test'"))
+			Expect(capturedRequest.GetOrder()).To(Equal("metadata.name desc"))
+		})
+	})
+
+	Describe("Get", func() {
+		It("returns status.resolved_data in response", func() {
+			mock := &mockPrivateSecretsServer{
+				getFunc: func(_ context.Context,
+					_ *privatev1.SecretsGetRequest) (*privatev1.SecretsGetResponse, error) {
+					resp := &privatev1.SecretsGetResponse{}
+					resp.SetObject(privatev1.Secret_builder{
+						Id: "secret-1",
+						Metadata: privatev1.Metadata_builder{
+							Name: "my-secret",
+						}.Build(),
+						Spec: privatev1.SecretSpec_builder{
+							Backend: privatev1.SecretBackend_SECRET_BACKEND_VAULT,
+						}.Build(),
+						Status: privatev1.SecretStatus_builder{
+							ResolvedData: map[string][]byte{
+								"tls.crt": []byte("cert-data"),
+								"tls.key": []byte("key-data"),
+							},
+						}.Build(),
+					}.Build())
+					return resp, nil
+				},
+			}
+
+			server := newTestSecretsServer(mock)
+			resp, err := server.Get(ctx, publicv1.SecretsGetRequest_builder{
+				Id: "secret-1",
+			}.Build())
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(resp.GetObject().GetStatus().GetResolvedData()).To(HaveLen(2))
+			Expect(resp.GetObject().GetStatus().GetResolvedData()).To(HaveKeyWithValue("tls.crt", []byte("cert-data")))
+			Expect(resp.GetObject().GetStatus().GetResolvedData()).To(HaveKeyWithValue("tls.key", []byte("key-data")))
+		})
+	})
+
+	Describe("Update", func() {
+		It("returns FAILED_PRECONDITION for hub-backed secret with non-empty data", func() {
+			mock := &mockPrivateSecretsServer{
+				getFunc: func(_ context.Context,
+					_ *privatev1.SecretsGetRequest) (*privatev1.SecretsGetResponse, error) {
+					resp := &privatev1.SecretsGetResponse{}
+					resp.SetObject(privatev1.Secret_builder{
+						Id: "hub-secret",
+						Spec: privatev1.SecretSpec_builder{
+							Backend: privatev1.SecretBackend_SECRET_BACKEND_HUB,
+						}.Build(),
+					}.Build())
+					return resp, nil
+				},
+			}
+
+			server := newTestSecretsServer(mock)
+			_, err := server.Update(ctx, publicv1.SecretsUpdateRequest_builder{
+				Object: publicv1.Secret_builder{
+					Id: "hub-secret",
+					Spec: publicv1.SecretSpec_builder{
+						Data: map[string][]byte{"key": []byte("value")},
+					}.Build(),
+				}.Build(),
+			}.Build())
+
+			Expect(err).To(HaveOccurred())
+			st, ok := grpcstatus.FromError(err)
+			Expect(ok).To(BeTrue())
+			Expect(st.Code()).To(Equal(grpccodes.FailedPrecondition))
+			Expect(st.Message()).To(ContainSubstring("hub-backed"))
+		})
+
+		It("allows update of hub-backed secret with empty data", func() {
+			mock := &mockPrivateSecretsServer{
+				getFunc: func(_ context.Context,
+					_ *privatev1.SecretsGetRequest) (*privatev1.SecretsGetResponse, error) {
+					resp := &privatev1.SecretsGetResponse{}
+					resp.SetObject(privatev1.Secret_builder{
+						Id: "hub-secret",
+						Metadata: privatev1.Metadata_builder{
+							Name: "hub-secret",
+						}.Build(),
+						Spec: privatev1.SecretSpec_builder{
+							Backend: privatev1.SecretBackend_SECRET_BACKEND_HUB,
+						}.Build(),
+					}.Build())
+					return resp, nil
+				},
+				updateFunc: func(_ context.Context,
+					_ *privatev1.SecretsUpdateRequest) (*privatev1.SecretsUpdateResponse, error) {
+					resp := &privatev1.SecretsUpdateResponse{}
+					resp.SetObject(privatev1.Secret_builder{
+						Id: "hub-secret",
+						Metadata: privatev1.Metadata_builder{
+							Name: "hub-secret-updated",
+						}.Build(),
+						Spec: privatev1.SecretSpec_builder{
+							Backend: privatev1.SecretBackend_SECRET_BACKEND_HUB,
+						}.Build(),
+					}.Build())
+					return resp, nil
+				},
+			}
+
+			server := newTestSecretsServer(mock)
+			resp, err := server.Update(ctx, publicv1.SecretsUpdateRequest_builder{
+				Object: publicv1.Secret_builder{
+					Id: "hub-secret",
+					Metadata: publicv1.Metadata_builder{
+						Name: "hub-secret-updated",
+					}.Build(),
+				}.Build(),
+			}.Build())
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(resp.GetObject().GetMetadata().GetName()).To(Equal("hub-secret-updated"))
+		})
+
+		It("delegates to private server for vault-backed secret", func() {
+			mock := &mockPrivateSecretsServer{
+				getFunc: func(_ context.Context,
+					_ *privatev1.SecretsGetRequest) (*privatev1.SecretsGetResponse, error) {
+					resp := &privatev1.SecretsGetResponse{}
+					resp.SetObject(privatev1.Secret_builder{
+						Id: "vault-secret",
+						Spec: privatev1.SecretSpec_builder{
+							Backend: privatev1.SecretBackend_SECRET_BACKEND_VAULT,
+						}.Build(),
+					}.Build())
+					return resp, nil
+				},
+				updateFunc: func(_ context.Context,
+					_ *privatev1.SecretsUpdateRequest) (*privatev1.SecretsUpdateResponse, error) {
+					resp := &privatev1.SecretsUpdateResponse{}
+					resp.SetObject(privatev1.Secret_builder{
+						Id: "vault-secret",
+						Spec: privatev1.SecretSpec_builder{
+							Backend: privatev1.SecretBackend_SECRET_BACKEND_VAULT,
+						}.Build(),
+					}.Build())
+					return resp, nil
+				},
+			}
+
+			server := newTestSecretsServer(mock)
+			resp, err := server.Update(ctx, publicv1.SecretsUpdateRequest_builder{
+				Object: publicv1.Secret_builder{
+					Id: "vault-secret",
+					Spec: publicv1.SecretSpec_builder{
+						Data: map[string][]byte{"key": []byte("new-value")},
+					}.Build(),
+				}.Build(),
+			}.Build())
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(resp.GetObject().GetId()).To(Equal("vault-secret"))
+		})
+	})
+
+	Describe("Delete", func() {
+		It("returns FAILED_PRECONDITION for hub-backed secret", func() {
+			mock := &mockPrivateSecretsServer{
+				getFunc: func(_ context.Context,
+					_ *privatev1.SecretsGetRequest) (*privatev1.SecretsGetResponse, error) {
+					resp := &privatev1.SecretsGetResponse{}
+					resp.SetObject(privatev1.Secret_builder{
+						Id: "hub-secret",
+						Spec: privatev1.SecretSpec_builder{
+							Backend: privatev1.SecretBackend_SECRET_BACKEND_HUB,
+						}.Build(),
+					}.Build())
+					return resp, nil
+				},
+			}
+
+			server := newTestSecretsServer(mock)
+			_, err := server.Delete(ctx, publicv1.SecretsDeleteRequest_builder{
+				Id: "hub-secret",
+			}.Build())
+
+			Expect(err).To(HaveOccurred())
+			st, ok := grpcstatus.FromError(err)
+			Expect(ok).To(BeTrue())
+			Expect(st.Code()).To(Equal(grpccodes.FailedPrecondition))
+			Expect(st.Message()).To(ContainSubstring("hub-backed"))
+		})
+
+		It("delegates to private server for vault-backed secret", func() {
+			var deleteCalled bool
+
+			mock := &mockPrivateSecretsServer{
+				getFunc: func(_ context.Context,
+					_ *privatev1.SecretsGetRequest) (*privatev1.SecretsGetResponse, error) {
+					resp := &privatev1.SecretsGetResponse{}
+					resp.SetObject(privatev1.Secret_builder{
+						Id: "vault-secret",
+						Spec: privatev1.SecretSpec_builder{
+							Backend: privatev1.SecretBackend_SECRET_BACKEND_VAULT,
+						}.Build(),
+					}.Build())
+					return resp, nil
+				},
+				deleteFunc: func(_ context.Context,
+					_ *privatev1.SecretsDeleteRequest) (*privatev1.SecretsDeleteResponse, error) {
+					deleteCalled = true
+					return &privatev1.SecretsDeleteResponse{}, nil
+				},
+			}
+
+			server := newTestSecretsServer(mock)
+			_, err := server.Delete(ctx, publicv1.SecretsDeleteRequest_builder{
+				Id: "vault-secret",
+			}.Build())
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(deleteCalled).To(BeTrue())
+		})
+	})
+})


### PR DESCRIPTION
- Adds a public Secrets API with CRUD + List operations
- Updates OPA policies for the aforementioned API
- Adds a table readout for the Secrets type

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added public Secrets API support for creating, listing, viewing, updating, and deleting secrets.
  * Public secret creation uses the Vault backend.
  * Added safeguards preventing public updates or deletion of hub-backed secret data.
  * Added table views for public and private secrets, including project, ID, name, backend, creation date, and labels.

* **Access Control**
  * Enabled authorized client and tenant access to public Secrets operations.

* **Tests**
  * Added coverage for public Secrets behavior and authorization rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->