### PR TITLE
OSAC-3548: Fix premature restart_trigger echo in syncStatus

### DIFF
--- a/internal/controllers/baremetalinstance/baremetalinstance_reconciler_function.go
+++ b/internal/controllers/baremetalinstance/baremetalinstance_reconciler_function.go
@@ -474,14 +474,23 @@ func (t *task) syncStatus(object *bmfov1alpha1.BareMetalInstance) {
 					privatev1.BareMetalInstanceConditionType_BARE_METAL_INSTANCE_CONDITION_TYPE_RESTART_IN_PROGRESS,
 					privatev1.ConditionStatus_CONDITION_STATUS_FALSE, "", "")
 			} else if cond.Status == metav1.ConditionTrue {
-				t.updateCondition(
-					privatev1.BareMetalInstanceConditionType_BARE_METAL_INSTANCE_CONDITION_TYPE_RESTART_IN_PROGRESS,
-					privatev1.ConditionStatus_CONDITION_STATUS_FALSE, "", "")
-				t.updateCondition(
-					privatev1.BareMetalInstanceConditionType_BARE_METAL_INSTANCE_CONDITION_TYPE_RESTART_FAILED,
-					privatev1.ConditionStatus_CONDITION_STATUS_FALSE, "", "")
-				t.bareMetalInstance.GetStatus().SetRestartTrigger(
-					t.bareMetalInstance.GetSpec().GetRestartTrigger())
+				if object.Spec.RestartTrigger == object.Status.RestartTrigger {
+					t.updateCondition(
+						privatev1.BareMetalInstanceConditionType_BARE_METAL_INSTANCE_CONDITION_TYPE_RESTART_IN_PROGRESS,
+						privatev1.ConditionStatus_CONDITION_STATUS_FALSE, "", "")
+					t.updateCondition(
+						privatev1.BareMetalInstanceConditionType_BARE_METAL_INSTANCE_CONDITION_TYPE_RESTART_FAILED,
+						privatev1.ConditionStatus_CONDITION_STATUS_FALSE, "", "")
+					t.bareMetalInstance.GetStatus().SetRestartTrigger(
+						t.bareMetalInstance.GetSpec().GetRestartTrigger())
+				} else {
+					t.updateCondition(
+						privatev1.BareMetalInstanceConditionType_BARE_METAL_INSTANCE_CONDITION_TYPE_RESTART_IN_PROGRESS,
+						privatev1.ConditionStatus_CONDITION_STATUS_TRUE, cond.Reason, "Restart in progress")
+					t.updateCondition(
+						privatev1.BareMetalInstanceConditionType_BARE_METAL_INSTANCE_CONDITION_TYPE_RESTART_FAILED,
+						privatev1.ConditionStatus_CONDITION_STATUS_FALSE, "", "")
+				}
 			}
 		}
 	}

--- a/internal/controllers/baremetalinstance/baremetalinstance_reconciler_function_test.go
+++ b/internal/controllers/baremetalinstance/baremetalinstance_reconciler_function_test.go
@@ -1458,7 +1458,11 @@ var _ = Describe("syncStatus", func() {
 	It("should clear restart conditions and sync restart trigger when PowerSynced is True", func() {
 		t := newTask(42)
 		object := &bmfov1alpha1.BareMetalInstance{
+			Spec: bmfov1alpha1.BareMetalInstanceSpec{
+				RestartTrigger: 42,
+			},
 			Status: bmfov1alpha1.BareMetalInstanceStatus{
+				RestartTrigger: 42,
 				Conditions: []metav1.Condition{
 					{
 						Type:    string(bmfov1alpha1.HostConditionPowerSynced),
@@ -1482,6 +1486,39 @@ var _ = Describe("syncStatus", func() {
 		Expect(failed.GetStatus()).To(Equal(privatev1.ConditionStatus_CONDITION_STATUS_FALSE))
 
 		Expect(t.bareMetalInstance.GetStatus().GetRestartTrigger()).To(Equal(int64(42)))
+	})
+
+	It("should not echo restart trigger when operator has not completed restart", func() {
+		t := newTask(42)
+		object := &bmfov1alpha1.BareMetalInstance{
+			Spec: bmfov1alpha1.BareMetalInstanceSpec{
+				RestartTrigger: 42,
+			},
+			Status: bmfov1alpha1.BareMetalInstanceStatus{
+				RestartTrigger: 0,
+				Conditions: []metav1.Condition{
+					{
+						Type:    string(bmfov1alpha1.HostConditionPowerSynced),
+						Status:  metav1.ConditionTrue,
+						Reason:  bmfov1alpha1.HostConditionReasonPowerOn,
+						Message: "Power on complete",
+					},
+				},
+			},
+		}
+		t.syncStatus(object)
+
+		Expect(t.bareMetalInstance.GetStatus().GetRestartTrigger()).To(Equal(int64(0)))
+
+		inProgress := findProtoCondition(t.bareMetalInstance,
+			privatev1.BareMetalInstanceConditionType_BARE_METAL_INSTANCE_CONDITION_TYPE_RESTART_IN_PROGRESS)
+		Expect(inProgress).ToNot(BeNil())
+		Expect(inProgress.GetStatus()).To(Equal(privatev1.ConditionStatus_CONDITION_STATUS_TRUE))
+
+		failed := findProtoCondition(t.bareMetalInstance,
+			privatev1.BareMetalInstanceConditionType_BARE_METAL_INSTANCE_CONDITION_TYPE_RESTART_FAILED)
+		Expect(failed).ToNot(BeNil())
+		Expect(failed.GetStatus()).To(Equal(privatev1.ConditionStatus_CONDITION_STATUS_FALSE))
 	})
 
 	It("should not set restart conditions when PowerSynced is False with unhandled reason", func() {


### PR DESCRIPTION
## Summary

Fix a race condition where the fulfillment controller prematurely echoes `status.restart_trigger` before the operator has processed the restart, leaving the BMI permanently stuck in `Starting` state.

## Root Cause

The fulfillment controller is event-driven via `pg_notify` and reconciles within milliseconds of a `restart_trigger` update. It reads stale `PowerSynced=True` from the K8s CR (the operator hasn't acted yet) and interprets it as "restart completed", echoing `status.restart_trigger = spec.restart_trigger`. This makes `restartPending=false` permanently, and the `if !restartPending { continue }` guard in `syncStatus()` skips all `PowerSynced` processing forever.

## Fix

Guard the trigger echo on the operator having also echoed `Status.RestartTrigger` on the K8s CR (`object.Spec.RestartTrigger == object.Status.RestartTrigger`). The operator only writes this after the restart truly completes (line 638 of `baremetalinstance_controller.go`), so a stale `PowerSynced=True` from before the restart is correctly skipped.

## Testing

- Updated existing test to set CR `Status.RestartTrigger` matching (happy path)
- Added new test: "should not echo restart trigger when operator has not completed restart" (the race condition scenario)
- All 70 baremetalinstance controller tests pass

## Evidence

Bug reproduced on CI (4 consecutive runs on [osac-test-infra PR #277](https://github.com/osac-project/osac-test-infra/pull/277)) and on remote dev cluster (osac-sno). Detailed analysis in [OSAC-3548](https://redhat.atlassian.net/browse/OSAC-3548).

## Jira

[OSAC-3548](https://redhat.atlassian.net/browse/OSAC-3548)

## Related

- E2E restart test: [osac-test-infra PR #302](https://github.com/osac-project/osac-test-infra/pull/302) (depends on this fix to pass)

Assisted-by: Claude Code <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved restart synchronization so completion is only reported after the expected restart trigger is observed.
  * Prevented restart conditions from being cleared prematurely during incomplete restarts.
  * Ensured completed restarts accurately reflect their fulfillment status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->