### PR TITLE
OSAC-3393: Remove users in Organization Group when removed from project

### DIFF
--- a/internal/controllers/projectmembership/project_membership_reconciler_function.go
+++ b/internal/controllers/projectmembership/project_membership_reconciler_function.go
@@ -22,6 +22,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"sort"
 	"strings"
 
 	"google.golang.org/grpc"
@@ -147,18 +148,37 @@ func (t *task) update(ctx context.Context) error {
 
 	state := t.membership.GetStatus().GetState()
 
-	// Skip reconciliation for terminal error state
-	if state == privatev1.ProjectMembershipState_PROJECT_MEMBERSHIP_STATE_FAILED {
-		return nil
-	}
-
 	// For READY memberships, detect user list changes and sync accordingly
 	if state == privatev1.ProjectMembershipState_PROJECT_MEMBERSHIP_STATE_READY {
-		return t.handleUserListChange(ctx)
+		return t.handleUserListChange(ctx, nil)
+	}
+
+	var existingProject *privatev1.Project
+
+	// For FAILED memberships, check if the failure is terminal before retrying.
+	// Terminal failures (deleted project, invalid role, missing tenant) will not
+	// resolve on their own, so we skip the retry to avoid unnecessary API calls.
+	if state == privatev1.ProjectMembershipState_PROJECT_MEMBERSHIP_STATE_FAILED {
+		terminal, reason, project := t.isTerminalFailure(ctx)
+		if terminal {
+			t.r.logger.DebugContext(ctx, "Skipping retry for terminal failure",
+				slog.String("!reason", reason),
+			)
+			t.membership.GetStatus().SetMessage(reason)
+			return nil
+		}
+		existingProject = project
+		if len(t.membership.GetStatus().GetUsers()) > 0 {
+			t.membership.GetStatus().SetState(privatev1.ProjectMembershipState_PROJECT_MEMBERSHIP_STATE_READY)
+			t.membership.GetStatus().SetMessage("")
+			return t.handleUserListChange(ctx, existingProject)
+		}
+		t.membership.GetStatus().SetState(privatev1.ProjectMembershipState_PROJECT_MEMBERSHIP_STATE_PENDING)
+		t.membership.GetStatus().SetMessage("")
 	}
 
 	// Project membership is PENDING, perform initial synchronization
-	return t.syncProjectMembership(ctx)
+	return t.syncProjectMembership(ctx, existingProject)
 }
 
 // getProjectByNameOrID fetches a project by ID or name. If the provided value is not found as an ID,
@@ -194,10 +214,10 @@ func (t *task) getProjectByNameOrID(ctx context.Context, nameOrID string) (*priv
 
 	projects := listResponse.GetItems()
 	if len(projects) == 0 {
-		return nil, fmt.Errorf("project with name or ID '%s' not found", nameOrID)
+		return nil, status.Errorf(codes.NotFound, "project with name or ID '%s' not found", nameOrID)
 	}
 	if len(projects) > 1 {
-		return nil, fmt.Errorf("multiple projects found with name '%s'", nameOrID)
+		return nil, status.Errorf(codes.FailedPrecondition, "multiple projects found with name '%s'", nameOrID)
 	}
 
 	return projects[0], nil
@@ -225,7 +245,41 @@ func (t *task) setDefaults() {
 	}
 }
 
-func (t *task) syncProjectMembership(ctx context.Context) error {
+// isTerminalFailure validates preconditions that must hold for a retry to
+// succeed. Returns true with a human-readable reason when the failure cannot
+// resolve on its own (e.g. the project was deleted).
+func (t *task) isTerminalFailure(ctx context.Context) (bool, string, *privatev1.Project) {
+	projectNameOrID := t.membership.GetMetadata().GetProject()
+	if projectNameOrID == "" {
+		return true, "Project reference is required", nil
+	}
+
+	role := t.membership.GetSpec().GetRole()
+	if t.mapRoleToGroupSuffix(role) == "" {
+		return true, fmt.Sprintf("Unknown project membership role: %v", role), nil
+	}
+
+	project, err := t.getProjectByNameOrID(ctx, projectNameOrID)
+	if err != nil {
+		code := status.Code(err)
+		if code == codes.NotFound || code == codes.FailedPrecondition {
+			return true, fmt.Sprintf("Project '%s' no longer exists", projectNameOrID), nil
+		}
+		return false, "", nil
+	}
+
+	if project.GetMetadata().HasDeletionTimestamp() {
+		return true, fmt.Sprintf("Project '%s' is being deleted", projectNameOrID), nil
+	}
+
+	if project.GetMetadata().GetTenant() == "" {
+		return true, "Project has no organization tenant", nil
+	}
+
+	return false, "", project
+}
+
+func (t *task) syncProjectMembership(ctx context.Context, existingProject *privatev1.Project) error {
 	users := t.membership.GetSpec().GetUsers()
 	if len(users) == 0 {
 		t.membership.GetStatus().SetState(privatev1.ProjectMembershipState_PROJECT_MEMBERSHIP_STATE_READY)
@@ -234,20 +288,24 @@ func (t *task) syncProjectMembership(ctx context.Context) error {
 		return nil
 	}
 
-	_, organizationName, groupID, err := t.resolveProjectGroup(ctx)
+	_, organizationName, groupID, err := t.resolveProjectGroup(ctx, existingProject)
 	if err != nil {
 		return nil
 	}
 
+	var successfulUsers []string
 	var assignmentErrors []string
 	for _, userID := range users {
 		if err := t.addUserToGroup(ctx, userID, organizationName, groupID); err != nil {
 			assignmentErrors = append(assignmentErrors, fmt.Sprintf("user %s: %v", userID, err))
+		} else {
+			successfulUsers = append(successfulUsers, userID)
 		}
 	}
 
 	if len(assignmentErrors) > 0 {
 		t.membership.GetStatus().SetState(privatev1.ProjectMembershipState_PROJECT_MEMBERSHIP_STATE_FAILED)
+		t.membership.GetStatus().SetUsers(successfulUsers)
 		t.membership.GetStatus().SetMessage(fmt.Sprintf(
 			"Failed to sync %d user(s): %s", len(assignmentErrors), strings.Join(assignmentErrors, "; "),
 		))
@@ -260,7 +318,7 @@ func (t *task) syncProjectMembership(ctx context.Context) error {
 	return nil
 }
 
-func (t *task) handleUserListChange(ctx context.Context) error {
+func (t *task) handleUserListChange(ctx context.Context, existingProject *privatev1.Project) error {
 	desiredUsers := t.membership.GetSpec().GetUsers()
 	syncedUsers := t.membership.GetStatus().GetUsers()
 
@@ -291,9 +349,15 @@ func (t *task) handleUserListChange(ctx context.Context) error {
 		return nil
 	}
 
-	_, organizationName, groupID, err := t.resolveProjectGroup(ctx)
+	_, organizationName, groupID, err := t.resolveProjectGroup(ctx, existingProject)
 	if err != nil {
 		return nil
+	}
+
+	// Track the actual synced user set so partial progress is preserved on failure.
+	actualUsers := make(map[string]bool)
+	for _, u := range syncedUsers {
+		actualUsers[u] = true
 	}
 
 	var syncErrors []string
@@ -301,17 +365,27 @@ func (t *task) handleUserListChange(ctx context.Context) error {
 	for _, userID := range usersToRemove {
 		if err := t.removeUserFromGroup(ctx, userID, organizationName, groupID); err != nil {
 			syncErrors = append(syncErrors, fmt.Sprintf("remove user %s: %v", userID, err))
+		} else {
+			delete(actualUsers, userID)
 		}
 	}
 
 	for _, userID := range usersToAdd {
 		if err := t.addUserToGroup(ctx, userID, organizationName, groupID); err != nil {
 			syncErrors = append(syncErrors, fmt.Sprintf("add user %s: %v", userID, err))
+		} else {
+			actualUsers[userID] = true
 		}
 	}
 
 	if len(syncErrors) > 0 {
+		currentUsers := make([]string, 0, len(actualUsers))
+		for u := range actualUsers {
+			currentUsers = append(currentUsers, u)
+		}
+		sort.Strings(currentUsers)
 		t.membership.GetStatus().SetState(privatev1.ProjectMembershipState_PROJECT_MEMBERSHIP_STATE_FAILED)
+		t.membership.GetStatus().SetUsers(currentUsers)
 		t.membership.GetStatus().SetMessage(fmt.Sprintf(
 			"Failed to sync user changes: %s", strings.Join(syncErrors, "; "),
 		))
@@ -327,22 +401,26 @@ func (t *task) handleUserListChange(ctx context.Context) error {
 
 // resolveProjectGroup resolves the project, organization, and group ID for the membership.
 // On failure, it sets the membership status to FAILED and returns a non-nil error.
-func (t *task) resolveProjectGroup(ctx context.Context) (
+func (t *task) resolveProjectGroup(ctx context.Context, existingProject *privatev1.Project) (
 	project *privatev1.Project, organizationName string, groupID string, err error,
 ) {
-	projectNameOrID := t.membership.GetMetadata().GetProject()
-	if projectNameOrID == "" {
-		t.membership.GetStatus().SetState(privatev1.ProjectMembershipState_PROJECT_MEMBERSHIP_STATE_FAILED)
-		t.membership.GetStatus().SetMessage("Project is required")
-		err = fmt.Errorf("project is required")
-		return
-	}
+	if existingProject != nil {
+		project = existingProject
+	} else {
+		projectNameOrID := t.membership.GetMetadata().GetProject()
+		if projectNameOrID == "" {
+			t.membership.GetStatus().SetState(privatev1.ProjectMembershipState_PROJECT_MEMBERSHIP_STATE_FAILED)
+			t.membership.GetStatus().SetMessage("Project is required")
+			err = fmt.Errorf("project is required")
+			return
+		}
 
-	project, err = t.getProjectByNameOrID(ctx, projectNameOrID)
-	if err != nil {
-		t.membership.GetStatus().SetState(privatev1.ProjectMembershipState_PROJECT_MEMBERSHIP_STATE_FAILED)
-		t.membership.GetStatus().SetMessage(fmt.Sprintf("Failed to fetch project: %v", err))
-		return
+		project, err = t.getProjectByNameOrID(ctx, projectNameOrID)
+		if err != nil {
+			t.membership.GetStatus().SetState(privatev1.ProjectMembershipState_PROJECT_MEMBERSHIP_STATE_FAILED)
+			t.membership.GetStatus().SetMessage(fmt.Sprintf("Failed to fetch project: %v", err))
+			return
+		}
 	}
 
 	role := t.membership.GetSpec().GetRole()
@@ -543,7 +621,7 @@ func (t *task) cleanupProjectMembership(ctx context.Context) error {
 
 	project, err := t.getProjectByNameOrID(ctx, projectNameOrID)
 	if err != nil {
-		if status.Code(err) == codes.NotFound || strings.Contains(err.Error(), "not found") {
+		if status.Code(err) == codes.NotFound {
 			t.r.logger.DebugContext(ctx, "Project not found during cleanup, skipping")
 			return nil
 		}

--- a/internal/controllers/projectmembership/project_membership_reconciler_function_test.go
+++ b/internal/controllers/projectmembership/project_membership_reconciler_function_test.go
@@ -22,6 +22,8 @@ import (
 	"go.uber.org/mock/gomock"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/timestamppb"
 
 	privatev1 "github.com/osac-project/fulfillment-service/internal/api/osac/private/v1"
 	"github.com/osac-project/fulfillment-service/internal/controllers/finalizers"
@@ -106,6 +108,760 @@ var _ = Describe("Default Values", func() {
 		task.setDefaults()
 
 		Expect(membership.GetStatus().GetState()).To(Equal(privatev1.ProjectMembershipState_PROJECT_MEMBERSHIP_STATE_READY))
+	})
+})
+
+var _ = Describe("Update with FAILED state", func() {
+	var (
+		ctrl                         *gomock.Controller
+		mockProjectsClient           *MockProjectsClient
+		mockProjectMembershipsClient *MockProjectMembershipsClient
+		mockUsersClient              *MockUsersClient
+		mockIdpClient                *idp.MockClientInterface
+		ctx                          context.Context
+		functionObj                  *function
+	)
+
+	BeforeEach(func() {
+		ctrl = gomock.NewController(GinkgoT())
+		mockProjectsClient = NewMockProjectsClient(ctrl)
+		mockProjectMembershipsClient = NewMockProjectMembershipsClient(ctrl)
+		mockUsersClient = NewMockUsersClient(ctrl)
+		mockIdpClient = idp.NewMockClientInterface(ctrl)
+		ctx = context.Background()
+
+		functionObj = &function{
+			logger:                   logger,
+			projectMembershipsClient: mockProjectMembershipsClient,
+			projectsClient:           mockProjectsClient,
+			usersClient:              mockUsersClient,
+			idpClient:                mockIdpClient,
+		}
+	})
+
+	AfterEach(func() {
+		ctrl.Finish()
+	})
+
+	It("should use diff path when FAILED with previous users", func() {
+		newUser := privatev1.User_builder{
+			Status: privatev1.UserStatus_builder{
+				KeycloakUserId: "keycloak-new-id",
+			}.Build(),
+		}.Build()
+
+		project := privatev1.Project_builder{
+			Metadata: privatev1.Metadata_builder{
+				Name:   "my-project",
+				Tenant: "acme",
+			}.Build(),
+			Spec: privatev1.ProjectSpec_builder{}.Build(),
+		}.Build()
+
+		membership := privatev1.ProjectMembership_builder{
+			Metadata: privatev1.Metadata_builder{
+				Finalizers: []string{finalizers.ProjectMembershipFinalizer},
+				Project:    "project-id",
+			}.Build(),
+			Spec: privatev1.ProjectMembershipSpec_builder{
+				Users: []string{"existing-user", "new-user"},
+				Role:  privatev1.ProjectMembershipRole_PROJECT_MEMBERSHIP_ROLE_MANAGER,
+			}.Build(),
+			Status: privatev1.ProjectMembershipStatus_builder{
+				State:   privatev1.ProjectMembershipState_PROJECT_MEMBERSHIP_STATE_FAILED,
+				Message: proto.String("previous error"),
+				Users:   []string{"existing-user"},
+			}.Build(),
+		}.Build()
+
+		// isTerminalFailure fetches the project, then passes it to handleUserListChange→resolveProjectGroup
+		mockProjectsClient.EXPECT().
+			Get(gomock.Any(), gomock.Any()).
+			Return(&privatev1.ProjectsGetResponse{Object: project}, nil)
+
+		mockIdpClient.EXPECT().
+			GetGroupIDByPath(gomock.Any(), "acme", "/my-project/system:managers").
+			Return("group-id", nil)
+
+		mockUsersClient.EXPECT().
+			Get(gomock.Any(), gomock.Any()).
+			Return(&privatev1.UsersGetResponse{Object: newUser}, nil)
+
+		mockIdpClient.EXPECT().
+			AddUserToGroup(gomock.Any(), "acme", "keycloak-new-id", "group-id").
+			Return(nil)
+
+		task := &task{
+			r:          functionObj,
+			membership: membership,
+		}
+
+		err := task.update(ctx)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(membership.GetStatus().GetUsers()).To(Equal([]string{"existing-user", "new-user"}))
+		Expect(membership.GetStatus().GetMessage()).ToNot(ContainSubstring("previous error"))
+	})
+
+	It("should fall through to full sync when FAILED with no previous users", func() {
+		user := privatev1.User_builder{
+			Status: privatev1.UserStatus_builder{
+				KeycloakUserId: "keycloak-alice-id",
+			}.Build(),
+		}.Build()
+
+		project := privatev1.Project_builder{
+			Metadata: privatev1.Metadata_builder{
+				Name:   "my-project",
+				Tenant: "acme",
+			}.Build(),
+			Spec: privatev1.ProjectSpec_builder{}.Build(),
+		}.Build()
+
+		membership := privatev1.ProjectMembership_builder{
+			Metadata: privatev1.Metadata_builder{
+				Finalizers: []string{finalizers.ProjectMembershipFinalizer},
+				Project:    "project-id",
+			}.Build(),
+			Spec: privatev1.ProjectMembershipSpec_builder{
+				Users: []string{"user-id"},
+				Role:  privatev1.ProjectMembershipRole_PROJECT_MEMBERSHIP_ROLE_MANAGER,
+			}.Build(),
+			Status: privatev1.ProjectMembershipStatus_builder{
+				State:   privatev1.ProjectMembershipState_PROJECT_MEMBERSHIP_STATE_FAILED,
+				Message: proto.String("previous error"),
+			}.Build(),
+		}.Build()
+
+		// isTerminalFailure fetches the project, then passes it to syncProjectMembership→resolveProjectGroup
+		mockProjectsClient.EXPECT().
+			Get(gomock.Any(), gomock.Any()).
+			Return(&privatev1.ProjectsGetResponse{Object: project}, nil)
+
+		mockIdpClient.EXPECT().
+			GetGroupIDByPath(gomock.Any(), "acme", "/my-project/system:managers").
+			Return("group-id", nil)
+
+		mockUsersClient.EXPECT().
+			Get(gomock.Any(), gomock.Any()).
+			Return(&privatev1.UsersGetResponse{Object: user}, nil)
+
+		mockIdpClient.EXPECT().
+			AddUserToGroup(gomock.Any(), "acme", "keycloak-alice-id", "group-id").
+			Return(nil)
+
+		task := &task{
+			r:          functionObj,
+			membership: membership,
+		}
+
+		err := task.update(ctx)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(membership.GetStatus().GetState()).To(Equal(privatev1.ProjectMembershipState_PROJECT_MEMBERSHIP_STATE_READY))
+		Expect(membership.GetStatus().GetUsers()).To(Equal([]string{"user-id"}))
+		Expect(membership.GetStatus().GetMessage()).To(Equal(""))
+	})
+
+	It("should not retry when project is deleted (terminal failure)", func() {
+		membership := privatev1.ProjectMembership_builder{
+			Metadata: privatev1.Metadata_builder{
+				Finalizers: []string{finalizers.ProjectMembershipFinalizer},
+				Project:    "deleted-project-id",
+			}.Build(),
+			Spec: privatev1.ProjectMembershipSpec_builder{
+				Users: []string{"user-id"},
+				Role:  privatev1.ProjectMembershipRole_PROJECT_MEMBERSHIP_ROLE_MANAGER,
+			}.Build(),
+			Status: privatev1.ProjectMembershipStatus_builder{
+				State:   privatev1.ProjectMembershipState_PROJECT_MEMBERSHIP_STATE_FAILED,
+				Message: proto.String("previous transient error"),
+			}.Build(),
+		}.Build()
+
+		// Get returns NotFound, then getProjectByNameOrID falls back to List by name
+		mockProjectsClient.EXPECT().
+			Get(gomock.Any(), gomock.Any()).
+			Return(nil, status.Errorf(codes.NotFound, "not found"))
+		mockProjectsClient.EXPECT().
+			List(gomock.Any(), gomock.Any()).
+			Return(&privatev1.ProjectsListResponse{}, nil)
+
+		task := &task{
+			r:          functionObj,
+			membership: membership,
+		}
+
+		err := task.update(ctx)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(membership.GetStatus().GetState()).To(Equal(
+			privatev1.ProjectMembershipState_PROJECT_MEMBERSHIP_STATE_FAILED,
+		))
+		Expect(membership.GetStatus().GetMessage()).To(ContainSubstring("no longer exists"))
+	})
+
+	It("should not retry when project is being deleted (terminal failure)", func() {
+		project := privatev1.Project_builder{
+			Metadata: privatev1.Metadata_builder{
+				Name:              "my-project",
+				Tenant:            "acme",
+				DeletionTimestamp: timestamppb.Now(),
+			}.Build(),
+			Spec: privatev1.ProjectSpec_builder{}.Build(),
+		}.Build()
+
+		membership := privatev1.ProjectMembership_builder{
+			Metadata: privatev1.Metadata_builder{
+				Finalizers: []string{finalizers.ProjectMembershipFinalizer},
+				Project:    "project-id",
+			}.Build(),
+			Spec: privatev1.ProjectMembershipSpec_builder{
+				Users: []string{"user-id"},
+				Role:  privatev1.ProjectMembershipRole_PROJECT_MEMBERSHIP_ROLE_MANAGER,
+			}.Build(),
+			Status: privatev1.ProjectMembershipStatus_builder{
+				State:   privatev1.ProjectMembershipState_PROJECT_MEMBERSHIP_STATE_FAILED,
+				Message: proto.String("previous error"),
+			}.Build(),
+		}.Build()
+
+		mockProjectsClient.EXPECT().
+			Get(gomock.Any(), gomock.Any()).
+			Return(&privatev1.ProjectsGetResponse{Object: project}, nil)
+
+		task := &task{
+			r:          functionObj,
+			membership: membership,
+		}
+
+		err := task.update(ctx)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(membership.GetStatus().GetState()).To(Equal(
+			privatev1.ProjectMembershipState_PROJECT_MEMBERSHIP_STATE_FAILED,
+		))
+		Expect(membership.GetStatus().GetMessage()).To(ContainSubstring("is being deleted"))
+	})
+
+	It("should not retry when role is invalid (terminal failure)", func() {
+		membership := privatev1.ProjectMembership_builder{
+			Metadata: privatev1.Metadata_builder{
+				Finalizers: []string{finalizers.ProjectMembershipFinalizer},
+				Project:    "project-id",
+			}.Build(),
+			Spec: privatev1.ProjectMembershipSpec_builder{
+				Users: []string{"user-id"},
+				Role:  privatev1.ProjectMembershipRole_PROJECT_MEMBERSHIP_ROLE_UNSPECIFIED,
+			}.Build(),
+			Status: privatev1.ProjectMembershipStatus_builder{
+				State:   privatev1.ProjectMembershipState_PROJECT_MEMBERSHIP_STATE_FAILED,
+				Message: proto.String("previous error"),
+			}.Build(),
+		}.Build()
+
+		task := &task{
+			r:          functionObj,
+			membership: membership,
+		}
+
+		err := task.update(ctx)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(membership.GetStatus().GetState()).To(Equal(
+			privatev1.ProjectMembershipState_PROJECT_MEMBERSHIP_STATE_FAILED,
+		))
+		Expect(membership.GetStatus().GetMessage()).To(ContainSubstring("Unknown project membership role"))
+	})
+
+	It("should not retry when project has no tenant (terminal failure)", func() {
+		project := privatev1.Project_builder{
+			Metadata: privatev1.Metadata_builder{
+				Name: "my-project",
+			}.Build(),
+			Spec: privatev1.ProjectSpec_builder{}.Build(),
+		}.Build()
+
+		membership := privatev1.ProjectMembership_builder{
+			Metadata: privatev1.Metadata_builder{
+				Finalizers: []string{finalizers.ProjectMembershipFinalizer},
+				Project:    "project-id",
+			}.Build(),
+			Spec: privatev1.ProjectMembershipSpec_builder{
+				Users: []string{"user-id"},
+				Role:  privatev1.ProjectMembershipRole_PROJECT_MEMBERSHIP_ROLE_MANAGER,
+			}.Build(),
+			Status: privatev1.ProjectMembershipStatus_builder{
+				State:   privatev1.ProjectMembershipState_PROJECT_MEMBERSHIP_STATE_FAILED,
+				Message: proto.String("previous error"),
+			}.Build(),
+		}.Build()
+
+		mockProjectsClient.EXPECT().
+			Get(gomock.Any(), gomock.Any()).
+			Return(&privatev1.ProjectsGetResponse{Object: project}, nil)
+
+		task := &task{
+			r:          functionObj,
+			membership: membership,
+		}
+
+		err := task.update(ctx)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(membership.GetStatus().GetState()).To(Equal(
+			privatev1.ProjectMembershipState_PROJECT_MEMBERSHIP_STATE_FAILED,
+		))
+		Expect(membership.GetStatus().GetMessage()).To(ContainSubstring("no organization tenant"))
+	})
+
+	It("should retry when project fetch fails transiently", func() {
+		user := privatev1.User_builder{
+			Status: privatev1.UserStatus_builder{
+				KeycloakUserId: "keycloak-id",
+			}.Build(),
+		}.Build()
+
+		project := privatev1.Project_builder{
+			Metadata: privatev1.Metadata_builder{
+				Name:   "my-project",
+				Tenant: "acme",
+			}.Build(),
+			Spec: privatev1.ProjectSpec_builder{}.Build(),
+		}.Build()
+
+		membership := privatev1.ProjectMembership_builder{
+			Metadata: privatev1.Metadata_builder{
+				Finalizers: []string{finalizers.ProjectMembershipFinalizer},
+				Project:    "project-id",
+			}.Build(),
+			Spec: privatev1.ProjectMembershipSpec_builder{
+				Users: []string{"user-id"},
+				Role:  privatev1.ProjectMembershipRole_PROJECT_MEMBERSHIP_ROLE_MANAGER,
+			}.Build(),
+			Status: privatev1.ProjectMembershipStatus_builder{
+				State:   privatev1.ProjectMembershipState_PROJECT_MEMBERSHIP_STATE_FAILED,
+				Message: proto.String("previous error"),
+			}.Build(),
+		}.Build()
+
+		// First Get call is for isTerminalFailure — returns transient error
+		mockProjectsClient.EXPECT().
+			Get(gomock.Any(), gomock.Any()).
+			Return(nil, status.Errorf(codes.Unavailable, "temporarily unavailable"))
+
+		// isTerminalFailure sees transient error and returns nil project, so retry re-fetches.
+		// Full sync calls getProjectByNameOrID again, which succeeds this time.
+		mockProjectsClient.EXPECT().
+			Get(gomock.Any(), gomock.Any()).
+			Return(&privatev1.ProjectsGetResponse{Object: project}, nil)
+
+		mockIdpClient.EXPECT().
+			GetGroupIDByPath(gomock.Any(), "acme", "/my-project/system:managers").
+			Return("group-id", nil)
+
+		mockUsersClient.EXPECT().
+			Get(gomock.Any(), gomock.Any()).
+			Return(&privatev1.UsersGetResponse{Object: user}, nil)
+
+		mockIdpClient.EXPECT().
+			AddUserToGroup(gomock.Any(), "acme", "keycloak-id", "group-id").
+			Return(nil)
+
+		task := &task{
+			r:          functionObj,
+			membership: membership,
+		}
+
+		err := task.update(ctx)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(membership.GetStatus().GetState()).To(Equal(
+			privatev1.ProjectMembershipState_PROJECT_MEMBERSHIP_STATE_READY,
+		))
+	})
+
+	It("should clear error message when FAILED state is recovered with previous users", func() {
+		project := privatev1.Project_builder{
+			Metadata: privatev1.Metadata_builder{
+				Name:   "my-project",
+				Tenant: "acme",
+			}.Build(),
+			Spec: privatev1.ProjectSpec_builder{}.Build(),
+		}.Build()
+
+		membership := privatev1.ProjectMembership_builder{
+			Metadata: privatev1.Metadata_builder{
+				Finalizers: []string{finalizers.ProjectMembershipFinalizer},
+				Project:    "project-id",
+			}.Build(),
+			Spec: privatev1.ProjectMembershipSpec_builder{
+				Users: []string{"user-a"},
+				Role:  privatev1.ProjectMembershipRole_PROJECT_MEMBERSHIP_ROLE_MANAGER,
+			}.Build(),
+			Status: privatev1.ProjectMembershipStatus_builder{
+				State:   privatev1.ProjectMembershipState_PROJECT_MEMBERSHIP_STATE_FAILED,
+				Message: proto.String("Failed to sync user changes: add user user-a: failed to fetch user"),
+				Users:   []string{"user-a"},
+			}.Build(),
+		}.Build()
+
+		// isTerminalFailure fetches the project to verify it still exists
+		mockProjectsClient.EXPECT().
+			Get(gomock.Any(), gomock.Any()).
+			Return(&privatev1.ProjectsGetResponse{Object: project}, nil)
+
+		task := &task{
+			r:          functionObj,
+			membership: membership,
+		}
+
+		err := task.update(ctx)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(membership.GetStatus().GetMessage()).To(Not(ContainSubstring("Failed to sync")))
+	})
+})
+
+var _ = Describe("Partial success tracking", func() {
+	var (
+		ctrl                         *gomock.Controller
+		mockProjectsClient           *MockProjectsClient
+		mockProjectMembershipsClient *MockProjectMembershipsClient
+		mockUsersClient              *MockUsersClient
+		mockIdpClient                *idp.MockClientInterface
+		ctx                          context.Context
+		functionObj                  *function
+	)
+
+	BeforeEach(func() {
+		ctrl = gomock.NewController(GinkgoT())
+		mockProjectsClient = NewMockProjectsClient(ctrl)
+		mockProjectMembershipsClient = NewMockProjectMembershipsClient(ctrl)
+		mockUsersClient = NewMockUsersClient(ctrl)
+		mockIdpClient = idp.NewMockClientInterface(ctrl)
+		ctx = context.Background()
+
+		functionObj = &function{
+			logger:                   logger,
+			projectMembershipsClient: mockProjectMembershipsClient,
+			projectsClient:           mockProjectsClient,
+			usersClient:              mockUsersClient,
+			idpClient:                mockIdpClient,
+		}
+	})
+
+	AfterEach(func() {
+		ctrl.Finish()
+	})
+
+	Context("syncProjectMembership (full sync)", func() {
+		It("should record successfully synced users on partial failure", func() {
+			userA := privatev1.User_builder{
+				Status: privatev1.UserStatus_builder{
+					KeycloakUserId: "keycloak-a",
+				}.Build(),
+			}.Build()
+
+			project := privatev1.Project_builder{
+				Metadata: privatev1.Metadata_builder{
+					Name:   "my-project",
+					Tenant: "acme",
+				}.Build(),
+				Spec: privatev1.ProjectSpec_builder{}.Build(),
+			}.Build()
+
+			membership := privatev1.ProjectMembership_builder{
+				Metadata: privatev1.Metadata_builder{
+					Finalizers: []string{finalizers.ProjectMembershipFinalizer},
+					Project:    "project-id",
+				}.Build(),
+				Spec: privatev1.ProjectMembershipSpec_builder{
+					Users: []string{"user-a", "user-b"},
+					Role:  privatev1.ProjectMembershipRole_PROJECT_MEMBERSHIP_ROLE_MANAGER,
+				}.Build(),
+				Status: privatev1.ProjectMembershipStatus_builder{
+					State: privatev1.ProjectMembershipState_PROJECT_MEMBERSHIP_STATE_PENDING,
+				}.Build(),
+			}.Build()
+
+			mockProjectsClient.EXPECT().
+				Get(gomock.Any(), gomock.Any()).
+				Return(&privatev1.ProjectsGetResponse{Object: project}, nil)
+
+			mockIdpClient.EXPECT().
+				GetGroupIDByPath(gomock.Any(), "acme", "/my-project/system:managers").
+				Return("group-id", nil)
+
+			// user-a succeeds
+			mockUsersClient.EXPECT().
+				Get(gomock.Any(), gomock.Any()).
+				DoAndReturn(func(_ context.Context, req *privatev1.UsersGetRequest, _ ...interface{}) (*privatev1.UsersGetResponse, error) {
+					if req.GetId() == "user-a" {
+						return &privatev1.UsersGetResponse{Object: userA}, nil
+					}
+					return nil, status.Errorf(codes.NotFound, "user not found")
+				}).Times(2)
+
+			mockIdpClient.EXPECT().
+				AddUserToGroup(gomock.Any(), "acme", "keycloak-a", "group-id").
+				Return(nil)
+
+			task := &task{
+				r:          functionObj,
+				membership: membership,
+			}
+
+			err := task.syncProjectMembership(ctx, nil)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(membership.GetStatus().GetState()).To(Equal(
+				privatev1.ProjectMembershipState_PROJECT_MEMBERSHIP_STATE_FAILED,
+			))
+			Expect(membership.GetStatus().GetUsers()).To(Equal([]string{"user-a"}))
+			Expect(membership.GetStatus().GetMessage()).To(ContainSubstring("user-b"))
+		})
+	})
+
+	Context("handleUserListChange (diff sync)", func() {
+		It("should track partial add progress on failure", func() {
+			userB := privatev1.User_builder{
+				Status: privatev1.UserStatus_builder{
+					KeycloakUserId: "keycloak-b",
+				}.Build(),
+			}.Build()
+
+			project := privatev1.Project_builder{
+				Metadata: privatev1.Metadata_builder{
+					Name:   "my-project",
+					Tenant: "acme",
+				}.Build(),
+				Spec: privatev1.ProjectSpec_builder{}.Build(),
+			}.Build()
+
+			membership := privatev1.ProjectMembership_builder{
+				Metadata: privatev1.Metadata_builder{
+					Finalizers: []string{finalizers.ProjectMembershipFinalizer},
+					Project:    "project-id",
+				}.Build(),
+				Spec: privatev1.ProjectMembershipSpec_builder{
+					Users: []string{"user-a", "user-b", "user-c"},
+					Role:  privatev1.ProjectMembershipRole_PROJECT_MEMBERSHIP_ROLE_MANAGER,
+				}.Build(),
+				Status: privatev1.ProjectMembershipStatus_builder{
+					State: privatev1.ProjectMembershipState_PROJECT_MEMBERSHIP_STATE_READY,
+					Users: []string{"user-a"},
+				}.Build(),
+			}.Build()
+
+			mockProjectsClient.EXPECT().
+				Get(gomock.Any(), gomock.Any()).
+				Return(&privatev1.ProjectsGetResponse{Object: project}, nil)
+
+			mockIdpClient.EXPECT().
+				GetGroupIDByPath(gomock.Any(), "acme", "/my-project/system:managers").
+				Return("group-id", nil)
+
+			// user-b succeeds, user-c fails
+			mockUsersClient.EXPECT().
+				Get(gomock.Any(), gomock.Any()).
+				DoAndReturn(func(_ context.Context, req *privatev1.UsersGetRequest, _ ...interface{}) (*privatev1.UsersGetResponse, error) {
+					if req.GetId() == "user-b" {
+						return &privatev1.UsersGetResponse{Object: userB}, nil
+					}
+					return nil, status.Errorf(codes.NotFound, "user not found")
+				}).Times(2)
+
+			mockIdpClient.EXPECT().
+				AddUserToGroup(gomock.Any(), "acme", "keycloak-b", "group-id").
+				Return(nil)
+
+			task := &task{
+				r:          functionObj,
+				membership: membership,
+			}
+
+			err := task.handleUserListChange(ctx, nil)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(membership.GetStatus().GetState()).To(Equal(
+				privatev1.ProjectMembershipState_PROJECT_MEMBERSHIP_STATE_FAILED,
+			))
+			Expect(membership.GetStatus().GetUsers()).To(ConsistOf("user-a", "user-b"))
+			Expect(membership.GetStatus().GetMessage()).To(ContainSubstring("user-c"))
+		})
+
+		It("should track partial remove progress on failure", func() {
+			userB := privatev1.User_builder{
+				Status: privatev1.UserStatus_builder{
+					KeycloakUserId: "keycloak-b",
+				}.Build(),
+			}.Build()
+
+			project := privatev1.Project_builder{
+				Metadata: privatev1.Metadata_builder{
+					Name:   "my-project",
+					Tenant: "acme",
+				}.Build(),
+				Spec: privatev1.ProjectSpec_builder{}.Build(),
+			}.Build()
+
+			membership := privatev1.ProjectMembership_builder{
+				Metadata: privatev1.Metadata_builder{
+					Finalizers: []string{finalizers.ProjectMembershipFinalizer},
+					Project:    "project-id",
+				}.Build(),
+				Spec: privatev1.ProjectMembershipSpec_builder{
+					Users: []string{"user-a"},
+					Role:  privatev1.ProjectMembershipRole_PROJECT_MEMBERSHIP_ROLE_MANAGER,
+				}.Build(),
+				Status: privatev1.ProjectMembershipStatus_builder{
+					State: privatev1.ProjectMembershipState_PROJECT_MEMBERSHIP_STATE_READY,
+					Users: []string{"user-a", "user-b", "user-c"},
+				}.Build(),
+			}.Build()
+
+			mockProjectsClient.EXPECT().
+				Get(gomock.Any(), gomock.Any()).
+				Return(&privatev1.ProjectsGetResponse{Object: project}, nil)
+
+			mockIdpClient.EXPECT().
+				GetGroupIDByPath(gomock.Any(), "acme", "/my-project/system:managers").
+				Return("group-id", nil)
+
+			// user-b removal succeeds, user-c removal fails
+			mockUsersClient.EXPECT().
+				Get(gomock.Any(), gomock.Any()).
+				DoAndReturn(func(_ context.Context, req *privatev1.UsersGetRequest, _ ...interface{}) (*privatev1.UsersGetResponse, error) {
+					if req.GetId() == "user-b" {
+						return &privatev1.UsersGetResponse{Object: userB}, nil
+					}
+					return nil, status.Errorf(codes.Internal, "internal error")
+				}).Times(2)
+
+			mockIdpClient.EXPECT().
+				RemoveUserFromGroup(gomock.Any(), "acme", "keycloak-b", "group-id").
+				Return(nil)
+
+			task := &task{
+				r:          functionObj,
+				membership: membership,
+			}
+
+			err := task.handleUserListChange(ctx, nil)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(membership.GetStatus().GetState()).To(Equal(
+				privatev1.ProjectMembershipState_PROJECT_MEMBERSHIP_STATE_FAILED,
+			))
+			Expect(membership.GetStatus().GetUsers()).To(ConsistOf("user-a", "user-c"))
+			Expect(membership.GetStatus().GetMessage()).To(ContainSubstring("user-c"))
+		})
+	})
+
+	Context("retry after partial failure", func() {
+		It("should only process remaining users on retry from partial sync", func() {
+			userB := privatev1.User_builder{
+				Status: privatev1.UserStatus_builder{
+					KeycloakUserId: "keycloak-b",
+				}.Build(),
+			}.Build()
+
+			project := privatev1.Project_builder{
+				Metadata: privatev1.Metadata_builder{
+					Name:   "my-project",
+					Tenant: "acme",
+				}.Build(),
+				Spec: privatev1.ProjectSpec_builder{}.Build(),
+			}.Build()
+
+			membership := privatev1.ProjectMembership_builder{
+				Metadata: privatev1.Metadata_builder{
+					Finalizers: []string{finalizers.ProjectMembershipFinalizer},
+					Project:    "project-id",
+				}.Build(),
+				Spec: privatev1.ProjectMembershipSpec_builder{
+					Users: []string{"user-a", "user-b"},
+					Role:  privatev1.ProjectMembershipRole_PROJECT_MEMBERSHIP_ROLE_MANAGER,
+				}.Build(),
+				Status: privatev1.ProjectMembershipStatus_builder{
+					State:   privatev1.ProjectMembershipState_PROJECT_MEMBERSHIP_STATE_FAILED,
+					Message: proto.String("Failed to sync 1 user(s): user user-b: failed to fetch user"),
+					Users:   []string{"user-a"},
+				}.Build(),
+			}.Build()
+
+			// isTerminalFailure fetches the project, then passes it to handleUserListChange→resolveProjectGroup
+			mockProjectsClient.EXPECT().
+				Get(gomock.Any(), gomock.Any()).
+				Return(&privatev1.ProjectsGetResponse{Object: project}, nil)
+
+			mockIdpClient.EXPECT().
+				GetGroupIDByPath(gomock.Any(), "acme", "/my-project/system:managers").
+				Return("group-id", nil)
+
+			// Only user-b should be fetched — user-a is already in status.users
+			mockUsersClient.EXPECT().
+				Get(gomock.Any(), gomock.Any()).
+				Return(&privatev1.UsersGetResponse{Object: userB}, nil)
+
+			mockIdpClient.EXPECT().
+				AddUserToGroup(gomock.Any(), "acme", "keycloak-b", "group-id").
+				Return(nil)
+
+			task := &task{
+				r:          functionObj,
+				membership: membership,
+			}
+
+			err := task.update(ctx)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(membership.GetStatus().GetUsers()).To(Equal([]string{"user-a", "user-b"}))
+			Expect(membership.GetStatus().GetMessage()).ToNot(ContainSubstring("Failed"))
+		})
+
+		It("should preserve user-a and stay FAILED when user-b still fails on retry", func() {
+			project := privatev1.Project_builder{
+				Metadata: privatev1.Metadata_builder{
+					Name:   "my-project",
+					Tenant: "acme",
+				}.Build(),
+				Spec: privatev1.ProjectSpec_builder{}.Build(),
+			}.Build()
+
+			membership := privatev1.ProjectMembership_builder{
+				Metadata: privatev1.Metadata_builder{
+					Finalizers: []string{finalizers.ProjectMembershipFinalizer},
+					Project:    "project-id",
+				}.Build(),
+				Spec: privatev1.ProjectMembershipSpec_builder{
+					Users: []string{"user-a", "user-b"},
+					Role:  privatev1.ProjectMembershipRole_PROJECT_MEMBERSHIP_ROLE_MANAGER,
+				}.Build(),
+				Status: privatev1.ProjectMembershipStatus_builder{
+					State:   privatev1.ProjectMembershipState_PROJECT_MEMBERSHIP_STATE_FAILED,
+					Message: proto.String("Failed to sync 1 user(s): user user-b: failed to fetch user"),
+					Users:   []string{"user-a"},
+				}.Build(),
+			}.Build()
+
+			// isTerminalFailure fetches the project — non-terminal, passes it downstream
+			mockProjectsClient.EXPECT().
+				Get(gomock.Any(), gomock.Any()).
+				Return(&privatev1.ProjectsGetResponse{Object: project}, nil)
+
+			// handleUserListChange → resolveProjectGroup reuses the project from isTerminalFailure
+			mockIdpClient.EXPECT().
+				GetGroupIDByPath(gomock.Any(), "acme", "/my-project/system:managers").
+				Return("group-id", nil)
+
+			// user-b still fails on retry
+			mockUsersClient.EXPECT().
+				Get(gomock.Any(), gomock.Any()).
+				Return(nil, status.Errorf(codes.Unavailable, "service unavailable"))
+
+			task := &task{
+				r:          functionObj,
+				membership: membership,
+			}
+
+			err := task.update(ctx)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(membership.GetStatus().GetState()).To(Equal(
+				privatev1.ProjectMembershipState_PROJECT_MEMBERSHIP_STATE_FAILED,
+			))
+			Expect(membership.GetStatus().GetUsers()).To(Equal([]string{"user-a"}))
+			Expect(membership.GetStatus().GetMessage()).To(ContainSubstring("user-b"))
+		})
 	})
 })
 
@@ -472,7 +1228,7 @@ var _ = Describe("Synchronization", func() {
 				membership: membership,
 			}
 
-			err := task.syncProjectMembership(ctx)
+			err := task.syncProjectMembership(ctx, nil)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(membership.GetStatus().GetState()).To(Equal(privatev1.ProjectMembershipState_PROJECT_MEMBERSHIP_STATE_READY))
 			Expect(membership.GetStatus().GetMessage()).To(Equal(""))
@@ -546,7 +1302,7 @@ var _ = Describe("Synchronization", func() {
 				membership: membership,
 			}
 
-			err := task.syncProjectMembership(ctx)
+			err := task.syncProjectMembership(ctx, nil)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(membership.GetStatus().GetState()).To(Equal(privatev1.ProjectMembershipState_PROJECT_MEMBERSHIP_STATE_READY))
 			Expect(membership.GetStatus().GetUsers()).To(Equal([]string{"user-id"}))
@@ -593,7 +1349,7 @@ var _ = Describe("Synchronization", func() {
 				membership: membership,
 			}
 
-			err := task.syncProjectMembership(ctx)
+			err := task.syncProjectMembership(ctx, nil)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(membership.GetStatus().GetState()).To(Equal(privatev1.ProjectMembershipState_PROJECT_MEMBERSHIP_STATE_FAILED))
 			Expect(membership.GetStatus().GetMessage()).To(ContainSubstring("failed to fetch user"))
@@ -626,7 +1382,7 @@ var _ = Describe("Synchronization", func() {
 				membership: membership,
 			}
 
-			err := task.syncProjectMembership(ctx)
+			err := task.syncProjectMembership(ctx, nil)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(membership.GetStatus().GetState()).To(Equal(privatev1.ProjectMembershipState_PROJECT_MEMBERSHIP_STATE_FAILED))
 			Expect(membership.GetStatus().GetMessage()).To(ContainSubstring("Failed to fetch project"))
@@ -667,7 +1423,7 @@ var _ = Describe("Synchronization", func() {
 				membership: membership,
 			}
 
-			err := task.syncProjectMembership(ctx)
+			err := task.syncProjectMembership(ctx, nil)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(membership.GetStatus().GetState()).To(Equal(privatev1.ProjectMembershipState_PROJECT_MEMBERSHIP_STATE_FAILED))
 			Expect(membership.GetStatus().GetMessage()).To(ContainSubstring("Failed to find authorization group"))
@@ -1033,7 +1789,7 @@ var _ = Describe("User List Change Handling", func() {
 			membership: membership,
 		}
 
-		err := task.handleUserListChange(ctx)
+		err := task.handleUserListChange(ctx, nil)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(membership.GetStatus().GetUsers()).To(Equal([]string{"existing-user", "new-user"}))
 	})
@@ -1088,7 +1844,7 @@ var _ = Describe("User List Change Handling", func() {
 			membership: membership,
 		}
 
-		err := task.handleUserListChange(ctx)
+		err := task.handleUserListChange(ctx, nil)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(membership.GetStatus().GetUsers()).To(Equal([]string{"remaining-user"}))
 	})
@@ -1157,7 +1913,7 @@ var _ = Describe("User List Change Handling", func() {
 			membership: membership,
 		}
 
-		err := task.handleUserListChange(ctx)
+		err := task.handleUserListChange(ctx, nil)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(membership.GetStatus().GetUsers()).To(Equal([]string{"kept-user", "new-user"}))
 	})
@@ -1182,7 +1938,7 @@ var _ = Describe("User List Change Handling", func() {
 			membership: membership,
 		}
 
-		err := task.handleUserListChange(ctx)
+		err := task.handleUserListChange(ctx, nil)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(membership.GetStatus().GetState()).To(Equal(privatev1.ProjectMembershipState_PROJECT_MEMBERSHIP_STATE_READY))
 	})
@@ -1227,7 +1983,7 @@ var _ = Describe("User List Change Handling", func() {
 			membership: membership,
 		}
 
-		err := task.handleUserListChange(ctx)
+		err := task.handleUserListChange(ctx, nil)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(membership.GetStatus().GetState()).To(Equal(privatev1.ProjectMembershipState_PROJECT_MEMBERSHIP_STATE_FAILED))
 		Expect(membership.GetStatus().GetMessage()).To(ContainSubstring("Failed to sync user changes"))

--- a/internal/idp/client_conflict_test.go
+++ b/internal/idp/client_conflict_test.go
@@ -179,6 +179,45 @@ var _ = Describe("Client conflict handling", func() {
 		})
 	})
 
+	Describe("AddUserToGroup", func() {
+		It("succeeds on 409 conflict (user already member of group)", func() {
+			mux.HandleFunc("GET /admin/realms/osac/organizations", func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				json.NewEncoder(w).Encode([]keycloakOrganization{
+					{ID: "org-123", Name: "shared"},
+				})
+			})
+			mux.HandleFunc("POST /admin/realms/osac/organizations/org-123/members", func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusConflict)
+			})
+			mux.HandleFunc("PUT /admin/realms/osac/organizations/org-123/groups/group-456/members/user-789", func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusConflict)
+			})
+
+			err := client.AddUserToGroup(ctx, "shared", "user-789", "group-456")
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("returns an error for non-conflict failures", func() {
+			mux.HandleFunc("GET /admin/realms/osac/organizations", func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				json.NewEncoder(w).Encode([]keycloakOrganization{
+					{ID: "org-123", Name: "shared"},
+				})
+			})
+			mux.HandleFunc("POST /admin/realms/osac/organizations/org-123/members", func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusConflict)
+			})
+			mux.HandleFunc("PUT /admin/realms/osac/organizations/org-123/groups/group-456/members/user-789", func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusInternalServerError)
+			})
+
+			err := client.AddUserToGroup(ctx, "shared", "user-789", "group-456")
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("failed to add user to organization group"))
+		})
+	})
+
 	Describe("CreateTenant end-to-end race simulation", func() {
 		It("succeeds when all IdP resources already exist from a concurrent create", func() {
 			// Simulate the race: another goroutine already created the org, user,

--- a/internal/idp/groups.go
+++ b/internal/idp/groups.go
@@ -349,6 +349,14 @@ func (c *Client) AddUserToGroup(ctx context.Context, tenantName, idpUserID, grou
 
 	response, err := c.httpClient.DoRequest(ctx, http.MethodPut, path, nil)
 	if err != nil {
+		var apiErr *apiclient.APIError
+		if errors.As(err, &apiErr) && apiErr.StatusCode == http.StatusConflict {
+			c.logger.DebugContext(ctx, "User already member of organization group",
+				slog.String("!idpUserID", idpUserID),
+				slog.String("groupID", groupID),
+			)
+			return nil
+		}
 		return fmt.Errorf("failed to add user to organization group: %w", err)
 	}
 	defer response.Body.Close()

--- a/internal/servers/project_memberships_server.go
+++ b/internal/servers/project_memberships_server.go
@@ -250,7 +250,25 @@ func (s *ProjectMembershipsServer) Update(ctx context.Context,
 		return
 	}
 
-	privateProjectMembership := &privatev1.ProjectMembership{}
+	// When no update mask is provided, fetch the current private object and copy public fields
+	// into it. This preserves private-only fields (like status.users) that don't exist in the
+	// public proto. With an update mask, start from a fresh object — the generic server will
+	// handle merging with the database object using field mask semantics.
+	var privateProjectMembership *privatev1.ProjectMembership
+	updateMask := request.GetUpdateMask()
+	if len(updateMask.GetPaths()) > 0 {
+		privateProjectMembership = &privatev1.ProjectMembership{}
+		privateProjectMembership.SetId(publicProjectMembership.GetId())
+	} else {
+		getRequest := &privatev1.ProjectMembershipsGetRequest{}
+		getRequest.SetId(publicProjectMembership.GetId())
+		var getResponse *privatev1.ProjectMembershipsGetResponse
+		getResponse, err = s.delegate.Get(ctx, getRequest)
+		if err != nil {
+			return nil, err
+		}
+		privateProjectMembership = getResponse.GetObject()
+	}
 	err = s.inMapper.Copy(ctx, publicProjectMembership, privateProjectMembership)
 	if err != nil {
 		s.logger.ErrorContext(
@@ -264,7 +282,7 @@ func (s *ProjectMembershipsServer) Update(ctx context.Context,
 
 	privateRequest := &privatev1.ProjectMembershipsUpdateRequest{}
 	privateRequest.SetObject(privateProjectMembership)
-	privateRequest.SetUpdateMask(request.GetUpdateMask())
+	privateRequest.SetUpdateMask(updateMask)
 	privateRequest.SetLock(request.GetLock())
 	privateResponse, err := s.delegate.Update(ctx, privateRequest)
 	if err != nil {


### PR DESCRIPTION
If a ProjectMembership still exists, but a user is removed from the list of users in that project, the user should be removed from the group in Keycloak.

Assisted-by: Claude Code <noreply@anthropic.com>

/cc @danielerez @DakCrowder @rccrdpccl 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved project membership recovery after failed synchronization attempts.
  - Preserved successfully processed users when some assignments or removals fail, enabling more targeted retries.
  - Prevented unnecessary retries for terminal failures such as deleted projects, invalid roles, or missing tenants.
  - Treated users already belonging to a group as successfully added.
  - Preserved private membership settings when updating records without an update mask.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->