### PR TITLE
OSAC-2361: add deletion protection for default networking resources

### DIFF
--- a/internal/servers/default_networking_provisioner.go
+++ b/internal/servers/default_networking_provisioner.go
@@ -20,6 +20,8 @@ import (
 	"log/slog"
 
 	"github.com/prometheus/client_golang/prometheus"
+	grpccodes "google.golang.org/grpc/codes"
+	grpcstatus "google.golang.org/grpc/status"
 
 	privatev1 "github.com/osac-project/fulfillment-service/internal/api/osac/private/v1"
 	"github.com/osac-project/fulfillment-service/internal/auth"
@@ -28,6 +30,14 @@ import (
 
 const defaultLabel = "osac.openshift.io/default"
 const ownerReferenceAnnotation = "osac.openshift.io/owner-reference"
+
+func validateNotDefault(labels map[string]string, resourceType string) error {
+	if labels[defaultLabel] == "true" {
+		return grpcstatus.Errorf(grpccodes.FailedPrecondition,
+			"cannot delete default %s: default networking resources are system-managed", resourceType)
+	}
+	return nil
+}
 
 type DefaultNetworkingProvisionerBuilder struct {
 	logger            *slog.Logger

--- a/internal/servers/private_external_ips_server.go
+++ b/internal/servers/private_external_ips_server.go
@@ -230,6 +230,10 @@ func (s *PrivateExternalIPsServer) Delete(ctx context.Context,
 
 	existingExternalIP := getResponse.GetObject()
 
+	if err = validateNotDefault(existingExternalIP.GetMetadata().GetLabels(), "external IP"); err != nil {
+		return
+	}
+
 	state := existingExternalIP.GetStatus().GetState()
 	if state != privatev1.ExternalIPState_EXTERNAL_IP_STATE_ALLOCATED {
 		err = grpcstatus.Errorf(grpccodes.FailedPrecondition,

--- a/internal/servers/private_external_ips_server_test.go
+++ b/internal/servers/private_external_ips_server_test.go
@@ -512,6 +512,30 @@ var _ = Describe("Private external IPs server", func() {
 			Expect(status.Code()).To(Equal(grpccodes.FailedPrecondition))
 			Expect(err.Error()).To(ContainSubstring("must be in ALLOCATED state"))
 		})
+
+		It("blocks deletion of default-labeled ExternalIP", func() {
+			object := createExternalIPInState(externalIPsServer, privatev1.ExternalIPState_EXTERNAL_IP_STATE_ALLOCATED)
+			object.GetMetadata().SetLabels(map[string]string{
+				"osac.openshift.io/default": "true",
+			})
+			eipDao, err := dao.NewGenericDAO[*privatev1.ExternalIP]().
+				SetLogger(logger).
+				SetTenancyLogic(tenancy).
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+			_, err = eipDao.Update().SetObject(object).Do(ctx)
+			Expect(err).ToNot(HaveOccurred())
+
+			_, err = externalIPsServer.Delete(ctx, privatev1.ExternalIPsDeleteRequest_builder{
+				Id: object.GetId(),
+			}.Build())
+			Expect(err).To(HaveOccurred())
+			status, ok := grpcstatus.FromError(err)
+			Expect(ok).To(BeTrue())
+			Expect(status.Code()).To(Equal(grpccodes.FailedPrecondition))
+			Expect(err.Error()).To(ContainSubstring("default"))
+			Expect(err.Error()).To(ContainSubstring("system-managed"))
+		})
 	})
 
 	Describe("Pool immutability on Update", func() {

--- a/internal/servers/private_nat_gateways_server.go
+++ b/internal/servers/private_nat_gateways_server.go
@@ -205,6 +205,9 @@ func (s *PrivateNATGatewaysServer) Delete(ctx context.Context,
 	if err != nil {
 		return
 	}
+	if err = validateNotDefault(getResponse.GetObject().GetMetadata().GetLabels(), "NAT gateway"); err != nil {
+		return
+	}
 
 	externalIPID := getResponse.GetObject().GetSpec().GetExternalIp()
 

--- a/internal/servers/private_nat_gateways_server_test.go
+++ b/internal/servers/private_nat_gateways_server_test.go
@@ -550,5 +550,36 @@ var _ = Describe("Private NAT gateways server", func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(getResp.GetObject().GetStatus().GetAttached()).To(BeFalse())
 		})
+
+		It("blocks deletion of default-labeled NATGateway", func() {
+			vnID := createVirtualNetwork()
+			eip := createAllocatedExternalIP()
+			createResponse, err := natGatewaysServer.Create(ctx, privatev1.NATGatewaysCreateRequest_builder{
+				Object: privatev1.NATGateway_builder{
+					Metadata: privatev1.Metadata_builder{
+						Finalizers: []string{"test-finalizer"},
+						Tenant:     auth.SharedTenant,
+						Labels: map[string]string{
+							"osac.openshift.io/default": "true",
+						},
+					}.Build(),
+					Spec: privatev1.NATGatewaySpec_builder{
+						VirtualNetwork: vnID,
+						ExternalIp:     eip.GetId(),
+					}.Build(),
+				}.Build(),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+
+			_, err = natGatewaysServer.Delete(ctx, privatev1.NATGatewaysDeleteRequest_builder{
+				Id: createResponse.GetObject().GetId(),
+			}.Build())
+			Expect(err).To(HaveOccurred())
+			status, ok := grpcstatus.FromError(err)
+			Expect(ok).To(BeTrue())
+			Expect(status.Code()).To(Equal(grpccodes.FailedPrecondition))
+			Expect(err.Error()).To(ContainSubstring("default"))
+			Expect(err.Error()).To(ContainSubstring("system-managed"))
+		})
 	})
 })

--- a/internal/servers/private_security_groups_server.go
+++ b/internal/servers/private_security_groups_server.go
@@ -201,6 +201,16 @@ func (s *PrivateSecurityGroupsServer) Update(ctx context.Context,
 
 func (s *PrivateSecurityGroupsServer) Delete(ctx context.Context,
 	request *privatev1.SecurityGroupsDeleteRequest) (response *privatev1.SecurityGroupsDeleteResponse, err error) {
+	getRequest := &privatev1.SecurityGroupsGetRequest{}
+	getRequest.SetId(request.GetId())
+	var getResponse *privatev1.SecurityGroupsGetResponse
+	err = s.generic.Get(ctx, getRequest, &getResponse)
+	if err != nil {
+		return
+	}
+	if err = validateNotDefault(getResponse.GetObject().GetMetadata().GetLabels(), "security group"); err != nil {
+		return
+	}
 	err = s.generic.Delete(ctx, request, &response)
 	return
 }

--- a/internal/servers/private_subnets_server.go
+++ b/internal/servers/private_subnets_server.go
@@ -190,6 +190,16 @@ func (s *PrivateSubnetsServer) Update(ctx context.Context,
 
 func (s *PrivateSubnetsServer) Delete(ctx context.Context,
 	request *privatev1.SubnetsDeleteRequest) (response *privatev1.SubnetsDeleteResponse, err error) {
+	getRequest := &privatev1.SubnetsGetRequest{}
+	getRequest.SetId(request.GetId())
+	var getResponse *privatev1.SubnetsGetResponse
+	err = s.generic.Get(ctx, getRequest, &getResponse)
+	if err != nil {
+		return
+	}
+	if err = validateNotDefault(getResponse.GetObject().GetMetadata().GetLabels(), "subnet"); err != nil {
+		return
+	}
 	err = s.generic.Delete(ctx, request, &response)
 	return
 }

--- a/internal/servers/private_subnets_server_test.go
+++ b/internal/servers/private_subnets_server_test.go
@@ -1439,6 +1439,36 @@ var _ = Describe("Private subnets server", func() {
 				}.Build())
 				Expect(err).ToNot(HaveOccurred())
 			})
+
+			It("blocks deletion of default-labeled Subnet", func() {
+				vn := createVirtualNetwork(ctx, "10.0.0.0/16", "")
+
+				createResponse, err := server.Create(ctx, privatev1.SubnetsCreateRequest_builder{
+					Object: privatev1.Subnet_builder{
+						Metadata: privatev1.Metadata_builder{
+							Tenant: auth.SharedTenant,
+							Labels: map[string]string{
+								"osac.openshift.io/default": "true",
+							},
+						}.Build(),
+						Spec: privatev1.SubnetSpec_builder{
+							Ipv4Cidr:       new("10.0.1.0/24"),
+							VirtualNetwork: vn.GetId(),
+						}.Build(),
+					}.Build(),
+				}.Build())
+				Expect(err).ToNot(HaveOccurred())
+
+				_, err = server.Delete(ctx, privatev1.SubnetsDeleteRequest_builder{
+					Id: createResponse.GetObject().GetId(),
+				}.Build())
+				Expect(err).To(HaveOccurred())
+				status, ok := grpcstatus.FromError(err)
+				Expect(ok).To(BeTrue())
+				Expect(status.Code()).To(Equal(grpccodes.FailedPrecondition))
+				Expect(err.Error()).To(ContainSubstring("default"))
+				Expect(err.Error()).To(ContainSubstring("system-managed"))
+			})
 		})
 	})
 

--- a/internal/servers/private_virtual_networks_server.go
+++ b/internal/servers/private_virtual_networks_server.go
@@ -187,6 +187,16 @@ func (s *PrivateVirtualNetworksServer) Update(ctx context.Context,
 
 func (s *PrivateVirtualNetworksServer) Delete(ctx context.Context,
 	request *privatev1.VirtualNetworksDeleteRequest) (response *privatev1.VirtualNetworksDeleteResponse, err error) {
+	getRequest := &privatev1.VirtualNetworksGetRequest{}
+	getRequest.SetId(request.GetId())
+	var getResponse *privatev1.VirtualNetworksGetResponse
+	err = s.generic.Get(ctx, getRequest, &getResponse)
+	if err != nil {
+		return
+	}
+	if err = validateNotDefault(getResponse.GetObject().GetMetadata().GetLabels(), "virtual network"); err != nil {
+		return
+	}
 	err = s.generic.Delete(ctx, request, &response)
 	return
 }

--- a/internal/servers/private_virtual_networks_server_test.go
+++ b/internal/servers/private_virtual_networks_server_test.go
@@ -1743,5 +1743,35 @@ var _ = Describe("Private virtual networks server", func() {
 			Expect(status.Code()).To(Equal(grpccodes.FailedPrecondition))
 			Expect(err.Error()).To(ContainSubstring("3 Subnet"))
 		})
+
+		It("blocks deletion of default-labeled VirtualNetwork", func() {
+			nc := createNetworkClass(ctx, privatev1.NetworkClassState_NETWORK_CLASS_STATE_READY)
+			createResp, err := vnServer.Create(ctx, privatev1.VirtualNetworksCreateRequest_builder{
+				Object: privatev1.VirtualNetwork_builder{
+					Metadata: privatev1.Metadata_builder{
+						Tenant: auth.SharedTenant,
+						Labels: map[string]string{
+							"osac.openshift.io/default": "true",
+						},
+					}.Build(),
+					Spec: privatev1.VirtualNetworkSpec_builder{
+						Ipv4Cidr:     proto.String("10.0.0.0/16"),
+						NetworkClass: nc.GetId(),
+						Region:       "us-west-1",
+					}.Build(),
+				}.Build(),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+
+			_, err = vnServer.Delete(ctx, privatev1.VirtualNetworksDeleteRequest_builder{
+				Id: createResp.GetObject().GetId(),
+			}.Build())
+			Expect(err).To(HaveOccurred())
+			status, ok := grpcstatus.FromError(err)
+			Expect(ok).To(BeTrue())
+			Expect(status.Code()).To(Equal(grpccodes.FailedPrecondition))
+			Expect(err.Error()).To(ContainSubstring("default"))
+			Expect(err.Error()).To(ContainSubstring("system-managed"))
+		})
 	})
 })

--- a/internal/servers/security_groups_server_test.go
+++ b/internal/servers/security_groups_server_test.go
@@ -18,6 +18,8 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	grpccodes "google.golang.org/grpc/codes"
+	grpcstatus "google.golang.org/grpc/status"
 	"google.golang.org/protobuf/proto"
 
 	privatev1 "github.com/osac-project/fulfillment-service/internal/api/osac/private/v1"
@@ -462,6 +464,32 @@ var _ = Describe("SecurityGroups server", func() {
 			Expect(err).ToNot(HaveOccurred())
 			object = getResponse.GetObject()
 			Expect(object.GetMetadata().GetDeletionTimestamp()).ToNot(BeNil())
+		})
+
+		It("blocks deletion of default-labeled SecurityGroup", func() {
+			createResponse, err := server.Create(ctx, publicv1.SecurityGroupsCreateRequest_builder{
+				Object: publicv1.SecurityGroup_builder{
+					Metadata: publicv1.Metadata_builder{
+						Labels: map[string]string{
+							"osac.openshift.io/default": "true",
+						},
+					}.Build(),
+					Spec: publicv1.SecurityGroupSpec_builder{
+						VirtualNetwork: virtualNetworkID,
+					}.Build(),
+				}.Build(),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+
+			_, err = server.Delete(ctx, publicv1.SecurityGroupsDeleteRequest_builder{
+				Id: createResponse.GetObject().GetId(),
+			}.Build())
+			Expect(err).To(HaveOccurred())
+			status, ok := grpcstatus.FromError(err)
+			Expect(ok).To(BeTrue())
+			Expect(status.Code()).To(Equal(grpccodes.FailedPrecondition))
+			Expect(err.Error()).To(ContainSubstring("default"))
+			Expect(err.Error()).To(ContainSubstring("system-managed"))
 		})
 	})
 })


### PR DESCRIPTION
Resources labeled osac.openshift.io/default: "true" (VirtualNetwork, Subnet, SecurityGroup, NATGateway, ExternalIP) are system-managed and cannot be deleted via the API. The Delete handler for each resource type now fetches the object and checks for the default label before proceeding, returning FailedPrecondition if present.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented deletion of default, system-managed networking resources.
  * Added protection for default external IPs, NAT gateways, security groups, subnets, and virtual networks.
  * Deletion attempts for protected resources now return a clear precondition error instead of proceeding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->