### PR TITLE
OSAC-3339: validate field_definition paths against proto schema and template parameters

### DIFF
--- a/internal/api/osac/private/v1/field_definition_type.pb.go
+++ b/internal/api/osac/private/v1/field_definition_type.pb.go
@@ -40,8 +40,8 @@ const (
 // the user can set the field, what default value to apply, and optional JSON Schema validation constraints.
 type FieldDefinition struct {
 	state protoimpl.MessageState `protogen:"hybrid.v1"`
-	// Dot-notation path referencing a field in the resource spec. For example: "spec.network.pod_cidr" or
-	// "spec.node_sets.workers.size". Wildcards are not supported.
+	// Dot-notation path relative to the resource spec. For example: "network.pod_cidr" or
+	// "template_parameters.vpc_id". Wildcards are not supported.
 	Path string `protobuf:"bytes,1,opt,name=path,proto3" json:"path,omitempty"`
 	// Human friendly label for this field, suitable for displaying in a UI.
 	DisplayName string `protobuf:"bytes,2,opt,name=display_name,json=displayName,proto3" json:"display_name,omitempty"`
@@ -152,8 +152,8 @@ func (x *FieldDefinition) ClearDefault() {
 type FieldDefinition_builder struct {
 	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
 
-	// Dot-notation path referencing a field in the resource spec. For example: "spec.network.pod_cidr" or
-	// "spec.node_sets.workers.size". Wildcards are not supported.
+	// Dot-notation path relative to the resource spec. For example: "network.pod_cidr" or
+	// "template_parameters.vpc_id". Wildcards are not supported.
 	Path string
 	// Human friendly label for this field, suitable for displaying in a UI.
 	DisplayName string

--- a/internal/api/osac/private/v1/field_definition_type_protoopaque.pb.go
+++ b/internal/api/osac/private/v1/field_definition_type_protoopaque.pb.go
@@ -143,8 +143,8 @@ func (x *FieldDefinition) ClearDefault() {
 type FieldDefinition_builder struct {
 	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
 
-	// Dot-notation path referencing a field in the resource spec. For example: "spec.network.pod_cidr" or
-	// "spec.node_sets.workers.size". Wildcards are not supported.
+	// Dot-notation path relative to the resource spec. For example: "network.pod_cidr" or
+	// "template_parameters.vpc_id". Wildcards are not supported.
 	Path string
 	// Human friendly label for this field, suitable for displaying in a UI.
 	DisplayName string

--- a/internal/api/osac/public/v1/field_definition_type.pb.go
+++ b/internal/api/osac/public/v1/field_definition_type.pb.go
@@ -39,7 +39,7 @@ const (
 // Defines a single field on the resource spec that a catalog item controls.
 type FieldDefinition struct {
 	state protoimpl.MessageState `protogen:"hybrid.v1"`
-	// Dot-notation path referencing a field in the resource spec.
+	// Dot-notation path relative to the resource spec (e.g. "network.pod_cidr").
 	Path string `protobuf:"bytes,1,opt,name=path,proto3" json:"path,omitempty"`
 	// Human friendly label for this field, suitable for displaying in a UI.
 	DisplayName string `protobuf:"bytes,2,opt,name=display_name,json=displayName,proto3" json:"display_name,omitempty"`
@@ -147,7 +147,7 @@ func (x *FieldDefinition) ClearDefault() {
 type FieldDefinition_builder struct {
 	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
 
-	// Dot-notation path referencing a field in the resource spec.
+	// Dot-notation path relative to the resource spec (e.g. "network.pod_cidr").
 	Path string
 	// Human friendly label for this field, suitable for displaying in a UI.
 	DisplayName string

--- a/internal/api/osac/public/v1/field_definition_type_protoopaque.pb.go
+++ b/internal/api/osac/public/v1/field_definition_type_protoopaque.pb.go
@@ -142,7 +142,7 @@ func (x *FieldDefinition) ClearDefault() {
 type FieldDefinition_builder struct {
 	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
 
-	// Dot-notation path referencing a field in the resource spec.
+	// Dot-notation path relative to the resource spec (e.g. "network.pod_cidr").
 	Path string
 	// Human friendly label for this field, suitable for displaying in a UI.
 	DisplayName string

--- a/internal/servers/catalog_item_validation.go
+++ b/internal/servers/catalog_item_validation.go
@@ -19,6 +19,7 @@ import (
 	"errors"
 	"fmt"
 	"slices"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -28,11 +29,13 @@ import (
 	grpcstatus "google.golang.org/grpc/status"
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/reflect/protoreflect"
 	"google.golang.org/protobuf/types/known/structpb"
 
 	privatev1 "github.com/osac-project/fulfillment-service/internal/api/osac/private/v1"
 	"github.com/osac-project/fulfillment-service/internal/database/dao"
 	"github.com/osac-project/fulfillment-service/internal/maputil"
+	"github.com/osac-project/fulfillment-service/internal/utils"
 )
 
 // catalogItem is implemented by both ClusterCatalogItem and ComputeInstanceCatalogItem.
@@ -62,6 +65,183 @@ func validateFieldDefinitions(fieldDefinitions []*privatev1.FieldDefinition) err
 		}
 	}
 	return nil
+}
+
+// validateFieldDefinitionPaths checks that each field definition path corresponds to a valid field
+// in the given spec message descriptor. Paths starting with "template_parameters" are skipped
+// (validated separately by validateFieldDefinitionTemplateParams).
+func validateFieldDefinitionPaths(
+	fieldDefinitions []*privatev1.FieldDefinition,
+	specDescriptor protoreflect.MessageDescriptor,
+) error {
+	for _, fd := range fieldDefinitions {
+		path := fd.GetPath()
+		if path == "" {
+			continue
+		}
+		segments := strings.Split(path, ".")
+		if segments[0] == "template_parameters" {
+			continue
+		}
+		if err := validatePathAgainstDescriptor(segments, specDescriptor); err != nil {
+			return grpcstatus.Errorf(grpccodes.InvalidArgument,
+				"invalid field_definition path '%s': %v", path, err)
+		}
+	}
+	return nil
+}
+
+func validatePathAgainstDescriptor(segments []string, md protoreflect.MessageDescriptor) error {
+	fields := md.Fields()
+	fd := fields.ByName(protoreflect.Name(segments[0]))
+	if fd == nil {
+		return fmt.Errorf("field '%s' does not exist; valid fields: %s",
+			segments[0], listFieldNames(fields))
+	}
+
+	remaining := segments[1:]
+	if len(remaining) == 0 {
+		return nil
+	}
+
+	if fd.IsMap() {
+		// Map field: next segment is a key (any value), then continue with value descriptor.
+		remaining = remaining[1:]
+		if len(remaining) == 0 {
+			return nil
+		}
+		valueDesc := fd.MapValue()
+		if valueDesc.Kind() != protoreflect.MessageKind {
+			return fmt.Errorf("field '%s' is a map with scalar values; path cannot continue beyond the key",
+				segments[0])
+		}
+		return validatePathAgainstDescriptor(remaining, valueDesc.Message())
+	}
+
+	if fd.Kind() == protoreflect.MessageKind {
+		return validatePathAgainstDescriptor(remaining, fd.Message())
+	}
+
+	return fmt.Errorf("field '%s' is a scalar; path cannot continue with '%s'",
+		segments[0], remaining[0])
+}
+
+func listFieldNames(fields protoreflect.FieldDescriptors) string {
+	names := make([]string, 0, fields.Len())
+	for i := range fields.Len() {
+		names = append(names, string(fields.Get(i).Name()))
+	}
+	sort.Strings(names)
+	return strings.Join(names, ", ")
+}
+
+// validateFieldDefinitionTemplateParams checks that template_parameters.* paths in field definitions
+// correspond to parameters declared in the referenced template.
+func validateFieldDefinitionTemplateParams(
+	fieldDefinitions []*privatev1.FieldDefinition,
+	template utils.Template,
+) error {
+	var paramPaths []string
+	for _, fd := range fieldDefinitions {
+		path := fd.GetPath()
+		if strings.HasPrefix(path, "template_parameters.") {
+			paramPaths = append(paramPaths, path)
+		}
+	}
+	if len(paramPaths) == 0 {
+		return nil
+	}
+
+	validNames := make(map[string]bool)
+	for _, p := range template.GetParameters() {
+		validNames[p.GetName()] = true
+	}
+
+	var invalid []string
+	for _, path := range paramPaths {
+		paramName := strings.TrimPrefix(path, "template_parameters.")
+		if !validNames[paramName] {
+			invalid = append(invalid, paramName)
+		}
+	}
+
+	if len(invalid) > 0 {
+		sort.Strings(invalid)
+		validList := make([]string, 0, len(validNames))
+		for name := range validNames {
+			validList = append(validList, name)
+		}
+		sort.Strings(validList)
+		return grpcstatus.Errorf(grpccodes.InvalidArgument,
+			"field_definition references unknown template parameter(s) %s; "+
+				"valid parameters for template '%s': %s",
+			strings.Join(invalid, ", "),
+			template.GetId(),
+			strings.Join(validList, ", "))
+	}
+	return nil
+}
+
+// templateResolver looks up a template by ID and returns it wrapped as a utils.Template.
+type templateResolver func(ctx context.Context, id string) (utils.Template, error)
+
+// validateCatalogItemFieldDefinitionPaths validates that field definition paths match the spec
+// proto schema and that template_parameters paths reference valid template parameters.
+func validateCatalogItemFieldDefinitionPaths(
+	ctx context.Context,
+	item catalogItem,
+	specDescriptor protoreflect.MessageDescriptor,
+	resolve templateResolver,
+) error {
+	fieldDefs := item.GetFieldDefinitions()
+	if len(fieldDefs) == 0 {
+		return nil
+	}
+
+	if err := validateFieldDefinitionPaths(fieldDefs, specDescriptor); err != nil {
+		return err
+	}
+
+	return validateTemplateParams(ctx, item.GetTemplate(), fieldDefs, resolve)
+}
+
+func validateTemplateParams(
+	ctx context.Context, templateRef string,
+	fieldDefs []*privatev1.FieldDefinition,
+	resolve templateResolver,
+) error {
+	hasTemplateParamPaths := false
+	for _, fd := range fieldDefs {
+		if strings.HasPrefix(fd.GetPath(), "template_parameters.") {
+			hasTemplateParamPaths = true
+			break
+		}
+	}
+	if !hasTemplateParamPaths {
+		return nil
+	}
+
+	if templateRef == "" {
+		return grpcstatus.Errorf(grpccodes.InvalidArgument,
+			"field_definitions reference template_parameters but no template is set")
+	}
+
+	template, err := resolve(ctx, templateRef)
+	if err != nil {
+		return err
+	}
+
+	return validateFieldDefinitionTemplateParams(fieldDefs, template)
+}
+
+func templateLookupError(id string, err error) error {
+	var notFoundErr *dao.ErrNotFound
+	if errors.As(err, &notFoundErr) {
+		return grpcstatus.Errorf(grpccodes.InvalidArgument,
+			"template '%s' not found", id)
+	}
+	return grpcstatus.Errorf(grpccodes.Internal,
+		"failed to retrieve template '%s'", id)
 }
 
 // applyFieldDefinitions validates and applies field definitions from a catalog item against a resource spec.

--- a/internal/servers/catalog_item_validation.go
+++ b/internal/servers/catalog_item_validation.go
@@ -81,6 +81,11 @@ func validateFieldDefinitionPaths(
 		}
 		segments := strings.Split(path, ".")
 		if segments[0] == "template_parameters" {
+			if len(segments) == 1 {
+				return grpcstatus.Errorf(grpccodes.InvalidArgument,
+					"invalid field_definition path 'template_parameters': "+
+						"must specify a parameter name (e.g., 'template_parameters.param_name')")
+			}
 			continue
 		}
 		if err := validatePathAgainstDescriptor(segments, specDescriptor); err != nil {

--- a/internal/servers/catalog_item_validation_test.go
+++ b/internal/servers/catalog_item_validation_test.go
@@ -541,6 +541,17 @@ var _ = Describe("validateFieldDefinitionPaths", func() {
 		Expect(err).ToNot(HaveOccurred())
 	})
 
+	It("rejects bare template_parameters path without parameter name", func() {
+		fieldDefs := []*privatev1.FieldDefinition{{
+			Path: "template_parameters",
+		}}
+		descriptor := (&privatev1.ClusterSpec{}).ProtoReflect().Descriptor()
+		err := validateFieldDefinitionPaths(fieldDefs, descriptor)
+		Expect(err).To(HaveOccurred())
+		Expect(status.Code(err)).To(Equal(codes.InvalidArgument))
+		Expect(err.Error()).To(ContainSubstring("must specify a parameter name"))
+	})
+
 	It("rejects invalid top-level path", func() {
 		fieldDefs := []*privatev1.FieldDefinition{{
 			Path: "nonexistent",

--- a/internal/servers/catalog_item_validation_test.go
+++ b/internal/servers/catalog_item_validation_test.go
@@ -24,7 +24,34 @@ import (
 	"google.golang.org/protobuf/types/known/wrapperspb"
 
 	privatev1 "github.com/osac-project/fulfillment-service/internal/api/osac/private/v1"
+	"github.com/osac-project/fulfillment-service/internal/utils"
 )
+
+type fakeTemplate struct {
+	id     string
+	params []string
+}
+
+func (t *fakeTemplate) GetId() string {
+	return t.id
+}
+
+func (t *fakeTemplate) GetParameters() []utils.TemplateParameterDefinition {
+	result := make([]utils.TemplateParameterDefinition, len(t.params))
+	for i, name := range t.params {
+		result[i] = &fakeParam{name: name}
+	}
+	return result
+}
+
+type fakeParam struct {
+	name string
+}
+
+func (p *fakeParam) GetName() string        { return p.name }
+func (p *fakeParam) GetRequired() bool      { return false }
+func (p *fakeParam) GetType() string        { return "" }
+func (p *fakeParam) GetDefault() *anypb.Any { return nil }
 
 var _ = Describe("applyFieldDefinitions", func() {
 	It("rejects editable field with no default and no user value", func() {
@@ -463,6 +490,165 @@ var _ = Describe("applyFieldDefinitions rejects unlisted fields", func() {
 		Expect(status.Code(err)).To(Equal(codes.InvalidArgument))
 		Expect(err.Error()).To(ContainSubstring("run_strategy"))
 		Expect(err.Error()).To(ContainSubstring("not allowed"))
+	})
+})
+
+var _ = Describe("validateFieldDefinitionPaths", func() {
+	It("accepts valid simple path", func() {
+		fieldDefs := []*privatev1.FieldDefinition{{
+			Path: "pull_secret",
+		}}
+		descriptor := (&privatev1.ClusterSpec{}).ProtoReflect().Descriptor()
+		err := validateFieldDefinitionPaths(fieldDefs, descriptor)
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	It("accepts valid nested path", func() {
+		fieldDefs := []*privatev1.FieldDefinition{{
+			Path: "network.pod_cidr",
+		}}
+		descriptor := (&privatev1.ClusterSpec{}).ProtoReflect().Descriptor()
+		err := validateFieldDefinitionPaths(fieldDefs, descriptor)
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	It("accepts valid map entry path", func() {
+		fieldDefs := []*privatev1.FieldDefinition{{
+			Path: "node_sets.workers.size",
+		}}
+		descriptor := (&privatev1.ClusterSpec{}).ProtoReflect().Descriptor()
+		err := validateFieldDefinitionPaths(fieldDefs, descriptor)
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	It("accepts parent message path without traversing children", func() {
+		fieldDefs := []*privatev1.FieldDefinition{{
+			Path: "network",
+		}}
+		descriptor := (&privatev1.ClusterSpec{}).ProtoReflect().Descriptor()
+		err := validateFieldDefinitionPaths(fieldDefs, descriptor)
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	It("skips template_parameters paths", func() {
+		fieldDefs := []*privatev1.FieldDefinition{
+			{Path: "pull_secret"},
+			{Path: "template_parameters.vpc_id"},
+			{Path: "template_parameters.nonexistent"},
+		}
+		descriptor := (&privatev1.ClusterSpec{}).ProtoReflect().Descriptor()
+		err := validateFieldDefinitionPaths(fieldDefs, descriptor)
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	It("rejects invalid top-level path", func() {
+		fieldDefs := []*privatev1.FieldDefinition{{
+			Path: "nonexistent",
+		}}
+		descriptor := (&privatev1.ClusterSpec{}).ProtoReflect().Descriptor()
+		err := validateFieldDefinitionPaths(fieldDefs, descriptor)
+		Expect(err).To(HaveOccurred())
+		Expect(status.Code(err)).To(Equal(codes.InvalidArgument))
+		Expect(err.Error()).To(ContainSubstring("nonexistent"))
+		Expect(err.Error()).To(ContainSubstring("does not exist"))
+	})
+
+	It("rejects invalid nested path", func() {
+		fieldDefs := []*privatev1.FieldDefinition{{
+			Path: "network.invalid_field",
+		}}
+		descriptor := (&privatev1.ClusterSpec{}).ProtoReflect().Descriptor()
+		err := validateFieldDefinitionPaths(fieldDefs, descriptor)
+		Expect(err).To(HaveOccurred())
+		Expect(status.Code(err)).To(Equal(codes.InvalidArgument))
+		Expect(err.Error()).To(ContainSubstring("invalid_field"))
+	})
+
+	It("rejects path continuing beyond a scalar field", func() {
+		fieldDefs := []*privatev1.FieldDefinition{{
+			Path: "pull_secret.nested",
+		}}
+		descriptor := (&privatev1.ClusterSpec{}).ProtoReflect().Descriptor()
+		err := validateFieldDefinitionPaths(fieldDefs, descriptor)
+		Expect(err).To(HaveOccurred())
+		Expect(status.Code(err)).To(Equal(codes.InvalidArgument))
+		Expect(err.Error()).To(ContainSubstring("scalar"))
+	})
+
+	It("accepts valid compute instance spec paths", func() {
+		fieldDefs := []*privatev1.FieldDefinition{
+			{Path: "ssh_public_key"},
+			{Path: "image.source_ref"},
+			{Path: "boot_disk.size_gib"},
+			{Path: "instance_type"},
+		}
+		descriptor := (&privatev1.ComputeInstanceSpec{}).ProtoReflect().Descriptor()
+		err := validateFieldDefinitionPaths(fieldDefs, descriptor)
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	It("accepts valid bare metal instance spec paths", func() {
+		fieldDefs := []*privatev1.FieldDefinition{
+			{Path: "ssh_public_key"},
+			{Path: "user_data"},
+			{Path: "image.source_ref"},
+		}
+		descriptor := (&privatev1.BareMetalInstanceSpec{}).ProtoReflect().Descriptor()
+		err := validateFieldDefinitionPaths(fieldDefs, descriptor)
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	It("skips empty paths", func() {
+		fieldDefs := []*privatev1.FieldDefinition{
+			{Path: ""},
+			{Path: "pull_secret"},
+		}
+		descriptor := (&privatev1.ClusterSpec{}).ProtoReflect().Descriptor()
+		err := validateFieldDefinitionPaths(fieldDefs, descriptor)
+		Expect(err).ToNot(HaveOccurred())
+	})
+})
+
+var _ = Describe("validateFieldDefinitionTemplateParams", func() {
+	It("accepts valid template parameter paths", func() {
+		fieldDefs := []*privatev1.FieldDefinition{
+			{Path: "pull_secret"},
+			{Path: "template_parameters.ip_block_id"},
+		}
+		template := &fakeTemplate{
+			id:     "my-template",
+			params: []string{"ip_block_id", "vpc_id"},
+		}
+		err := validateFieldDefinitionTemplateParams(fieldDefs, template)
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	It("rejects unknown template parameter", func() {
+		fieldDefs := []*privatev1.FieldDefinition{
+			{Path: "template_parameters.nonexistent"},
+		}
+		template := &fakeTemplate{
+			id:     "my-template",
+			params: []string{"ip_block_id", "vpc_id"},
+		}
+		err := validateFieldDefinitionTemplateParams(fieldDefs, template)
+		Expect(err).To(HaveOccurred())
+		Expect(status.Code(err)).To(Equal(codes.InvalidArgument))
+		Expect(err.Error()).To(ContainSubstring("nonexistent"))
+		Expect(err.Error()).To(ContainSubstring("ip_block_id"))
+	})
+
+	It("is a no-op when there are no template_parameters paths", func() {
+		fieldDefs := []*privatev1.FieldDefinition{
+			{Path: "pull_secret"},
+			{Path: "ssh_public_key"},
+		}
+		template := &fakeTemplate{
+			id:     "my-template",
+			params: []string{"ip_block_id"},
+		}
+		err := validateFieldDefinitionTemplateParams(fieldDefs, template)
+		Expect(err).ToNot(HaveOccurred())
 	})
 })
 

--- a/internal/servers/private_baremetal_instance_catalog_items_server.go
+++ b/internal/servers/private_baremetal_instance_catalog_items_server.go
@@ -27,6 +27,7 @@ import (
 	"github.com/osac-project/fulfillment-service/internal/auth"
 	"github.com/osac-project/fulfillment-service/internal/database/dao"
 	"github.com/osac-project/fulfillment-service/internal/events"
+	"github.com/osac-project/fulfillment-service/internal/utils"
 )
 
 type PrivateBareMetalInstanceCatalogItemsServerBuilder struct {
@@ -45,6 +46,7 @@ type PrivateBareMetalInstanceCatalogItemsServer struct {
 	logger           *slog.Logger
 	generic          *GenericServer[*privatev1.BareMetalInstanceCatalogItem]
 	referenceChecker catalogItemReferenceChecker
+	templatesDao     *dao.GenericDAO[*privatev1.BareMetalInstanceTemplate]
 }
 
 func NewPrivateBareMetalInstanceCatalogItemsServer() *PrivateBareMetalInstanceCatalogItemsServerBuilder {
@@ -121,10 +123,20 @@ func (b *PrivateBareMetalInstanceCatalogItemsServerBuilder) Build() (result *Pri
 		refChecker = &daoReferenceChecker[*privatev1.BareMetalInstance]{resourceDao: bmiDao}
 	}
 
+	templatesDao, err := dao.NewGenericDAO[*privatev1.BareMetalInstanceTemplate]().
+		SetLogger(b.logger).
+		SetTenancyLogic(b.tenancyLogic).
+		SetMetricsRegisterer(b.metricsRegisterer).
+		Build()
+	if err != nil {
+		return
+	}
+
 	result = &PrivateBareMetalInstanceCatalogItemsServer{
 		logger:           b.logger,
 		generic:          generic,
 		referenceChecker: refChecker,
+		templatesDao:     templatesDao,
 	}
 	return
 }
@@ -147,6 +159,9 @@ func (s *PrivateBareMetalInstanceCatalogItemsServer) Create(ctx context.Context,
 		if err = validateFieldDefinitions(object.GetFieldDefinitions()); err != nil {
 			return
 		}
+		if err = s.validateFieldDefinitionPathsAndTemplateParams(ctx, object); err != nil {
+			return
+		}
 	}
 	err = s.generic.Create(ctx, request, &response)
 	return
@@ -156,6 +171,9 @@ func (s *PrivateBareMetalInstanceCatalogItemsServer) Update(ctx context.Context,
 	request *privatev1.BareMetalInstanceCatalogItemsUpdateRequest) (response *privatev1.BareMetalInstanceCatalogItemsUpdateResponse, err error) {
 	if object := request.GetObject(); object != nil {
 		if err = validateFieldDefinitions(object.GetFieldDefinitions()); err != nil {
+			return
+		}
+		if err = s.validateFieldDefinitionPathsAndTemplateParams(ctx, object); err != nil {
 			return
 		}
 	}
@@ -185,4 +203,21 @@ func (s *PrivateBareMetalInstanceCatalogItemsServer) Signal(ctx context.Context,
 	request *privatev1.BareMetalInstanceCatalogItemsSignalRequest) (response *privatev1.BareMetalInstanceCatalogItemsSignalResponse, err error) {
 	err = s.generic.Signal(ctx, request, &response)
 	return
+}
+
+func (s *PrivateBareMetalInstanceCatalogItemsServer) validateFieldDefinitionPathsAndTemplateParams(
+	ctx context.Context, object *privatev1.BareMetalInstanceCatalogItem,
+) error {
+	return validateCatalogItemFieldDefinitionPaths(ctx, object,
+		(&privatev1.BareMetalInstanceSpec{}).ProtoReflect().Descriptor(),
+		s.resolveTemplate,
+	)
+}
+
+func (s *PrivateBareMetalInstanceCatalogItemsServer) resolveTemplate(ctx context.Context, id string) (utils.Template, error) {
+	resp, err := s.templatesDao.Get().SetId(id).Do(ctx)
+	if err != nil {
+		return nil, templateLookupError(id, err)
+	}
+	return utils.BareMetalInstanceTemplateAdapter{BareMetalInstanceTemplate: resp.GetObject()}, nil
 }

--- a/internal/servers/private_baremetal_instance_catalog_items_server_test.go
+++ b/internal/servers/private_baremetal_instance_catalog_items_server_test.go
@@ -25,6 +25,7 @@ import (
 	grpcstatus "google.golang.org/grpc/status"
 
 	privatev1 "github.com/osac-project/fulfillment-service/internal/api/osac/private/v1"
+	"github.com/osac-project/fulfillment-service/internal/auth"
 	"github.com/osac-project/fulfillment-service/internal/database/dao"
 )
 
@@ -81,6 +82,25 @@ var _ = Describe("Private bare metal instance catalog items server", func() {
 				Build()
 			Expect(err).ToNot(HaveOccurred())
 		})
+
+		createBareMetalInstanceTemplate := func(id, paramName string) {
+			_, err := server.templatesDao.Create().SetObject(
+				privatev1.BareMetalInstanceTemplate_builder{
+					Id: id,
+					Metadata: privatev1.Metadata_builder{
+						Tenant: auth.SharedTenant,
+					}.Build(),
+					Title: "Template with params",
+					Parameters: []*privatev1.BareMetalInstanceTemplateParameterDefinition{
+						privatev1.BareMetalInstanceTemplateParameterDefinition_builder{
+							Name: paramName,
+							Type: "type.googleapis.com/google.protobuf.StringValue",
+						}.Build(),
+					},
+				}.Build(),
+			).Do(ctx)
+			Expect(err).ToNot(HaveOccurred())
+		}
 
 		It("Creates object", func() {
 			response, err := server.Create(ctx, privatev1.BareMetalInstanceCatalogItemsCreateRequest_builder{
@@ -210,7 +230,7 @@ var _ = Describe("Private bare metal instance catalog items server", func() {
 					Template: "my-template-id",
 					FieldDefinitions: []*privatev1.FieldDefinition{
 						privatev1.FieldDefinition_builder{
-							Path:        "spec.run_strategy",
+							Path:        "run_strategy",
 							DisplayName: "Run strategy",
 							Editable:    true,
 						}.Build(),
@@ -219,7 +239,7 @@ var _ = Describe("Private bare metal instance catalog items server", func() {
 			}.Build())
 			Expect(err).ToNot(HaveOccurred())
 			Expect(response.GetObject().GetFieldDefinitions()).To(HaveLen(1))
-			Expect(response.GetObject().GetFieldDefinitions()[0].GetPath()).To(Equal("spec.run_strategy"))
+			Expect(response.GetObject().GetFieldDefinitions()[0].GetPath()).To(Equal("run_strategy"))
 		})
 
 		It("Rejects non-editable field definition without default value", func() {
@@ -229,7 +249,7 @@ var _ = Describe("Private bare metal instance catalog items server", func() {
 					Template: "my-template-id",
 					FieldDefinitions: []*privatev1.FieldDefinition{
 						privatev1.FieldDefinition_builder{
-							Path:     "spec.pull_secret",
+							Path:     "user_data",
 							Editable: false,
 						}.Build(),
 					},
@@ -239,7 +259,7 @@ var _ = Describe("Private bare metal instance catalog items server", func() {
 			status, ok := grpcstatus.FromError(err)
 			Expect(ok).To(BeTrue())
 			Expect(status.Code()).To(Equal(grpccodes.InvalidArgument))
-			Expect(status.Message()).To(ContainSubstring("pull_secret"))
+			Expect(status.Message()).To(ContainSubstring("user_data"))
 			Expect(status.Message()).To(ContainSubstring("default value"))
 		})
 
@@ -250,7 +270,7 @@ var _ = Describe("Private bare metal instance catalog items server", func() {
 					Template: "my-template-id",
 					FieldDefinitions: []*privatev1.FieldDefinition{
 						privatev1.FieldDefinition_builder{
-							Path:     "spec.pull_secret",
+							Path:     "user_data",
 							Editable: false,
 							Default:  structpb.NewStringValue("my-secret"),
 						}.Build(),
@@ -275,7 +295,7 @@ var _ = Describe("Private bare metal instance catalog items server", func() {
 					Template: "my-template-id",
 					FieldDefinitions: []*privatev1.FieldDefinition{
 						privatev1.FieldDefinition_builder{
-							Path:     "spec.pull_secret",
+							Path:     "user_data",
 							Editable: true,
 						}.Build(),
 					},
@@ -299,11 +319,11 @@ var _ = Describe("Private bare metal instance catalog items server", func() {
 					Template: "my-template-id",
 					FieldDefinitions: []*privatev1.FieldDefinition{
 						privatev1.FieldDefinition_builder{
-							Path:     "spec.pull_secret",
+							Path:     "user_data",
 							Editable: true,
 						}.Build(),
 						privatev1.FieldDefinition_builder{
-							Path:     "spec.ssh_public_key",
+							Path:     "ssh_public_key",
 							Editable: false,
 						}.Build(),
 					},
@@ -323,7 +343,7 @@ var _ = Describe("Private bare metal instance catalog items server", func() {
 					Template: "my-template-id",
 					FieldDefinitions: []*privatev1.FieldDefinition{
 						privatev1.FieldDefinition_builder{
-							Path:             "spec.cores",
+							Path:             "restart_trigger",
 							Editable:         true,
 							ValidationSchema: "{not valid json}",
 						}.Build(),
@@ -334,7 +354,7 @@ var _ = Describe("Private bare metal instance catalog items server", func() {
 			status, ok := grpcstatus.FromError(err)
 			Expect(ok).To(BeTrue())
 			Expect(status.Code()).To(Equal(grpccodes.InvalidArgument))
-			Expect(status.Message()).To(ContainSubstring("cores"))
+			Expect(status.Message()).To(ContainSubstring("restart_trigger"))
 			Expect(status.Message()).To(ContainSubstring("invalid validation_schema"))
 		})
 
@@ -345,7 +365,7 @@ var _ = Describe("Private bare metal instance catalog items server", func() {
 					Template: "my-template-id",
 					FieldDefinitions: []*privatev1.FieldDefinition{
 						privatev1.FieldDefinition_builder{
-							Path:             "spec.cores",
+							Path:             "restart_trigger",
 							Editable:         true,
 							ValidationSchema: `{"type":"number","minimum":1}`,
 						}.Build(),
@@ -384,7 +404,7 @@ var _ = Describe("Private bare metal instance catalog items server", func() {
 					Id: id,
 					FieldDefinitions: []*privatev1.FieldDefinition{
 						privatev1.FieldDefinition_builder{
-							Path:     "spec.cores",
+							Path:     "restart_trigger",
 							Editable: false,
 						}.Build(),
 					},
@@ -397,7 +417,7 @@ var _ = Describe("Private bare metal instance catalog items server", func() {
 			status, ok := grpcstatus.FromError(err)
 			Expect(ok).To(BeTrue())
 			Expect(status.Code()).To(Equal(grpccodes.InvalidArgument))
-			Expect(status.Message()).To(ContainSubstring("cores"))
+			Expect(status.Message()).To(ContainSubstring("restart_trigger"))
 			Expect(status.Message()).To(ContainSubstring("default value"))
 		})
 
@@ -422,7 +442,7 @@ var _ = Describe("Private bare metal instance catalog items server", func() {
 					Id: id,
 					FieldDefinitions: []*privatev1.FieldDefinition{
 						privatev1.FieldDefinition_builder{
-							Path:             "spec.cores",
+							Path:             "restart_trigger",
 							Editable:         true,
 							ValidationSchema: "{bad json}",
 						}.Build(),
@@ -437,6 +457,127 @@ var _ = Describe("Private bare metal instance catalog items server", func() {
 			Expect(ok).To(BeTrue())
 			Expect(status.Code()).To(Equal(grpccodes.InvalidArgument))
 			Expect(status.Message()).To(ContainSubstring("invalid validation_schema"))
+		})
+
+		It("Rejects field definition with invalid spec path on Create", func() {
+			_, err := server.Create(ctx, privatev1.BareMetalInstanceCatalogItemsCreateRequest_builder{
+				Object: privatev1.BareMetalInstanceCatalogItem_builder{
+					Title:    "Bad path catalog item",
+					Template: "my-template-id",
+					FieldDefinitions: []*privatev1.FieldDefinition{
+						privatev1.FieldDefinition_builder{
+							Path:     "nonexistent_field",
+							Editable: true,
+						}.Build(),
+					},
+				}.Build(),
+			}.Build())
+			Expect(err).To(HaveOccurred())
+			status, ok := grpcstatus.FromError(err)
+			Expect(ok).To(BeTrue())
+			Expect(status.Code()).To(Equal(grpccodes.InvalidArgument))
+			Expect(status.Message()).To(ContainSubstring("nonexistent_field"))
+			Expect(status.Message()).To(ContainSubstring("does not exist"))
+		})
+
+		It("Rejects field definition with invalid spec path on Update", func() {
+			response, err := server.Create(ctx, privatev1.BareMetalInstanceCatalogItemsCreateRequest_builder{
+				Object: privatev1.BareMetalInstanceCatalogItem_builder{
+					Title:    "Will update with bad path",
+					Template: "my-template-id",
+				}.Build(),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+			id := response.GetObject().GetId()
+			DeferCleanup(func() {
+				_, _ = server.Delete(ctx, privatev1.BareMetalInstanceCatalogItemsDeleteRequest_builder{
+					Id: id,
+				}.Build())
+			})
+
+			_, err = server.Update(ctx, privatev1.BareMetalInstanceCatalogItemsUpdateRequest_builder{
+				Object: privatev1.BareMetalInstanceCatalogItem_builder{
+					Id:       id,
+					Title:    "Will update with bad path",
+					Template: "my-template-id",
+					FieldDefinitions: []*privatev1.FieldDefinition{
+						privatev1.FieldDefinition_builder{
+							Path:     "nonexistent_field",
+							Editable: true,
+						}.Build(),
+					},
+				}.Build(),
+				UpdateMask: &fieldmaskpb.FieldMask{
+					Paths: []string{"field_definitions"},
+				},
+			}.Build())
+			Expect(err).To(HaveOccurred())
+			status, ok := grpcstatus.FromError(err)
+			Expect(ok).To(BeTrue())
+			Expect(status.Code()).To(Equal(grpccodes.InvalidArgument))
+			Expect(status.Message()).To(ContainSubstring("nonexistent_field"))
+		})
+
+		It("Rejects field definition with unknown template parameter on Create", func() {
+			createBareMetalInstanceTemplate("tpl_bm_param_create", "valid_param")
+
+			_, err := server.Create(ctx, privatev1.BareMetalInstanceCatalogItemsCreateRequest_builder{
+				Object: privatev1.BareMetalInstanceCatalogItem_builder{
+					Title:    "Bad template param",
+					Template: "tpl_bm_param_create",
+					FieldDefinitions: []*privatev1.FieldDefinition{
+						privatev1.FieldDefinition_builder{
+							Path:     "template_parameters.unknown_param",
+							Editable: true,
+						}.Build(),
+					},
+				}.Build(),
+			}.Build())
+			Expect(err).To(HaveOccurred())
+			status, ok := grpcstatus.FromError(err)
+			Expect(ok).To(BeTrue())
+			Expect(status.Code()).To(Equal(grpccodes.InvalidArgument))
+			Expect(status.Message()).To(ContainSubstring("unknown_param"))
+		})
+
+		It("Rejects field definition with unknown template parameter on Update", func() {
+			createBareMetalInstanceTemplate("tpl_bm_param_update", "valid_param")
+
+			response, err := server.Create(ctx, privatev1.BareMetalInstanceCatalogItemsCreateRequest_builder{
+				Object: privatev1.BareMetalInstanceCatalogItem_builder{
+					Title:    "Will update with bad param",
+					Template: "tpl_bm_param_update",
+				}.Build(),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+			id := response.GetObject().GetId()
+			DeferCleanup(func() {
+				_, _ = server.Delete(ctx, privatev1.BareMetalInstanceCatalogItemsDeleteRequest_builder{
+					Id: id,
+				}.Build())
+			})
+
+			_, err = server.Update(ctx, privatev1.BareMetalInstanceCatalogItemsUpdateRequest_builder{
+				Object: privatev1.BareMetalInstanceCatalogItem_builder{
+					Id:       id,
+					Title:    "Will update with bad param",
+					Template: "tpl_bm_param_update",
+					FieldDefinitions: []*privatev1.FieldDefinition{
+						privatev1.FieldDefinition_builder{
+							Path:     "template_parameters.unknown_param",
+							Editable: true,
+						}.Build(),
+					},
+				}.Build(),
+				UpdateMask: &fieldmaskpb.FieldMask{
+					Paths: []string{"field_definitions"},
+				},
+			}.Build())
+			Expect(err).To(HaveOccurred())
+			status, ok := grpcstatus.FromError(err)
+			Expect(ok).To(BeTrue())
+			Expect(status.Code()).To(Equal(grpccodes.InvalidArgument))
+			Expect(status.Message()).To(ContainSubstring("unknown_param"))
 		})
 	})
 })

--- a/internal/servers/private_cluster_catalog_items_server.go
+++ b/internal/servers/private_cluster_catalog_items_server.go
@@ -22,7 +22,9 @@ import (
 
 	privatev1 "github.com/osac-project/fulfillment-service/internal/api/osac/private/v1"
 	"github.com/osac-project/fulfillment-service/internal/auth"
+	"github.com/osac-project/fulfillment-service/internal/database/dao"
 	"github.com/osac-project/fulfillment-service/internal/events"
+	"github.com/osac-project/fulfillment-service/internal/utils"
 )
 
 type PrivateClusterCatalogItemsServerBuilder struct {
@@ -37,8 +39,9 @@ var _ privatev1.ClusterCatalogItemsServer = (*PrivateClusterCatalogItemsServer)(
 
 type PrivateClusterCatalogItemsServer struct {
 	privatev1.UnimplementedClusterCatalogItemsServer
-	logger  *slog.Logger
-	generic *GenericServer[*privatev1.ClusterCatalogItem]
+	logger       *slog.Logger
+	generic      *GenericServer[*privatev1.ClusterCatalogItem]
+	templatesDao *dao.GenericDAO[*privatev1.ClusterTemplate]
 }
 
 func NewPrivateClusterCatalogItemsServer() *PrivateClusterCatalogItemsServerBuilder {
@@ -80,6 +83,16 @@ func (b *PrivateClusterCatalogItemsServerBuilder) Build() (result *PrivateCluste
 		err = errors.New("tenancy logic is mandatory")
 		return
 	}
+
+	templatesDao, err := dao.NewGenericDAO[*privatev1.ClusterTemplate]().
+		SetLogger(b.logger).
+		SetTenancyLogic(b.tenancyLogic).
+		SetMetricsRegisterer(b.metricsRegisterer).
+		Build()
+	if err != nil {
+		return
+	}
+
 	generic, err := NewGenericServer[*privatev1.ClusterCatalogItem]().
 		SetLogger(b.logger).
 		SetService(privatev1.ClusterCatalogItems_ServiceDesc.ServiceName).
@@ -93,8 +106,9 @@ func (b *PrivateClusterCatalogItemsServerBuilder) Build() (result *PrivateCluste
 	}
 
 	result = &PrivateClusterCatalogItemsServer{
-		logger:  b.logger,
-		generic: generic,
+		logger:       b.logger,
+		generic:      generic,
+		templatesDao: templatesDao,
 	}
 	return
 }
@@ -117,6 +131,9 @@ func (s *PrivateClusterCatalogItemsServer) Create(ctx context.Context,
 		if err = validateFieldDefinitions(object.GetFieldDefinitions()); err != nil {
 			return
 		}
+		if err = s.validateFieldDefinitionPathsAndTemplateParams(ctx, object); err != nil {
+			return
+		}
 	}
 	err = s.generic.Create(ctx, request, &response)
 	return
@@ -126,6 +143,9 @@ func (s *PrivateClusterCatalogItemsServer) Update(ctx context.Context,
 	request *privatev1.ClusterCatalogItemsUpdateRequest) (response *privatev1.ClusterCatalogItemsUpdateResponse, err error) {
 	if object := request.GetObject(); object != nil {
 		if err = validateFieldDefinitions(object.GetFieldDefinitions()); err != nil {
+			return
+		}
+		if err = s.validateFieldDefinitionPathsAndTemplateParams(ctx, object); err != nil {
 			return
 		}
 	}
@@ -143,4 +163,21 @@ func (s *PrivateClusterCatalogItemsServer) Signal(ctx context.Context,
 	request *privatev1.ClusterCatalogItemsSignalRequest) (response *privatev1.ClusterCatalogItemsSignalResponse, err error) {
 	err = s.generic.Signal(ctx, request, &response)
 	return
+}
+
+func (s *PrivateClusterCatalogItemsServer) validateFieldDefinitionPathsAndTemplateParams(
+	ctx context.Context, object *privatev1.ClusterCatalogItem,
+) error {
+	return validateCatalogItemFieldDefinitionPaths(ctx, object,
+		(&privatev1.ClusterSpec{}).ProtoReflect().Descriptor(),
+		s.resolveTemplate,
+	)
+}
+
+func (s *PrivateClusterCatalogItemsServer) resolveTemplate(ctx context.Context, id string) (utils.Template, error) {
+	resp, err := s.templatesDao.Get().SetId(id).Do(ctx)
+	if err != nil {
+		return nil, templateLookupError(id, err)
+	}
+	return utils.ClusterTemplateAdapter{ClusterTemplate: resp.GetObject()}, nil
 }

--- a/internal/servers/private_cluster_catalog_items_server_test.go
+++ b/internal/servers/private_cluster_catalog_items_server_test.go
@@ -26,6 +26,7 @@ import (
 	grpcstatus "google.golang.org/grpc/status"
 
 	privatev1 "github.com/osac-project/fulfillment-service/internal/api/osac/private/v1"
+	"github.com/osac-project/fulfillment-service/internal/auth"
 	"github.com/osac-project/fulfillment-service/internal/database/dao"
 )
 
@@ -85,6 +86,25 @@ var _ = Describe("Private cluster catalog items server", func() {
 				Build()
 			Expect(err).ToNot(HaveOccurred())
 		})
+
+		createClusterTemplate := func(id, paramName string) {
+			_, err := server.templatesDao.Create().SetObject(
+				privatev1.ClusterTemplate_builder{
+					Id: id,
+					Metadata: privatev1.Metadata_builder{
+						Tenant: auth.SharedTenant,
+					}.Build(),
+					Title: "Template with params",
+					Parameters: []*privatev1.ClusterTemplateParameterDefinition{
+						privatev1.ClusterTemplateParameterDefinition_builder{
+							Name: paramName,
+							Type: "type.googleapis.com/google.protobuf.StringValue",
+						}.Build(),
+					},
+				}.Build(),
+			).Do(ctx)
+			Expect(err).ToNot(HaveOccurred())
+		}
 
 		It("Creates object", func() {
 			response, err := server.Create(ctx, privatev1.ClusterCatalogItemsCreateRequest_builder{
@@ -283,13 +303,13 @@ var _ = Describe("Private cluster catalog items server", func() {
 					Template: "my-template-id",
 					FieldDefinitions: []*privatev1.FieldDefinition{
 						privatev1.FieldDefinition_builder{
-							Path:             "spec.network.pod_cidr",
+							Path:             "network.pod_cidr",
 							DisplayName:      "Pod CIDR",
 							Editable:         true,
 							ValidationSchema: `{"type":"string","pattern":"^[0-9./]+$"}`,
 						}.Build(),
 						privatev1.FieldDefinition_builder{
-							Path:        "spec.node_sets.workers.size",
+							Path:        "node_sets.workers.size",
 							DisplayName: "Worker count",
 							Editable:    false,
 							Default:     structpb.NewNumberValue(3),
@@ -314,13 +334,13 @@ var _ = Describe("Private cluster catalog items server", func() {
 			Expect(fetched.GetFieldDefinitions()).To(HaveLen(2))
 
 			fd0 := fetched.GetFieldDefinitions()[0]
-			Expect(fd0.GetPath()).To(Equal("spec.network.pod_cidr"))
+			Expect(fd0.GetPath()).To(Equal("network.pod_cidr"))
 			Expect(fd0.GetDisplayName()).To(Equal("Pod CIDR"))
 			Expect(fd0.GetEditable()).To(BeTrue())
 			Expect(fd0.GetValidationSchema()).To(Equal(`{"type":"string","pattern":"^[0-9./]+$"}`))
 
 			fd1 := fetched.GetFieldDefinitions()[1]
-			Expect(fd1.GetPath()).To(Equal("spec.node_sets.workers.size"))
+			Expect(fd1.GetPath()).To(Equal("node_sets.workers.size"))
 			Expect(fd1.GetDisplayName()).To(Equal("Worker count"))
 			Expect(fd1.GetEditable()).To(BeFalse())
 			Expect(fd1.GetDefault()).ToNot(BeNil())
@@ -437,7 +457,7 @@ var _ = Describe("Private cluster catalog items server", func() {
 				Object: privatev1.ClusterCatalogItem_builder{
 					Metadata: privatev1.Metadata_builder{
 						Name:   "dev-sandbox",
-						Tenant: "shared",
+						Tenant: auth.SharedTenant,
 					}.Build(),
 					Title:    "Catalog item for shared tenant",
 					Template: "my-template-id",
@@ -493,7 +513,7 @@ var _ = Describe("Private cluster catalog items server", func() {
 					Template: "my-template-id",
 					FieldDefinitions: []*privatev1.FieldDefinition{
 						privatev1.FieldDefinition_builder{
-							Path:     "spec.pull_secret",
+							Path:     "pull_secret",
 							Editable: false,
 						}.Build(),
 					},
@@ -514,7 +534,7 @@ var _ = Describe("Private cluster catalog items server", func() {
 					Template: "my-template-id",
 					FieldDefinitions: []*privatev1.FieldDefinition{
 						privatev1.FieldDefinition_builder{
-							Path:     "spec.pull_secret",
+							Path:     "pull_secret",
 							Editable: false,
 							Default:  structpb.NewStringValue("my-secret"),
 						}.Build(),
@@ -539,7 +559,7 @@ var _ = Describe("Private cluster catalog items server", func() {
 					Template: "my-template-id",
 					FieldDefinitions: []*privatev1.FieldDefinition{
 						privatev1.FieldDefinition_builder{
-							Path:     "spec.pull_secret",
+							Path:     "pull_secret",
 							Editable: true,
 						}.Build(),
 					},
@@ -563,11 +583,11 @@ var _ = Describe("Private cluster catalog items server", func() {
 					Template: "my-template-id",
 					FieldDefinitions: []*privatev1.FieldDefinition{
 						privatev1.FieldDefinition_builder{
-							Path:     "spec.pull_secret",
+							Path:     "pull_secret",
 							Editable: true,
 						}.Build(),
 						privatev1.FieldDefinition_builder{
-							Path:     "spec.ssh_public_key",
+							Path:     "ssh_public_key",
 							Editable: false,
 						}.Build(),
 					},
@@ -587,7 +607,7 @@ var _ = Describe("Private cluster catalog items server", func() {
 					Template: "my-template-id",
 					FieldDefinitions: []*privatev1.FieldDefinition{
 						privatev1.FieldDefinition_builder{
-							Path:             "spec.network.pod_cidr",
+							Path:             "network.pod_cidr",
 							Editable:         true,
 							ValidationSchema: "{not valid json}",
 						}.Build(),
@@ -609,7 +629,7 @@ var _ = Describe("Private cluster catalog items server", func() {
 					Template: "my-template-id",
 					FieldDefinitions: []*privatev1.FieldDefinition{
 						privatev1.FieldDefinition_builder{
-							Path:             "spec.network.pod_cidr",
+							Path:             "network.pod_cidr",
 							Editable:         true,
 							ValidationSchema: `{"type":"string","pattern":"^[0-9./]+$"}`,
 						}.Build(),
@@ -648,7 +668,7 @@ var _ = Describe("Private cluster catalog items server", func() {
 					Id: id,
 					FieldDefinitions: []*privatev1.FieldDefinition{
 						privatev1.FieldDefinition_builder{
-							Path:     "spec.pull_secret",
+							Path:     "pull_secret",
 							Editable: false,
 						}.Build(),
 					},
@@ -686,7 +706,7 @@ var _ = Describe("Private cluster catalog items server", func() {
 					Id: id,
 					FieldDefinitions: []*privatev1.FieldDefinition{
 						privatev1.FieldDefinition_builder{
-							Path:             "spec.network.pod_cidr",
+							Path:             "network.pod_cidr",
 							Editable:         true,
 							ValidationSchema: "{bad json}",
 						}.Build(),
@@ -724,12 +744,12 @@ var _ = Describe("Private cluster catalog items server", func() {
 					Id: id,
 					FieldDefinitions: []*privatev1.FieldDefinition{
 						privatev1.FieldDefinition_builder{
-							Path:     "spec.pull_secret",
+							Path:     "pull_secret",
 							Editable: false,
 							Default:  structpb.NewStringValue("locked-secret"),
 						}.Build(),
 						privatev1.FieldDefinition_builder{
-							Path:             "spec.network.pod_cidr",
+							Path:             "network.pod_cidr",
 							Editable:         true,
 							ValidationSchema: `{"type":"string"}`,
 						}.Build(),
@@ -741,6 +761,127 @@ var _ = Describe("Private cluster catalog items server", func() {
 			}.Build())
 			Expect(err).ToNot(HaveOccurred())
 			Expect(updateResponse.GetObject().GetFieldDefinitions()).To(HaveLen(2))
+		})
+
+		It("Rejects field definition with invalid spec path on Create", func() {
+			_, err := server.Create(ctx, privatev1.ClusterCatalogItemsCreateRequest_builder{
+				Object: privatev1.ClusterCatalogItem_builder{
+					Title:    "Bad path catalog item",
+					Template: "my-template-id",
+					FieldDefinitions: []*privatev1.FieldDefinition{
+						privatev1.FieldDefinition_builder{
+							Path:     "nonexistent_field",
+							Editable: true,
+						}.Build(),
+					},
+				}.Build(),
+			}.Build())
+			Expect(err).To(HaveOccurred())
+			status, ok := grpcstatus.FromError(err)
+			Expect(ok).To(BeTrue())
+			Expect(status.Code()).To(Equal(grpccodes.InvalidArgument))
+			Expect(status.Message()).To(ContainSubstring("nonexistent_field"))
+			Expect(status.Message()).To(ContainSubstring("does not exist"))
+		})
+
+		It("Rejects field definition with invalid spec path on Update", func() {
+			response, err := server.Create(ctx, privatev1.ClusterCatalogItemsCreateRequest_builder{
+				Object: privatev1.ClusterCatalogItem_builder{
+					Title:    "Will update with bad path",
+					Template: "my-template-id",
+				}.Build(),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+			id := response.GetObject().GetId()
+			DeferCleanup(func() {
+				_, _ = server.Delete(ctx, privatev1.ClusterCatalogItemsDeleteRequest_builder{
+					Id: id,
+				}.Build())
+			})
+
+			_, err = server.Update(ctx, privatev1.ClusterCatalogItemsUpdateRequest_builder{
+				Object: privatev1.ClusterCatalogItem_builder{
+					Id:       id,
+					Title:    "Will update with bad path",
+					Template: "my-template-id",
+					FieldDefinitions: []*privatev1.FieldDefinition{
+						privatev1.FieldDefinition_builder{
+							Path:     "nonexistent_field",
+							Editable: true,
+						}.Build(),
+					},
+				}.Build(),
+				UpdateMask: &fieldmaskpb.FieldMask{
+					Paths: []string{"field_definitions"},
+				},
+			}.Build())
+			Expect(err).To(HaveOccurred())
+			status, ok := grpcstatus.FromError(err)
+			Expect(ok).To(BeTrue())
+			Expect(status.Code()).To(Equal(grpccodes.InvalidArgument))
+			Expect(status.Message()).To(ContainSubstring("nonexistent_field"))
+		})
+
+		It("Rejects field definition with unknown template parameter on Create", func() {
+			createClusterTemplate("tpl-cluster-param-create", "valid_param")
+
+			_, err := server.Create(ctx, privatev1.ClusterCatalogItemsCreateRequest_builder{
+				Object: privatev1.ClusterCatalogItem_builder{
+					Title:    "Bad template param",
+					Template: "tpl-cluster-param-create",
+					FieldDefinitions: []*privatev1.FieldDefinition{
+						privatev1.FieldDefinition_builder{
+							Path:     "template_parameters.unknown_param",
+							Editable: true,
+						}.Build(),
+					},
+				}.Build(),
+			}.Build())
+			Expect(err).To(HaveOccurred())
+			status, ok := grpcstatus.FromError(err)
+			Expect(ok).To(BeTrue())
+			Expect(status.Code()).To(Equal(grpccodes.InvalidArgument))
+			Expect(status.Message()).To(ContainSubstring("unknown_param"))
+		})
+
+		It("Rejects field definition with unknown template parameter on Update", func() {
+			createClusterTemplate("tpl-cluster-param-update", "valid_param")
+
+			response, err := server.Create(ctx, privatev1.ClusterCatalogItemsCreateRequest_builder{
+				Object: privatev1.ClusterCatalogItem_builder{
+					Title:    "Will update with bad param",
+					Template: "tpl-cluster-param-update",
+				}.Build(),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+			id := response.GetObject().GetId()
+			DeferCleanup(func() {
+				_, _ = server.Delete(ctx, privatev1.ClusterCatalogItemsDeleteRequest_builder{
+					Id: id,
+				}.Build())
+			})
+
+			_, err = server.Update(ctx, privatev1.ClusterCatalogItemsUpdateRequest_builder{
+				Object: privatev1.ClusterCatalogItem_builder{
+					Id:       id,
+					Title:    "Will update with bad param",
+					Template: "tpl-cluster-param-update",
+					FieldDefinitions: []*privatev1.FieldDefinition{
+						privatev1.FieldDefinition_builder{
+							Path:     "template_parameters.unknown_param",
+							Editable: true,
+						}.Build(),
+					},
+				}.Build(),
+				UpdateMask: &fieldmaskpb.FieldMask{
+					Paths: []string{"field_definitions"},
+				},
+			}.Build())
+			Expect(err).To(HaveOccurred())
+			status, ok := grpcstatus.FromError(err)
+			Expect(ok).To(BeTrue())
+			Expect(status.Code()).To(Equal(grpccodes.InvalidArgument))
+			Expect(status.Message()).To(ContainSubstring("unknown_param"))
 		})
 
 		It("Allows empty name without conflict", func() {

--- a/internal/servers/private_compute_instance_catalog_items_server.go
+++ b/internal/servers/private_compute_instance_catalog_items_server.go
@@ -24,6 +24,7 @@ import (
 	"github.com/osac-project/fulfillment-service/internal/auth"
 	"github.com/osac-project/fulfillment-service/internal/database/dao"
 	"github.com/osac-project/fulfillment-service/internal/events"
+	"github.com/osac-project/fulfillment-service/internal/utils"
 )
 
 type PrivateComputeInstanceCatalogItemsServerBuilder struct {
@@ -41,6 +42,7 @@ type PrivateComputeInstanceCatalogItemsServer struct {
 	logger           *slog.Logger
 	generic          *GenericServer[*privatev1.ComputeInstanceCatalogItem]
 	instanceTypesDao *dao.GenericDAO[*privatev1.InstanceType]
+	templatesDao     *dao.GenericDAO[*privatev1.ComputeInstanceTemplate]
 }
 
 func NewPrivateComputeInstanceCatalogItemsServer() *PrivateComputeInstanceCatalogItemsServerBuilder {
@@ -92,6 +94,15 @@ func (b *PrivateComputeInstanceCatalogItemsServerBuilder) Build() (result *Priva
 		return
 	}
 
+	templatesDao, err := dao.NewGenericDAO[*privatev1.ComputeInstanceTemplate]().
+		SetLogger(b.logger).
+		SetTenancyLogic(b.tenancyLogic).
+		SetMetricsRegisterer(b.metricsRegisterer).
+		Build()
+	if err != nil {
+		return
+	}
+
 	generic, err := NewGenericServer[*privatev1.ComputeInstanceCatalogItem]().
 		SetLogger(b.logger).
 		SetService(privatev1.ComputeInstanceCatalogItems_ServiceDesc.ServiceName).
@@ -108,6 +119,7 @@ func (b *PrivateComputeInstanceCatalogItemsServerBuilder) Build() (result *Priva
 		logger:           b.logger,
 		generic:          generic,
 		instanceTypesDao: instanceTypesDao,
+		templatesDao:     templatesDao,
 	}
 	return
 }
@@ -127,11 +139,14 @@ func (s *PrivateComputeInstanceCatalogItemsServer) Get(ctx context.Context,
 func (s *PrivateComputeInstanceCatalogItemsServer) Create(ctx context.Context,
 	request *privatev1.ComputeInstanceCatalogItemsCreateRequest) (response *privatev1.ComputeInstanceCatalogItemsCreateResponse, err error) {
 	var warnings []string
-	if request.GetObject() != nil {
-		if err = validateFieldDefinitions(request.GetObject().GetFieldDefinitions()); err != nil {
+	if object := request.GetObject(); object != nil {
+		if err = validateFieldDefinitions(object.GetFieldDefinitions()); err != nil {
 			return
 		}
-		warnings, err = s.validateFieldDefinitionsInstanceType(ctx, request.GetObject().GetFieldDefinitions())
+		if err = s.validateFieldDefinitionPathsAndTemplateParams(ctx, object); err != nil {
+			return
+		}
+		warnings, err = s.validateFieldDefinitionsInstanceType(ctx, object.GetFieldDefinitions())
 		if err != nil {
 			return
 		}
@@ -149,11 +164,14 @@ func (s *PrivateComputeInstanceCatalogItemsServer) Create(ctx context.Context,
 func (s *PrivateComputeInstanceCatalogItemsServer) Update(ctx context.Context,
 	request *privatev1.ComputeInstanceCatalogItemsUpdateRequest) (response *privatev1.ComputeInstanceCatalogItemsUpdateResponse, err error) {
 	var warnings []string
-	if request.GetObject() != nil {
-		if err = validateFieldDefinitions(request.GetObject().GetFieldDefinitions()); err != nil {
+	if object := request.GetObject(); object != nil {
+		if err = validateFieldDefinitions(object.GetFieldDefinitions()); err != nil {
 			return
 		}
-		warnings, err = s.validateFieldDefinitionsInstanceType(ctx, request.GetObject().GetFieldDefinitions())
+		if err = s.validateFieldDefinitionPathsAndTemplateParams(ctx, object); err != nil {
+			return
+		}
+		warnings, err = s.validateFieldDefinitionsInstanceType(ctx, object.GetFieldDefinitions())
 		if err != nil {
 			return
 		}
@@ -180,16 +198,33 @@ func (s *PrivateComputeInstanceCatalogItemsServer) Signal(ctx context.Context,
 	return
 }
 
+func (s *PrivateComputeInstanceCatalogItemsServer) validateFieldDefinitionPathsAndTemplateParams(
+	ctx context.Context, object *privatev1.ComputeInstanceCatalogItem,
+) error {
+	return validateCatalogItemFieldDefinitionPaths(ctx, object,
+		(&privatev1.ComputeInstanceSpec{}).ProtoReflect().Descriptor(),
+		s.resolveTemplate,
+	)
+}
+
+func (s *PrivateComputeInstanceCatalogItemsServer) resolveTemplate(ctx context.Context, id string) (utils.Template, error) {
+	resp, err := s.templatesDao.Get().SetId(id).Do(ctx)
+	if err != nil {
+		return nil, templateLookupError(id, err)
+	}
+	return utils.ComputeInstanceTemplateAdapter{ComputeInstanceTemplate: resp.GetObject()}, nil
+}
+
 // validateFieldDefinitionsInstanceType validates instance_type constraints in field_definitions.
 // Rejects OBSOLETE instance types, warns on DEPRECATED.
 func (s *PrivateComputeInstanceCatalogItemsServer) validateFieldDefinitionsInstanceType(
 	ctx context.Context,
 	fieldDefinitions []*privatev1.FieldDefinition,
 ) ([]string, error) {
-	// Scan field_definitions to extract the spec.instance_type default value.
+	// Scan field_definitions to extract the instance_type default value.
 	var instanceTypeName string
 	for _, fd := range fieldDefinitions {
-		if fd.GetPath() == "spec.instance_type" {
+		if fd.GetPath() == "instance_type" {
 			defaultValue := fd.GetDefault()
 			if defaultValue != nil {
 				instanceTypeName = defaultValue.GetStringValue()

--- a/internal/servers/private_compute_instance_catalog_items_server_test.go
+++ b/internal/servers/private_compute_instance_catalog_items_server_test.go
@@ -26,6 +26,7 @@ import (
 	grpcstatus "google.golang.org/grpc/status"
 
 	privatev1 "github.com/osac-project/fulfillment-service/internal/api/osac/private/v1"
+	"github.com/osac-project/fulfillment-service/internal/auth"
 	"github.com/osac-project/fulfillment-service/internal/database/dao"
 )
 
@@ -85,6 +86,25 @@ var _ = Describe("Private compute instance catalog items server", func() {
 				Build()
 			Expect(err).ToNot(HaveOccurred())
 		})
+
+		createComputeInstanceTemplate := func(id, paramName string) {
+			_, err := server.templatesDao.Create().SetObject(
+				privatev1.ComputeInstanceTemplate_builder{
+					Id: id,
+					Metadata: privatev1.Metadata_builder{
+						Tenant: auth.SharedTenant,
+					}.Build(),
+					Title: "Template with params",
+					Parameters: []*privatev1.ComputeInstanceTemplateParameterDefinition{
+						privatev1.ComputeInstanceTemplateParameterDefinition_builder{
+							Name: paramName,
+							Type: "type.googleapis.com/google.protobuf.StringValue",
+						}.Build(),
+					},
+				}.Build(),
+			).Do(ctx)
+			Expect(err).ToNot(HaveOccurred())
+		}
 
 		It("Creates object", func() {
 			response, err := server.Create(ctx, privatev1.ComputeInstanceCatalogItemsCreateRequest_builder{
@@ -282,13 +302,13 @@ var _ = Describe("Private compute instance catalog items server", func() {
 					Template: "my-ci-template-id",
 					FieldDefinitions: []*privatev1.FieldDefinition{
 						privatev1.FieldDefinition_builder{
-							Path:             "spec.ssh_public_key",
+							Path:             "ssh_public_key",
 							DisplayName:      "SSH Key",
 							Editable:         true,
 							ValidationSchema: `{"type":"string","minLength":1}`,
 						}.Build(),
 						privatev1.FieldDefinition_builder{
-							Path:        "spec.run_strategy",
+							Path:        "run_strategy",
 							DisplayName: "Run Strategy",
 							Editable:    false,
 							Default:     structpb.NewNumberValue(16),
@@ -313,13 +333,13 @@ var _ = Describe("Private compute instance catalog items server", func() {
 			Expect(fetched.GetFieldDefinitions()).To(HaveLen(2))
 
 			fd0 := fetched.GetFieldDefinitions()[0]
-			Expect(fd0.GetPath()).To(Equal("spec.ssh_public_key"))
+			Expect(fd0.GetPath()).To(Equal("ssh_public_key"))
 			Expect(fd0.GetDisplayName()).To(Equal("SSH Key"))
 			Expect(fd0.GetEditable()).To(BeTrue())
 			Expect(fd0.GetValidationSchema()).To(Equal(`{"type":"string","minLength":1}`))
 
 			fd1 := fetched.GetFieldDefinitions()[1]
-			Expect(fd1.GetPath()).To(Equal("spec.run_strategy"))
+			Expect(fd1.GetPath()).To(Equal("run_strategy"))
 			Expect(fd1.GetDisplayName()).To(Equal("Run Strategy"))
 			Expect(fd1.GetEditable()).To(BeFalse())
 			Expect(fd1.GetDefault()).ToNot(BeNil())
@@ -436,7 +456,7 @@ var _ = Describe("Private compute instance catalog items server", func() {
 				Object: privatev1.ComputeInstanceCatalogItem_builder{
 					Metadata: privatev1.Metadata_builder{
 						Name:   "dev-sandbox",
-						Tenant: "shared",
+						Tenant: auth.SharedTenant,
 					}.Build(),
 					Title:    "CI catalog item for shared tenant",
 					Template: "my-ci-template-id",
@@ -492,7 +512,7 @@ var _ = Describe("Private compute instance catalog items server", func() {
 					Template: "my-ci-template-id",
 					FieldDefinitions: []*privatev1.FieldDefinition{
 						privatev1.FieldDefinition_builder{
-							Path:     "spec.pull_secret",
+							Path:     "user_data",
 							Editable: false,
 						}.Build(),
 					},
@@ -502,7 +522,7 @@ var _ = Describe("Private compute instance catalog items server", func() {
 			status, ok := grpcstatus.FromError(err)
 			Expect(ok).To(BeTrue())
 			Expect(status.Code()).To(Equal(grpccodes.InvalidArgument))
-			Expect(status.Message()).To(ContainSubstring("pull_secret"))
+			Expect(status.Message()).To(ContainSubstring("user_data"))
 			Expect(status.Message()).To(ContainSubstring("default value"))
 		})
 
@@ -513,7 +533,7 @@ var _ = Describe("Private compute instance catalog items server", func() {
 					Template: "my-ci-template-id",
 					FieldDefinitions: []*privatev1.FieldDefinition{
 						privatev1.FieldDefinition_builder{
-							Path:     "spec.pull_secret",
+							Path:     "user_data",
 							Editable: false,
 							Default:  structpb.NewStringValue("my-secret"),
 						}.Build(),
@@ -538,7 +558,7 @@ var _ = Describe("Private compute instance catalog items server", func() {
 					Template: "my-ci-template-id",
 					FieldDefinitions: []*privatev1.FieldDefinition{
 						privatev1.FieldDefinition_builder{
-							Path:     "spec.pull_secret",
+							Path:     "user_data",
 							Editable: true,
 						}.Build(),
 					},
@@ -562,11 +582,11 @@ var _ = Describe("Private compute instance catalog items server", func() {
 					Template: "my-ci-template-id",
 					FieldDefinitions: []*privatev1.FieldDefinition{
 						privatev1.FieldDefinition_builder{
-							Path:     "spec.cores",
+							Path:     "instance_type",
 							Editable: true,
 						}.Build(),
 						privatev1.FieldDefinition_builder{
-							Path:     "spec.memory_gib",
+							Path:     "is_windows",
 							Editable: false,
 						}.Build(),
 					},
@@ -576,7 +596,7 @@ var _ = Describe("Private compute instance catalog items server", func() {
 			status, ok := grpcstatus.FromError(err)
 			Expect(ok).To(BeTrue())
 			Expect(status.Code()).To(Equal(grpccodes.InvalidArgument))
-			Expect(status.Message()).To(ContainSubstring("memory_gib"))
+			Expect(status.Message()).To(ContainSubstring("is_windows"))
 		})
 
 		It("Rejects field definition with invalid validation_schema JSON", func() {
@@ -586,7 +606,7 @@ var _ = Describe("Private compute instance catalog items server", func() {
 					Template: "my-ci-template-id",
 					FieldDefinitions: []*privatev1.FieldDefinition{
 						privatev1.FieldDefinition_builder{
-							Path:             "spec.cores",
+							Path:             "instance_type",
 							Editable:         true,
 							ValidationSchema: "{not valid json}",
 						}.Build(),
@@ -597,7 +617,7 @@ var _ = Describe("Private compute instance catalog items server", func() {
 			status, ok := grpcstatus.FromError(err)
 			Expect(ok).To(BeTrue())
 			Expect(status.Code()).To(Equal(grpccodes.InvalidArgument))
-			Expect(status.Message()).To(ContainSubstring("cores"))
+			Expect(status.Message()).To(ContainSubstring("instance_type"))
 			Expect(status.Message()).To(ContainSubstring("invalid validation_schema"))
 		})
 
@@ -608,7 +628,7 @@ var _ = Describe("Private compute instance catalog items server", func() {
 					Template: "my-ci-template-id",
 					FieldDefinitions: []*privatev1.FieldDefinition{
 						privatev1.FieldDefinition_builder{
-							Path:             "spec.cores",
+							Path:             "instance_type",
 							Editable:         true,
 							ValidationSchema: `{"type":"number","minimum":1}`,
 						}.Build(),
@@ -647,7 +667,7 @@ var _ = Describe("Private compute instance catalog items server", func() {
 					Id: id,
 					FieldDefinitions: []*privatev1.FieldDefinition{
 						privatev1.FieldDefinition_builder{
-							Path:     "spec.cores",
+							Path:     "instance_type",
 							Editable: false,
 						}.Build(),
 					},
@@ -660,7 +680,7 @@ var _ = Describe("Private compute instance catalog items server", func() {
 			status, ok := grpcstatus.FromError(err)
 			Expect(ok).To(BeTrue())
 			Expect(status.Code()).To(Equal(grpccodes.InvalidArgument))
-			Expect(status.Message()).To(ContainSubstring("cores"))
+			Expect(status.Message()).To(ContainSubstring("instance_type"))
 			Expect(status.Message()).To(ContainSubstring("default value"))
 		})
 
@@ -685,7 +705,7 @@ var _ = Describe("Private compute instance catalog items server", func() {
 					Id: id,
 					FieldDefinitions: []*privatev1.FieldDefinition{
 						privatev1.FieldDefinition_builder{
-							Path:             "spec.cores",
+							Path:             "instance_type",
 							Editable:         true,
 							ValidationSchema: "{bad json}",
 						}.Build(),
@@ -723,12 +743,12 @@ var _ = Describe("Private compute instance catalog items server", func() {
 					Id: id,
 					FieldDefinitions: []*privatev1.FieldDefinition{
 						privatev1.FieldDefinition_builder{
-							Path:     "spec.cores",
+							Path:     "instance_type",
 							Editable: false,
 							Default:  structpb.NewNumberValue(4),
 						}.Build(),
 						privatev1.FieldDefinition_builder{
-							Path:             "spec.memory_gib",
+							Path:             "is_windows",
 							Editable:         true,
 							ValidationSchema: `{"type":"number"}`,
 						}.Build(),
@@ -740,6 +760,127 @@ var _ = Describe("Private compute instance catalog items server", func() {
 			}.Build())
 			Expect(err).ToNot(HaveOccurred())
 			Expect(updateResponse.GetObject().GetFieldDefinitions()).To(HaveLen(2))
+		})
+
+		It("Rejects field definition with invalid spec path on Create", func() {
+			_, err := server.Create(ctx, privatev1.ComputeInstanceCatalogItemsCreateRequest_builder{
+				Object: privatev1.ComputeInstanceCatalogItem_builder{
+					Title:    "Bad path catalog item",
+					Template: "my-ci-template-id",
+					FieldDefinitions: []*privatev1.FieldDefinition{
+						privatev1.FieldDefinition_builder{
+							Path:     "nonexistent_field",
+							Editable: true,
+						}.Build(),
+					},
+				}.Build(),
+			}.Build())
+			Expect(err).To(HaveOccurred())
+			status, ok := grpcstatus.FromError(err)
+			Expect(ok).To(BeTrue())
+			Expect(status.Code()).To(Equal(grpccodes.InvalidArgument))
+			Expect(status.Message()).To(ContainSubstring("nonexistent_field"))
+			Expect(status.Message()).To(ContainSubstring("does not exist"))
+		})
+
+		It("Rejects field definition with invalid spec path on Update", func() {
+			response, err := server.Create(ctx, privatev1.ComputeInstanceCatalogItemsCreateRequest_builder{
+				Object: privatev1.ComputeInstanceCatalogItem_builder{
+					Title:    "Will update with bad path",
+					Template: "my-ci-template-id",
+				}.Build(),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+			id := response.GetObject().GetId()
+			DeferCleanup(func() {
+				_, _ = server.Delete(ctx, privatev1.ComputeInstanceCatalogItemsDeleteRequest_builder{
+					Id: id,
+				}.Build())
+			})
+
+			_, err = server.Update(ctx, privatev1.ComputeInstanceCatalogItemsUpdateRequest_builder{
+				Object: privatev1.ComputeInstanceCatalogItem_builder{
+					Id:       id,
+					Title:    "Will update with bad path",
+					Template: "my-ci-template-id",
+					FieldDefinitions: []*privatev1.FieldDefinition{
+						privatev1.FieldDefinition_builder{
+							Path:     "nonexistent_field",
+							Editable: true,
+						}.Build(),
+					},
+				}.Build(),
+				UpdateMask: &fieldmaskpb.FieldMask{
+					Paths: []string{"field_definitions"},
+				},
+			}.Build())
+			Expect(err).To(HaveOccurred())
+			status, ok := grpcstatus.FromError(err)
+			Expect(ok).To(BeTrue())
+			Expect(status.Code()).To(Equal(grpccodes.InvalidArgument))
+			Expect(status.Message()).To(ContainSubstring("nonexistent_field"))
+		})
+
+		It("Rejects field definition with unknown template parameter on Create", func() {
+			createComputeInstanceTemplate("tpl-ci-param-create", "valid_param")
+
+			_, err := server.Create(ctx, privatev1.ComputeInstanceCatalogItemsCreateRequest_builder{
+				Object: privatev1.ComputeInstanceCatalogItem_builder{
+					Title:    "Bad template param",
+					Template: "tpl-ci-param-create",
+					FieldDefinitions: []*privatev1.FieldDefinition{
+						privatev1.FieldDefinition_builder{
+							Path:     "template_parameters.unknown_param",
+							Editable: true,
+						}.Build(),
+					},
+				}.Build(),
+			}.Build())
+			Expect(err).To(HaveOccurred())
+			status, ok := grpcstatus.FromError(err)
+			Expect(ok).To(BeTrue())
+			Expect(status.Code()).To(Equal(grpccodes.InvalidArgument))
+			Expect(status.Message()).To(ContainSubstring("unknown_param"))
+		})
+
+		It("Rejects field definition with unknown template parameter on Update", func() {
+			createComputeInstanceTemplate("tpl-ci-param-update", "valid_param")
+
+			response, err := server.Create(ctx, privatev1.ComputeInstanceCatalogItemsCreateRequest_builder{
+				Object: privatev1.ComputeInstanceCatalogItem_builder{
+					Title:    "Will update with bad param",
+					Template: "tpl-ci-param-update",
+				}.Build(),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+			id := response.GetObject().GetId()
+			DeferCleanup(func() {
+				_, _ = server.Delete(ctx, privatev1.ComputeInstanceCatalogItemsDeleteRequest_builder{
+					Id: id,
+				}.Build())
+			})
+
+			_, err = server.Update(ctx, privatev1.ComputeInstanceCatalogItemsUpdateRequest_builder{
+				Object: privatev1.ComputeInstanceCatalogItem_builder{
+					Id:       id,
+					Title:    "Will update with bad param",
+					Template: "tpl-ci-param-update",
+					FieldDefinitions: []*privatev1.FieldDefinition{
+						privatev1.FieldDefinition_builder{
+							Path:     "template_parameters.unknown_param",
+							Editable: true,
+						}.Build(),
+					},
+				}.Build(),
+				UpdateMask: &fieldmaskpb.FieldMask{
+					Paths: []string{"field_definitions"},
+				},
+			}.Build())
+			Expect(err).To(HaveOccurred())
+			status, ok := grpcstatus.FromError(err)
+			Expect(ok).To(BeTrue())
+			Expect(status.Code()).To(Equal(grpccodes.InvalidArgument))
+			Expect(status.Message()).To(ContainSubstring("unknown_param"))
 		})
 
 		It("Allows empty name without conflict", func() {
@@ -819,7 +960,7 @@ var _ = Describe("Private compute instance catalog items server", func() {
 						Template: "my-ci-template-id",
 						FieldDefinitions: []*privatev1.FieldDefinition{
 							privatev1.FieldDefinition_builder{
-								Path:     "spec.instance_type",
+								Path:     "instance_type",
 								Editable: true,
 								Default:  structpb.NewStringValue("deprecated-type"),
 							}.Build(),
@@ -852,7 +993,7 @@ var _ = Describe("Private compute instance catalog items server", func() {
 						Template: "my-ci-template-id",
 						FieldDefinitions: []*privatev1.FieldDefinition{
 							privatev1.FieldDefinition_builder{
-								Path:     "spec.instance_type",
+								Path:     "instance_type",
 								Editable: true,
 								Default:  structpb.NewStringValue("deprecated-type-upd"),
 							}.Build(),
@@ -873,7 +1014,7 @@ var _ = Describe("Private compute instance catalog items server", func() {
 						Template: "my-ci-template-id",
 						FieldDefinitions: []*privatev1.FieldDefinition{
 							privatev1.FieldDefinition_builder{
-								Path:     "spec.instance_type",
+								Path:     "instance_type",
 								Editable: true,
 								Default:  structpb.NewStringValue("obsolete-type"),
 							}.Build(),
@@ -908,7 +1049,7 @@ var _ = Describe("Private compute instance catalog items server", func() {
 						Template: "my-ci-template-id",
 						FieldDefinitions: []*privatev1.FieldDefinition{
 							privatev1.FieldDefinition_builder{
-								Path:     "spec.instance_type",
+								Path:     "instance_type",
 								Editable: true,
 								Default:  structpb.NewStringValue("obsolete-type-upd"),
 							}.Build(),
@@ -931,7 +1072,7 @@ var _ = Describe("Private compute instance catalog items server", func() {
 						Template: "my-ci-template-id",
 						FieldDefinitions: []*privatev1.FieldDefinition{
 							privatev1.FieldDefinition_builder{
-								Path:     "spec.instance_type",
+								Path:     "instance_type",
 								Editable: true,
 								Default:  structpb.NewStringValue("active-type"),
 							}.Build(),
@@ -949,7 +1090,7 @@ var _ = Describe("Private compute instance catalog items server", func() {
 						Template: "my-ci-template-id",
 						FieldDefinitions: []*privatev1.FieldDefinition{
 							privatev1.FieldDefinition_builder{
-								Path:     "spec.instance_type",
+								Path:     "instance_type",
 								Editable: true,
 								Default:  structpb.NewStringValue("non-existent-type"),
 							}.Build(),
@@ -969,7 +1110,7 @@ var _ = Describe("Private compute instance catalog items server", func() {
 						Template: "my-ci-template-id",
 						FieldDefinitions: []*privatev1.FieldDefinition{
 							privatev1.FieldDefinition_builder{
-								Path:     "spec.ssh_public_key",
+								Path:     "ssh_public_key",
 								Editable: true,
 							}.Build(),
 						},

--- a/proto/private/osac/private/v1/field_definition_type.proto
+++ b/proto/private/osac/private/v1/field_definition_type.proto
@@ -20,8 +20,8 @@ import "google/protobuf/struct.proto";
 // Defines a single field on the resource spec that a catalog item controls. Each field definition specifies whether
 // the user can set the field, what default value to apply, and optional JSON Schema validation constraints.
 message FieldDefinition {
-  // Dot-notation path referencing a field in the resource spec. For example: "spec.network.pod_cidr" or
-  // "spec.node_sets.workers.size". Wildcards are not supported.
+  // Dot-notation path relative to the resource spec. For example: "network.pod_cidr" or
+  // "template_parameters.vpc_id". Wildcards are not supported.
   string path = 1;
 
   // Human friendly label for this field, suitable for displaying in a UI.

--- a/proto/public/osac/public/v1/field_definition_type.proto
+++ b/proto/public/osac/public/v1/field_definition_type.proto
@@ -19,7 +19,7 @@ import "google/protobuf/struct.proto";
 
 // Defines a single field on the resource spec that a catalog item controls.
 message FieldDefinition {
-  // Dot-notation path referencing a field in the resource spec.
+  // Dot-notation path relative to the resource spec (e.g. "network.pod_cidr").
   string path = 1;
 
   // Human friendly label for this field, suitable for displaying in a UI.


### PR DESCRIPTION
## Summary

- **Field definition path validation:** Add proto-reflection-based validation of `field_definition` paths against the spec message descriptor (`ClusterSpec`, `ComputeInstanceSpec`, `BareMetalInstanceSpec`) at catalog item Create/Update time. Invalid paths are rejected with an `InvalidArgument` error listing the valid fields.
- **Template parameter validation:** Add validation of `template_parameters.*` paths against the referenced template's declared parameters. If a field definition references an unknown parameter, the error lists valid parameter names.
- **Shared validation logic:** Extract the validation into `catalog_item_validation.go` as shared functions used by all three catalog item servers, using a `templateResolver` function type for dependency injection of template lookups.
- **Proto comment fixes:** Correct `FieldDefinition.path` examples in both public and private proto files — paths are relative to the spec message (e.g. `network.pod_cidr`), not prefixed with `spec.`.
- **Server-level validation tests:** Add 12 new tests (4 per server × 3 servers) verifying that `Create` and `Update` reject invalid spec paths and unknown template parameters.

## Jira

[OSAC-3339](https://issues.redhat.com/browse/OSAC-3339)

## Test plan
- [x] `gofmt -s -w .` — no formatting changes
- [x] `buf lint` + `buf generate` — proto lint passes, generated code up to date
- [x] `go build ./...` — compiles cleanly
- [x] `ginkgo run -r internal` — 83 suites pass (including 12 new validation tests)
- [x] All changed production files have corresponding test changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Validation Improvements**
  * Catalog item field definitions now reject invalid resource-spec paths during creation and updates.
  * Template parameter references are validated against the selected template.
  * Clear invalid-argument errors identify unknown fields or parameters.

* **Documentation**
  * Clarified that field-definition paths are relative to the resource specification and use dot notation without a `spec.` prefix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->